### PR TITLE
Build time optimization

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -161,7 +161,7 @@ const sentryConfig = {
     create: !disableSentryReleaseCreate,
     finalize: !disableSentryReleaseFinalize
   },
-  silent: !process.env.CI,
+  silent: !isCi,
   disableLogger: true
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Switch default Next.js bundling to `webpackBuildWorker`, optimize Sentry CI build profile while keeping Sentry enabled, and fix CI boolean consistency for Sentry plugin verbosity.

What changed:
- Keep `webpackBuildWorker` as the default bundling strategy (`NEXT_BUNDLING_PROFILE=worker` by default).
- Add explicit Sentry build-profile controls in `next.config.ts`:
  - `SENTRY_BUILD_PROFILE` (`ci-fast` or `full`)
  - `SENTRY_DISABLE_COMPONENT_ANNOTATION`
  - `SENTRY_DISABLE_ROUTE_MANIFEST_INJECTION`
  - `SENTRY_DISABLE_RELEASE_CREATE`
  - `SENTRY_DISABLE_RELEASE_FINALIZE`
  - `SENTRY_DISABLE_SOURCEMAPS`
  - `SENTRY_USE_RUN_AFTER_PRODUCTION_COMPILE`
- Default Sentry behavior is now:
  - CI (`CI=1|true`): `SENTRY_BUILD_PROFILE=ci-fast` (Sentry still enabled; trims build-time instrumentation overhead)
  - Non-CI: `SENTRY_BUILD_PROFILE=full`
- Fix consistency bug: `sentryConfig.silent` now uses parsed `isCi` instead of raw `process.env.CI`, so `CI=false` correctly behaves as non-CI.

Profiling summary (cold builds):
- CI baseline (`worker` + default Sentry build features): **4m20.027s**
- CI default after this PR (`worker` + `ci-fast`): **3m40.323s** (~**13.7% faster**)
- CI full override (`SENTRY_BUILD_PROFILE=full`): **4m05.550s**

Notes:
- Turbopack build remains not-ready for this app due to Monaco dynamic import resolution failures.
- This PR intentionally keeps Sentry runtime/error reporting enabled in CI deployments while reducing build-only overhead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build configuration flexibility through environment-driven settings, enabling better control over bundling and error monitoring behavior.
  * Refactored and optimized build-time configurations for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->