### PR TITLE
add hidden autograder jsonb blob

### DIFF
--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -2070,6 +2070,7 @@ export type Database = {
         Row: {
           class_id: number;
           created_at: string;
+          extra_data: Json | null;
           grader_result_test_id: number;
           id: number;
           output: string;
@@ -2078,6 +2079,7 @@ export type Database = {
         Insert: {
           class_id: number;
           created_at?: string;
+          extra_data?: Json | null;
           grader_result_test_id: number;
           id?: number;
           output: string;
@@ -2086,6 +2088,7 @@ export type Database = {
         Update: {
           class_id?: number;
           created_at?: string;
+          extra_data?: Json | null;
           grader_result_test_id?: number;
           id?: number;
           output?: string;

--- a/supabase/functions/autograder-submit-feedback/index.ts
+++ b/supabase/functions/autograder-submit-feedback/index.ts
@@ -379,10 +379,11 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
             grader_result_test_id: testResultIDs[idx].id,
             class_id,
             output: eachTest.hidden_output || "",
-            output_format: eachTest.hidden_output_format || "text"
+            output_format: eachTest.hidden_output_format || "text",
+            extra_data: eachTest.hidden_extra_data
           };
         })
-        .filter((eachTest) => eachTest.output.length > 0);
+        .filter((eachTest) => eachTest.output.length > 0 || eachTest.extra_data != null);
       if (hiddenTestOutputs.length > 0) {
         const { error: hiddenTestOutputsError } = await adminSupabase
           .from("grader_result_test_output")

--- a/supabase/migrations/20250817223557_grader_result_test_output.sql
+++ b/supabase/migrations/20250817223557_grader_result_test_output.sql
@@ -1,0 +1,3 @@
+-- Add `extra_data` column to `grader_result_test_output` table
+ALTER TABLE "public"."grader_result_test_output" 
+ADD COLUMN "extra_data" jsonb DEFAULT NULL;

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -2070,6 +2070,7 @@ export type Database = {
         Row: {
           class_id: number;
           created_at: string;
+          extra_data: Json | null;
           grader_result_test_id: number;
           id: number;
           output: string;
@@ -2078,6 +2079,7 @@ export type Database = {
         Insert: {
           class_id: number;
           created_at?: string;
+          extra_data?: Json | null;
           grader_result_test_id: number;
           id?: number;
           output: string;
@@ -2086,6 +2088,7 @@ export type Database = {
         Update: {
           class_id?: number;
           created_at?: string;
+          extra_data?: Json | null;
           grader_result_test_id?: number;
           id?: number;
           output?: string;


### PR DESCRIPTION
Allows the autograder to send arbitrary data that isn't visible to students; needed for upcoming embed pyret REPL PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced autograder feedback storage with a new field for additional JSON metadata on test outputs, enabling richer context for results.
* **Improvements**
  * Hidden test outputs are now retained when supplemental metadata is present, even if the visible output is empty—ensuring more complete grading records.
* **Chores**
  * Database updated to support the new metadata field across relevant test output records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->