### PR TITLE
draft mobile improvements

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/page.tsx
@@ -106,8 +106,7 @@ export default async function AssignmentPage({
     <Box p={4}>
       <Heading size="lg">{assignment.title}</Heading>
       <HStack>
-        <Text>Due: </Text>
-        <AssignmentDueDate assignment={assignment} showLateTokenButton={true} showTimeZone={true} />
+        <AssignmentDueDate assignment={assignment} showLateTokenButton={true} showTimeZone={true} showDue={true} />
       </HStack>
       <Markdown>{assignment.description}</Markdown>
       {!assignment.template_repo || !assignment.template_repo.includes("/") ? (

--- a/app/course/[course_id]/discussion/DiscussionThreadList.tsx
+++ b/app/course/[course_id]/discussion/DiscussionThreadList.tsx
@@ -237,7 +237,7 @@ export default function DiscussionThreadList() {
   }, []);
 
   return (
-    <Flex width="314px" height="100vh" bottom={0} direction="column" top={0} justify="space-between" align="center">
+    <Flex width={"100%"} height={"100vh"} bottom={0} direction="column" top={0} justify="space-between" align="center">
       <Box p="4" w="100%">
         <Heading size="md" mb="2">
           Discussion Feed

--- a/app/course/[course_id]/discussion/[root_id]/page.tsx
+++ b/app/course/[course_id]/discussion/[root_id]/page.tsx
@@ -9,7 +9,7 @@ import useDiscussionThreadChildren, {
 import { useDiscussionThreadWatchStatus } from "@/hooks/useDiscussionThreadWatches";
 import { useUserProfile } from "@/hooks/useUserProfiles";
 import { DiscussionThread as DiscussionThreadType, DiscussionTopic } from "@/utils/supabase/DatabaseTypes";
-import { Avatar, Badge, Box, Button, Heading, HStack, Link, Text, VStack } from "@chakra-ui/react";
+import { Avatar, Badge, Box, Button, Flex, Heading, HStack, Link, Text, VStack } from "@chakra-ui/react";
 import { useList, useOne, useUpdate } from "@refinedev/core";
 import { formatRelative } from "date-fns";
 import { useParams } from "next/navigation";
@@ -35,7 +35,7 @@ function ThreadHeader({ thread, topic }: { thread: DiscussionThreadType; topic: 
           )}
           <VStack gap="0" alignSelf="flex-start" align="start">
             {thread.instructors_only && <Badge colorPalette="blue">Viewable by poster and staff only</Badge>}
-            <HStack>
+            <Flex wrap="wrap">
               {userProfile ? (
                 <Heading size="sm">
                   {userProfile?.name}
@@ -52,7 +52,7 @@ function ThreadHeader({ thread, topic }: { thread: DiscussionThreadType; topic: 
               ) : (
                 <Skeleton width="100px" height="20px" />
               )}
-            </HStack>
+            </Flex>
             <Text fontSize="sm" color="text.muted">
               {formatRelative(new Date(thread.created_at), new Date())}
             </Text>

--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -1,10 +1,17 @@
 import { Box, Flex } from "@chakra-ui/react";
 import DiscussionThreadList from "./DiscussionThreadList";
+
 const DiscussionLayout = async ({ children }: Readonly<{ children: React.ReactNode }>) => {
   return (
     <Box>
-      <Flex flex="1">
-        <Box w="314px" borderRight="1px solid" borderColor="border.emphasized" pt="4">
+      <Flex flex="1" wrap={{ base: "wrap", md: "nowrap" }}>
+        <Box
+          width={{ base: "100%", md: "314px" }}
+          borderRight={{ base: "none", md: "1px solid" }}
+          borderBottom={{ base: "1px solid", md: "none" }}
+          borderColor="border.emphasized"
+          pt="4"
+        >
           <DiscussionThreadList />
         </Box>
         <Box p="8" width="100%">

--- a/app/course/[course_id]/discussion/new/page.tsx
+++ b/app/course/[course_id]/discussion/new/page.tsx
@@ -269,6 +269,7 @@ export default function NewDiscussionThread() {
             </Fieldset.Content>
             <Fieldset.Content>
               <Field
+                maxWidth={"100%"}
                 label="Subject"
                 helperText="A short, descriptive subject for your post. Be specific."
                 errorText={errors.title?.message?.toString()}

--- a/components/github/link-account.tsx
+++ b/components/github/link-account.tsx
@@ -11,7 +11,7 @@ export default function LinkAccount() {
   );
 
   return (
-    <Alert w="lg" m="5" status="error">
+    <Alert width="lg" m="5" status="error" maxWidth="100%">
       <VStack>
         In order to use this application, you need to link your GitHub account.
         <Button

--- a/components/ui/assignment-due-date.tsx
+++ b/components/ui/assignment-due-date.tsx
@@ -3,7 +3,7 @@
 import { useClassProfiles } from "@/hooks/useClassProfiles";
 import { useAssignmentDueDate, useLateTokens } from "@/hooks/useCourseController";
 import { Assignment, AssignmentDueDateException, AssignmentGroup } from "@/utils/supabase/DatabaseTypes";
-import { Dialog, Heading, HStack, Text } from "@chakra-ui/react";
+import { Dialog, Flex, Heading, Text } from "@chakra-ui/react";
 import { TZDate } from "@date-fns/tz";
 import { useCreate, useList } from "@refinedev/core";
 import { addHours, isAfter } from "date-fns";
@@ -145,11 +145,13 @@ function LateTokenButton({ assignment }: { assignment: Assignment }) {
 export function AssignmentDueDate({
   assignment,
   showLateTokenButton = false,
-  showTimeZone = false
+  showTimeZone = false,
+  showDue = false
 }: {
   assignment: Assignment;
   showLateTokenButton?: boolean;
   showTimeZone?: boolean;
+  showDue?: boolean;
 }) {
   const { dueDate, originalDueDate, hoursExtended, lateTokensConsumed, time_zone } = useAssignmentDueDate(assignment);
   if (!dueDate || !originalDueDate) {
@@ -157,15 +159,18 @@ export function AssignmentDueDate({
   }
   console.log(dueDate);
   return (
-    <HStack gap={1}>
-      <Text>{formatInTimeZone(new TZDate(dueDate), time_zone || "America/New_York", "MMM d h:mm aaa")}</Text>
-      {showTimeZone && <Text fontSize="sm">({time_zone})</Text>}
+    <Flex gap={1} wrap="wrap">
+      <Flex alignItems={"center"} gap={1}>
+        {showDue && <Text>Due: </Text>}
+        <Text>{formatInTimeZone(new TZDate(dueDate), time_zone || "America/New_York", "MMM d h:mm aaa")}</Text>
+        {showTimeZone && <Text fontSize="sm">({time_zone})</Text>}
+      </Flex>
       {hoursExtended > 0 && (
         <Text>
           ({hoursExtended}-hour extension applied, {lateTokensConsumed} late tokens consumed)
         </Text>
       )}
       {showLateTokenButton && <LateTokenButton assignment={assignment} />}
-    </HStack>
+    </Flex>
   );
 }


### PR DESCRIPTION
Fixes of miscellaneous formatting bugs (especially visible on mobile)  

Navigation before: 

<img width="422" alt="Screenshot 2025-06-05 at 2 55 29 PM" src="https://github.com/user-attachments/assets/565175d5-4cdd-43e8-be38-325daec4bc19" />

<img width="408" alt="Screenshot 2025-06-05 at 2 55 34 PM" src="https://github.com/user-attachments/assets/a902a06e-5d88-498a-b852-767ab92490c2" />

Navigation after:

<img width="378" alt="Screenshot 2025-06-05 at 4 18 42 PM" src="https://github.com/user-attachments/assets/1ac47b78-8fe0-4706-b4e3-50603714ebf2" />

Discussion boards before:
<img width="392" alt="Screenshot 2025-06-05 at 4 42 18 PM" src="https://github.com/user-attachments/assets/cc64cd68-7b37-426f-adc0-cad2cefb6fde" />

<img width="397" alt="Screenshot 2025-06-05 at 4 42 58 PM" src="https://github.com/user-attachments/assets/271900d1-2e9a-4647-8358-bdc351824058" />

Discussion boards after:

<img width="367" alt="Screenshot 2025-06-05 at 4 19 28 PM" src="https://github.com/user-attachments/assets/04654bf3-b479-45b6-ba30-002fcf8a7889" />

<img width="381" alt="Screenshot 2025-06-05 at 4 19 42 PM" src="https://github.com/user-attachments/assets/bdcfa976-f4ca-427c-8e13-8985312b492d" />

Discussion cards before:

<img width="394" alt="Screenshot 2025-06-05 at 4 41 40 PM" src="https://github.com/user-attachments/assets/53e39e36-a2a0-4de0-a1c5-bfb7f884b7b9" />

Discussion thread cards after:

<img width="429" alt="Screenshot 2025-06-05 at 4 38 45 PM" src="https://github.com/user-attachments/assets/6cca59bc-33ca-4410-8199-8d87adbd2235" />

Assignment info before:

<img width="354" alt="Screenshot 2025-06-05 at 4 45 03 PM" src="https://github.com/user-attachments/assets/69137026-aac3-43d8-98ea-09f6e98e342b" />

