### PR TITLE
Fix visibility of self-review rubric with options

### DIFF
--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -882,7 +882,6 @@ export function RubricCheckGlobal({
 
   const points = check.points === 0 ? "" : criteria.is_additive ? `+${check.points}` : `-${check.points}`;
   const format = criteria.max_checks_per_submission != 1 ? "checkbox" : "radio";
-  const showOptions = isGrader && hasOptions;
   const gradingIsRequired = reviewForThisRubric && check.is_required && rubricCheckComments.length == 0;
   const gradingIsPermitted =
     (isGrader ||
@@ -892,6 +891,7 @@ export function RubricCheckGlobal({
     reviewForThisRubric &&
     (criteria.max_checks_per_submission === null ||
       criteriaCheckComments.length < (criteria.max_checks_per_submission || 1000));
+  const showOptions = gradingIsPermitted && hasOptions;
 
   const isApplied = rubricCheckComments.length > 0;
   const isReleased = reviewForThisRubric?.released || false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rubric sidebar options (checkbox/radio) now appear only when grading is permitted and relevant options exist.
  * Honors per-submission limits for criterion-check comments before showing options.
  * Prevents options from appearing in read-only or non-grading contexts, reducing confusion and accidental interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->