### PR TITLE
Escape HTML tags instead of stripping them in markdown renderers

### DIFF
--- a/app/course/[course_id]/office-hours/page.tsx
+++ b/app/course/[course_id]/office-hours/page.tsx
@@ -13,7 +13,7 @@ import { useClassProfiles } from "@/hooks/useClassProfiles";
 import { Box, Button, Flex, Heading, HStack, Icon, Link, Stack, Text, VStack } from "@chakra-ui/react";
 import { redirect, useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import Markdown from "react-markdown";
+import Markdown from "@/components/ui/markdown";
 import { useOfficeHoursSchedule } from "@/hooks/useCalendarEvents";
 import { format, parseISO, isAfter, isSameDay, isWithinInterval } from "date-fns";
 import { BsCalendar, BsClock } from "react-icons/bs";

--- a/components/help-queue/help-drawer.tsx
+++ b/components/help-queue/help-drawer.tsx
@@ -28,7 +28,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { BsCalendar, BsChatText } from "react-icons/bs";
 import { FaPlus } from "react-icons/fa";
-import Markdown from "react-markdown";
+import Markdown from "@/components/ui/markdown";
 
 interface HelpDrawerProps {
   isOpen: boolean;

--- a/components/ui/markdown-file-preview.tsx
+++ b/components/ui/markdown-file-preview.tsx
@@ -21,6 +21,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import ReactMarkdown, { Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
+import remarkEscapeHtml from "@/lib/remark-escape-html";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkGemoji from "remark-gemoji";
@@ -1182,7 +1183,7 @@ export default function MarkdownFilePreview({ file, allFiles, onNavigateToFile }
             }}
           >
             <ReactMarkdown
-              remarkPlugins={[remarkGfm, remarkMath, remarkGemoji]}
+              remarkPlugins={[remarkEscapeHtml, remarkGfm, remarkMath, remarkGemoji]}
               rehypePlugins={[rehypeKatex, rehypeHighlight, rehypeSourcePositions]}
               components={components}
             >

--- a/components/ui/markdown-file-preview.tsx
+++ b/components/ui/markdown-file-preview.tsx
@@ -21,6 +21,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import ReactMarkdown, { Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
+import rehypeSanitize from "rehype-sanitize";
 import remarkEscapeHtml from "@/lib/remark-escape-html";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -1184,7 +1185,7 @@ export default function MarkdownFilePreview({ file, allFiles, onNavigateToFile }
           >
             <ReactMarkdown
               remarkPlugins={[remarkEscapeHtml, remarkGfm, remarkMath, remarkGemoji]}
-              rehypePlugins={[rehypeKatex, rehypeHighlight, rehypeSourcePositions]}
+              rehypePlugins={[rehypeSanitize, rehypeKatex, rehypeHighlight, rehypeSourcePositions]}
               components={components}
             >
               {content}

--- a/components/ui/markdown.tsx
+++ b/components/ui/markdown.tsx
@@ -1,3 +1,4 @@
+import remarkEscapeHtml from "@/lib/remark-escape-html";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
@@ -72,7 +73,14 @@ const additionalStyles = `
 export default function Markdown(props: MarkdownProps) {
   const { style, remarkPlugins, rehypePlugins, ...rest } = props;
 
-  const combinedRemark = [remarkMath, remarkGfm, remarkBreaks, remarkGemoji, ...(remarkPlugins || [])];
+  const combinedRemark = [
+    remarkEscapeHtml,
+    remarkMath,
+    remarkGfm,
+    remarkBreaks,
+    remarkGemoji,
+    ...(remarkPlugins || [])
+  ];
   const combinedRehype = [rehypeSanitize, rehypeKatex, rehypeHighlight, ...(rehypePlugins || [])];
 
   return (

--- a/components/ui/md-editor.tsx
+++ b/components/ui/md-editor.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { createClient } from "@/utils/supabase/client";
 import { useParams } from "next/navigation";
 import type { MDEditorProps } from "@uiw/react-md-editor";
+import remarkEscapeHtml from "@/lib/remark-escape-html";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
 import { isTextFile, getLanguageFromFile } from "@/lib/utils";
@@ -175,7 +176,7 @@ const MdEditor = (props: ExtendedMdEditorProps) => {
         e.preventDefault();
         e.stopPropagation();
       }}
-      previewOptions={{ rehypePlugins: [rehypeKatex], remarkPlugins: [remarkMath] }}
+      previewOptions={{ rehypePlugins: [rehypeKatex], remarkPlugins: [remarkEscapeHtml, remarkMath] }}
     />
   );
 };

--- a/components/ui/message-input.tsx
+++ b/components/ui/message-input.tsx
@@ -1,5 +1,7 @@
 "use client";
 import remarkEscapeHtml from "@/lib/remark-escape-html";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import Markdown from "@/components/ui/markdown";
 import { PopoverArrow, PopoverBody, PopoverContent, PopoverRoot, PopoverTrigger } from "@/components/ui/popover";
 import { useClassProfiles } from "@/hooks/useClassProfiles";
@@ -710,8 +712,8 @@ export default function MessageInput(props: MessageInputProps) {
             }
           }, 0);
         }}
-        previewOptions={{ remarkPlugins: [remarkEscapeHtml] }}
         {...editorProps}
+        previewOptions={{ remarkPlugins: [remarkEscapeHtml, remarkMath], rehypePlugins: [rehypeKatex] }}
       />
       <MentionDropdown
         threads={mentionState.filteredThreads}

--- a/components/ui/message-input.tsx
+++ b/components/ui/message-input.tsx
@@ -1,4 +1,5 @@
 "use client";
+import remarkEscapeHtml from "@/lib/remark-escape-html";
 import Markdown from "@/components/ui/markdown";
 import { PopoverArrow, PopoverBody, PopoverContent, PopoverRoot, PopoverTrigger } from "@/components/ui/popover";
 import { useClassProfiles } from "@/hooks/useClassProfiles";
@@ -709,6 +710,7 @@ export default function MessageInput(props: MessageInputProps) {
             }
           }, 0);
         }}
+        previewOptions={{ remarkPlugins: [remarkEscapeHtml] }}
         {...editorProps}
       />
       <MentionDropdown

--- a/lib/remark-escape-html.ts
+++ b/lib/remark-escape-html.ts
@@ -1,0 +1,15 @@
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+
+/**
+ * Remark plugin that converts raw HTML nodes to text nodes so that
+ * angle-bracketed content (e.g. `<foobar>`) is displayed literally
+ * instead of being stripped or interpreted as HTML.
+ */
+export default function remarkEscapeHtml() {
+  return (tree: Root) => {
+    visit(tree, "html", (node) => {
+      (node as unknown as { type: string }).type = "text";
+    });
+  };
+}

--- a/lib/remark-escape-html.ts
+++ b/lib/remark-escape-html.ts
@@ -1,5 +1,20 @@
-import type { Root } from "mdast";
+import type { Html, Paragraph, Root, Text } from "mdast";
 import { visit } from "unist-util-visit";
+
+/**
+ * Parents where raw HTML is block-level; a lone text node is invalid here, so
+ * we wrap the escaped content in a paragraph.
+ */
+const FLOW_BLOCK_PARENT_TYPES = new Set<string>(["root", "blockquote", "listItem", "footnoteDefinition"]);
+
+function isFlowBlockParent(node: unknown): boolean {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    "type" in node &&
+    FLOW_BLOCK_PARENT_TYPES.has(String((node as { type: unknown }).type))
+  );
+}
 
 /**
  * Remark plugin that converts raw HTML nodes to text nodes so that
@@ -8,8 +23,18 @@ import { visit } from "unist-util-visit";
  */
 export default function remarkEscapeHtml() {
   return (tree: Root) => {
-    visit(tree, "html", (node) => {
-      (node as unknown as { type: string }).type = "text";
+    visit(tree, "html", (node, index, parent) => {
+      const htmlNode = node as Html;
+      if (parent && typeof index === "number" && isFlowBlockParent(parent)) {
+        const textNode: Text = { type: "text", value: htmlNode.value };
+        const paragraphNode: Paragraph = {
+          type: "paragraph",
+          children: [textNode]
+        };
+        parent.children.splice(index, 1, paragraphNode);
+      } else {
+        (node as unknown as { type: string }).type = "text";
+      }
     });
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When users type angle-bracketed content like `<foobar>` in markdown fields (grading comments, discussion posts, replies, etc.), the text inside the brackets is silently stripped and disappears from the rendered output. This happens because `react-markdown` parses `<foobar>` as an HTML node, which then gets removed by `rehype-sanitize` or by default behavior.

Fixes #646

## Solution

Created a new remark plugin (`lib/remark-escape-html.ts`) that converts raw HTML AST nodes to text nodes during markdown processing. This preserves angle-bracketed content as visible literal text instead of interpreting it as HTML.

Applied the plugin to **all** markdown rendering paths in the application:

| File | Change |
|------|--------|
| `lib/remark-escape-html.ts` | New remark plugin that converts `html` → `text` nodes |
| `components/ui/markdown.tsx` | Added plugin to shared Markdown component |
| `components/ui/markdown-file-preview.tsx` | Added plugin to file preview renderer |
| `components/ui/md-editor.tsx` | Added plugin to editor preview options |
| `components/ui/message-input.tsx` | Added plugin to MDEditor preview options |
| `components/help-queue/help-drawer.tsx` | Switched from bare `react-markdown` to shared `Markdown` component |
| `app/course/[course_id]/office-hours/page.tsx` | Switched from bare `react-markdown` to shared `Markdown` component |

## Testing

Manually tested in the discussion thread UI:
- Created a post with `Hello <world> this is a <test> message` — angle brackets render correctly
- Created a reply with `<div>`, `<span>`, `<script>`, `<foobar>` — all display as literal text
- Editor live preview also shows angle brackets correctly

[demo_html_tag_escaping.mp4](https://cursor.com/agents/bc-d0757ebe-ac03-4f7a-aba4-00edf6a46e35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_html_tag_escaping.mp4)
[Discussion post with HTML tags escaped and visible](https://cursor.com/agents/bc-d0757ebe-ac03-4f7a-aba4-00edf6a46e35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhtml_tags_escaped_discussion.webp)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0757ebe-ac03-4f7a-aba4-00edf6a46e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0757ebe-ac03-4f7a-aba4-00edf6a46e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced markdown rendering security. Raw HTML content in markdown is now properly escaped and displayed as plain text, preventing unintended HTML rendering across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->