### PR TITLE
Timezone display consistency

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -34,7 +34,7 @@ import { createClient } from "@/utils/supabase/client";
 import { Icon } from "@chakra-ui/react";
 import { TZDate } from "@date-fns/tz";
 import { CrudFilter, useInvalidate, useList, useUpdate } from "@refinedev/core";
-import { format, formatRelative } from "date-fns";
+import { formatRelative } from "date-fns";
 import NextLink from "next/link";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ElementType as ReactElementType, useRef, useState } from "react";
@@ -48,6 +48,7 @@ import { RxQuestionMarkCircled } from "react-icons/rx";
 import { TbMathFunction } from "react-icons/tb";
 import { GraderResultTestData } from "./results/page";
 import { linkToSubPage } from "./utils";
+import { formatDueDateInTimezone } from "@/lib/utils";
 
 // Create a mapping of icon names to their components
 const iconMap: { [key: string]: ReactElementType } = {
@@ -438,6 +439,7 @@ function RubricView() {
   const isGraderOrInstructor = useIsGraderOrInstructor();
   const activeReviewAssignmentId = useActiveReviewAssignmentId();
   const scrollRootRef = useRef<HTMLDivElement>(null);
+  const course = useCourse();
 
   const {
     reviewAssignment,
@@ -472,11 +474,25 @@ function RubricView() {
             </Heading>
             <Text fontSize="sm">Assigned to: {reviewAssignment.profiles?.name || "N/A"}</Text>
             <Text fontSize="sm">
-              Due: {reviewAssignment.due_date ? format(new TZDate(reviewAssignment.due_date), "Pp") : "N/A"}
+              Due:{" "}
+              {reviewAssignment.due_date
+                ? formatDueDateInTimezone(
+                    reviewAssignment.due_date,
+                    course.time_zone ?? "America/New_York",
+                    false,
+                    false
+                  )
+                : "N/A"}
             </Text>
             {reviewAssignment.release_date && (
               <Text fontSize="sm">
-                Grading visible to student after: {format(new TZDate(reviewAssignment.release_date), "Pp")}
+                Grading visible to student after:{" "}
+                {formatDueDateInTimezone(
+                  reviewAssignment.release_date,
+                  course.time_zone ?? "America/New_York",
+                  false,
+                  false
+                )}
               </Text>
             )}
           </Box>

--- a/components/ui/submission-review-toolbar.tsx
+++ b/components/ui/submission-review-toolbar.tsx
@@ -13,7 +13,7 @@ import {
   useMissingRubricChecksForActiveReview,
   useSetActiveSubmissionReviewId
 } from "@/hooks/useSubmissionReview";
-import { formatDueDate } from "@/lib/utils";
+import { formatDueDateInTimezone } from "@/lib/utils";
 import { SubmissionReviewWithRubric } from "@/utils/supabase/DatabaseTypes";
 import { useUpdate } from "@refinedev/core";
 import { formatDate } from "date-fns";
@@ -186,8 +186,8 @@ function ReviewAssignmentActions() {
       {activeReviewAssignment && (
         <Text textAlign="left">
           Your {activeSubmissionReview?.rubrics.name} review is required by{" "}
-          {formatDueDate(activeReviewAssignment.due_date, time_zone || "America/New_York")}. When you are done, click
-          &quot;Complete Review&quot;.
+          {formatDueDateInTimezone(activeReviewAssignment.due_date, time_zone || "America/New_York", false, true)}. When
+          you are done, click &quot;Complete Review&quot;.
         </Text>
       )}
       {activeSubmissionReview && <CompleteReviewButton />}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
 import { TZDate } from "@date-fns/tz";
 import { clsx, type ClassValue } from "clsx";
 import { differenceInHours, formatDistance } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
@@ -28,6 +29,20 @@ export function formatDueDate(date: string | null, courseTimezone?: string) {
     new Date(date).toLocaleTimeString() +
     dueDateAdvice(date, courseTimezone)
   );
+}
+
+export function formatDueDateInTimezone(
+  date: string | null,
+  courseTimezone?: string,
+  includeTimezone?: boolean,
+  giveAdvice?: boolean
+) {
+  if (!date) {
+    return "N/A";
+  }
+  const timezone = includeTimezone ? ` (${courseTimezone}) ` : "";
+  const advice = giveAdvice === true ? dueDateAdvice(date, courseTimezone) : "";
+  return formatInTimeZone(date, courseTimezone || "America/New_York", "MMM d h:mm aaa") + timezone + advice;
 }
 
 export function appendTimezoneOffset(date: string | null, timezone: string) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,18 +19,6 @@ export function dueDateAdvice(date: string | null, courseTimezone?: string) {
   return advice;
 }
 
-export function formatDueDate(date: string | null, courseTimezone?: string) {
-  if (!date) {
-    return "N/A";
-  }
-  return (
-    new Date(date).toLocaleDateString() +
-    " " +
-    new Date(date).toLocaleTimeString() +
-    dueDateAdvice(date, courseTimezone)
-  );
-}
-
 export function formatDueDateInTimezone(
   date: string | null,
   courseTimezone?: string,


### PR DESCRIPTION
Issue: concerns about timezone consistency from user testing
Changes:
Three dates in the grading / self eval interface used local time, while the rest used course time.  Changed these dates to be in course time, as that is used more consistently throughout.