### PR TITLE
Fix a few cases that did not handle dropped students correctly for instructors

### DIFF
--- a/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
@@ -779,6 +779,7 @@ export default function EnrollmentsTable() {
     ],
     [
       currentUser,
+      course_id,
       openEditProfileModal,
       openEditUserRoleModal,
       openRemoveStudentModal,
@@ -864,8 +865,8 @@ export default function EnrollmentsTable() {
 
   // CSV Export function
   const exportToCSV = useCallback(() => {
-    // Use getFilteredRowModel to get ALL filtered data, not just what's displayed
-    const filteredRows = table.getFilteredRowModel().rows;
+    // Use getPreFilteredRowModel to get ALL filtered data, not just what's displayed
+    const filteredRows = table.getPreFilteredRowModel().rows;
 
     // Define CSV headers
     const headers = [
@@ -892,6 +893,9 @@ export default function EnrollmentsTable() {
         const invitation = original;
         const isExpired = invitation.expires_at && new Date(invitation.expires_at) < new Date();
         status = invitation.status === "pending" && isExpired ? "Expired" : invitation.status;
+      }
+      if ("disabled" in original && original.disabled) {
+        status = "Dropped";
       }
 
       // Get name

--- a/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
+++ b/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
@@ -504,6 +504,7 @@ export default function ImportGradebookColumns() {
 
                       // Build normalized identifier sets for O(1) membership checks
                       const rosterIdentifiers = new Set<string>();
+                      const nonDroppedIdentifiers = new Set<string>();
                       const rosterEmailToId = new Map<string, string>();
                       const rosterSidToId = new Map<string, string>();
 
@@ -514,16 +515,24 @@ export default function ImportGradebookColumns() {
                         if (previewData.idType === "email" && rosterEntry.users.email) {
                           const normalizedEmail = normalizeIdentifier(String(rosterEntry.users.email), true);
                           rosterIdentifiers.add(normalizedEmail);
+                          if (!rosterEntry.disabled) {
+                            nonDroppedIdentifiers.add(normalizedEmail);
+                          }
                           rosterEmailToId.set(normalizedEmail, s.id);
                         } else if (previewData.idType === "sid" && rosterEntry.users.sis_user_id != null) {
                           const normalizedSid = normalizeIdentifier(String(rosterEntry.users.sis_user_id), false);
                           rosterIdentifiers.add(normalizedSid);
+                          if (!rosterEntry.disabled) {
+                            nonDroppedIdentifiers.add(normalizedSid);
+                          }
                           rosterSidToId.set(normalizedSid, s.id);
                         }
                       });
 
                       const notInRoster = importIdentifiers.filter((id) => !rosterIdentifiers.has(id));
-                      const notInImport = Array.from(rosterIdentifiers).filter((id) => !importIdentifiers.includes(id));
+                      const notInImport = Array.from(nonDroppedIdentifiers).filter(
+                        (id) => !importIdentifiers.includes(id)
+                      );
 
                       return (
                         <VStack mb={2} align="stretch">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enrollment table now refreshes correctly when switching courses.
  * CSV export includes all relevant rows and labels dropped enrollments as “Dropped.”
  * Status display shows “Dropped” for disabled enrollments.
  * Gradebook import preview and warnings consider only active (non-dropped) roster entries, reducing false “missing-in-roster” and “in-roster-not-in-import” alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->