### PR TITLE
#13 - fixed async race condition

### DIFF
--- a/app/course/[course_id]/discussion/DiscussionThreadList.tsx
+++ b/app/course/[course_id]/discussion/DiscussionThreadList.tsx
@@ -101,8 +101,8 @@ export const DiscussionThreadTeaser = (props: Props) => {
                                 </Text>
                             </HStack>
                         )}
-                        {readStatus?.numReadDescendants !== thread?.children_count && (
-                            <Badge colorScheme="blue">{(thread?.children_count ?? 0) - (readStatus?.numReadDescendants ?? 0)} new</Badge>
+                        {(readStatus?.numReadDescendants ?? 0) < (readStatus?.current_children_count ?? 0) && (
+                            <Badge colorScheme="blue">{Math.max(0, (readStatus?.current_children_count ?? 0) - (readStatus?.numReadDescendants ?? 0))} new</Badge>
                         )}
                         <Spacer />
                         <Text fontSize="xs" color="text.muted">{thread?.created_at ? formatRelative(new Date(thread?.created_at), new Date()) : ""}</Text>

--- a/hooks/useDiscussionThreadRootController.tsx
+++ b/hooks/useDiscussionThreadRootController.tsx
@@ -39,6 +39,7 @@ export default function useDiscussionThreadChildren(threadId: number) {
 }
 export type DiscussionThreadReadWithAllDescendants = DiscussionThreadReadStatus & {
     numReadDescendants: number;
+    current_children_count: number;
 }
 export class DiscussionThreadsController {
     private discussionThreadWithChildrenSubscribers: Map<number, UpdateCallback<DiscussionThreadWithChildren>[]> = new Map();


### PR DESCRIPTION
There was a race condition where the total reply count `children_count` and the calculated count of read replies `numReadDescendants` could update asynchronously. This led to brief moments where the read count exceeded the total count during UI calculation, resulting in a negative value.

Closes #13 