### PR TITLE
Enable metadata editing for score expression columns

### DIFF
--- a/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
@@ -163,19 +163,17 @@ export function OverrideScoreForm({
           </Box>
         )}
         <HStack justify="space-between">
-          {!showWarning && (
-            <HStack gap={4}>
-              <Checkbox {...register("is_droppable")} checked={watchedValues.is_droppable ?? false}>
-                Droppable
-              </Checkbox>
-              <Checkbox {...register("is_excused")} checked={watchedValues.is_excused ?? false}>
-                Excused
-              </Checkbox>
-              <Checkbox {...register("is_missing")} checked={watchedValues.is_missing ?? false}>
-                Missing
-              </Checkbox>
-            </HStack>
-          )}
+          <HStack gap={4}>
+            <Checkbox {...register("is_droppable")} checked={watchedValues.is_droppable ?? false}>
+              Droppable
+            </Checkbox>
+            <Checkbox {...register("is_excused")} checked={watchedValues.is_excused ?? false}>
+              Excused
+            </Checkbox>
+            <Checkbox {...register("is_missing")} checked={watchedValues.is_missing ?? false}>
+              Missing
+            </Checkbox>
+          </HStack>
           <Button
             type="submit"
             loading={isSubmitting}

--- a/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
@@ -195,7 +195,7 @@ export function OverrideScoreForm({
                 if (onSuccess) onSuccess();
               }}
             >
-              Reset 
+              Reset
             </Button>
           )}
         </HStack>

--- a/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookCell.tsx
@@ -178,14 +178,14 @@ export function OverrideScoreForm({
             type="submit"
             loading={isSubmitting}
             colorPalette={showWarning ? "orange" : "green"}
-            size="sm"
+            size="xs"
             alignSelf="end"
           >
-            {showWarning ? "Save Override" : "Update"}
+            {showWarning ? "Override" : "Update"}
           </Button>
           {showWarning && (
             <Button
-              size="sm"
+              size="xs"
               colorPalette="orange"
               variant="surface"
               onClick={async () => {
@@ -195,7 +195,7 @@ export function OverrideScoreForm({
                 if (onSuccess) onSuccess();
               }}
             >
-              Clear Override
+              Reset 
             </Button>
           )}
         </HStack>


### PR DESCRIPTION
Always display metadata checkboxes in the gradebook score override form to allow editing properties regardless of a column's score expression.

---
<a href="https://cursor.com/background-agent?bcId=bc-969ed3c6-40aa-470b-8c95-befa4c416d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-969ed3c6-40aa-470b-8c95-befa4c416d9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Gradebook: Droppable, Excused, and Missing checkboxes are now always visible in each cell, even when a warning is shown.
- UI Updates
  - Primary action buttons reduced in size.
  - Primary button label toggles between "Override" and "Update".
  - Secondary button label now reads "Reset" when warnings are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->