### PR TITLE
Allowed decimal values to be entered in Score Override form

### DIFF
--- a/app/course/[course_id]/manage/gradebook/overrideScoreForm.tsx
+++ b/app/course/[course_id]/manage/gradebook/overrideScoreForm.tsx
@@ -140,7 +140,8 @@ export function OverrideScoreForm({
             <HStack gap={0}>
               <Field label="Score" errorText={errors.score_override?.message?.toString()} flex={1} minW="5em">
                 <Input
-                  type="number" step="any"
+                  type="number"
+                  step="any"
                   {...register("score_override", { valueAsNumber: true })}
                   placeholder={studentGradebookColumn.score?.toString()}
                 />


### PR DESCRIPTION
Added a "step" attribute to the second Score field. Addresses issue #539.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gradebook score input fields to accept decimal values, allowing more precise scoring and override calculations instead of whole numbers only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->