### PR TITLE
Auto-sync github username, tolerate duplicate-specified org

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1089,6 +1089,74 @@ async function getOrgMembers(
   });
   return members;
 }
+async function updateGitHubUsernameForUser(
+  oldUsername: string,
+  octokit: Octokit,
+  adminSupabase: ReturnType<typeof createClient<Database>>,
+  scope?: Sentry.Scope
+): Promise<{ oldUsername: string; newUsername: string | null }> {
+  // Find the github user id from the public.users table for the given github username
+  const { data: userData, error: userError } = await adminSupabase
+    .from("users")
+    .select("github_user_id, user_id")
+    .eq("github_username", oldUsername)
+    .single();
+
+  if (userError || !userData?.github_user_id) {
+    // User not found or no github_user_id, skip
+    return { oldUsername, newUsername: null };
+  }
+
+  try {
+    // Get the current github user name from that id
+    const gitHubUser = await octokit.request("GET /user/{account_id}", {
+      account_id: Number(userData.github_user_id),
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28"
+      }
+    });
+
+    if (gitHubUser.status === 200 && gitHubUser.data.login) {
+      const newUsername = gitHubUser.data.login.toLowerCase();
+
+      // Update our users record with that new username
+      const { error: updateError } = await adminSupabase
+        .from("users")
+        .update({
+          github_username: newUsername,
+          last_github_user_sync: new Date().toISOString()
+        })
+        .eq("user_id", userData.user_id);
+
+      if (updateError) {
+        scope?.addBreadcrumb({
+          category: "github",
+          message: `Failed to update username for user ${userData.user_id}: ${updateError.message}`,
+          level: "error"
+        });
+        console.log(`Failed to update username for user ${userData.user_id}: ${updateError.message}`);
+        return { oldUsername, newUsername: null };
+      } else if (newUsername !== oldUsername) {
+        scope?.addBreadcrumb({
+          category: "github",
+          message: `Updated GitHub username from ${oldUsername} to ${newUsername} for user ${userData.user_id}`,
+          level: "info"
+        });
+        console.log(`Updated GitHub username from ${oldUsername} to ${newUsername} for user ${userData.user_id}`);
+        return { oldUsername, newUsername };
+      }
+    }
+  } catch (error) {
+    scope?.addBreadcrumb({
+      category: "github",
+      message: `Error fetching GitHub user for user_id ${userData.user_id}: ${error}`,
+      level: "error"
+    });
+    console.log(`Error fetching GitHub user for user_id ${userData.user_id}:`, error);
+  }
+
+  return { oldUsername, newUsername: null };
+}
 export async function syncRepoPermissions(
   org: string,
   repo: string,
@@ -1171,6 +1239,42 @@ export async function syncRepoPermissions(
       permission: "maintain"
     });
   }
+  const desiredUsersNotInOrg = githubUsernames.filter((u) => !allOrgMembers?.includes(u));
+  console.log(`${org}/${repo} desired users not in org: ${desiredUsersNotInOrg.join(", ")}`);
+  //The API for PUT /repos/{owner}/{repo}/collaborators/{username} REQUIRES the username, can't be user id.
+  //So, if a student changes their username, we won't be able to sync their repo permissions here because
+  //we have the old username on file. But, we can find those becuase they won't be in the org members list.
+
+  // Update usernames for users who may have changed their GitHub username
+  if (desiredUsersNotInOrg.length > 0) {
+    const adminSupabase = createClient<Database>(
+      Deno.env.get("SUPABASE_URL") || "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+    );
+
+    // Create a bottleneck limiter to run no more than 20 at once
+    const limiter = new Bottleneck({
+      maxConcurrent: 20
+    });
+
+    // Use Promise.all with the limiter to update usernames in parallel
+    const updateResults = await Promise.all(
+      desiredUsersNotInOrg.map((oldUsername) =>
+        limiter.schedule(() => updateGitHubUsernameForUser(oldUsername, octokit, adminSupabase, scope))
+      )
+    );
+
+    // Update our local githubUsernames array to use those new names
+    for (const { oldUsername, newUsername } of updateResults) {
+      if (newUsername) {
+        const index = githubUsernames.indexOf(oldUsername);
+        if (index !== -1) {
+          githubUsernames[index] = newUsername;
+        }
+      }
+    }
+  }
+
   const newAccess = githubUsernames.filter(
     (u) => !existingUsernames.includes(u) && allOrgMembers?.includes(u) // && !existingInvitations.some((i) => i.invitee?.login === u)
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository permission synchronization to handle GitHub username changes automatically
  * Enhanced repository name consistency in permission syncing operations to ensure accurate synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->