### PR TITLE
Fix rubric sidebar url search params craziness

### DIFF
--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -1420,11 +1420,14 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
 
   // Scroll event logic for active rubric - simplified with hash-based state
   useEffect(() => {
-    let scrollTimeout: NodeJS.Timeout;
+    let scrollTimeout: number | null = null;
 
     const handleScroll = () => {
       // Clear any existing timeout to debounce the scroll handling
-      clearTimeout(scrollTimeout);
+      if (scrollTimeout !== null) {
+        clearTimeout(scrollTimeout);
+        scrollTimeout = null;
+      }
 
       scrollTimeout = setTimeout(() => {
         if (!scrollRootRef.current) return;
@@ -1469,7 +1472,10 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
     }
 
     return () => {
-      clearTimeout(scrollTimeout);
+      if (scrollTimeout !== null) {
+        clearTimeout(scrollTimeout);
+        scrollTimeout = null;
+      }
       if (container) {
         container.removeEventListener("scroll", handleScroll);
       }
@@ -1478,6 +1484,8 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
 
   // Scroll to active rubric when it changes
   useEffect(() => {
+    let manualSelectTimeout: number | null = null;
+
     if (scrollToRubricId && rubricRefs.current[scrollToRubricId]) {
       const container = scrollRootRef.current;
       const target = rubricRefs.current[scrollToRubricId];
@@ -1496,12 +1504,19 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
       container.scrollTo({ top: scrollTop, behavior: "smooth" });
 
       // Clear the flag after scroll animation completes
-      setTimeout(() => {
+      manualSelectTimeout = setTimeout(() => {
         isManuallySelecting.current = false;
       }, 1000); // Give time for smooth scroll to complete
 
       setScrollToRubricId(undefined);
     }
+
+    return () => {
+      if (manualSelectTimeout !== null) {
+        clearTimeout(manualSelectTimeout);
+        manualSelectTimeout = null;
+      }
+    };
   }, [scrollToRubricId, scrollRootRef, setScrollToRubricId, setActiveRubricId]);
 
   // Callback to set refs

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -1420,7 +1420,7 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
 
   // Scroll event logic for active rubric - simplified with hash-based state
   useEffect(() => {
-    let scrollTimeout: number | null = null;
+    let scrollTimeout: NodeJS.Timeout | null = null;
 
     const handleScroll = () => {
       // Clear any existing timeout to debounce the scroll handling
@@ -1484,7 +1484,7 @@ export function ListOfRubricsInSidebar({ scrollRootRef }: { scrollRootRef: React
 
   // Scroll to active rubric when it changes
   useEffect(() => {
-    let manualSelectTimeout: number | null = null;
+    let manualSelectTimeout: NodeJS.Timeout | null = null;
 
     if (scrollToRubricId && rubricRefs.current[scrollToRubricId]) {
       const container = scrollRootRef.current;

--- a/components/ui/submission-review-toolbar.tsx
+++ b/components/ui/submission-review-toolbar.tsx
@@ -477,7 +477,6 @@ function ReviewAssignmentActions() {
 
   const rubric = useRubricById(activeReviewAssignment?.rubric_id);
   const { time_zone } = useCourse();
-  console.log("assignedRubricParts", assignedRubricParts);
   const rubricPartsAdvice = useMemo(() => {
     return assignedRubricParts
       .map((part) => rubric?.rubric_parts.find((p) => p.id === part.rubric_part_id)?.name)


### PR DESCRIPTION
Work on fixing issue #201 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Client-side rubric selection added so choosing a rubric no longer mutates the URL; programmatic smooth-scroll now temporarily marks manual selection to avoid interrupting users.

- Bug Fixes
  - More stable active-rubric highlighting during scroll; avoids flicker/oscillation and handles no-visible-rubric or scrolled-past-last-item cases.
  - Removed stray debug log.

- Performance
  - Debounced scroll handling (100ms) to reduce unnecessary updates.

- Style
  - Removed extra spacer after the last rubric item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->