### PR TITLE
make it so flashcards, discussion, OH can be hidden

### DIFF
--- a/app/course/[course_id]/dynamicCourseNav.tsx
+++ b/app/course/[course_id]/dynamicCourseNav.tsx
@@ -68,8 +68,20 @@ const LinkItems = (courseID: number) => [
     target: `/course/${courseID}/manage/office-hours`,
     feature_flag: "office-hours"
   },
-  { name: "Gradebook", icon: FiBookOpen, student_only: true, target: `/course/${courseID}/gradebook` },
-  { name: "Gradebook", icon: FiBookOpen, instructor_only: true, target: `/course/${courseID}/manage/gradebook` },
+  {
+    name: "Gradebook",
+    icon: FiBookOpen,
+    student_only: true,
+    target: `/course/${courseID}/gradebook`,
+    feature_flag: "gradebook"
+  },
+  {
+    name: "Gradebook",
+    icon: FiBookOpen,
+    instructor_only: true,
+    target: `/course/${courseID}/manage/gradebook`,
+    feature_flag: "gradebook"
+  },
   {
     name: "Course Settings",
     icon: FiSettings,


### PR DESCRIPTION
This uses the existing infrastructure for feature flags and partly implemented dynamic menu filtering to make it so that certain menu items can be disabled for students, to reduce confusion in case courses are not using those features.

No UI for setting the flags; direct DB manipulation only. 

Default if flags are absent is to display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Gradebook links for students and instructors; navigation now includes flags for Discussion, Flashcards, Office Hours, and Gradebook.

- **Bug Fixes**
  - Course navigation no longer hides items when feature data is missing; items without flags always display.
  - Tabs respect course feature availability and remain visible by default if a course’s feature record is absent.
  - Office Hours continue routing students to sessions and staff to management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->