### PR TITLE
Handle handout repos in submission creation

### DIFF
--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -99,6 +99,10 @@ export type GradeResponse = {
 export type SubmissionResponse = {
   grader_url: string;
   grader_sha: string;
+  handout_notice?: {
+    message: string;
+    assignments: { id: number; title: string; slug?: string }[];
+  };
 };
 export type RegressionTestRunResponse = {
   regression_test_url: string;


### PR DESCRIPTION
Refactor `create-submission` handler to detect handout repositories and return a specific notice, preventing grading and providing user feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-217d3680-b829-4d45-9f43-c70434785f26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-217d3680-b829-4d45-9f43-c70434785f26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

