### PR TITLE
Floating help request widget X (dismiss) button added

### DIFF
--- a/components/help-queue/floating-help-request-widget.tsx
+++ b/components/help-queue/floating-help-request-widget.tsx
@@ -101,7 +101,7 @@ export function FloatingHelpRequestWidget() {
     setIsExpanded((prev) => !prev);
   }, []);
 
-  const handleToggleDismiss = useCallback(() => {
+  const handleDismiss = useCallback(() => {
     setIsDismissed(true);
     setIsExpanded(false);
   }, []);
@@ -295,7 +295,7 @@ export function FloatingHelpRequestWidget() {
                   size="sm"
                   onClick={(e) => {
                     e.stopPropagation();
-                    handleToggleDismiss();
+                    handleDismiss();
                   }}
                 >
                   <Icon as={BsX} />
@@ -347,12 +347,12 @@ export function FloatingHelpRequestWidget() {
                   </IconButton>
                   
                   <IconButton
-                    aria-label="Close"
+                    aria-label="Dismiss widget"
                     variant="ghost"
                     size="sm"
                     onClick={(e) => {
                       e.stopPropagation();
-                      handleToggleDismiss();
+                      handleDismiss();
                     }}
                   >
                     <Icon as={BsX} />


### PR DESCRIPTION
I'm a student in CS3100

When we had to create the help request for Lab 3, I realized every time I went on PawToGrader, my help request was taking app the bottom right portion of my screen, so I decided to take it upon myself and add a dismiss feature with an X button. 

# What
I simply added a small X button using BsX to stay consistent in styling. 

# Why
Having the help request widget up at all times while it is open is cumbersome and obstructs the view of the page. 

# Behavior
X button is visible in the minimized widget and the expanded. The widget will come back on reload, where it can be dismissed again. 

# Scope

Only a small UI change, no changes to the backend

If this is Professor Bell reading this, please feel free to reach out to me via email with any questions: gribbin.t@northeastern.edu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The floating help request widget gains a dismiss capability: users can close it via close buttons in both minimized and expanded states. Dismissing also collapses the widget and keeps it hidden until the page is reloaded, preventing accidental reopening while browsing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->