### PR TITLE
Add clickable links from review assignments to grading pages

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/ReviewsTable.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/reviews/ReviewsTable.tsx
@@ -427,11 +427,7 @@ export default function ReviewsTable({ assignmentId, openAssignModal, onReviewAs
           // If we have a valid submission, make it clickable
           if (submission) {
             const url = `/course/${course_id}/assignments/${assignmentId}/submissions/${submission.id}?review_assignment_id=${row.original.id}`;
-            return (
-              <Link href={url}>
-                {submitterName}
-              </Link>
-            );
+            return <Link href={url}>{submitterName}</Link>;
           }
 
           return submitterName;
@@ -552,7 +548,7 @@ export default function ReviewsTable({ assignmentId, openAssignModal, onReviewAs
         }
       }
     ],
-    [handleDelete, openAssignModal, getReviewStatus, course.classes.time_zone]
+    [handleDelete, openAssignModal, getReviewStatus, course.classes.time_zone, course_id, assignmentId]
   );
   const joinedSelect =
     "*, profiles!assignee_profile_id(*), rubrics(*), submissions(*, profiles!profile_id(*), assignment_groups(*, assignment_groups_members(*,profiles!profile_id(*))), assignments(*), submission_reviews!submission_reviews_submission_id_fkey(completed_at, grader, rubric_id, submission_id)), review_assignment_rubric_parts(*, rubric_parts!review_assignment_rubric_parts_rubric_part_id_fkey(id, name))";


### PR DESCRIPTION
Fixes #455

## Summary
Added clickable links to the Submission/Student column in the "Manage Review Assignments" page, allowing instructors to navigate directly to grading pages instead of having to search separately.

## Changes
- Made student names and group names in the review assignments table clickable
- Links navigate to `/course/{course_id}/assignments/{assignment_id}/submissions/{submission_id}?review_assignment_id={id}`
- Follows the same pattern used in the TA's review assignments table for consistency

## Testing
- Verified TypeScript compiles without errors
- Links include the proper `review_assignment_id` query parameter for context
- Both individual students and group submissions are clickable

This minimal change solves the problem described in #455 where reviewing 80+ assignments was extremely labor-intensive without direct links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submissions in the reviews table are now clickable, opening the submission details page.
  * Navigation preserves course, assignment and review context so users land directly in the relevant submission view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->