### PR TITLE
Preserve message content when chat send fails

### DIFF
--- a/components/realtime-chat.tsx
+++ b/components/realtime-chat.tsx
@@ -244,11 +244,7 @@ export const RealtimeChat = ({
   const handleSendMessage = useCallback(
     async (message: string) => {
       if (!isConnected) {
-        toaster.error({
-          title: "Not connected to chat",
-          description: "Please wait for the chat to connect before sending messages."
-        });
-        return;
+        throw new Error("Please wait for the chat to connect before sending messages.");
       }
       if (!message.trim() || !sendMessage || moderationStatus.isBanned) return;
 


### PR DESCRIPTION
When users try to send a message while disconnected from the chat,
the message was being cleared even though it failed to send. This was
because handleSendMessage returned early without throwing an error,
so the .then() block in MessageInput executed and cleared the input.

Now handleSendMessage throws an error when not connected, which is
caught by MessageInput's error handler, preserving the user's message
in the input box so they don't lose their typed content.

https://claude.ai/code/session_012EqUZa3tCdhg3hHkBQkDdg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in real-time chat for disconnected states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->