### PR TITLE
Make submit-feedback retriable under failure

### DIFF
--- a/supabase/functions/autograder-submit-feedback/index.ts
+++ b/supabase/functions/autograder-submit-feedback/index.ts
@@ -15,6 +15,11 @@ import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/
 import { Database, Json } from "../_shared/SupabaseTypes.d.ts";
 import * as Sentry from "npm:@sentry/deno";
 
+type GraderResultRow = Database["public"]["Tables"]["grader_results"]["Row"];
+type GraderResultErrors = Database["public"]["Tables"]["grader_results"]["Row"]["errors"];
+
+const RESET_WINDOW_MS = 60_000;
+
 async function insertComments({
   adminSupabase,
   class_id,
@@ -41,6 +46,7 @@ async function insertComments({
           .maybeSingle();
         if (profileError) {
           console.error(profileError);
+          Sentry.captureException(profileError, scope);
           throw new UserVisibleError(
             `Failed to find profile for comment: ${comment.author.name}, ${profileError.message}`,
             400
@@ -66,6 +72,7 @@ async function insertComments({
             profileMap.set(comment.author.name, newProfile.id);
           } else {
             console.error(newProfileError);
+            Sentry.captureException(newProfileError, scope);
             throw new UserVisibleError(
               `Failed to create profile for comment: ${comment.author.name}, ${newProfileError.message}`
             );
@@ -90,6 +97,7 @@ async function insertComments({
             fileMap.set(comment.file_name, file.id);
           } else {
             console.error(fileError);
+            Sentry.captureException(fileError, scope);
             throw new UserVisibleError(`Submission file not found: ${comment.file_name}, ${fileError?.message}`);
           }
         }
@@ -112,6 +120,7 @@ async function insertComments({
     );
     if (submissionFileCommentsError) {
       console.error(submissionFileCommentsError);
+      Sentry.captureException(submissionFileCommentsError, scope);
       throw new UserVisibleError(`Failed to insert submission file comments: ${submissionFileCommentsError.message}`);
     }
   }
@@ -131,6 +140,7 @@ async function insertComments({
             artifactMap.set(comment.artifact_name, artifact.id);
           } else {
             console.error(artifactError);
+            Sentry.captureException(artifactError, scope);
             throw new UserVisibleError(
               `Submission artifact not found: ${comment.artifact_name}, ${artifactError?.message}`
             );
@@ -154,6 +164,7 @@ async function insertComments({
     );
     if (submissionArtifactCommentsError) {
       console.error(submissionArtifactCommentsError);
+      Sentry.captureException(submissionArtifactCommentsError, scope);
       throw new UserVisibleError(
         `Failed to insert submission artifact comments: ${submissionArtifactCommentsError.message}`
       );
@@ -178,9 +189,129 @@ async function insertComments({
     );
     if (submissionCommentsError) {
       console.error(submissionCommentsError);
+      Sentry.captureException(submissionCommentsError, scope);
       throw new UserVisibleError(`Failed to insert submission comments: ${submissionCommentsError.message}`);
     }
   }
+}
+
+async function resetExistingGraderResult({
+  adminSupabase,
+  grader_result_id,
+  submission_id,
+  autograder_regression_test_id,
+  artifactNames
+}: {
+  adminSupabase: SupabaseClient<Database>;
+  grader_result_id: number;
+  submission_id?: number | null;
+  autograder_regression_test_id?: number | null;
+  artifactNames: string[];
+}) {
+  const { data: existingTests, error: existingTestsError } = await adminSupabase
+    .from("grader_result_tests")
+    .select("id")
+    .eq("grader_result_id", grader_result_id);
+  if (existingTestsError) {
+    console.error(existingTestsError);
+    Sentry.captureException(existingTestsError, scope);
+    throw new UserVisibleError(
+      `Internal error: Failed to load existing grader result tests: ${existingTestsError.message}`
+    );
+  }
+
+  const existingTestIds = existingTests?.map((test) => test.id) ?? [];
+  if (existingTestIds.length > 0) {
+    const { error: deleteTestOutputsError } = await adminSupabase
+      .from("grader_result_test_output")
+      .delete()
+      .in("grader_result_test_id", existingTestIds);
+    if (deleteTestOutputsError) {
+      console.error(deleteTestOutputsError);
+      Sentry.captureException(deleteTestOutputsError, scope);
+      throw new UserVisibleError(
+        `Internal error: Failed to remove previous hidden test outputs: ${deleteTestOutputsError.message}`
+      );
+    }
+  }
+
+  const { error: deleteTestsError } = await adminSupabase
+    .from("grader_result_tests")
+    .delete()
+    .eq("grader_result_id", grader_result_id);
+  if (deleteTestsError) {
+    console.error(deleteTestsError);
+    Sentry.captureException(deleteTestsError, scope);
+    throw new UserVisibleError(`Internal error: Failed to remove previous test results: ${deleteTestsError.message}`);
+  }
+
+  const { error: deleteOutputsError } = await adminSupabase
+    .from("grader_result_output")
+    .delete()
+    .eq("grader_result_id", grader_result_id);
+  if (deleteOutputsError) {
+    console.error(deleteOutputsError);
+    Sentry.captureException(deleteOutputsError, scope);
+    throw new UserVisibleError(
+      `Internal error: Failed to remove previous grader outputs: ${deleteOutputsError.message}`
+    );
+  }
+
+  if (submission_id && artifactNames.length > 0) {
+    const artifactSelect = adminSupabase
+      .from("submission_artifacts")
+      .select("id")
+      .eq("submission_id", submission_id)
+      .in("name", artifactNames);
+    const constrainedArtifactSelect =
+      autograder_regression_test_id != null
+        ? artifactSelect.eq("autograder_regression_test_id", autograder_regression_test_id)
+        : artifactSelect.is("autograder_regression_test_id", null);
+
+    const { data: existingArtifacts, error: existingArtifactsError } = await constrainedArtifactSelect;
+    if (existingArtifactsError) {
+      console.error(existingArtifactsError);
+      Sentry.captureException(existingArtifactsError, scope);
+      throw new UserVisibleError(
+        `Internal error: Failed to load previous grader artifacts: ${existingArtifactsError.message}`
+      );
+    }
+
+    const artifactIds = existingArtifacts?.map((artifact) => artifact.id) ?? [];
+    if (artifactIds.length > 0) {
+      const { error: deleteArtifactCommentsError } = await adminSupabase
+        .from("submission_artifact_comments")
+        .delete()
+        .in("submission_artifact_id", artifactIds);
+      if (deleteArtifactCommentsError) {
+        console.error(deleteArtifactCommentsError);
+        Sentry.captureException(deleteArtifactCommentsError, scope);
+        throw new UserVisibleError(
+          `Internal error: Failed to remove previous grader artifact comments: ${deleteArtifactCommentsError.message}`
+        );
+      }
+
+      const { error: deleteArtifactsError } = await adminSupabase
+        .from("submission_artifacts")
+        .delete()
+        .in("id", artifactIds);
+      if (deleteArtifactsError) {
+        console.error(deleteArtifactsError);
+        Sentry.captureException(deleteArtifactsError, scope);
+        throw new UserVisibleError(
+          `Internal error: Failed to remove previous grader artifacts: ${deleteArtifactsError.message}`
+        );
+      }
+    }
+  }
+}
+
+function isConflictError(response: { error: { code?: string; message?: string } | null }): boolean {
+  return (
+    !!response.error &&
+    response.error.code === "23505" &&
+    Boolean(response.error.message?.includes("grader_results_submission_id_key_uniq"))
+  );
 }
 async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeResponse> {
   scope?.setTag("function", "autograder-submit-feedback");
@@ -305,33 +436,100 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
     const max_score =
       requestBody.feedback.max_score ||
       requestBody.feedback.tests.reduce((acc, test) => acc + (test.max_score || 0), 0);
-    const { error, data: resultID } = await adminSupabase
-      .from("grader_results")
-      .insert({
-        submission_id,
-        profile_id,
-        class_id,
-        assignment_group_id,
-        ret_code: requestBody.ret_code,
-        grader_sha: requestBody.grader_sha,
-        score,
-        max_score,
-        lint_output: requestBody.feedback.lint.output,
-        lint_output_format: requestBody.feedback.lint.output_format || "text",
-        lint_passed: requestBody.feedback.lint.status === "pass",
-        execution_time: requestBody.execution_time,
-        autograder_regression_test: autograder_regression_test_id,
-        grader_action_sha: action_sha
-      })
-      .select("id")
-      .single();
-    if (error) {
-      console.error(error);
-      throw new UserVisibleError(`Internal error: Failed to insert feedback: ${error.message}`);
+    const baseGraderResultPayload = {
+      submission_id: submission_id ?? null,
+      profile_id: profile_id ?? null,
+      class_id: class_id!,
+      assignment_group_id: assignment_group_id ?? null,
+      ret_code: requestBody.ret_code ?? null,
+      grader_sha: requestBody.grader_sha ?? null,
+      score,
+      max_score,
+      lint_output: requestBody.feedback.lint.output ?? "",
+      lint_output_format: requestBody.feedback.lint.output_format || "text",
+      lint_passed: requestBody.feedback.lint.status === "pass",
+      execution_time: requestBody.execution_time ?? null,
+      autograder_regression_test: autograder_regression_test_id ?? null,
+      grader_action_sha: action_sha ?? null
+    } satisfies Omit<Database["public"]["Tables"]["grader_results"]["Insert"], "errors">;
+
+    const graderResultPayload: Database["public"]["Tables"]["grader_results"]["Insert"] = {
+      ...baseGraderResultPayload,
+      errors: null
+    };
+
+    const insertResponse = await adminSupabase.from("grader_results").insert(graderResultPayload).select("id").single();
+
+    let resultID = insertResponse.data;
+    let reusedExistingResult = false;
+
+    if (insertResponse.error) {
+      if (isConflictError(insertResponse) && submission_id != null) {
+        const { data: existingResult, error: existingResultError } = await adminSupabase
+          .from("grader_results")
+          .select("id, created_at")
+          .eq("submission_id", submission_id)
+          .single();
+        if (existingResultError || !existingResult) {
+          console.error(existingResultError);
+          Sentry.captureException(existingResultError, scope);
+          throw new UserVisibleError(
+            `Internal error: Failed to reuse existing feedback record: ${existingResultError?.message}`
+          );
+        }
+
+        const existingCreatedAt = new Date(existingResult.created_at ?? "").getTime();
+        if (!Number.isFinite(existingCreatedAt)) {
+          Sentry.captureException(new Error("Internal error: Existing grader result timestamp missing"), scope);
+          throw new UserVisibleError("Internal error: Existing grader result timestamp missing");
+        }
+
+        if (Date.now() - existingCreatedAt > RESET_WINDOW_MS) {
+          throw new SecurityError("Request to rewrite submission feedback is too old");
+        }
+
+        const { error: updateExistingError } = await adminSupabase
+          .from("grader_results")
+          .update({
+            ...baseGraderResultPayload,
+            errors: null
+          })
+          .eq("id", existingResult.id);
+        if (updateExistingError) {
+          console.error(updateExistingError);
+          Sentry.captureException(updateExistingError, scope);
+          throw new UserVisibleError(
+            `Internal error: Failed to update existing feedback: ${updateExistingError.message}`
+          );
+        }
+        resultID = { id: existingResult.id };
+        reusedExistingResult = true;
+      } else {
+        console.error(insertResponse.error);
+        Sentry.captureException(insertResponse.error, scope);
+        throw new UserVisibleError(`Internal error: Failed to insert feedback: ${insertResponse.error.message}`);
+      }
     }
+
+    if (!resultID) {
+      Sentry.captureException(new Error("Internal error: Missing grader result identifier after insert"), scope);
+      throw new UserVisibleError("Internal error: Missing grader result identifier after insert");
+    }
+
     let artifactUploadLinks: { name: string; token: string; path: string }[] = [];
 
     try {
+      const artifactNames =
+        requestBody.feedback.artifacts?.map((artifact) => artifact.name).filter((name): name is string => !!name) ?? [];
+      if (reusedExistingResult) {
+        await resetExistingGraderResult({
+          adminSupabase,
+          grader_result_id: resultID.id,
+          submission_id,
+          autograder_regression_test_id,
+          artifactNames
+        });
+      }
       // Insert feedback for each visibility level
       for (const visibility of ["hidden", "visible", "after_due_date", "after_published"]) {
         //Insert output if it exists
@@ -348,6 +546,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
               output: output.output
             });
             if (outputError) {
+              Sentry.captureException(outputError, scope);
               console.error(outputError);
               throw new UserVisibleError(`Internal error: Failed to insert output: ${outputError.message}`);
             }
@@ -377,6 +576,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
         )
         .select("id");
       if (testResultsError) {
+        Sentry.captureException(testResultsError, scope);
         throw new UserVisibleError(`Internal error: Failed to insert test results: ${testResultsError.message}`);
       }
       //Insert any hidden output
@@ -397,6 +597,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
           .insert(hiddenTestOutputs);
         if (hiddenTestOutputsError) {
           console.error(hiddenTestOutputsError);
+          Sentry.captureException(hiddenTestOutputsError, scope);
           throw new UserVisibleError(
             `Internal error: Failed to insert hidden test outputs: ${hiddenTestOutputsError.message}`
           );
@@ -420,6 +621,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
           .select("id");
         if (artifactError) {
           console.error(artifactError);
+          Sentry.captureException(artifactError, scope);
           throw new UserVisibleError(`Internal error: Failed to insert artifact: ${artifactError.message}`);
         }
 
@@ -433,6 +635,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
               .createSignedUploadUrl(aritfactPath);
             if (!signedLink.data?.signedUrl) {
               console.error(signedLink.error);
+              Sentry.captureException(signedLink.error, scope);
               throw new UserVisibleError(`Internal error: Failed to create signed URL for artifact: ${artifact.name}`);
             }
             return {
@@ -474,16 +677,14 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
     } catch (e) {
       console.error(e);
       if (submission_id) {
-        await adminSupabase
-          .from("grader_results")
-          .update({
-            errors:
-              e instanceof UserVisibleError
-                ? { user_visible_message: e.details }
-                : { error: JSON.parse(JSON.stringify(e)) }
-          })
-          .eq("id", resultID.id);
+        const normalizedError: GraderResultErrors =
+          e instanceof UserVisibleError
+            ? { user_visible_message: e.details }
+            : { error: JSON.parse(JSON.stringify(e)) };
+
+        await adminSupabase.from("grader_results").update({ errors: normalizedError }).eq("id", resultID.id);
       }
+      Sentry.captureException(e, scope);
       throw new UserVisibleError(`Internal error: Failed to insert feedback: ${(e as Error).message}`);
     }
 

--- a/supabase/migrations/20250930133813_unique_submission_constraint.sql
+++ b/supabase/migrations/20250930133813_unique_submission_constraint.sql
@@ -1,0 +1,46 @@
+-- Migration to add unique constraint on submissions (repository, sha, run_number, run_attempt)
+-- This migration will fix any duplicate submissions before adding the constraint
+-- by incrementing run_attempt to 100 + run_attempt for older duplicates
+
+-- Step 1: Create a temporary table to store duplicate submissions (excluding the most recent)
+-- Include the row_num to ensure each duplicate gets a unique run_attempt
+CREATE TEMP TABLE duplicate_submissions AS
+WITH ranked_submissions AS (
+  SELECT 
+    id,
+    repository,
+    sha,
+    run_number,
+    run_attempt,
+    created_at,
+    ROW_NUMBER() OVER (
+      PARTITION BY repository, sha, run_number, run_attempt 
+      ORDER BY created_at DESC
+    ) AS row_num
+  FROM public.submissions
+)
+SELECT 
+  id,
+  repository,
+  sha,
+  run_number,
+  run_attempt,
+  created_at,
+  row_num
+FROM ranked_submissions
+WHERE row_num > 1;
+
+-- Step 2: Update the duplicate submissions to have run_attempt = (row_num - 1) * 100 + run_attempt
+-- This makes them unique since nobody has 100+ run attempts
+-- For example: 
+--   - 2nd occurrence (row_num=2): run_attempt = 100 + original
+--   - 3rd occurrence (row_num=3): run_attempt = 200 + original
+UPDATE public.submissions s
+SET run_attempt = (ds.row_num - 1) * 100 + ds.run_attempt
+FROM duplicate_submissions ds
+WHERE s.id = ds.id;
+
+-- Step 3: Add the unique constraint
+ALTER TABLE public.submissions
+ADD CONSTRAINT submissions_repository_sha_run_unique 
+UNIQUE (repository, sha, run_number, run_attempt);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Attach artifacts to autograder feedback with signed upload links.
  - Safe quick resubmits: recent submissions and grader results can be retried/reused within a short window.

- Bug Fixes
  - More consistent success payloads for standard and regression runs.
  - Improved error normalization and visibility when submission or grading actions fail.

- Refactor
  - Automatic cleanup when reusing submissions or results to prevent stale outputs and comments.
  - Safer reuse flow to avoid unsafe rewrites on conflicts.

- Chores
  - Enforce uniqueness of submissions to prevent duplicate records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->