### PR TITLE
move group repo logic to async worker

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1440,3 +1440,53 @@ export async function isUserInOrg(github_username: string, org: string) {
     throw error;
   }
 }
+
+export async function enqueueSyncRepoPermissions({
+  class_id,
+  course_slug,
+  org,
+  repo,
+  githubUsernames,
+  debug_id
+}: {
+  class_id: number;
+  course_slug: string;
+  org: string;
+  repo: string;
+  githubUsernames: string[];
+  debug_id?: string;
+}) {
+  const adminSupabase = createClient<Database>(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+  const { data, error } = await adminSupabase.rpc("enqueue_github_sync_repo_permissions", {
+    p_class_id: class_id,
+    p_org: org,
+    p_repo: repo,
+    p_course_slug: course_slug,
+    p_github_usernames: githubUsernames,
+    p_debug_id: debug_id
+  });
+  if (error) {
+    Sentry.captureException(error);
+    throw new Error("Failed to enqueue sync repo permissions");
+  }
+  return data;
+}
+export async function enqueueGithubArchiveRepo(class_id: number, org: string, repo: string) {
+  const adminSupabase = createClient<Database>(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+  const { data, error } = await adminSupabase.rpc("enqueue_github_archive_repo", {
+    p_class_id: class_id,
+    p_org: org,
+    p_repo: repo
+  });
+  if (error) {
+    Sentry.captureException(error);
+    throw new Error("Failed to enqueue github archive repo");
+  }
+  return data;
+}

--- a/supabase/functions/assignment-group-join/index.ts
+++ b/supabase/functions/assignment-group-join/index.ts
@@ -1,8 +1,9 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { TZDate } from "npm:@date-fns/tz";
+import * as Sentry from "npm:@sentry/deno";
 import { AssignmentGroupJoinRequest } from "../_shared/FunctionTypes.d.ts";
-import { syncRepoPermissions } from "../_shared/GitHubWrapper.ts";
+import { enqueueSyncRepoPermissions } from "../_shared/GitHubWrapper.ts";
 import {
   IllegalArgumentError,
   SecurityError,
@@ -11,7 +12,6 @@ import {
   wrapRequestHandler
 } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
 async function handleAssignmentGroupJoin(
   req: Request,
   scope: Sentry.Scope
@@ -87,13 +87,14 @@ async function handleAssignmentGroupJoin(
       )
       .eq("assignment_group_id", assignment_group_id);
     if (remaining_members) {
-      await syncRepoPermissions(
-        assignmentGroup.classes!.github_org!,
-        assignmentGroup.repositories[0].repository,
-        assignmentGroup.classes!.slug!,
-        remaining_members.map((m) => m.profiles!.user_roles!.users!.github_username!),
-        scope
-      );
+      await enqueueSyncRepoPermissions({
+        class_id: assignmentGroup.class_id,
+        course_slug: assignmentGroup.classes!.slug!,
+        org: assignmentGroup.classes!.github_org!,
+        repo: assignmentGroup.repositories[0].repository,
+        githubUsernames: remaining_members.map((m) => m.profiles!.user_roles!.users!.github_username!),
+        debug_id: `assignment-group-join-${assignment_group_id}`
+      });
     } else if (remaining_members_error) {
       console.log(remaining_members_error);
       throw new UserVisibleError("Failed to get remaining members");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * GitHub repository operations including creation, permission synchronization, and archiving now use asynchronous job queuing instead of synchronous processing, improving system reliability and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->