### PR TITLE
Fix path for recording grading script-provided errors, better tolerate grading actions that we don't host

### DIFF
--- a/supabase/functions/autograder-submit-feedback/index.ts
+++ b/supabase/functions/autograder-submit-feedback/index.ts
@@ -227,7 +227,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
       run_number: Number.parseInt(run_id),
       run_attempt: Number.parseInt(run_attempt),
       class_id: class_id,
-      regression_test_id: autograder_regression_test_id ?? null,
+      autograder_regression_test_id: autograder_regression_test_id ?? null,
       submission_id: submission_id ?? null,
       repository_id: repository_id ?? null,
       name,
@@ -291,7 +291,12 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
   scope?.setTag("checkRun", checkRun ? JSON.stringify(checkRun) : "(null)");
   try {
     //Resolve the action SHA
-    const action_sha = await resolveRef(requestBody.action_repository, requestBody.action_ref);
+    let action_sha: string | undefined = undefined;
+    try{
+      action_sha = await resolveRef(requestBody.action_repository, requestBody.action_ref);
+    } catch (e) {
+      console.error(e);
+    }
     const score =
       requestBody.feedback.score ||
       requestBody.feedback.tests


### PR DESCRIPTION
@ironm00n this is deployed on prod and looks like it works (?) for your use-case, please confirm and I will merge + finalize this PR

see: https://github.com/neu-cs2000/f25-hw3-ironm00n/actions/runs/17752660323/job/50686328721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Made action version resolution more resilient; failures are logged without blocking feedback submission.
  - Prevented hard errors by allowing missing action data when unavailable.

- Chores
  - Aligned error payload field naming with the backend schema to ensure accurate linking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->