### PR TITLE
Changes Allow NOT-GRADED button to reflect expected behavior (highlight = on)

### DIFF
--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -533,6 +533,7 @@ export default function AssignmentForm({
     handleSubmit,
     register,
     control,
+    watch,
     // refineCore: {
     //     onFinish
     // },
@@ -542,8 +543,21 @@ export default function AssignmentForm({
   const { role: classRole } = useClassProfiles();
   const course = classRole.classes;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [allowNotGradedSubmissions, setAllowNotGradedSubmissions] = useState<boolean>(
+    form.getValues("allow_not_graded_submissions") == true
+  );
   const timezone = course.time_zone || "America/New_York";
   const isEditing = !!form.getValues("id");
+
+  // Keep checkbox state synced with form value
+  useEffect(() => {
+    const subscription = watch((value, { name }) => {
+      if (name === "allow_not_graded_submissions" || !name) {
+        setAllowNotGradedSubmissions(value.allow_not_graded_submissions);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, [watch]);
   // Enforce that release date must be strictly in the future
   const nowPlusOneMinute = addMinutes(TZDate.tz(timezone), 1);
   const minReleaseLocal = new TZDate(nowPlusOneMinute, timezone).toISOString().slice(0, -13);
@@ -718,7 +732,7 @@ export default function AssignmentForm({
           </Fieldset.Content>
           <Fieldset.Content>
             <Field helperText="Allow students to submit after the deadline by including #NOT-GRADED in their commit message. These submissions will not be graded and cannot become active, but students can still see autograder feedback.">
-              <Checkbox.Root {...register("allow_not_graded_submissions")} defaultChecked={true}>
+              <Checkbox.Root {...register("allow_not_graded_submissions")} checked={allowNotGradedSubmissions}>
                 <Checkbox.HiddenInput />
                 <Checkbox.Control>
                   <LuCheck />

--- a/app/course/[course_id]/manage/assignments/new/page.tsx
+++ b/app/course/[course_id]/manage/assignments/new/page.tsx
@@ -19,7 +19,12 @@ import { Box, Heading, Text } from "@chakra-ui/react";
 
 export default function NewAssignmentPage() {
   const { course_id } = useParams();
-  const form = useForm<Assignment>({ refineCoreProps: { resource: "assignments", action: "create" } });
+  const form = useForm<Assignment>({
+    refineCoreProps: { resource: "assignments", action: "create" },
+    defaultValues: {
+      allow_not_graded_submissions: true
+    }
+  });
   const router = useRouter();
   const { getValues } = form;
   const { time_zone } = useCourse();
@@ -84,6 +89,7 @@ export default function NewAssignmentPage() {
             allow_late: getValues("allow_late"),
             description: getValues("description"),
             max_late_tokens: getValues("max_late_tokens") || null,
+            allow_not_graded_submissions: getValues("allow_not_graded_submissions"),
             total_points: getValues("total_points"),
             template_repo: getValues("template_repo"),
             submission_files: getValues("submission_files"),


### PR DESCRIPTION
Fixes issue #352. 
Tested locally on both light/dark views for both truthy/falsy values (properly reflected in online supabase instance). 
Confirmed changes within the assignments edit page were correctly displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Allow not graded submissions” option when creating assignments. It’s enabled by default and is saved with the assignment.
* **Bug Fixes**
  * Improved reliability of the “Allow not graded submissions” checkbox so it stays in sync with the form during editing, preventing unexpected toggling or mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->