### PR TITLE
Submission grading reassignment

### DIFF
--- a/supabase/migrations/20260303120000_issue_618_keep_grading_comments_on_old_submission.sql
+++ b/supabase/migrations/20260303120000_issue_618_keep_grading_comments_on_old_submission.sql
@@ -17,30 +17,47 @@ DECLARE
 BEGIN
     -- Only proceed if is_active changed from true to false.
     IF OLD.is_active = true AND NEW.is_active = false THEN
-        -- Find the new active submission for the same assignment and student/group.
+        -- Find the replacement submission for the same assignment and student/group.
+        -- Prefer currently-active successors, but fall back to the most recent submission
+        -- to support out-of-order activation/deactivation flows.
         IF OLD.assignment_group_id IS NOT NULL THEN
             SELECT id INTO new_active_submission_id
             FROM public.submissions
             WHERE assignment_id = OLD.assignment_id
               AND assignment_group_id = OLD.assignment_group_id
+              AND is_active = true
               AND id != OLD.id
-            ORDER BY
-                CASE WHEN is_active THEN 0 ELSE 1 END,
-                created_at DESC,
-                id DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT 1;
+
+            IF new_active_submission_id IS NULL THEN
+                SELECT id INTO new_active_submission_id
+                FROM public.submissions
+                WHERE assignment_id = OLD.assignment_id
+                  AND assignment_group_id = OLD.assignment_group_id
+                  AND id != OLD.id
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1;
+            END IF;
         ELSE
             SELECT id INTO new_active_submission_id
             FROM public.submissions
             WHERE assignment_id = OLD.assignment_id
               AND profile_id = OLD.profile_id
-              AND assignment_group_id IS NULL
+              AND is_active = true
               AND id != OLD.id
-            ORDER BY
-                CASE WHEN is_active THEN 0 ELSE 1 END,
-                created_at DESC,
-                id DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT 1;
+
+            IF new_active_submission_id IS NULL THEN
+                SELECT id INTO new_active_submission_id
+                FROM public.submissions
+                WHERE assignment_id = OLD.assignment_id
+                  AND profile_id = OLD.profile_id
+                  AND id != OLD.id
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1;
+            END IF;
         END IF;
 
         IF new_active_submission_id IS NOT NULL THEN


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a migration to ensure grading comments remain with the old submission when a new submission is activated and assignments are reopened.

---
<p><a href="https://cursor.com/agents/bc-37814ebc-4976-4d1a-9fea-1d52e343326b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37814ebc-4976-4d1a-9fea-1d52e343326b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a submission is deactivated, grading comments remain attached to the original submission while review work and assignments are moved to the newly active submission.
  * Reassignment now detects and prevents conflicting in-progress work, removes only unstarted duplicate assignments, re-links and reopens moved reviews, and logs a summary of the changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->