### PR TITLE
Graders can only edit their own comments, not others'

### DIFF
--- a/components/ui/regrade-request-wrapper.tsx
+++ b/components/ui/regrade-request-wrapper.tsx
@@ -89,12 +89,6 @@ function RegradeRequestComment({ comment }: { comment: RegradeRequestCommentType
     resource: "submission_regrade_request_comments"
   });
 
-  // Check if current user can edit this comment
-  const { private_profile_id } = useClassProfiles();
-  const isInstructor = useIsInstructor();
-  const isGraderOrInstructor = useIsGraderOrInstructor();
-  const canEditComment = isInstructor || (isGraderOrInstructor && comment.author === private_profile_id);
-
   if (!authorProfile) {
     return <Skeleton height="60px" width="100%" />;
   }
@@ -166,14 +160,7 @@ function RegradeRequestComment({ comment }: { comment: RegradeRequestCommentType
                 }}
               />
             ) : (
-              <Box
-                onClick={canEditComment ? () => setIsEditing(true) : undefined}
-                cursor={canEditComment ? "pointer" : "default"}
-                _hover={canEditComment ? { bg: "bg.muted" } : {}}
-                borderRadius="sm"
-                p={1}
-                m={-1}
-              >
+              <Box borderRadius="sm" p={1} m={-1}>
                 <Markdown>{comment.comment}</Markdown>
               </Box>
             )}

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -48,7 +48,7 @@ import {
   useRubricCheck,
   useRubrics
 } from "@/hooks/useAssignment";
-import { useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
+import { useIsGraderOrInstructor, useIsInstructor, useClassProfiles } from "@/hooks/useClassProfiles";
 import { useShouldShowRubricCheck } from "@/hooks/useRubricVisibility";
 import {
   useReferencedRubricCheckInstances,
@@ -315,6 +315,18 @@ export function CommentActions({
   setIsEditing: (isEditing: boolean) => void;
 }) {
   const submissionController = useSubmissionController();
+  const { private_profile_id } = useClassProfiles();
+  const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+
+  // Check if current user can edit/delete this comment
+  // Instructors can edit all comments, graders can only edit their own
+  const canEditComment = isInstructor || (isGraderOrInstructor && comment.author === private_profile_id);
+
+  // Don't show actions if user can't edit
+  if (!canEditComment) {
+    return null;
+  }
 
   return (
     <HStack gap={1}>

--- a/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
+++ b/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
@@ -7,6 +7,7 @@ drop policy if exists "Only graders and instructors can update" on "public"."sub
 drop policy if exists "Only graders and instructors can update" on "public"."submission_artifact_comments";
 drop policy if exists "Update self only" on "public"."submission_file_comments";
 
+
 -- Create new update policies that allow:
 -- 1. Instructors to update any comment in their class
 -- 2. Graders to only update comments they authored
@@ -16,18 +17,21 @@ on "public"."submission_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
+with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
 
 create policy "Instructors can update all, graders only own comments"
 on "public"."submission_artifact_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
+with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
 
 create policy "Instructors can update all, graders only own comments"
 on "public"."submission_file_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
+with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));

--- a/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
+++ b/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
@@ -1,6 +1,7 @@
 -- Update RLS policies for submission comment tables
+-- INSTRUCTORS: can edit all comments
 -- GRADERS: only allow update if author matches (authorizeforprofile(author))
--- INSTRUCTORS: can still edit all comments
+-- STUDENTS: can edit their own comments IF the review is not completed
 
 -- Drop existing update policies for all three submission comment tables
 drop policy if exists "Only graders and instructors can update" on "public"."submission_comments";
@@ -11,27 +12,82 @@ drop policy if exists "Update self only" on "public"."submission_file_comments";
 -- Create new update policies that allow:
 -- 1. Instructors to update any comment in their class
 -- 2. Graders to only update comments they authored
+-- 3. Students to update their own comments IF the associated review is not completed
 
-create policy "Instructors can update all, graders only own comments"
+create policy "Instructors can update all, graders and students only own comments with restrictions"
 on "public"."submission_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
-with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+)
+with check (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+);
 
-create policy "Instructors can update all, graders only own comments"
+create policy "Instructors can update all, graders and students only own comments with restrictions"
 on "public"."submission_artifact_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
-with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+)
+with check (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+);
 
