### PR TITLE
Validate release date and warn user

### DIFF
--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -20,6 +20,7 @@ import { useCourse } from "@/hooks/useAuthState";
 import { appendTimezoneOffset } from "@/lib/utils";
 import { Assignment } from "@/utils/supabase/DatabaseTypes";
 import { TZDate } from "@date-fns/tz";
+import { addMinutes } from "date-fns";
 import { useList } from "@refinedev/core";
 import { UseFormReturnType } from "@refinedev/react-hook-form";
 import { useParams } from "next/navigation";
@@ -321,7 +322,7 @@ export default function AssignmentForm({
   const timezone = course.classes.time_zone || "America/New_York";
   const isEditing = !!form.getValues("id");
   // Enforce that release date must be strictly in the future
-  const nowPlusOneMinute = new Date(TZDate.tz(timezone).getTime() + 60 * 1000);
+  const nowPlusOneMinute = addMinutes(TZDate.tz(timezone), 1);
   const minReleaseLocal = new TZDate(nowPlusOneMinute, timezone).toISOString().slice(0, -13);
   const onSubmitWrapper = useCallback(
     async (values: FieldValues) => {

--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -14,6 +14,7 @@ import {
 import { Controller, FieldValues } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
+import { Alert } from "@/components/ui/alert";
 import { toaster, Toaster } from "@/components/ui/toaster";
 import { useCourse } from "@/hooks/useAuthState";
 import { appendTimezoneOffset } from "@/lib/utils";
@@ -319,6 +320,9 @@ export default function AssignmentForm({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const timezone = course.classes.time_zone || "America/New_York";
   const isEditing = !!form.getValues("id");
+  // Enforce that release date must be strictly in the future
+  const nowPlusOneMinute = new Date(TZDate.tz(timezone).getTime() + 60 * 1000);
+  const minReleaseLocal = new TZDate(nowPlusOneMinute, timezone).toISOString().slice(0, -13);
   const onSubmitWrapper = useCallback(
     async (values: FieldValues) => {
       setIsSubmitting(true);
@@ -390,7 +394,7 @@ export default function AssignmentForm({
           <Fieldset.Content>
             <Field
               label={`Release Date (${course.classes.time_zone})`}
-              helperText="Date that students can see the assignment"
+              helperText="Date that students can see the assignment. Student repositories will be created at the release date. Ensure all handout materials are in place before this time."
               errorText={errors.release_date?.message?.toString()}
               invalid={errors.release_date ? true : false}
               required={true}
@@ -398,7 +402,15 @@ export default function AssignmentForm({
               <Controller
                 name="release_date"
                 control={control}
-                rules={{ required: "This is required" }}
+                rules={{
+                  required: "This is required",
+                  validate: (value: string) => {
+                    if (!value) return "This is required";
+                    const selected = new TZDate(value, timezone).getTime();
+                    const now = TZDate.tz(timezone).getTime();
+                    return selected > now || "Release date must be in the future";
+                  }
+                }}
                 render={({ field }) => {
                   const hasATimezoneOffset =
                     field.value &&
@@ -411,6 +423,7 @@ export default function AssignmentForm({
                   return (
                     <Input
                       type="datetime-local"
+                      min={minReleaseLocal}
                       value={localValue || ""}
                       onChange={field.onChange}
                       onBlur={field.onBlur}
@@ -419,6 +432,12 @@ export default function AssignmentForm({
                 }}
               />
             </Field>
+          </Fieldset.Content>
+          <Fieldset.Content>
+            <Alert status="warning" variant="subtle" title="Student repositories will be created at the release date">
+              Ensure all handout materials are in place before this time. Repositories for students are created at the
+              release date.
+            </Alert>
           </Fieldset.Content>
           <Fieldset.Content>
             <Field


### PR DESCRIPTION
Enforce future-only release dates and add a warning about repository creation timing.

---
<a href="https://cursor.com/background-agent?bcId=bc-525bef10-40c4-4482-9777-11751e792aba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-525bef10-40c4-4482-9777-11751e792aba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release Date must now be in the future (validated in the course timezone); past selections show an error.
  * The date picker prevents choosing past times to reduce input mistakes.
  * Inline warning clarifies that student repositories are created at the release date; prompts instructors to ensure materials are ready beforehand.
  * Helper text updated to explain repository creation timing and preparation guidance.
  * Form submission behavior remains the same aside from the added validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->