### PR TITLE
fix: eliminate blob URL memory leaks in submission file viewer

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
@@ -765,9 +765,8 @@ function ArtifactWithComments({
   );
 }
 function RenderedArtifact({ artifact, artifactKey }: { artifact: SubmissionArtifact; artifactKey: string }) {
-  const [artifactData, setArtifactData] = useState<Blob | null>(null);
   const [siteUrl, setSiteUrl] = useState<string | null>(null);
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
   const [textContent, setTextContent] = useState<string | null>(null);
 
   useEffect(() => {
@@ -786,24 +785,29 @@ function RenderedArtifact({ artifact, artifactKey }: { artifact: SubmissionArtif
             artifactId: artifact.id
           })
         });
-        setSiteUrl(data.data.url);
+        if (isMounted) setSiteUrl(data.data.url);
       }
-      const data = await client.storage.from("submission-artifacts").download(artifactKey);
 
-      if (!isMounted) return; // Component unmounted, exit early
-
-      if (data.data) {
-        setArtifactData(data.data);
-        if (artifact.data.format === "plaintext" || artifact.data.format === "markdown") {
+      if (artifact.data.format === "png") {
+        const { data: urlData, error: urlError } = await client.storage
+          .from("submission-artifacts")
+          .createSignedUrl(artifactKey, 60 * 60 * 24);
+        if (!isMounted) return;
+        if (urlError) {
+          toaster.error({ title: "Error loading artifact image", description: urlError.message });
+          return;
+        }
+        if (urlData) setSignedUrl(urlData.signedUrl);
+      } else if (artifact.data.format === "plaintext" || artifact.data.format === "markdown") {
+        const data = await client.storage.from("submission-artifacts").download(artifactKey);
+        if (!isMounted) return;
+        if (data.data) {
           const text = await data.data.text();
           if (isMounted) setTextContent(text);
         }
-      }
-      if (data.error && isMounted) {
-        toaster.error({
-          title: "Error processing ZIP file: " + data.error,
-          description: "Please try again."
-        });
+        if (data.error) {
+          toaster.error({ title: "Error loading artifact: " + data.error, description: "Please try again." });
+        }
       }
     }
 
@@ -821,29 +825,14 @@ function RenderedArtifact({ artifact, artifactKey }: { artifact: SubmissionArtif
     artifact.id
   ]);
 
-  // Create object URL when artifactData changes and cleanup previous URL
-  useEffect(() => {
-    let newObjectUrl: string | null = null;
-    if (artifactData && artifact.data.format === "png") {
-      newObjectUrl = URL.createObjectURL(artifactData);
-      setObjectUrl(newObjectUrl);
-    }
-
-    return () => {
-      // Cleanup on unmount or when artifactData changes
-      if (newObjectUrl) {
-        URL.revokeObjectURL(newObjectUrl);
-      }
-    };
-  }, [artifactData, artifact.data?.format]);
-
   if (artifact.data.format === "png") {
-    if (objectUrl) {
+    if (signedUrl) {
       return (
         //eslint-disable-next-line @next/next/no-img-element
         <img
-          src={objectUrl}
+          src={signedUrl}
           alt={artifact.name}
+          loading="lazy"
           style={{
             maxWidth: "100%",
             height: "auto",

--- a/components/ui/binary-file-preview.tsx
+++ b/components/ui/binary-file-preview.tsx
@@ -19,14 +19,12 @@ function formatFileSize(bytes: number | null): string {
 }
 
 export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let isMounted = true;
-    let currentObjectUrl: string | null = null;
 
     async function loadFile() {
       if (!file.storage_key) {
@@ -39,52 +37,31 @@ export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
 
       const client = createClient();
 
-      // Create signed URL for download
       const { data: signedUrlData, error: signedUrlError } = await client.storage
         .from("submission-files")
-        .createSignedUrl(file.storage_key, 60 * 60 * 24); // 24 hour expiry
+        .createSignedUrl(file.storage_key, 60 * 60 * 24);
 
-      if (isMounted && signedUrlData) {
-        setDownloadUrl(signedUrlData.signedUrl);
-      }
-      if (signedUrlError && isMounted) {
+      if (!isMounted) return;
+
+      if (signedUrlError) {
         setError(`Failed to create download link: ${signedUrlError.message}`);
         setLoading(false);
         return;
       }
 
-      // For images, also create an object URL for inline display
-      if (isImageMime(file.mime_type)) {
-        const { data: blob, error: downloadError } = await client.storage
-          .from("submission-files")
-          .download(file.storage_key);
-
-        if (downloadError && isMounted) {
-          setError(`Failed to load image: ${downloadError.message}`);
-          setLoading(false);
-          return;
-        }
-
-        if (blob && isMounted) {
-          currentObjectUrl = URL.createObjectURL(blob);
-          setObjectUrl(currentObjectUrl);
-        }
+      if (signedUrlData) {
+        setSignedUrl(signedUrlData.signedUrl);
       }
 
-      if (isMounted) {
-        setLoading(false);
-      }
+      setLoading(false);
     }
 
     loadFile();
 
     return () => {
       isMounted = false;
-      if (currentObjectUrl) {
-        URL.revokeObjectURL(currentObjectUrl);
-      }
     };
-  }, [file.storage_key, file.mime_type]);
+  }, [file.storage_key]);
 
   return (
     <Box border="1px solid" borderColor="border.emphasized" borderRadius="md" m={2} w="100%">
@@ -115,8 +92,8 @@ export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
             </Box>
           )}
         </HStack>
-        {downloadUrl && (
-          <DownloadLink href={downloadUrl} filename={file.name}>
+        {signedUrl && (
+          <DownloadLink href={signedUrl} filename={file.name}>
             <HStack gap={1}>
               <Icon as={FaDownload} />
               <Text fontSize="xs">Download</Text>
@@ -137,12 +114,13 @@ export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
           <Box p={4} bg="bg.error" borderRadius="md">
             <Text color="fg.error">{error}</Text>
           </Box>
-        ) : isImageMime(file.mime_type) && objectUrl ? (
+        ) : isImageMime(file.mime_type) && signedUrl ? (
           <Flex justify="center">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={objectUrl}
+              src={signedUrl}
               alt={file.name}
+              loading="lazy"
               style={{
                 maxWidth: "100%",
                 height: "auto",
@@ -151,10 +129,10 @@ export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
               }}
             />
           </Flex>
-        ) : file.mime_type === "application/pdf" && downloadUrl ? (
+        ) : file.mime_type === "application/pdf" && signedUrl ? (
           <Box w="100%" h="600px">
             <iframe
-              src={downloadUrl}
+              src={signedUrl}
               style={{ width: "100%", height: "100%", border: "none", borderRadius: "0.375rem" }}
               title={file.name}
             />
@@ -163,8 +141,8 @@ export default function BinaryFilePreview({ file }: { file: SubmissionFile }) {
           <Flex direction="column" align="center" py={8} gap={3}>
             <Icon as={FaFile} boxSize={12} color="fg.muted" />
             <Text color="fg.muted">No preview available for this file type</Text>
-            {downloadUrl && (
-              <DownloadLink href={downloadUrl} filename={file.name}>
+            {signedUrl && (
+              <DownloadLink href={signedUrl} filename={file.name}>
                 <HStack gap={1}>
                   <Icon as={FaDownload} />
                   <Text>Download {file.name}</Text>

--- a/components/ui/markdown-file-preview.tsx
+++ b/components/ui/markdown-file-preview.tsx
@@ -210,35 +210,18 @@ function resolveRelativePath(currentFilePath: string, relativePath: string): str
   return resolved.join("/");
 }
 
-/** Max size (10MB) for inlining images as data URIs. Larger files return "" to avoid OOM. */
-const MAX_INLINE_IMAGE_SIZE = 10 * 1024 * 1024;
-
 /**
- * Fetches binary file content from Supabase Storage and returns a data URI.
- * Uses FileReader.readAsDataURL for O(n) base64 encoding (avoids quadratic reduce on large files).
- * Returns "" if the file exceeds MAX_INLINE_IMAGE_SIZE to avoid OOM; callers should render a
- * placeholder for oversized or failed images.
+ * Returns a signed URL for a binary file in Supabase Storage.
+ * Uses signed URLs instead of downloading full blobs to avoid holding large files in JS memory.
+ * Returns "" on error; callers should render a placeholder for failed images.
  */
-async function fetchBinaryFileAsDataUri(storageKey: string, mimeType: string): Promise<string> {
+async function fetchBinaryFileSignedUrl(storageKey: string): Promise<string> {
   const client = createClient();
-  const { data, error } = await client.storage.from("submission-files").download(storageKey);
+  const { data, error } = await client.storage.from("submission-files").createSignedUrl(storageKey, 60 * 60 * 24);
   if (error || !data) {
     return "";
   }
-  const size = data.size ?? 0;
-  if (size > MAX_INLINE_IMAGE_SIZE) {
-    return "";
-  }
-  const blob = new Blob([data], { type: mimeType });
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result;
-      resolve(typeof result === "string" ? result : `data:${mimeType};base64,`);
-    };
-    reader.onerror = () => resolve("");
-    reader.readAsDataURL(blob);
-  });
+  return data.signedUrl;
 }
 
 /**
@@ -831,12 +814,9 @@ export default function MarkdownFilePreview({ file, allFiles, onNavigateToFile }
 
         if (matchingFile) {
           if (matchingFile.is_binary && matchingFile.storage_key) {
-            // Binary file - fetch from Supabase Storage. Returns "" if oversized (exceeds MAX_INLINE_IMAGE_SIZE)
-            // or on error; we skip adding to resolved so the img component renders its placeholder.
-            const mime = matchingFile.mime_type || getMimeFromExtension(matchingFile.name);
-            const dataUri = await fetchBinaryFileAsDataUri(matchingFile.storage_key, mime);
-            if (dataUri) {
-              resolved[imgPath] = dataUri;
+            const signedUrl = await fetchBinaryFileSignedUrl(matchingFile.storage_key);
+            if (signedUrl) {
+              resolved[imgPath] = signedUrl;
             }
           } else if (!matchingFile.is_binary && matchingFile.contents && isImageFile(matchingFile.name)) {
             // SVG or text-based image stored inline


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Graders report that after viewing submissions with many large binary files (e.g. 10x10MB JPG), browser performance degrades severely and the app eventually crashes. The root cause is that `BinaryFilePreview`, `RenderedArtifact`, and `MarkdownFilePreview` download entire file blobs into JS heap memory via `storage.download()` and then create blob URLs with `URL.createObjectURL()`. For 10 large images, this accumulates 100MB+ of unreleasable blob data in the browser.

## Solution

Replace `URL.createObjectURL(blob)` with Supabase Storage **signed URLs** (`createSignedUrl()`) for all binary file rendering. Signed URLs let the browser stream images directly from Supabase Storage without holding the full file contents in JS memory.

### Changes

**`components/ui/binary-file-preview.tsx`**
- Replace `storage.download()` + `URL.createObjectURL()` with `createSignedUrl()` for image display
- Use the same signed URL for both the download link and inline `<img>` preview
- Remove `URL.revokeObjectURL()` cleanup (no longer needed)
- Add `loading="lazy"` to `<img>` for deferred loading

**`app/.../files/page.tsx` (`RenderedArtifact`)**
- Replace blob download + object URL with `createSignedUrl()` for PNG artifacts
- Only download blobs for plaintext/markdown artifacts that need text extraction
- Remove the separate `objectUrl` state and cleanup effect

**`components/ui/markdown-file-preview.tsx`**
- Replace `fetchBinaryFileAsDataUri()` (downloaded full blob → FileReader → data URI) with `fetchBinaryFileSignedUrl()` (single signed URL API call)
- Eliminates the 10MB `MAX_INLINE_IMAGE_SIZE` limit since signed URLs don't load data into JS memory

## Testing

Reproduced locally with a test submission containing 10 JPEG image files. Verified images render correctly, file switching is smooth, and download links work via signed URLs.

[demo_real_images_rendering_signed_urls.mp4](https://cursor.com/agents/bc-5a0dc1e6-2f75-4c5a-89af-b32f329fb26f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_real_images_rendering_signed_urls.mp4)
[photo_03.jpg rendering correctly via signed URL](https://cursor.com/agents/bc-5a0dc1e6-2f75-4c5a-89af-b32f329fb26f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freal_image_photo03_rendering.webp)
[photo_07.jpg rendering correctly via signed URL](https://cursor.com/agents/bc-5a0dc1e6-2f75-4c5a-89af-b32f329fb26f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freal_image_photo07_rendering.webp)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a0dc1e6-2f75-4c5a-89af-b32f329fb26f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a0dc1e6-2f75-4c5a-89af-b32f329fb26f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled lazy loading for images in file previews to improve performance.

* **Bug Fixes**
  * Enhanced error handling and user feedback when file previews fail to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->