### PR TITLE
Fix link color blending with blue chat bubble background

### DIFF
--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -63,6 +63,10 @@ const additionalStyles = `
   .wmde-markdown i {
     color: inherit !important;
   }
+  .wmde-markdown a {
+    color: inherit !important;
+    text-decoration: underline !important;
+  }
 `;
 
 export default function Markdown(props: MarkdownProps) {


### PR DESCRIPTION
Links in the Markdown component were using the default browser blue color, making them invisible against the blue background of own-message bubbles in the office hours chat. Add `color: inherit` so links match the parent text color, and `text-decoration: underline` so they remain visually distinguishable as clickable links.

Fixes #599

https://claude.ai/code/session_01LGCd6rEoyBJahrxPphRVND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced link styling in Markdown content to ensure links properly inherit color and display underlines for improved visibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->