-create policy "Instructors can update all, graders only own comments"
+create policy "Instructors can update all, graders and students only own comments with restrictions"
 on "public"."submission_file_comments"
 as permissive
 for update
 to public
-using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)))
-with check (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+using (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+)
+with check (
+  authorizeforclassinstructor(class_id) OR 
+  (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
+  (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
+   EXISTS (
+     SELECT 1 FROM submission_reviews sr 
+     WHERE sr.id = submission_review_id 
+     AND sr.completed_at IS NULL
+   ))
+);

--- a/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
+++ b/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
@@ -1,0 +1,33 @@
+-- Update RLS policies for submission comment tables
+-- GRADERS: only allow update if author matches (authorizeforprofile(author))
+-- INSTRUCTORS: can still edit all comments
+
+-- Drop existing update policies for all three submission comment tables
+drop policy if exists "Only graders and instructors can update" on "public"."submission_comments";
+drop policy if exists "Only graders and instructors can update" on "public"."submission_artifact_comments";
+drop policy if exists "Update self only" on "public"."submission_file_comments";
+
+-- Create new update policies that allow:
+-- 1. Instructors to update any comment in their class
+-- 2. Graders to only update comments they authored
+
+create policy "Instructors can update all, graders only own comments"
+on "public"."submission_comments"
+as permissive
+for update
+to public
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+
+create policy "Instructors can update all, graders only own comments"
+on "public"."submission_artifact_comments"
+as permissive
+for update
+to public
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));
+
+create policy "Instructors can update all, graders only own comments"
+on "public"."submission_file_comments"
+as permissive
+for update
+to public
+using (authorizeforclassinstructor(class_id) OR (authorizeforclassgrader(class_id) AND authorizeforprofile(author)));

--- a/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
+++ b/supabase/migrations/20250904003046_graders-only-edit-own-comments.sql
@@ -12,7 +12,7 @@ drop policy if exists "Update self only" on "public"."submission_file_comments";
 -- Create new update policies that allow:
 -- 1. Instructors to update any comment in their class
 -- 2. Graders to only update comments they authored
--- 3. Students to update their own comments IF the associated review is not completed
+-- 3. Students to update their own comments IF the associated review is not completed OR no review exists
 
 create policy "Instructors can update all, graders and students only own comments with restrictions"
 on "public"."submission_comments"
@@ -23,20 +23,26 @@ using (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 )
 with check (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 );
 
@@ -49,20 +55,26 @@ using (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 )
 with check (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 );
 
@@ -75,19 +87,25 @@ using (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 )
 with check (
   authorizeforclassinstructor(class_id) OR 
   (authorizeforclassgrader(class_id) AND authorizeforprofile(author)) OR
   (authorizeforclass(class_id) AND authorizeforprofile(author) AND 
-   EXISTS (
-     SELECT 1 FROM submission_reviews sr 
-     WHERE sr.id = submission_review_id 
-     AND sr.completed_at IS NULL
+   (
+     submission_review_id IS NULL OR
+     EXISTS (
+       SELECT 1 FROM submission_reviews sr 
+       WHERE sr.id = submission_review_id 
+       AND sr.completed_at IS NULL
+     )
    ))
 );


### PR DESCRIPTION
(instructors can still update others)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - UI: comment text now has a subtle bordered container when not editing for clearer visual separation.

- Permissions
  - Instructors can edit any comment; graders can edit only their own.
  - Students can edit their own comments only if the related review is not completed (or no review).
  - Edit/Delete actions are hidden when a user lacks permission; applies across comment contexts.

- Chores
  - Database policies updated to enforce these editing rules uniformly.

- Refactor
  - Minor import reorganization (no user-facing impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->