### PR TITLE
Fix issue 498 - missing check name on global rubric checks

### DIFF
--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -559,6 +559,11 @@ export function RubricCheckComment({
             </HStack>
           </Box>
           <Box pl={1} pr={1} color="fg.muted">
+            {check && (
+              <Text fontSize="sm" fontWeight="semibold" mb={1} color="fg.default" wordBreak="break-word">
+                {check.name}
+              </Text>
+            )}
             <HStack gap={1}>
               <Box flexShrink={0}>{pointsText}</Box>{" "}
               {isLineComment(comment) && <SubmissionFileCommentLink comment={comment} />}{" "}


### PR DESCRIPTION
No idea how we made it this long with nobody noticing this until all at once?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Rubric check names are now displayed in evaluation comments when present, providing clearer context and visibility during the review process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->