### PR TITLE
more state cleanup for line action popup

### DIFF
--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -759,7 +759,12 @@ function LineActionPopup({ lineNumber, top, left, visible, close, mode, file }: 
 
   useEffect(() => {
     setSelectedCheckOption(null);
+    setSelectedSubOption(null);
   }, [lineNumber]);
+  useEffect(() => {
+    // When the selected check changes, clear any previously selected sub-option
+    setSelectedSubOption(null);
+  }, [selectedCheckOption]);
   useEffect(() => {
     if (messageInputRef.current) {
       messageInputRef.current.focus();
@@ -775,7 +780,11 @@ function LineActionPopup({ lineNumber, top, left, visible, close, mode, file }: 
   }, [mode]);
   useEffect(() => {
     if (!visible) {
+      // Reset transient popup state any time it is closed
       setCurrentMode(mode);
+      setSelectedCheckOption(null);
+      setSelectedSubOption(null);
+      setSelectOpen(true);
     }
   }, [visible, mode]);
   if (!visible) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resets option selections when switching lines to prevent stale choices.
  * Automatically clears sub-options when the primary option changes.
  * Restores the default mode after the popup is closed to avoid lingering states.
  * Reopens the option selector when returning to the popup for a smoother workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->