### PR TITLE
Group by tag

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/GroupManagementContext.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/GroupManagementContext.tsx
@@ -5,6 +5,7 @@ export type GroupCreateData = {
   name: string;
   member_ids: string[];
   tagName?: string;
+  tagColor?: string;
 };
 
 export type StudentMoveData = {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/GroupManagementContext.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/GroupManagementContext.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState } from "react";
 export type GroupCreateData = {
   name: string;
   member_ids: string[];
+  tagName?: string;
 };
 
 export type StudentMoveData = {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
@@ -232,6 +232,7 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
                       <Table.Row>
                         <Table.ColumnHeader>Group</Table.ColumnHeader>
                         <Table.ColumnHeader>Members</Table.ColumnHeader>
+                        <Table.ColumnHeader>Common Tag</Table.ColumnHeader>
                         <Table.ColumnHeader>Actions</Table.ColumnHeader>
                       </Table.Row>
                     </Table.Header>
@@ -249,6 +250,7 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
                                 );
                               })}
                             </Table.Cell>
+                            <Table.Cell>{group.tagName}</Table.Cell>
                             <Table.Cell>
                               <Button
                                 variant={"surface"}

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
@@ -36,6 +36,8 @@ import {
   StudentMoveData,
   useGroupManagement
 } from "./GroupManagementContext";
+import useTags from "@/hooks/useTags";
+import TagDisplay from "@/components/ui/tag";
 
 export type RolesWithProfilesAndGroupMemberships = GetResult<
   Database["public"],
@@ -78,7 +80,7 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
     removeMoveToFulfill
   } = useGroupManagement();
   const invalidate = useInvalidate();
