### PR TITLE
Fix #331: Bulk assign grading included graders that dropped

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/bulk-assign/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/bulk-assign/page.tsx
@@ -8,6 +8,7 @@ import { toaster } from "@/components/ui/toaster";
 import { useActiveSubmissions, useAssignmentController, useRubrics } from "@/hooks/useAssignment";
 import { useClassProfiles } from "@/hooks/useClassProfiles";
 import {
+  useActiveUserRolesWithProfiles,
   useAssignments,
   useClassSections,
   useCourseController,
@@ -156,7 +157,7 @@ function BulkAssignGradingForm({ handleReviewAssignmentChange }: { handleReviewA
   const gradingRubric = rubrics.find((rubric) => rubric.review_round === "grading-review");
   const allActiveSubmissions = useActiveSubmissions();
 
-  const userRoles = useUserRolesWithProfiles();
+  const userRoles = useActiveUserRolesWithProfiles();
 
   const courseController = useCourseController();
 

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/bulk-assign/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/bulk-assign/page.tsx
@@ -13,8 +13,7 @@ import {
   useClassSections,
   useCourseController,
   useGradersAndInstructors,
-  useLabSections,
-  useUserRolesWithProfiles
+  useLabSections
 } from "@/hooks/useCourseController";
 import useTags from "@/hooks/useTags";
 import TableController, {

--- a/hooks/useCourseController.tsx
+++ b/hooks/useCourseController.tsx
@@ -1451,6 +1451,7 @@ export function useRosterWithUserInfo() {
 
 /**
  * Hook to get user roles with full profile and user information for enrollments management
+ * Includes disabled user roles
  */
 export function useUserRolesWithProfiles() {
   const controller = useCourseController();
@@ -1461,6 +1462,26 @@ export function useUserRolesWithProfiles() {
       setUserRoles(updatedUserRoles as UserRoleWithPrivateProfileAndUser[]);
     });
     setUserRoles(data as UserRoleWithPrivateProfileAndUser[]);
+    return unsubscribe;
+  }, [controller]);
+
+  return userRoles;
+}
+
+/**
+ * Hook to get user roles with full profile and user information for enrollments management
+ * Only includes active user roles
+ */
+export function useActiveUserRolesWithProfiles() {
+  const controller = useCourseController();
+  const [userRoles, setUserRoles] = useState<UserRoleWithPrivateProfileAndUser[]>([]);
+
+  useEffect(() => {
+    const { data, unsubscribe } = controller.userRolesWithProfiles.list((updatedUserRoles) => {
+      const activeUserRoles = updatedUserRoles.filter((r) => r.disabled === false);
+      setUserRoles(activeUserRoles as UserRoleWithPrivateProfileAndUser[]);
+    });
+    setUserRoles(data.filter((r) => r.disabled === false) as UserRoleWithPrivateProfileAndUser[]);
     return unsubscribe;
   }, [controller]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk assignment of reviews now shows only active users, preventing assignments to disabled accounts.

* **Refactor**
  * Role data sourcing standardized to use active-only role lists on the bulk-assignment page for more accurate results.

* **Documentation**
  * Internal notes clarified to distinguish datasets that include disabled users from those that show only active users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->