### PR TITLE
Enable squash merging (why was this off?), ensure repos have actions enabled

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -734,20 +734,40 @@ export async function createRepo(
     );
     console.log(JSON.stringify(resp.headers, null, 2));
     scope?.setTag("github_operation", "create_repo_request_done");
-    //Disable squash merging, make template
+    // Enable squash merging; set template flag when applicable
     scope?.setTag("github_operation", "patch_repo_settings");
     await retryWithBackoff(
       () =>
         octokit.request("PATCH /repos/{owner}/{repo}", {
           owner: org,
           repo: repoName,
-          allow_squash_merge: false,
+          allow_squash_merge: true,
           is_template: is_template_repo ? true : false
         }),
       3, // maxRetries
       1000, // baseDelayMs
       scope
     );
+    // Enable GitHub Actions (workaround for GitHub bug where Actions isn't always enabled on template-generated repos)
+    scope?.setTag("github_operation", "enable_actions");
+    try {
+      await retryWithBackoff(
+        () =>
+          octokit.request("PUT /repos/{owner}/{repo}/actions/permissions", {
+            owner: org,
+            repo: repoName,
+            enabled: true,
+            allowed_actions: "all"
+          }),
+        3,
+        1000,
+        scope
+      );
+    } catch (actionsErr) {
+      console.error("Error enabling GitHub Actions", actionsErr);
+      scope?.setTag("enable_actions_failed", "true");
+      Sentry.captureException(actionsErr, scope);
+    }
     //Get the head SHA
     scope?.setTag("github_operation", "get_head_sha");
     scope?.setTag("ref", "heads/main");
@@ -793,6 +813,45 @@ export async function createRepo(
           scope
         );
         scope?.setTag("head_sha", heads.data.object.sha);
+        // Match settings we apply on fresh creates (e.g. squash merge).
+        try {
+          await retryWithBackoff(
+            () =>
+              octokit.request("PATCH /repos/{owner}/{repo}", {
+                owner: org,
+                repo: repoName,
+                allow_squash_merge: true,
+                is_template: is_template_repo ? true : false
+              }),
+            3,
+            1000,
+            scope
+          );
+        } catch (patchErr) {
+          console.error("Error patching repo settings for pre-existing repo", patchErr);
+          scope?.setTag("patch_existing_repo_settings_failed", "true");
+          Sentry.captureException(patchErr, scope);
+        }
+        // Enable GitHub Actions (workaround for GitHub bug where Actions isn't always enabled on template-generated repos)
+        scope?.setTag("github_operation", "enable_actions");
+        try {
+          await retryWithBackoff(
+            () =>
+              octokit.request("PUT /repos/{owner}/{repo}/actions/permissions", {
+                owner: org,
+                repo: repoName,
+                enabled: true,
+                allowed_actions: "all"
+              }),
+            3,
+            1000,
+            scope
+          );
+        } catch (actionsErr) {
+          console.error("Error enabling GitHub Actions for pre-existing repo", actionsErr);
+          scope?.setTag("enable_actions_failed", "true");
+          Sentry.captureException(actionsErr, scope);
+        }
         return heads.data.object.sha as string;
       } else {
         throw e;

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -825,6 +825,7 @@ export async function processEnvelope(
         }
         Sentry.addBreadcrumb({ message: `Creating repo ${repoName} for org ${org}`, level: "info" });
         const limiter = getCreateContentLimiter(org);
+        // createRepo patches repo settings after generate (squash merge on, template flag, branch ruleset, …).
         const headSha = await limiter.schedule(() =>
           github.createRepo(org, repoName, templateRepo, { is_template_repo: isTemplateRepo }, scope)
         );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Squash merge is now enabled by default for new repositories.
  * GitHub Actions are automatically enabled on newly created repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->