-
+  const { tags } = useTags();
   const supabase = createClient();
 
   /**
@@ -175,6 +177,17 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
     invalidate({ resource: "assignment_groups_members", invalidates: ["all"] });
   };
 
+  const tagDisplay = (group: GroupCreateData) => {
+    const tag = tags.find((t) => {
+      return t.name === group.tagName && t.color === group.tagColor;
+    });
+    if (tag) {
+      return <TagDisplay tag={tag} />;
+    } else {
+      return <></>;
+    }
+  };
+
   if (!groupsData || !assignment) {
     return (
       <Box>
@@ -250,7 +263,7 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
                                 );
                               })}
                             </Table.Cell>
-                            <Table.Cell>{group.tagName}</Table.Cell>
+                            <Table.Cell>{tagDisplay(group)}</Table.Cell>
                             <Table.Cell>
                               <Button
                                 variant={"surface"}

--- a/app/course/[course_id]/manage/course/enrollments/page.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Button } from "@/components/ui/button";
 import InlineAddTag from "@/components/ui/inline-add-tag";
+import InlineRemoveTag from "@/components/ui/inline-remove-tag";
 import PersonTags from "@/components/ui/person-tags";
 import { toaster, Toaster } from "@/components/ui/toaster";
 import { Tooltip } from "@/components/ui/tooltip";
@@ -38,13 +39,12 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FaEdit, FaFileImport, FaLink, FaTrash, FaUserCog } from "react-icons/fa";
+import { PiArrowBendLeftUpBold } from "react-icons/pi";
 import AddSingleStudent from "./addSingleStudent";
 import EditUserProfileModal from "./editUserProfileModal";
 import EditUserRoleModal from "./editUserRoleModal";
 import ImportStudentsCSVModal from "./importStudentsCSVModal";
 import RemoveStudentModal from "./removeStudentModal";
-import { PiArrowBendLeftUpBold } from "react-icons/pi";
-import InlineRemoveTag from "@/components/ui/inline-remove-tag";
 
 type EditProfileModalData = string; // userId
 type EditUserRoleModalData = {
@@ -279,25 +279,10 @@ function EnrollmentsTable() {
           return profileTagNames.includes(filterValue);
         },
         cell: ({ row }) => {
-          const tagsFor = RetrieveTagsForProfile(row.original.private_profile_id);
           return (
             <Flex flexDirection={"row"} width="100%" gap="5px" wrap="wrap">
               <PersonTags profile_id={row.original.private_profile_id} showRemove />
-              <InlineAddTag
-                addTag={async (name: string, color?: string) => {
-                  await addTag({
-                    values: {
-                      name: name.startsWith("~") ? name.slice(1) : name,
-                      color: color || "gray",
-                      visible: !name.startsWith("~"),
-                      profile_id: row.original.private_profile_id,
-                      class_id: course_id as string
-                    }
-                  });
-                }}
-                currentTags={tagsFor.tags}
-                allowExpand={false}
-              />
+              <InlineAddTag profile_id={row.original.private_profile_id} allowExpand={false} />
             </Flex>
           );
         }
@@ -390,8 +375,6 @@ function EnrollmentsTable() {
       openEditUserRoleModal,
       openRemoveStudentModal,
       tagData,
-      addTag,
-      course_id,
       handleSingleCheckboxChange
     ]
   );

--- a/components/ui/inline-add-tag.tsx
+++ b/components/ui/inline-add-tag.tsx
@@ -2,11 +2,13 @@
 
 import { TagColor } from "@/app/course/[course_id]/manage/course/enrollments/TagColors";
 import TagDisplay from "@/components/ui/tag";
-import useTags from "@/hooks/useTags";
+import useTags, { useTagsForProfile } from "@/hooks/useTags";
 import { Tag } from "@/utils/supabase/DatabaseTypes";
 import { Box, Button, Flex, Grid, Heading, Icon, SegmentGroup } from "@chakra-ui/react";
+import { useCreate, useInvalidate } from "@refinedev/core";
 import { Select } from "chakra-react-select";
-import { useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FaPlus } from "react-icons/fa6";
 
 interface TagOption {
@@ -49,15 +51,37 @@ function KeyboardAwareSegmentGroup({
   );
 }
 
-export default function InlineAddTag({
-  addTag,
-  currentTags,
-  allowExpand
-}: {
-  addTag: (name: string, color: string) => void;
-  currentTags: Tag[];
-  allowExpand: boolean;
-}) {
+export default function InlineAddTag({ profile_id, allowExpand }: { profile_id: string; allowExpand: boolean }) {
+  const currentTags = useTagsForProfile(profile_id).tags;
+  const { course_id } = useParams();
+  const invalidate = useInvalidate();
+  const mutationOptions = useMemo(
+    () => ({
+      onSuccess: () => {
+        invalidate({ resource: "tags", invalidates: ["list"] });
+      }
+    }),
+    [invalidate]
+  );
+  const { mutateAsync } = useCreate<Tag>({
+    resource: "tags",
+    mutationOptions
+  });
+  const addTag = useCallback(
+    async (name: string, color: string) => {
+      await mutateAsync({
+        values: {
+          name,
+          color,
+          visible: !name.startsWith("~"),
+          profile_id,
+          class_id: course_id as string
+        }
+      });
+    },
+    [mutateAsync, profile_id, course_id]
+  );
+
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [showColorPicker, setShowColorPicker] = useState(false);


### PR DESCRIPTION
Instructors should be able to group students based on a set of tags.  

This will optionally allow instructors to add certain tags to group together when bulk generating groups.

(Enrollment for reference)
<img width="1408" alt="Screenshot 2025-06-03 at 2 12 45 PM" src="https://github.com/user-attachments/assets/f56d6a5c-390f-4ad9-8572-78622d9ac17e" />

Examples:
"Group Oakland students with other Oakland students and Boston students with other Boston students." 
<img width="676" alt="Screenshot 2025-06-03 at 2 05 35 PM" src="https://github.com/user-attachments/assets/0907b878-c028-4aec-8322-cdf5c45b6311" />

"Group Boston students together" (students without the Boston tag can be grouped with anyone else).
<img width="681" alt="Screenshot 2025-06-03 at 2 06 57 PM" src="https://github.com/user-attachments/assets/3e3bfb9e-a9c5-4c17-a7ba-20223eae573c" />

"Group any students with any"
<img width="679" alt="Screenshot 2025-06-03 at 2 07 25 PM" src="https://github.com/user-attachments/assets/20b5a34a-be5a-46b5-813e-3c01b7cc9e49" />


Main page
Displays the a "common tag" if the group was created using the tag filter 
<img width="1233" alt="Screenshot 2025-06-03 at 2 08 38 PM" src="https://github.com/user-attachments/assets/35da7239-41f3-4362-a645-d728bac4650e" />
