### PR TITLE
Fix CSV import to highlight new grade entries (#475)

### DIFF
--- a/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
+++ b/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
@@ -911,12 +911,26 @@ export default function ImportGradebookColumns() {
                                   );
                                 }
 
-                                if (
-                                  col.isNew ||
+                                // Check if this is a new entry (has new value but no old value)
+                                const isNewEntry = !hasOldValue && hasNewValue;
+
+                                // Check if values are unchanged
+                                const isUnchanged =
                                   s.oldValue === null ||
                                   s.oldValue === undefined ||
-                                  String(s.oldValue).trim() === String(s.newValue).trim()
-                                ) {
+                                  String(s.oldValue).trim() === String(s.newValue).trim();
+
+                                if (isNewEntry) {
+                                  // New entry - highlight in green/bold
+                                  return (
+                                    <Table.Cell key={colIdx} style={{ width: gradeColWidth, minWidth: gradeColWidth }}>
+                                      <Text as="b" color="fg.success">
+                                        {s.newValue}
+                                      </Text>
+                                    </Table.Cell>
+                                  );
+                                } else if (isUnchanged) {
+                                  // Unchanged or no value
                                   return (
                                     <Table.Cell key={colIdx} style={{ width: gradeColWidth, minWidth: gradeColWidth }}>
                                       {s.newValue !== null && s.newValue !== undefined && s.newValue !== ""
@@ -925,6 +939,7 @@ export default function ImportGradebookColumns() {
                                     </Table.Cell>
                                   );
                                 } else {
+                                  // Updated value - show old value struck through and new value in green/bold
                                   return (
                                     <Table.Cell key={colIdx} style={{ width: gradeColWidth, minWidth: gradeColWidth }}>
                                       <s>{s.oldValue}</s>{" "}


### PR DESCRIPTION
Fixes #475

The CSV import preview now highlights new grade entries (green/bold) to distinguish them from existing/unchanged entries, making it easier to identify which grades are being added versus updated.

**Changes:**
- Added visual highlighting for new entries (no old value, has new value)
- Maintains existing styling for updated and unchanged values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced gradebook import preview with clearer visual differentiation: new entries display in green/bold, updated entries show struck-through old values with new values highlighted in green/bold, and unchanged records render normally for easier import review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->