### PR TITLE
Support reasoning models by bypassing langchain

### DIFF
--- a/app/api/llm-hint/route.ts
+++ b/app/api/llm-hint/route.ts
@@ -104,7 +104,8 @@ class OpenAISDKAdapter {
 
 // This is a bit clumsy, but not sure of a better option.
 function isReasoningModel(model: string): boolean {
-  return /^o[134](-[a-z]+)*$/.test(model);
+  // Match o1/o3/o4 and typical suffixes (e.g., -mini, -preview, -2024-08-06)
+  return /^(?:o1|o3|o4)(?:[-._a-z0-9]+)?$/i.test(model);
 }
 
 async function getChatModel({

--- a/app/api/llm-hint/route.ts
+++ b/app/api/llm-hint/route.ts
@@ -64,8 +64,9 @@ class OpenAISDKAdapter {
     try {
       // Back to chat completions with correct URL structure
       const requestParams: OpenAISDK.Chat.ChatCompletionCreateParams = {
-        // Don't pass model since it's already in the URL path
-        model: this.model, // OpenAI SDK requires model parameter
+        // Model is required by both OpenAI and Azure clients in the request body
+        // (even though Azure may also include it in the URL path)
+        model: this.model,
         messages: [
           { role: "developer", content: "You are a helpful assistant that provides feedback on code." },
           { role: "user", content: input.input }

--- a/app/api/llm-hint/route.ts
+++ b/app/api/llm-hint/route.ts
@@ -63,8 +63,9 @@ class OpenAISDKAdapter {
   async invoke(input: { input: string }) {
     try {
       // Back to chat completions with correct URL structure
-      const requestParams: any = {
+      const requestParams: OpenAISDK.Chat.ChatCompletionCreateParams = {
         // Don't pass model since it's already in the URL path
+        model: this.model, // OpenAI SDK requires model parameter
         messages: [
           { role: "developer", content: "You are a helpful assistant that provides feedback on code." },
           { role: "user", content: input.input }


### PR DESCRIPTION
As far as I can tell, langchain with azure openai doesn't support the API that reasoning models (i.e., o1, o3, o4, and variants) require require.

This PR adds a shim that uses the ordinary open ai SDK in those cases. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Routes reasoning-capable models to a dedicated SDK adapter path for direct reasoning-model use and consistent response shaping.
  - Supports adapter-style responses with usage metadata and safe handling for varied or missing content formats.

- Bug Fixes
  - Enhanced error handling, logging and telemetry for the new model path.
  - Prevents empty AI responses and ensures results are returned even when partial failures occur.

- Chores
  - Maintains backward compatibility and consistent behavior for non-reasoning models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->