### PR TITLE
Skip pawtograder emails

### DIFF
--- a/app/course/[course_id]/manage/course/enrollments/addSingleStudent.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/addSingleStudent.tsx
@@ -14,6 +14,7 @@ type FormData = {
   email: string;
   name: string;
   role: "student" | "grader" | "instructor";
+  notify?: boolean;
 };
 
 export default function AddSingleStudent() {
@@ -33,10 +34,10 @@ export default function AddSingleStudent() {
       });
       const supabase = createClient();
       try {
-        await enrollmentAdd(
-          { courseId: Number(course_id), email: data.email, name: data.name, role: data.role },
-          supabase
-        );
+                 await enrollmentAdd(
+           { courseId: Number(course_id), email: data.email, name: data.name, role: data.role, notify: !!data.notify },
+           supabase
+         );
         toaster.create({
           title: "Student added",
           description: "Refreshing user_roles",
@@ -94,6 +95,12 @@ export default function AddSingleStudent() {
                   </NativeSelect.Field>
                 </NativeSelect.Root>
                 <Field.ErrorText>{errors.role?.message}</Field.ErrorText>
+              </Field.Root>
+              <Field.Root>
+                <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <input type="checkbox" {...register("notify")} />
+                  Notify user they were added to this course
+                </label>
               </Field.Root>
               <Button type="submit" mt={2}>
                 Add Student

--- a/app/course/[course_id]/manage/course/enrollments/importStudentsCSVModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/importStudentsCSVModal.tsx
@@ -39,6 +39,7 @@ const ImportStudentsCSVModal = ({ isOpen, onClose }: ImportStudentsCSVModalProps
   const [usersToPreviewAdd, setUsersToPreviewAdd] = useState<
     Array<{ email: string; name: string; role: AppRole; canvas_id?: number }>
   >([]);
+  const [notifyOnAdd, setNotifyOnAdd] = useState<boolean>(false);
   const [usersToPreviewIgnore, setUsersToPreviewIgnore] = useState<
     Array<{ email: string; name: string; role: AppRole; canvas_id?: number }>
   >([]);
@@ -208,7 +209,8 @@ const ImportStudentsCSVModal = ({ isOpen, onClose }: ImportStudentsCSVModalProps
                 email: user.email!,
                 name: user.name!,
                 role: user.role,
-                canvasId: user.canvas_id
+                canvasId: user.canvas_id,
+                notify: notifyOnAdd
               },
               supabase
             );
@@ -304,6 +306,14 @@ const ImportStudentsCSVModal = ({ isOpen, onClose }: ImportStudentsCSVModalProps
                       <Text fontWeight="bold" mb={2}>
                         Users to be added ({usersToPreviewAdd.length}):
                       </Text>
+                      <label style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                        <input
+                          type="checkbox"
+                          checked={notifyOnAdd}
+                          onChange={(e) => setNotifyOnAdd(e.target.checked)}
+                        />
+                        Notify users they were added to this course
+                      </label>
                       <VStack
                         as="ul"
                         listStyleType="none"

--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -116,6 +116,7 @@ export type AddEnrollmentRequest = {
   courseId: number;
   canvasId?: number;
   classSectionId?: number;
+  notify?: boolean;
 };
 
 export type LiveMeetingForHelpRequestRequest = {

--- a/supabase/functions/enrollments-add/index.ts
+++ b/supabase/functions/enrollments-add/index.ts
@@ -8,7 +8,7 @@ import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import * as Sentry from "npm:@sentry/deno";
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {
-  const { email, name, role, courseId } = (await req.json()) as AddEnrollmentRequest;
+  const { email, name, role, courseId, notify } = (await req.json()) as AddEnrollmentRequest;
   if (!courseId) {
     throw new UserVisibleError("Course ID is required");
   }
@@ -38,6 +38,47 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
     },
     role
   );
+
+  if (notify) {
+    // Resolve the user's ID (existing or newly created)
+    const { data: resolvedUser } = await adminSupabase
+      .rpc("get_user_id_by_email", {
+        email: email
+      })
+      .single();
+
+    if (resolvedUser?.id) {
+      // Create a simple email entry which will be converted into a notification via trigger
+      const subject = "You were added to a course";
+      const body =
+        "You have been added to a course on Pawtograder. Please sign in to view details.";
+
+      await adminSupabase
+        .from("email_batches")
+        .insert({
+          class_id: courseId,
+          subject,
+          body,
+          cc_emails: { emails: [] },
+          reply_to: Deno.env.get("SMTP_REPLY_TO") || null
+        })
+        .select("id")
+        .single()
+        .then(async ({ data: batch }) => {
+          if (batch?.id) {
+            await adminSupabase.from("emails").insert({
+              user_id: resolvedUser.id,
+              class_id: courseId,
+              batch_id: batch.id,
+              subject,
+              body,
+              cc_emails: { emails: [] },
+              reply_to: Deno.env.get("SMTP_REPLY_TO") || null
+            });
+          }
+        });
+    }
+  }
 }
 
 Deno.serve(async (req) => {

--- a/supabase/functions/notification-queue-processor/index.ts
+++ b/supabase/functions/notification-queue-processor/index.ts
@@ -159,6 +159,16 @@ async function sendEmail(params: {
     return;
   }
 
+  // Skip sending/logging for internal test emails and archive the message
+  const recipientEmailLower = recipient.email?.toLowerCase() ?? "";
+  if (recipientEmailLower.endsWith("@pawtograder.net")) {
+    await adminSupabase.schema("pgmq_public").rpc("archive", {
+      queue_name: "notification_emails",
+      message_id: notification.msg_id
+    });
+    return;
+  }
+
   // Replace user-specific template variables
   const userRole = userRoles.find((role) => role.user_id === recipient.user_id);
   if (userRole) {


### PR DESCRIPTION
Adds an option to notify users when added to a course and prevents sending emails to internal test domains.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3365488-4439-4c34-818c-25a0dcb7ed41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3365488-4439-4c34-818c-25a0dcb7ed41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

