### PR TITLE
Add bottom padding to prevent floating help button from obscuring content

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -1308,6 +1308,7 @@ function RubricView() {
       borderLeftWidth={{ base: "0", lg: "1px" }}
       borderColor="border.emphasized"
       padding="2"
+      pb="80px"
       height="100vh"
       overflowX="hidden"
       overflowY="auto"

--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -62,7 +62,7 @@ const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>)
         discussionBaseHref={discussionBaseHref}
         currentThread={currentThread}
       />
-      <Box flex="1" minH="0" overflow="auto" px={{ base: 3, md: 6 }} py={{ base: 3, md: 6 }}>
+      <Box flex="1" minH="0" overflow="auto" px={{ base: 3, md: 6 }} pt={{ base: 3, md: 6 }} pb="80px">
         {threadId ? (
           <Flex direction="row" gap={{ base: 3, lg: 6 }} align="stretch">
             <Box

--- a/app/course/[course_id]/layout.tsx
+++ b/app/course/[course_id]/layout.tsx
@@ -59,7 +59,7 @@ const ProtectedLayout = async ({
               <DynamicCourseNav />
               {/* <SidebarContent courseID={Number.parseInt(course_id)} /> */}
               {/* mobilenav */}
-              <Box pt="0" ml="0" mr="0">
+              <Box pt="0" ml="0" mr="0" pb="80px">
                 {children}
               </Box>
               <FloatingHelpRequestWidget />


### PR DESCRIPTION
The fixed-position "Get Help" button (bottom-right corner) could overlap
and hide content in discussion posts, rubric sidebar, and other pages.
Added pb="80px" to the course layout content wrapper, discussion scroll
container, and rubric sidebar scroll container so users can always scroll
past the floating widget.

https://claude.ai/code/session_012tQEji4uZCSLG57K5Q9yT9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced bottom spacing consistency across course layouts, discussion pages, and assignment submission views for improved visual hierarchy and content separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->