### PR TITLE
Move grading assignments to new active submissions

### DIFF
--- a/supabase/migrations/20250904013351_grading-assignments-by-active-submission.sql
+++ b/supabase/migrations/20250904013351_grading-assignments-by-active-submission.sql
@@ -1,0 +1,134 @@
+-- Migration: Update grading review assignments when submission is_active changes from true to false
+-- This ensures that review assignments always point to the currently active submission
+
+-- Create the trigger function
+CREATE OR REPLACE FUNCTION "public"."update_review_assignments_on_submission_deactivation"()
+RETURNS "trigger"
+LANGUAGE "plpgsql" SECURITY DEFINER
+AS $$
+DECLARE
+    new_active_submission_id bigint;
+    updated_count integer;
+BEGIN
+    -- Only proceed if is_active changed from true to false
+    IF OLD.is_active = true AND NEW.is_active = false THEN
+        
+        -- Find the new active submission for the same assignment and student/group
+        IF OLD.assignment_group_id IS NOT NULL THEN
+            -- Group submission: find active submission for the same assignment_group_id
+            SELECT id INTO new_active_submission_id
+            FROM submissions
+            WHERE assignment_id = OLD.assignment_id
+              AND assignment_group_id = OLD.assignment_group_id
+              AND is_active = true
+              AND id != OLD.id  -- Exclude the submission being deactivated
+            LIMIT 1;
+        ELSE
+            -- Individual submission: find active submission for the same profile_id
+            SELECT id INTO new_active_submission_id
+            FROM submissions
+            WHERE assignment_id = OLD.assignment_id
+              AND profile_id = OLD.profile_id
+              AND assignment_group_id IS NULL
+              AND is_active = true
+              AND id != OLD.id  -- Exclude the submission being deactivated
+            LIMIT 1;
+        END IF;
+        
+        -- If we found a new active submission, update review assignments
+        IF new_active_submission_id IS NOT NULL THEN
+            UPDATE review_assignments
+            SET submission_id = new_active_submission_id
+            WHERE submission_id = OLD.id;
+            
+            GET DIAGNOSTICS updated_count = ROW_COUNT;
+            
+            -- Log the update for debugging (optional)
+            RAISE NOTICE 'Updated % review_assignments from submission_id % to %', 
+                updated_count, OLD.id, new_active_submission_id;
+        ELSE
+            -- Log when no new active submission is found
+            RAISE NOTICE 'No new active submission found for deactivated submission_id %', OLD.id;
+        END IF;
+    END IF;
+    
+    RETURN NEW;
+END;
+$$;
+
+-- Create the trigger
+CREATE OR REPLACE TRIGGER "trigger_update_review_assignments_on_submission_deactivation"
+    AFTER UPDATE OF "is_active" ON "public"."submissions"
+    FOR EACH ROW
+    EXECUTE FUNCTION "public"."update_review_assignments_on_submission_deactivation"();
+
+-- Add comment explaining the trigger
+COMMENT ON FUNCTION "public"."update_review_assignments_on_submission_deactivation"() IS 
+'Updates review_assignments to point to the new active submission when a submission is deactivated (is_active changes from true to false). This ensures grading review assignments always reference the currently active submission for a student/group.';
+
+COMMENT ON TRIGGER "trigger_update_review_assignments_on_submission_deactivation" ON "public"."submissions" IS 
+'Automatically updates review_assignments when a submission becomes inactive to maintain referential integrity with the active submission.';
+
+-- Update submission_set_active function to check effective due date with extensions
+-- Only allow changes before the effective due date (with extensions) OR if user has grader authorization
+CREATE OR REPLACE FUNCTION "public"."submission_set_active"("_submission_id" bigint) RETURNS boolean
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+DECLARE
+    submission_record RECORD;
+    effective_due_date_with_extensions timestamp with time zone;
+    current_time timestamp with time zone;
+BEGIN
+    -- Get the submission details
+    SELECT * INTO submission_record 
+    FROM submissions 
+    WHERE id = _submission_id;
+    
+    -- Check if submission exists
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+    
+    -- Prevent NOT-GRADED submissions from becoming active
+    IF submission_record.is_not_graded THEN
+        RETURN FALSE;
+    END IF;
+    
+    -- Get current time
+    current_time := NOW();
+    
+    -- Calculate effective due date with extensions for this submission
+    effective_due_date_with_extensions := public.calculate_final_due_date(
+        submission_record.assignment_id, 
+        submission_record.profile_id, 
+        submission_record.assignment_group_id
+    );
+    
+    -- Check authorization: allow if before due date OR user has grader permissions
+    IF current_time > effective_due_date_with_extensions THEN
+        -- Past due date - check if user has grader authorization
+        IF NOT public.authorizeforclassgrader(submission_record.class_id) THEN
+            -- Not authorized and past due date
+            RAISE EXCEPTION 'Cannot set submission active: past effective due date (%) and user lacks grader authorization', 
+                effective_due_date_with_extensions;
+        END IF;
+    END IF;
+    
+    -- Set all other submissions for this assignment/student to inactive
+    UPDATE submissions 
+    SET is_active = false 
+    WHERE assignment_id = submission_record.assignment_id 
+    AND (profile_id = submission_record.profile_id OR assignment_group_id = submission_record.assignment_group_id)
+    AND id != _submission_id;
+    
+    -- Set this submission as active
+    UPDATE submissions 
+    SET is_active = true 
+    WHERE id = _submission_id;
+    
+    RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."submission_set_active"("_submission_id" bigint) IS 
+'Sets a submission as active, but only allows changes before the effective due date (including extensions) OR if the user has grader authorization for the class.';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Review assignments now automatically move to the next eligible active submission when a prior one is deactivated, reducing manual intervention and confusion.
  - Submission activation is now restricted after the effective due date (including extensions) unless performed by an authorized grader, ensuring fair and consistent timelines.
  - Activating a submission automatically deactivates other submissions for the same assignment and student/group, preventing conflicts and ensuring a single active record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->