### PR TITLE
Migrate group copying to an RPC

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -5,7 +5,7 @@ import PersonName from "@/components/ui/person-name";
 import { PopConfirm } from "@/components/ui/popconfirm";
 import { toaster, Toaster } from "@/components/ui/toaster";
 import { useClassProfiles } from "@/hooks/useClassProfiles";
-import { useCourse, useCourseController, useProfiles } from "@/hooks/useCourseController";
+import { useAllStudentRoles, useCourse, useCourseController, useProfiles } from "@/hooks/useCourseController";
 import { useUserProfile } from "@/hooks/useUserProfiles";
 import {
   assignmentGroupApproveRequest,
@@ -157,7 +157,8 @@ function CreateGroupButton({
 }
 
 export function useUngroupedProfiles(groups: AssignmentGroupWithMembersInvitationsAndJoinRequests[]) {
-  const profiles = useProfiles();
+  const studentRoles = useAllStudentRoles();
+  const profiles = useMemo(() => studentRoles.map((r) => r.profiles), [studentRoles]);
   const ungroupedProfiles = useMemo(() => {
     if (!groups) {
       return [];

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/bulkCreateGroupModal.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/bulkCreateGroupModal.tsx
@@ -17,7 +17,7 @@ import {
   Table
 } from "@chakra-ui/react";
 import { useEffect, useMemo, useState } from "react";
-import { useStudentRoster } from "@/hooks/useCourseController";
+import { useAllStudentRoles } from "@/hooks/useCourseController";
 import { GroupCreateData, useGroupManagement } from "./GroupManagementContext";
 import { createClient } from "@/utils/supabase/client";
 import { MultiValue, Select } from "chakra-react-select";
@@ -26,16 +26,17 @@ import { useList } from "@refinedev/core";
 import TagDisplay from "@/components/ui/tag";
 
 export function useUngroupedStudentProfiles(groups: AssignmentGroupWithMembersInvitationsAndJoinRequests[]) {
-  const students = useStudentRoster();
+  const studentRoles = useAllStudentRoles();
+  const profiles = useMemo(() => studentRoles.map((r) => r.profiles), [studentRoles]);
   const ungroupedProfiles = useMemo(() => {
     if (!groups) {
       return [];
     }
-    return students?.filter(
+    return profiles.filter(
       (p: { is_private_profile: boolean; id: string }) =>
         p.is_private_profile && !groups.some((g) => g.assignment_groups_members.some((m) => m.profile_id === p.id))
     );
-  }, [students, groups]);
+  }, [profiles, groups]);
   return ungroupedProfiles;
 }
 

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/page.tsx
@@ -76,6 +76,7 @@ function AssignmentGroupsTable({ assignment, course_id }: { assignment: Assignme
     filters: [
       { field: "class_id", operator: "eq", value: course_id },
       { field: "role", operator: "eq", value: "student" },
+      { field: "disabled", operator: "eq", value: false },
       { field: "profiles.assignment_groups_members.assignment_id", operator: "eq", value: assignment.id }
     ],
     pagination: { pageSize: 1000 }

--- a/lib/edgeFunctions.ts
+++ b/lib/edgeFunctions.ts
@@ -166,10 +166,17 @@ export async function assignmentGroupCopyGroupsFromAssignment(
   params: FunctionTypes.AssignmentGroupCopyGroupsFromAssignmentRequest,
   supabase: SupabaseClient<Database>
 ) {
-  const { data } = await supabase.functions.invoke("assignment-group-copy-groups-from-assignment", { body: params });
-  const { error } = data as FunctionTypes.GenericResponse;
+  const { data, error } = await (supabase.rpc as CallableFunction)("copy_groups_from_assignment", {
+    p_class_id: params.class_id,
+    p_source_assignment_id: params.source_assignment_id,
+    p_target_assignment_id: params.target_assignment_id
+  });
   if (error) {
-    throw new EdgeFunctionError(error);
+    throw new EdgeFunctionError({
+      details: error.message,
+      message: error.message,
+      recoverable: false
+    });
   }
   return data as unknown;
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -542,7 +542,7 @@ entrypoint = "./functions/assignment-group-instructor-move-student/index.ts"
 # static_files = [ "./functions/assignment-group-instructor-move-student/*.html" ]
 
 [functions.assignment-group-copy-groups-from-assignment]
-enabled = true
+enabled = false
 verify_jwt = false
 import_map = "./functions/assignment-group-copy-groups-from-assignment/deno.json"
 # Uncomment to specify a custom file path to the entrypoint.

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -10917,6 +10917,14 @@ export type Database = {
         Args: { p_assignment_id: number };
         Returns: number;
       };
+      copy_groups_from_assignment: {
+        Args: {
+          p_class_id: number;
+          p_source_assignment_id: number;
+          p_target_assignment_id: number;
+        };
+        Returns: Json;
+      };
       create_all_repos_for_assignment:
         | {
             Args: {
@@ -11194,6 +11202,15 @@ export type Database = {
       enqueue_gradebook_row_recalculation_batch: {
         Args: { p_rows: Json[] };
         Returns: undefined;
+      };
+      enqueue_repo_analytics_fetch: {
+        Args: {
+          p_assignment_id: number;
+          p_class_id: number;
+          p_org: string;
+          p_repository_id?: number;
+        };
+        Returns: number;
       };
       evaluate_error_pin_rule: {
         Args: {

--- a/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
+++ b/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
@@ -36,7 +36,26 @@ BEGIN
       USING ERRCODE = 'data_exception';
   END IF;
 
-  -- 3. Validate source has groups
+  -- 3. Both assignments must belong to this class
+  IF NOT EXISTS (
+    SELECT 1 FROM assignments
+    WHERE id = p_source_assignment_id
+      AND class_id = p_class_id
+  ) THEN
+    RAISE EXCEPTION 'Source assignment not found in this class'
+      USING ERRCODE = 'data_exception';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM assignments
+    WHERE id = p_target_assignment_id
+      AND class_id = p_class_id
+  ) THEN
+    RAISE EXCEPTION 'Target assignment not found in this class'
+      USING ERRCODE = 'data_exception';
+  END IF;
+
+  -- 4. Validate source has groups
   IF NOT EXISTS (
     SELECT 1 FROM assignment_groups
     WHERE assignment_id = p_source_assignment_id
@@ -46,7 +65,7 @@ BEGIN
       USING ERRCODE = 'data_exception';
   END IF;
 
-  -- 4. Bulk upsert groups (preserving mentor_profile_id)
+  -- 5. Bulk upsert groups (preserving mentor_profile_id)
   WITH inserted_groups AS (
     INSERT INTO assignment_groups (assignment_id, class_id, name, mentor_profile_id)
     SELECT p_target_assignment_id, class_id, name, mentor_profile_id
@@ -59,7 +78,7 @@ BEGIN
   )
   SELECT COUNT(*) INTO v_groups_processed FROM inserted_groups;
 
-  -- 5. Bulk upsert members (mapping source groups to target groups via name)
+  -- 6. Bulk upsert members (mapping source groups to target groups via name)
   WITH inserted_members AS (
     INSERT INTO assignment_groups_members (
       assignment_id,

--- a/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
+++ b/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
@@ -113,6 +113,7 @@ BEGIN
 END;
 $$;
 
+REVOKE ALL ON FUNCTION public.copy_groups_from_assignment(bigint, bigint, bigint) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.copy_groups_from_assignment(bigint, bigint, bigint) TO authenticated;
 
 COMMENT ON FUNCTION public.copy_groups_from_assignment IS

--- a/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
+++ b/supabase/migrations/20260318000000_copy_groups_from_assignment_rpc.sql
@@ -1,0 +1,101 @@
+-- Replace assignment-group-copy-groups-from-assignment Edge Function with Postgres RPC
+-- Efficiently copies groups and members from source to target assignment using bulk SQL
+
+CREATE OR REPLACE FUNCTION public.copy_groups_from_assignment(
+  p_class_id bigint,
+  p_source_assignment_id bigint,
+  p_target_assignment_id bigint
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller_profile_id uuid;
+  v_groups_processed int;
+  v_members_copied int;
+BEGIN
+  -- 1. Auth check: only instructors can copy groups
+  IF NOT authorizeforclassinstructor(p_class_id) THEN
+    RAISE EXCEPTION 'Permission denied'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- 2. Get caller's profile for added_by (instructor performing the copy)
+  SELECT private_profile_id INTO v_caller_profile_id
+  FROM user_roles
+  WHERE user_id = auth.uid()
+    AND class_id = p_class_id
+    AND role = 'instructor'
+    AND disabled = false
+  LIMIT 1;
+
+  IF v_caller_profile_id IS NULL THEN
+    RAISE EXCEPTION 'Could not find instructor profile for caller'
+      USING ERRCODE = 'data_exception';
+  END IF;
+
+  -- 3. Validate source has groups
+  IF NOT EXISTS (
+    SELECT 1 FROM assignment_groups
+    WHERE assignment_id = p_source_assignment_id
+      AND class_id = p_class_id
+  ) THEN
+    RAISE EXCEPTION 'Source assignment has no groups'
+      USING ERRCODE = 'data_exception';
+  END IF;
+
+  -- 4. Bulk upsert groups (preserving mentor_profile_id)
+  WITH inserted_groups AS (
+    INSERT INTO assignment_groups (assignment_id, class_id, name, mentor_profile_id)
+    SELECT p_target_assignment_id, class_id, name, mentor_profile_id
+    FROM assignment_groups
+    WHERE assignment_id = p_source_assignment_id
+      AND class_id = p_class_id
+    ON CONFLICT (assignment_id, name)
+    DO UPDATE SET mentor_profile_id = EXCLUDED.mentor_profile_id
+    RETURNING id
+  )
+  SELECT COUNT(*) INTO v_groups_processed FROM inserted_groups;
+
+  -- 5. Bulk upsert members (mapping source groups to target groups via name)
+  WITH inserted_members AS (
+    INSERT INTO assignment_groups_members (
+      assignment_id,
+      class_id,
+      profile_id,
+      assignment_group_id,
+      added_by
+    )
+    SELECT
+      p_target_assignment_id,
+      p_class_id,
+      sm.profile_id,
+      tg.id,
+      v_caller_profile_id
+    FROM assignment_groups_members sm
+    JOIN assignment_groups sg ON sg.id = sm.assignment_group_id
+    JOIN assignment_groups tg ON tg.name = sg.name
+      AND tg.assignment_id = p_target_assignment_id
+      AND tg.class_id = p_class_id
+    WHERE sm.assignment_id = p_source_assignment_id
+      AND sm.class_id = p_class_id
+    ON CONFLICT (assignment_id, profile_id)
+    DO UPDATE SET assignment_group_id = EXCLUDED.assignment_group_id
+    RETURNING id
+  )
+  SELECT COUNT(*) INTO v_members_copied FROM inserted_members;
+
+  RETURN jsonb_build_object(
+    'groups_processed', v_groups_processed,
+    'members_copied', v_members_copied
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.copy_groups_from_assignment(bigint, bigint, bigint) TO authenticated;
+
+COMMENT ON FUNCTION public.copy_groups_from_assignment IS
+  'Copies assignment groups and members from a source assignment to a target assignment. '
+  'Only instructors can call. Uses auth.uid() for authorization and added_by.';

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -10917,6 +10917,14 @@ export type Database = {
         Args: { p_assignment_id: number };
         Returns: number;
       };
+      copy_groups_from_assignment: {
+        Args: {
+          p_class_id: number;
+          p_source_assignment_id: number;
+          p_target_assignment_id: number;
+        };
+        Returns: Json;
+      };
       create_all_repos_for_assignment:
         | {
             Args: {
@@ -11194,6 +11202,15 @@ export type Database = {
       enqueue_gradebook_row_recalculation_batch: {
         Args: { p_rows: Json[] };
         Returns: undefined;
+      };
+      enqueue_repo_analytics_fetch: {
+        Args: {
+          p_assignment_id: number;
+          p_class_id: number;
+          p_org: string;
+          p_repository_id?: number;
+        };
+        Returns: number;
       };
       evaluate_error_pin_rule: {
         Args: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled user accounts are excluded from group management selections and assignment operations.

* **Improvements**
  * Student/profile retrieval for group management and bulk-group creation updated for more accurate ungrouped student listings.
  * Group-copying between assignments made more robust with improved server-side handling and error wrapping.

* **New Features**
  * Added server-side operations to copy groups between assignments and to enqueue repository analytics fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->