### PR TITLE
feat: add click-to-copy functionality for build number - Add copy icon

### DIFF
--- a/app/course/[course_id]/UserMenu.tsx
+++ b/app/course/[course_id]/UserMenu.tsx
@@ -144,11 +144,8 @@ function SupportMenu() {
               </Link>
             </Menu.Item>
             <Menu.Item value="view-open-bugs">
-              <Link
-                href={"https://github.com/pawtograder/platform/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug"}
-                target="_blank"
-              >
-                View open bugs
+              <Link href={"https://github.com/pawtograder/platform/issues?q=is%3Aissue%20state%3Aopen"} target="_blank">
+                View open issues
               </Link>
             </Menu.Item>
             <Menu.Item


### PR DESCRIPTION
**Title:** 
feat: add click-to-copy functionality for build number

**Description:**
Closes #416

## Summary
Implemented click-to-copy functionality for the build number in the Support menu, making it easier for users to copy the build hash when reporting bugs.

## Changes
- Added click-to-copy functionality to build number in Support menu
- Build hash is copied to clipboard on click
- Added copy icon (LuCopy) with visual feedback
- Shows green checkmark (LuCheck) for 2 seconds after copying
- Menu stays open after clicking using `closeOnSelect={false}`
- Imported LuCopy and LuCheck icons from react-icons/lu

## Testing
- ✅ Tested locally in development environment
- ✅ Copy functionality works correctly  
- ✅ Visual feedback (checkmark) appears immediately and disappears after 2 seconds
- ✅ Menu stays open when clicking build number
- ✅ Build hash successfully copied to clipboard

## Screenshots

<img width="1916" height="437" alt="image" src="https://github.com/user-attachments/assets/dd5dfa13-2065-4fb3-a5e4-e0fa438d63ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy build number to clipboard with one-click and temporary visual confirmation (icon switches to a green check for 2 seconds).
  * Build menu item remains open after copying so you can take other actions without reopening the menu.
  * Shows a clear error notification if copying fails.
  * Ensures the temporary confirmation is cleared when the menu is closed or component unmounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->