### PR TITLE
Metrics: Bottleneck/Upstash limiter running, queued, concurrent clients

### DIFF
--- a/supabase/functions/_shared/BottleneckRedisMetrics.ts
+++ b/supabase/functions/_shared/BottleneckRedisMetrics.ts
@@ -50,7 +50,19 @@ function settingsKeyToLimiterId(key: string): string | null {
   return key.slice(2, -suffix.length);
 }
 
+/** Upper bound on limiters exported per scrape (cardinality / latency). Override via METRICS_MAX_BOTTLENECK_LIMITERS. */
+const DEFAULT_MAX_BOTTLENECK_LIMITERS = 200;
+const ABSOLUTE_MAX_BOTTLENECK_LIMITERS = 5000;
+
+function readMaxExportedLimiters(): number {
+  const raw = Deno.env.get("METRICS_MAX_BOTTLENECK_LIMITERS");
+  const parsed = raw != null && raw !== "" ? Number.parseInt(raw, 10) : DEFAULT_MAX_BOTTLENECK_LIMITERS;
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_MAX_BOTTLENECK_LIMITERS;
+  return Math.min(parsed, ABSOLUTE_MAX_BOTTLENECK_LIMITERS);
+}
+
 async function scanAllSettingsKeys(redis: Redis): Promise<string[]> {
+  const maxLimiters = readMaxExportedLimiters();
   let cursor = 0;
   const ids = new Set<string>();
   do {
@@ -61,7 +73,15 @@ async function scanAllSettingsKeys(redis: Redis): Promise<string[]> {
       if (id) ids.add(id);
     }
   } while (cursor !== 0);
-  return Array.from(ids);
+
+  const sorted = Array.from(ids).sort();
+  if (sorted.length > maxLimiters) {
+    console.warn(
+      `Bottleneck Redis metrics: capping exported limiters from ${sorted.length} to ${maxLimiters} (raise METRICS_MAX_BOTTLENECK_LIMITERS if needed)`
+    );
+    return sorted.slice(0, maxLimiters);
+  }
+  return sorted;
 }
 
 function safeNum(v: unknown): number {
@@ -80,8 +100,15 @@ function parseEvalTriple(raw: unknown): { running: number; concurrent_clients: n
 }
 
 /**
- * Snapshot all Bottleneck limiters that have Redis keys (shared Upstash store).
- * Requires UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.
+ * Snapshot Bottleneck limiters from the shared Upstash store.
+ *
+ * Requires `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`. Returns [] if unset.
+ *
+ * Discovery is capped per scrape (default 200, max 5000) via `METRICS_MAX_BOTTLENECK_LIMITERS`
+ * to bound Prometheus cardinality and scrape time.
+ *
+ * Throws if at least one limiter was discovered but every EVAL failed or returned no data,
+ * so callers can record a single error in Sentry.
  */
 export async function collectBottleneckRedisSnapshots(): Promise<BottleneckLimiterSnapshot[]> {
   const url = Deno.env.get("UPSTASH_REDIS_REST_URL");
@@ -99,18 +126,28 @@ export async function collectBottleneckRedisSnapshots(): Promise<BottleneckLimit
       try {
         const raw = await redis.eval(METRICS_LUA, [], [limiter_id, String(now)]);
         const parsed = parseEvalTriple(raw);
-        if (!parsed) return null;
+        if (!parsed) {
+          console.warn(
+            `Bottleneck metrics: EVAL returned no data for limiter_id=${limiter_id} (settings key likely removed after scan)`
+          );
+          return null;
+        }
         return {
           limiter_id,
           running: parsed.running,
           concurrent_clients: parsed.concurrent_clients,
           queued: parsed.queued
         } satisfies BottleneckLimiterSnapshot;
-      } catch {
+      } catch (err) {
+        console.error(`Bottleneck metrics: EVAL failed for limiter_id=${limiter_id}`, err);
         return null;
       }
     })
   );
 
