### PR TITLE
Filter feedbot errors before logging

### DIFF
--- a/app/api/llm-hint/route.ts
+++ b/app/api/llm-hint/route.ts
@@ -496,7 +496,7 @@ export async function POST(request: NextRequest) {
 
     // If it's a UserVisibleError, return the message directly
     if (error instanceof UserVisibleError) {
-      if (!error.isBug) {
+      if (error.isBug) {
         Sentry.captureException(error, {
           tags: {
             operation: "llm_hint_api"

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/results/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/results/page.tsx
@@ -112,6 +112,11 @@ function LLMHintButton({ testId, onHintGenerated }: { testId: number; onHintGene
       console.error("LLM Hint Error:", err);
       setError(errorMessage);
 
+      // Do NOT log 429 errors to Sentry
+      if (err instanceof Error && err.message.startsWith("Rate limit:")) {
+        return;
+      }
+
       // Log to Sentry for debugging
       Sentry.captureException(err, {
         tags: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Rate-limit (429) responses no longer trigger noisy error reports; users still receive clear messages when limits are reached.
  - Other unexpected errors continue to be reported for investigation, preserving troubleshooting visibility.

- Chores
  - Harmonized error handling so expected vs. unexpected issues are distinguished, reducing false alarms and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->