### PR TITLE
Improve the discussion thread sidebar with feedback from @BohMatej (#430)

### DIFF
--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import DiscussionThreadList from "./DiscussionThreadList";
 
 const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
-  const [listWidth, setListWidth] = useState(450);
+  const [listWidth, setListWidth] = useState(320);
   const cleanupRef = useRef<(() => void) | null>(null);
 
   // Cleanup effect - removes listeners if component unmounts during drag

--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -47,26 +47,23 @@ const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>)
     [listWidth]
   );
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      const step = e.shiftKey ? 50 : 10; // Larger steps with Shift key
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const step = e.shiftKey ? 50 : 10; // Larger steps with Shift key
 
-      if (e.key === "ArrowLeft") {
-        e.preventDefault();
-        setListWidth((prev) => Math.max(300, prev - step));
-      } else if (e.key === "ArrowRight") {
-        e.preventDefault();
-        setListWidth((prev) => Math.min(800, prev + step));
-      } else if (e.key === "Home") {
-        e.preventDefault();
-        setListWidth(300); // Min width
-      } else if (e.key === "End") {
-        e.preventDefault();
-        setListWidth(800); // Max width
-      }
-    },
-    []
-  );
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setListWidth((prev) => Math.max(300, prev - step));
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setListWidth((prev) => Math.min(800, prev + step));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setListWidth(300); // Min width
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setListWidth(800); // Max width
+    }
+  }, []);
 
   return (
     <Box height="100dvh" overflow="hidden">

--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -1,12 +1,37 @@
+"use client";
+
 import { Box, Flex } from "@chakra-ui/react";
+import { useState } from "react";
 import DiscussionThreadList from "./DiscussionThreadList";
 
-const DiscussionLayout = async ({ children }: Readonly<{ children: React.ReactNode }>) => {
+const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>) => {
+  const [listWidth, setListWidth] = useState(450);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = listWidth;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const newWidth = Math.max(300, Math.min(800, startWidth + (e.clientX - startX)));
+      setListWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  };
+
   return (
     <Box height="100dvh" overflow="hidden">
       <Flex flex="1" wrap={{ base: "wrap", md: "nowrap" }} height="100%" minHeight="0">
+        {/* Discussion Thread List */}
         <Box
-          width={{ base: "100%", md: "314px" }}
+          width={{ base: "100%", md: `${listWidth}px` }}
           borderRightWidth={{ base: "0", md: "1px" }}
           borderBottomWidth={{ base: "1px", md: "0" }}
           borderStyle="solid"
@@ -14,10 +39,27 @@ const DiscussionLayout = async ({ children }: Readonly<{ children: React.ReactNo
           pt="4"
           height="100%"
           overflow="hidden"
+          position="relative"
         >
           <DiscussionThreadList />
         </Box>
-        <Box p={{ base: "4", md: "8" }} width="100%" height="100%" overflow="auto">
+
+        {/* Draggable Divider - Only visible on desktop */}
+        <Box
+          display={{ base: "none", md: "block" }}
+          width="4px"
+          cursor="ew-resize"
+          bg="transparent"
+          _hover={{ bg: "blue.500" }}
+          transition="background 0.2s"
+          height="100%"
+          position="relative"
+          onMouseDown={handleMouseDown}
+          userSelect="none"
+        />
+
+        {/* Main Content */}
+        <Box p={{ base: "4", md: "8" }} flex="1" height="100%" overflow="auto">
           {children}
         </Box>
       </Flex>

--- a/tests/e2e/discussion-threads.test.tsx
+++ b/tests/e2e/discussion-threads.test.tsx
@@ -45,9 +45,6 @@ test.describe("Discussion Thread Page", () => {
     await navRegion.getByRole("link").filter({ hasText: "Discussion" }).click();
     await expect(page.getByRole("heading", { name: "Discussion Feed" })).toBeVisible();
     await expect(page.getByRole("link").filter({ hasText: "New Thread" })).toBeVisible();
-    await expect(page.getByPlaceholder("Search threads...")).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Filter discussion threads" })).toBeVisible();
-    await expect(page.getByRole("combobox", { name: "Sort discussion threads" })).toBeVisible();
     await expect(page.getByText("No threads match your criteria.")).toBeVisible();
     await expect(page.getByRole("heading", { name: "Unanswered Questions" })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Answered Questions", exact: true })).toBeVisible();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter, search and sort controls for discussion threads moved into a compact dropdown menu for single-click access.
  * Discussion layout is now resizable—drag the divider between the thread list and content to adjust pane width.

* **Changes**
  * Thread teasers simplified (avatar tooltips removed); New Thread button placed beside the filter menu for a streamlined header.
  * Inline search and separate filter/sort controls consolidated into the dropdown menu.

* **Tests**
  * Updated UI tests to remove expectations for the old inline search and filter/sort controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->