### PR TITLE
Fix reassigned grading not appearing in TA's pending work list

### DIFF
--- a/supabase/migrations/20260221120000_fix-bulk-assign-reviews-completed-at-bug.sql
+++ b/supabase/migrations/20260221120000_fix-bulk-assign-reviews-completed-at-bug.sql
@@ -306,7 +306,8 @@ BEGIN
     UPDATE public.review_assignments ra
     SET submission_id = ura.new_submission_id,
         submission_review_id = ura.new_submission_review_id,
-        completed_at = NULL
+        completed_at = NULL,
+        completed_by = NULL
     FROM updated_ra ura
     WHERE ra.id = ura.review_assignment_id;
 


### PR DESCRIPTION
When reassigning a rubric part to a TA who already completed grading a
different rubric part for the same submission, the new work would not
appear in their pending list because the existing review_assignment's
completed_at timestamp was preserved.

Now clears completed_at and completed_by when adding new rubric parts
to an already-completed review_assignment, ensuring the new work shows
as pending.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed review completion clearing so adding new rubric parts to bulk assignments reopens completed reviews.

* **Improvements**
  * Enhanced bulk assignment with stronger validation, instructor authorization checks, transactional safety, idempotent handling, retargeting to active submissions, and structured error reporting.
  * Added diagnostics output summarizing creations, updates, retargets, reopenings, and totals for bulk operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->