-  return snapshots.filter((s): s is BottleneckLimiterSnapshot => s != null);
+  const ok = snapshots.filter((s): s is BottleneckLimiterSnapshot => s != null);
+  if (limiterIds.length > 0 && ok.length === 0) {
+    throw new Error(`Bottleneck Redis metrics: all ${limiterIds.length} limiter EVALs failed or returned no data`);
+  }
+  return ok;
 }

--- a/supabase/functions/metrics/index.ts
+++ b/supabase/functions/metrics/index.ts
@@ -93,7 +93,8 @@ pawtograder_discord_dlq_size ${discordDlqQueueCount} ${timestamp}
       }
     }
 
-    output += `
+    if (bottleneckSnapshots.length > 0) {
+      output += `
 # HELP pawtograder_bottleneck_running Total running job weight for a Bottleneck limiter (Upstash Redis)
 # TYPE pawtograder_bottleneck_running gauge
 # HELP pawtograder_bottleneck_concurrent_clients Number of Bottleneck clients with active running work (Redis ZSET score greater than zero)
@@ -102,12 +103,13 @@ pawtograder_discord_dlq_size ${discordDlqQueueCount} ${timestamp}
 # TYPE pawtograder_bottleneck_queued gauge
 `;
 
-    for (const snap of bottleneckSnapshots) {
-      const lid = escapeLabel(snap.limiter_id);
-      const labels = `limiter_id="${lid}"`;
-      output += `pawtograder_bottleneck_running{${labels}} ${snap.running} ${timestamp}\n`;
-      output += `pawtograder_bottleneck_concurrent_clients{${labels}} ${snap.concurrent_clients} ${timestamp}\n`;
-      output += `pawtograder_bottleneck_queued{${labels}} ${snap.queued} ${timestamp}\n`;
+      for (const snap of bottleneckSnapshots) {
+        const lid = escapeLabel(snap.limiter_id);
+        const labels = `limiter_id="${lid}"`;
+        output += `pawtograder_bottleneck_running{${labels}} ${snap.running} ${timestamp}\n`;
+        output += `pawtograder_bottleneck_concurrent_clients{${labels}} ${snap.concurrent_clients} ${timestamp}\n`;
+        output += `pawtograder_bottleneck_queued{${labels}} ${snap.queued} ${timestamp}\n`;
+      }
     }
 
     output += "\n";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `metrics` Edge Function now scrapes Bottleneck state from the shared Upstash Redis store (same key layout as [Bottleneck’s Redis scripts](https://github.com/SGrondin/bottleneck): `b_<id>_settings`, etc.).

## New Prometheus metrics

All use label `limiter_id` (the Bottleneck `id`, e.g. `create_content:org:…`, `discord_global`, `pawtograder-production`).

- `pawtograder_bottleneck_running` — total running job weight (`HGET` on settings; matches Bottleneck’s notion of running load).
- `pawtograder_bottleneck_concurrent_clients` — number of clients with active running work (`ZCOUNT` on `client_running` with score greater than zero).
- `pawtograder_bottleneck_queued` — queued jobs summed over clients still within `clientTimeout` (same logic as Bottleneck `queued.lua`).

Discovery is via `SCAN` on `b_*_settings` so every limiter that has ever written to Redis is reported without maintaining a static list.

## Behavior

- If `UPSTASH_REDIS_*` is unset, no bottleneck lines are emitted (same as before for that dimension).
- If Redis fails, the error is logged to Sentry and Postgres-backed metrics still return (bottleneck section is skipped).

## Files

- `supabase/functions/_shared/BottleneckRedisMetrics.ts` — scan + Lua aggregation
- `supabase/functions/metrics/index.ts` — wire-up and Prometheus text
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2238a85d-d571-4277-86e2-623e2d8539d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2238a85d-d571-4277-86e2-623e2d8539d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for rate limiters (running tasks, concurrent clients, queued requests) collected from Redis/Upstash.
  * Prometheus output now exposes rate limiter gauges with a limiter_id label.
  * Redis collection is resilient: collection errors are logged (non-fatal) and missing config yields no snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->