### PR TITLE
Fix #533: allow decimal scores in gradebook number inputs

### DIFF
--- a/app/course/[course_id]/gradebook/whatIf.tsx
+++ b/app/course/[course_id]/gradebook/whatIf.tsx
@@ -126,7 +126,7 @@ function WhatIfScoreCell({
   }
   if (isShowingWhatIf) {
     if (whatIfVal?.what_if !== null && whatIfVal?.what_if !== undefined) {
-      scoreToShow = Math.round(whatIfVal?.what_if ?? 0);
+      scoreToShow = whatIfVal.what_if;
     } else {
       scoreToShow = "0";
     }

--- a/app/course/[course_id]/gradebook/whatIf.tsx
+++ b/app/course/[course_id]/gradebook/whatIf.tsx
@@ -74,6 +74,7 @@ function WhatIfScoreCell({
           minW="5em"
           autoFocus
           type="number"
+          step="any"
           value={whatIfVal?.what_if === undefined ? "" : whatIfVal.what_if}
           onChange={(e) => {
             const v = e.target.value === "" ? undefined : Number(e.target.value.trim());

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -267,6 +267,7 @@ function AddColumnDialog() {
                       valueAsNumber: true,
                       min: { value: 1, message: "Max Score must be at least 1" }
                     })}
+                    step="any"
                     placeholder="Max Score"
                   />
                   {errors.maxScore && (
@@ -487,6 +488,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                       valueAsNumber: true,
                       min: { value: 1, message: "Max Score must be at least 1" }
                     })}
+                    step="any"
                     placeholder="Max Score"
                   />
                   {errors.maxScore && (

--- a/app/course/[course_id]/manage/gradebook/overrideScoreForm.tsx
+++ b/app/course/[course_id]/manage/gradebook/overrideScoreForm.tsx
@@ -99,7 +99,8 @@ export function OverrideScoreForm({
         {!isAutoCalculated && (
           <HStack gap={2} align="stretch">
             <Field label="Score" errorText={errors.score?.message?.toString()} flexGrow={1}>
-              <Input type="number" step="any" {...register("score", { valueAsNumber: true })} />
+              {/* step after register: default step=1 blocks decimals (issue #533) */}
+              <Input type="number" {...register("score", { valueAsNumber: true })} step="any" />
             </Field>
             {renderer && (
               <Field label="New Score" flexGrow={0} flexShrink={1}>
@@ -141,8 +142,8 @@ export function OverrideScoreForm({
               <Field label="Score" errorText={errors.score_override?.message?.toString()} flex={1} minW="5em">
                 <Input
                   type="number"
-                  step="any"
                   {...register("score_override", { valueAsNumber: true })}
+                  step="any"
                   placeholder={studentGradebookColumn.score?.toString()}
                 />
               </Field>

--- a/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
+++ b/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
@@ -1,9 +1,20 @@
--- Gradebook batch RPC: skip no-op cell updates (reduces trigger churn) and keep
--- full clearing/archive/re-enqueue behavior from 20251124233922_extend-more-rpc-timeouts.sql.
+-- Fix gradebook recalculation flakiness caused by version-check deadlock.
 --
--- enqueue_gradebook_row_recalculation: when a row is already recalculating, send a follow-up
--- queue message but do not bump version (worker stability).
+-- Root cause: update_gradebook_rows_batch() updates gradebook_column_students,
+-- which fires row-level triggers that call enqueue_gradebook_row_recalculation().
+-- That function bumps the version in gradebook_row_recalc_state. The batch RPC
+-- then tries to clear the recalc state using the OLD expected_version, which no
+-- longer matches. Result: rows stay dirty/recalculating forever, scores stall.
+--
+-- Fix 1: Skip no-op updates (IS DISTINCT FROM) to reduce unnecessary trigger
+--         firing when values haven't changed.
+-- Fix 2: Clear the recalc state by (class_id, gradebook_id, student_id, is_private)
+--         without requiring version match. Since the edge function already computes
+--         ALL columns for a student in topological order, its results are always
+--         current. The version check was causing false negatives when triggers
+--         inside the same RPC bumped the version.
 
+-- Restore the original enqueue function (revert session-variable change)
 CREATE OR REPLACE FUNCTION public.enqueue_gradebook_row_recalculation(
   p_class_id bigint,
   p_gradebook_id bigint,
@@ -20,6 +31,7 @@ AS $$
 DECLARE
   row_message jsonb;
 BEGIN
+  -- Per-row advisory lock to avoid duplicate enqueues under concurrency
   PERFORM pg_advisory_xact_lock(
     hashtextextended(
       p_class_id::text || ':' || p_gradebook_id::text || ':' || p_student_id::text || ':' || p_is_private::text,
@@ -27,6 +39,11 @@ BEGIN
     )::bigint
   );
 
+  -- Gating rules against row-state table:
+  -- - If row is currently recalculating, send a new message (so the worker
+  --   re-processes with fresh data) but do NOT bump the version. The running
+  --   worker's expected_version must remain valid so its RPC update succeeds.
+  -- - Else if row is already dirty (and not recalculating), skip enqueue.
   IF EXISTS (
     SELECT 1 FROM public.gradebook_row_recalc_state s
     WHERE s.class_id = p_class_id
@@ -35,6 +52,9 @@ BEGIN
       AND s.is_private = p_is_private
       AND s.is_recalculating = true
   ) THEN
+    -- Row is currently being recalculated by an edge function worker.
+    -- Send a new message so the worker re-processes after its current batch,
+    -- but do NOT bump the version (the worker needs version stability).
     PERFORM pgmq_public.send(
       queue_name := 'gradebook_row_recalculate',
       message := jsonb_build_object(
@@ -69,6 +89,7 @@ BEGIN
     RETURN;
   END IF;
 
+  -- Normal case: row is idle — enqueue, mark dirty, and bump version.
   row_message := jsonb_build_object(
     'class_id', p_class_id,
     'gradebook_id', p_gradebook_id,
@@ -94,6 +115,7 @@ BEGIN
 END;
 $$;
 
+-- Updated batch RPC: IS DISTINCT FROM + unconditional state clearing
 CREATE OR REPLACE FUNCTION public.update_gradebook_rows_batch(p_batch_updates jsonb[])
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -127,6 +149,8 @@ BEGIN
       AND jsonb_typeof(su->'updates') = 'array'
       AND jsonb_array_length(su->'updates') > 0
   ),
+  -- Version check gates updates to prevent stale data from overwriting fresh data
+  -- when multiple workers process the same student concurrently.
   updates_with_context AS (
     SELECT
       sue.*,
@@ -145,6 +169,7 @@ BEGIN
         AND rs.version = sue.expected_version
     )
   ),
+  -- Only touch rows where at least one value actually differs
   updated_rows AS (
     UPDATE public.gradebook_column_students gcs
     SET
@@ -167,142 +192,61 @@ BEGIN
     RETURNING gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private, uwc.expected_version
   ),
   update_counts AS (
-    SELECT
-      class_id,
-      gradebook_id,
-      student_id,
-      is_private,
-      expected_version,
-      COUNT(*) AS updated_count
-    FROM updated_rows
-    GROUP BY class_id, gradebook_id, student_id, is_private, expected_version
+    SELECT class_id, gradebook_id, student_id, is_private, expected_version, COUNT(*) AS updated_count
+    FROM updated_rows GROUP BY class_id, gradebook_id, student_id, is_private, expected_version
   ),
   students_with_no_updates AS (
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id,
-      (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id,
-      (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version
     FROM unnest(p_batch_updates) AS su
-    WHERE (
-      su->'updates' IS NULL
-      OR jsonb_typeof(su->'updates') != 'array'
-      OR jsonb_array_length(su->'updates') = 0
-    )
+    WHERE (su->'updates' IS NULL OR jsonb_typeof(su->'updates') != 'array' OR jsonb_array_length(su->'updates') = 0)
     AND EXISTS (
       SELECT 1 FROM public.gradebook_row_recalc_state rs
-      WHERE rs.class_id = (su->>'class_id')::bigint
-        AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-        AND rs.student_id = (su->>'student_id')::uuid
-        AND rs.is_private = (su->>'is_private')::boolean
+      WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+        AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean
         AND rs.version = (su->>'expected_version')::bigint
     )
   ),
+  -- Clear recalc state for students where version matched (updates applied
+  -- or no updates needed). For version mismatches the state stays dirty so
+  -- the re-enqueue below can proceed.
   all_students_to_clear AS (
-    SELECT
-      class_id,
-      gradebook_id,
-      student_id,
-      is_private,
-      expected_version
-    FROM update_counts
-    UNION
-    SELECT
-      class_id,
-      gradebook_id,
-      student_id,
-      is_private,
-      expected_version
-    FROM students_with_no_updates
-    UNION
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id,
-      (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id,
-      (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version
     FROM unnest(p_batch_updates) AS su
     WHERE EXISTS (
       SELECT 1 FROM public.gradebook_row_recalc_state rs
-      WHERE rs.class_id = (su->>'class_id')::bigint
-        AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-        AND rs.student_id = (su->>'student_id')::uuid
-        AND rs.is_private = (su->>'is_private')::boolean
+      WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+        AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean
         AND rs.version = (su->>'expected_version')::bigint
     )
   ),
   cleared_rows AS (
-    UPDATE public.gradebook_row_recalc_state
-    SET
-      dirty = false,
-      is_recalculating = false,
-      updated_at = NOW()
-    FROM (
-      SELECT
-        astc.class_id,
-        astc.gradebook_id,
-        astc.student_id,
-        astc.is_private,
-        astc.expected_version
-      FROM all_students_to_clear astc
-      ORDER BY astc.class_id, astc.gradebook_id, astc.student_id, astc.is_private
-    ) ordered_astc
-    WHERE gradebook_row_recalc_state.class_id = ordered_astc.class_id
-      AND gradebook_row_recalc_state.gradebook_id = ordered_astc.gradebook_id
-      AND gradebook_row_recalc_state.student_id = ordered_astc.student_id
-      AND gradebook_row_recalc_state.is_private = ordered_astc.is_private
-      AND gradebook_row_recalc_state.version = ordered_astc.expected_version
-    RETURNING
-      gradebook_row_recalc_state.class_id,
-      gradebook_row_recalc_state.gradebook_id,
-      gradebook_row_recalc_state.student_id,
-      gradebook_row_recalc_state.is_private,
-      gradebook_row_recalc_state.dirty,
-      gradebook_row_recalc_state.is_recalculating,
-      gradebook_row_recalc_state.version
+    UPDATE public.gradebook_row_recalc_state rs
+    SET dirty = false, is_recalculating = false, updated_at = NOW()
+    FROM (SELECT * FROM all_students_to_clear ORDER BY class_id, gradebook_id, student_id, is_private) astc
+    WHERE rs.class_id = astc.class_id
+      AND rs.gradebook_id = astc.gradebook_id
+      AND rs.student_id = astc.student_id
+      AND rs.is_private = astc.is_private
+      AND rs.version = astc.expected_version
+    RETURNING rs.class_id, rs.gradebook_id, rs.student_id, rs.is_private, rs.dirty, rs.is_recalculating, rs.version
   ),
   student_results AS (
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id,
-      (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id,
-      (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version,
-      COALESCE(
-        (SELECT jsonb_agg(elem::text::bigint)
-         FROM jsonb_array_elements_text(su->'message_ids') AS elem),
-        '[]'::jsonb
-      ) AS message_ids,
+      COALESCE((SELECT jsonb_agg(elem::text::bigint) FROM jsonb_array_elements_text(su->'message_ids') AS elem), '[]'::jsonb) AS message_ids,
       COALESCE(uc.updated_count, 0) AS updated_count,
-      CASE
-        WHEN EXISTS (
-          SELECT 1 FROM public.gradebook_row_recalc_state rs
-          WHERE rs.class_id = (su->>'class_id')::bigint
-            AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-            AND rs.student_id = (su->>'student_id')::uuid
-            AND rs.is_private = (su->>'is_private')::boolean
-            AND rs.version = (su->>'expected_version')::bigint
-        ) THEN true
-        ELSE false
-      END AS version_matched,
-      CASE
-        WHEN EXISTS (
-          SELECT 1 FROM public.gradebook_row_recalc_state rs
-          WHERE rs.class_id = (su->>'class_id')::bigint
-            AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-            AND rs.student_id = (su->>'student_id')::uuid
-            AND rs.is_private = (su->>'is_private')::boolean
-            AND rs.version = (su->>'expected_version')::bigint
-        ) THEN true
-        ELSE false
-      END AS cleared
+      EXISTS (SELECT 1 FROM public.gradebook_row_recalc_state rs WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean AND rs.version = (su->>'expected_version')::bigint) AS version_matched,
+      EXISTS (SELECT 1 FROM cleared_rows cr WHERE cr.class_id = (su->>'class_id')::bigint AND cr.gradebook_id = (su->>'gradebook_id')::bigint AND cr.student_id = (su->>'student_id')::uuid AND cr.is_private = (su->>'is_private')::boolean) AS cleared
     FROM unnest(p_batch_updates) AS su
-    LEFT JOIN update_counts uc ON
-      uc.class_id = (su->>'class_id')::bigint
-      AND uc.gradebook_id = (su->>'gradebook_id')::bigint
-      AND uc.student_id = (su->>'student_id')::uuid
-      AND uc.is_private = (su->>'is_private')::boolean
+    LEFT JOIN update_counts uc ON uc.class_id = (su->>'class_id')::bigint AND uc.gradebook_id = (su->>'gradebook_id')::bigint AND uc.student_id = (su->>'student_id')::uuid AND uc.is_private = (su->>'is_private')::boolean
   ),
   debug_counts AS (
     SELECT
@@ -310,57 +254,23 @@ BEGIN
       (SELECT COUNT(*) FROM updates_with_context) AS version_matched_count_val,
       (SELECT COUNT(*) FROM updated_rows) AS updated_gcs_count_val,
       (SELECT COUNT(DISTINCT (class_id, gradebook_id, student_id, is_private)) FROM update_counts) AS unique_students_count_val,
-      (SELECT COUNT(*) FROM cleared_rows) AS cleared_state_count_val,
-      '[]'::jsonb AS cleared_rows_details
+      (SELECT COUNT(*) FROM cleared_rows) AS cleared_state_count_val
   ),
   final_results AS (
     SELECT
-      jsonb_agg(
-        jsonb_build_object(
-          'class_id', class_id,
-          'gradebook_id', gradebook_id,
-          'student_id', student_id,
-          'is_private', is_private,
-          'message_ids', message_ids,
-          'updated_count', updated_count,
-          'version_matched', version_matched,
-          'cleared', cleared
-        ) ORDER BY student_id
-      ) AS results_jsonb,
-      (SELECT expanded_count_val FROM debug_counts LIMIT 1) AS expanded_count_val,
-      (SELECT version_matched_count_val FROM debug_counts LIMIT 1) AS version_matched_count_val,
-      (SELECT updated_gcs_count_val FROM debug_counts LIMIT 1) AS updated_gcs_count_val,
-      (SELECT unique_students_count_val FROM debug_counts LIMIT 1) AS unique_students_count_val,
-      (SELECT cleared_state_count_val FROM debug_counts LIMIT 1) AS cleared_state_count_val,
-      (SELECT cleared_rows_details FROM debug_counts LIMIT 1) AS cleared_rows_details_val
+      jsonb_agg(jsonb_build_object('class_id', class_id, 'gradebook_id', gradebook_id, 'student_id', student_id, 'is_private', is_private, 'message_ids', message_ids, 'updated_count', updated_count, 'version_matched', version_matched, 'cleared', cleared) ORDER BY student_id) AS results_jsonb,
+      (SELECT expanded_count_val FROM debug_counts LIMIT 1) AS ecv,
+      (SELECT version_matched_count_val FROM debug_counts LIMIT 1) AS vmcv,
+      (SELECT updated_gcs_count_val FROM debug_counts LIMIT 1) AS ugcv,
+      (SELECT unique_students_count_val FROM debug_counts LIMIT 1) AS uscv,
+      (SELECT cleared_state_count_val FROM debug_counts LIMIT 1) AS cscv
     FROM student_results
   )
-  SELECT
-    results_jsonb,
-    expanded_count_val,
-    version_matched_count_val,
-    updated_gcs_count_val,
-    unique_students_count_val,
-    cleared_state_count_val,
-    cleared_rows_details_val
-  INTO
-    results,
-    expanded_count,
-    version_matched_count,
-    updated_gcs_count,
-    unique_students_count,
-    cleared_state_count,
-    cleared_details
+  SELECT results_jsonb, ecv, vmcv, ugcv, uscv, cscv
+  INTO results, expanded_count, version_matched_count, updated_gcs_count, unique_students_count, cleared_state_count
   FROM final_results;
 
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 1: Expanded % update rows from input', expanded_count;
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 2: % rows matched version check (will be updated)', version_matched_count;
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 3: Updated % gradebook_column_students rows', updated_gcs_count;
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 4: Found % unique students with updates, preparing to clear recalc state', unique_students_count;
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 5: Cleared recalc state for % rows', cleared_state_count;
-
-  RAISE NOTICE '[update_gradebook_rows_batch] Step 6: Built results for % students', jsonb_array_length(results);
-
+  -- Archive all messages
   SELECT ARRAY_AGG(DISTINCT msg_ids.msg_id) INTO message_ids_to_archive
   FROM (
     SELECT UNNEST(
@@ -373,60 +283,11 @@ BEGIN
   ) AS msg_ids;
 
   IF message_ids_to_archive IS NOT NULL AND array_length(message_ids_to_archive, 1) > 0 THEN
-    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: Archiving % messages (all messages from batch)', array_length(message_ids_to_archive, 1);
-    FOREACH msg_id IN ARRAY message_ids_to_archive
-    LOOP
+    FOREACH msg_id IN ARRAY message_ids_to_archive LOOP
       PERFORM pgmq_public.archive('gradebook_row_recalculate', msg_id);
     END LOOP;
-    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: Archived % messages', array_length(message_ids_to_archive, 1);
-  ELSE
-    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: No messages to archive';
   END IF;
 
-  SELECT COALESCE(
-    jsonb_agg(
-      jsonb_build_object(
-        'class_id', (sr->>'class_id')::bigint,
-        'gradebook_id', (sr->>'gradebook_id')::bigint,
-        'student_id', sr->>'student_id',
-        'is_private', (sr->>'is_private')::boolean
-      )
-    ),
-    '[]'::jsonb
-  ) INTO rows_to_reenqueue
-  FROM jsonb_array_elements(results) AS sr
-  WHERE (sr->>'version_matched')::boolean = false;
-
-  IF rows_to_reenqueue IS NOT NULL AND jsonb_array_length(rows_to_reenqueue) > 0 THEN
-    RAISE NOTICE '[update_gradebook_rows_batch] Step 8: Re-enqueueing % rows with version mismatches', jsonb_array_length(rows_to_reenqueue);
-    SELECT ARRAY_AGG(
-      jsonb_build_object(
-        'class_id', (sr->>'class_id')::bigint,
-        'gradebook_id', (sr->>'gradebook_id')::bigint,
-        'student_id', sr->>'student_id',
-        'is_private', (sr->>'is_private')::boolean
-      )
-    ) INTO messages_to_send
-    FROM jsonb_array_elements(rows_to_reenqueue) AS sr;
-
-    IF messages_to_send IS NOT NULL AND array_length(messages_to_send, 1) > 0 THEN
-      PERFORM pgmq_public.send_batch(
-        queue_name := 'gradebook_row_recalculate',
-        messages := messages_to_send
-      );
-      RAISE NOTICE '[update_gradebook_rows_batch] Step 8: Re-enqueued % messages', array_length(messages_to_send, 1);
-    END IF;
-  END IF;
-
-  RETURN jsonb_build_object(
-    'results', results,
-    'expanded_count', expanded_count,
-    'version_matched_count', version_matched_count,
-    'updated_gcs_count', updated_gcs_count,
-    'unique_students_count', unique_students_count,
-    'cleared_state_count', cleared_state_count
-  );
+  RETURN jsonb_build_object('results', results, 'expanded_count', expanded_count, 'version_matched_count', version_matched_count, 'updated_gcs_count', updated_gcs_count, 'unique_students_count', unique_students_count, 'cleared_state_count', cleared_state_count);
 END;
 $$;
-
-COMMENT ON FUNCTION public.update_gradebook_rows_batch(jsonb[]) IS 'Batch updates gradebook rows and clears recalculation state. Skips no-op cell updates (IS DISTINCT FROM).';

--- a/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
+++ b/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
@@ -1,20 +1,18 @@
--- Fix gradebook recalculation flakiness caused by version-check deadlock.
+-- Issue #533: Gradebook recalculation flakiness / stuck "recalculating" state.
 --
 -- Root cause: update_gradebook_rows_batch() updates gradebook_column_students,
--- which fires row-level triggers that call enqueue_gradebook_row_recalculation().
--- That function bumps the version in gradebook_row_recalc_state. The batch RPC
--- then tries to clear the recalc state using the OLD expected_version, which no
--- longer matches. Result: rows stay dirty/recalculating forever, scores stall.
+-- which fires triggers that call enqueue_gradebook_row_recalculation() and can
+-- bump gradebook_row_recalc_state.version before the batch clears state. The
+-- clear step used expected_version, so it failed to clear; rows stayed dirty.
 --
--- Fix 1: Skip no-op updates (IS DISTINCT FROM) to reduce unnecessary trigger
---         firing when values haven't changed.
--- Fix 2: Clear the recalc state by (class_id, gradebook_id, student_id, is_private)
---         without requiring version match. Since the edge function already computes
---         ALL columns for a student in topological order, its results are always
---         current. The version check was causing false negatives when triggers
---         inside the same RPC bumped the version.
+-- Fix 1: Skip no-op updates (IS DISTINCT FROM) so identical writes do not fire
+--        triggers unnecessarily.
+-- Fix 2: Clear recalc state by (class_id, gradebook_id, student_id, is_private)
+--        without requiring version = expected_version after updates (worker
+--        output for the batch is authoritative for that pass).
+-- Fix 3: Report version_matched/cleared from cleared_rows (actual clears), not
+--        from a post-hoc version equality check that can be false after triggers.
 
--- Restore the original enqueue function (revert session-variable change)
 CREATE OR REPLACE FUNCTION public.enqueue_gradebook_row_recalculation(
   p_class_id bigint,
   p_gradebook_id bigint,
@@ -31,7 +29,6 @@ AS $$
 DECLARE
   row_message jsonb;
 BEGIN
-  -- Per-row advisory lock to avoid duplicate enqueues under concurrency
   PERFORM pg_advisory_xact_lock(
     hashtextextended(
       p_class_id::text || ':' || p_gradebook_id::text || ':' || p_student_id::text || ':' || p_is_private::text,
@@ -39,11 +36,6 @@ BEGIN
     )::bigint
   );
 
-  -- Gating rules against row-state table:
-  -- - If row is currently recalculating, send a new message (so the worker
-  --   re-processes with fresh data) but do NOT bump the version. The running
-  --   worker's expected_version must remain valid so its RPC update succeeds.
-  -- - Else if row is already dirty (and not recalculating), skip enqueue.
   IF EXISTS (
     SELECT 1 FROM public.gradebook_row_recalc_state s
     WHERE s.class_id = p_class_id
@@ -52,9 +44,6 @@ BEGIN
       AND s.is_private = p_is_private
       AND s.is_recalculating = true
   ) THEN
-    -- Row is currently being recalculated by an edge function worker.
-    -- Send a new message so the worker re-processes after its current batch,
-    -- but do NOT bump the version (the worker needs version stability).
     PERFORM pgmq_public.send(
       queue_name := 'gradebook_row_recalculate',
       message := jsonb_build_object(
@@ -89,7 +78,6 @@ BEGIN
     RETURN;
   END IF;
 
-  -- Normal case: row is idle — enqueue, mark dirty, and bump version.
   row_message := jsonb_build_object(
     'class_id', p_class_id,
     'gradebook_id', p_gradebook_id,
@@ -115,7 +103,6 @@ BEGIN
 END;
 $$;
 
--- Updated batch RPC: IS DISTINCT FROM + unconditional state clearing
 CREATE OR REPLACE FUNCTION public.update_gradebook_rows_batch(p_batch_updates jsonb[])
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -149,8 +136,6 @@ BEGIN
       AND jsonb_typeof(su->'updates') = 'array'
       AND jsonb_array_length(su->'updates') > 0
   ),
-  -- Version check gates updates to prevent stale data from overwriting fresh data
-  -- when multiple workers process the same student concurrently.
   updates_with_context AS (
     SELECT
       sue.*,
@@ -169,7 +154,6 @@ BEGIN
         AND rs.version = sue.expected_version
     )
   ),
-  -- Only touch rows where at least one value actually differs
   updated_rows AS (
     UPDATE public.gradebook_column_students gcs
     SET
@@ -192,61 +176,132 @@ BEGIN
     RETURNING gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private, uwc.expected_version
   ),
   update_counts AS (
-    SELECT class_id, gradebook_id, student_id, is_private, expected_version, COUNT(*) AS updated_count
-    FROM updated_rows GROUP BY class_id, gradebook_id, student_id, is_private, expected_version
+    SELECT
+      class_id,
+      gradebook_id,
+      student_id,
+      is_private,
+      expected_version,
+      COUNT(*) AS updated_count
+    FROM updated_rows
+    GROUP BY class_id, gradebook_id, student_id, is_private, expected_version
   ),
   students_with_no_updates AS (
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id,
+      (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id,
+      (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version
     FROM unnest(p_batch_updates) AS su
-    WHERE (su->'updates' IS NULL OR jsonb_typeof(su->'updates') != 'array' OR jsonb_array_length(su->'updates') = 0)
+    WHERE (
+      su->'updates' IS NULL
+      OR jsonb_typeof(su->'updates') != 'array'
+      OR jsonb_array_length(su->'updates') = 0
+    )
     AND EXISTS (
       SELECT 1 FROM public.gradebook_row_recalc_state rs
-      WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-        AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean
+      WHERE rs.class_id = (su->>'class_id')::bigint
+        AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+        AND rs.student_id = (su->>'student_id')::uuid
+        AND rs.is_private = (su->>'is_private')::boolean
         AND rs.version = (su->>'expected_version')::bigint
     )
   ),
-  -- Clear recalc state for students where version matched (updates applied
-  -- or no updates needed). For version mismatches the state stays dirty so
-  -- the re-enqueue below can proceed.
   all_students_to_clear AS (
+    SELECT
+      class_id,
+      gradebook_id,
+      student_id,
+      is_private,
+      expected_version
+    FROM update_counts
+    UNION
+    SELECT
+      class_id,
+      gradebook_id,
+      student_id,
+      is_private,
+      expected_version
+    FROM students_with_no_updates
+    UNION
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id,
+      (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id,
+      (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version
     FROM unnest(p_batch_updates) AS su
     WHERE EXISTS (
       SELECT 1 FROM public.gradebook_row_recalc_state rs
-      WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint
-        AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean
+      WHERE rs.class_id = (su->>'class_id')::bigint
+        AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+        AND rs.student_id = (su->>'student_id')::uuid
+        AND rs.is_private = (su->>'is_private')::boolean
         AND rs.version = (su->>'expected_version')::bigint
     )
   ),
   cleared_rows AS (
-    UPDATE public.gradebook_row_recalc_state rs
-    SET dirty = false, is_recalculating = false, updated_at = NOW()
-    FROM (SELECT * FROM all_students_to_clear ORDER BY class_id, gradebook_id, student_id, is_private) astc
-    WHERE rs.class_id = astc.class_id
-      AND rs.gradebook_id = astc.gradebook_id
-      AND rs.student_id = astc.student_id
-      AND rs.is_private = astc.is_private
-      AND rs.version = astc.expected_version
-    RETURNING rs.class_id, rs.gradebook_id, rs.student_id, rs.is_private, rs.dirty, rs.is_recalculating, rs.version
+    UPDATE public.gradebook_row_recalc_state grs
+    SET
+      dirty = false,
+      is_recalculating = false,
+      updated_at = NOW()
+    FROM (
+      SELECT
+        astc.class_id,
+        astc.gradebook_id,
+        astc.student_id,
+        astc.is_private
+      FROM all_students_to_clear astc
+      ORDER BY astc.class_id, astc.gradebook_id, astc.student_id, astc.is_private
+    ) ordered_astc
+    WHERE grs.class_id = ordered_astc.class_id
+      AND grs.gradebook_id = ordered_astc.gradebook_id
+      AND grs.student_id = ordered_astc.student_id
+      AND grs.is_private = ordered_astc.is_private
+    RETURNING
+      grs.class_id,
+      grs.gradebook_id,
+      grs.student_id,
+      grs.is_private,
+      grs.dirty,
+      grs.is_recalculating,
+      grs.version
   ),
   student_results AS (
     SELECT DISTINCT
-      (su->>'class_id')::bigint AS class_id, (su->>'gradebook_id')::bigint AS gradebook_id,
-      (su->>'student_id')::uuid AS student_id, (su->>'is_private')::boolean AS is_private,
+      (su->>'class_id')::bigint AS class_id,
+      (su->>'gradebook_id')::bigint AS gradebook_id,
+      (su->>'student_id')::uuid AS student_id,
+      (su->>'is_private')::boolean AS is_private,
       (su->>'expected_version')::bigint AS expected_version,
-      COALESCE((SELECT jsonb_agg(elem::text::bigint) FROM jsonb_array_elements_text(su->'message_ids') AS elem), '[]'::jsonb) AS message_ids,
+      COALESCE(
+        (SELECT jsonb_agg(elem::text::bigint)
+         FROM jsonb_array_elements_text(su->'message_ids') AS elem),
+        '[]'::jsonb
+      ) AS message_ids,
       COALESCE(uc.updated_count, 0) AS updated_count,
-      EXISTS (SELECT 1 FROM public.gradebook_row_recalc_state rs WHERE rs.class_id = (su->>'class_id')::bigint AND rs.gradebook_id = (su->>'gradebook_id')::bigint AND rs.student_id = (su->>'student_id')::uuid AND rs.is_private = (su->>'is_private')::boolean AND rs.version = (su->>'expected_version')::bigint) AS version_matched,
-      EXISTS (SELECT 1 FROM cleared_rows cr WHERE cr.class_id = (su->>'class_id')::bigint AND cr.gradebook_id = (su->>'gradebook_id')::bigint AND cr.student_id = (su->>'student_id')::uuid AND cr.is_private = (su->>'is_private')::boolean) AS cleared
+      EXISTS (
+        SELECT 1 FROM cleared_rows cr
+        WHERE cr.class_id = (su->>'class_id')::bigint
+          AND cr.gradebook_id = (su->>'gradebook_id')::bigint
+          AND cr.student_id = (su->>'student_id')::uuid
+          AND cr.is_private = (su->>'is_private')::boolean
+      ) AS version_matched,
+      EXISTS (
+        SELECT 1 FROM cleared_rows cr
+        WHERE cr.class_id = (su->>'class_id')::bigint
+          AND cr.gradebook_id = (su->>'gradebook_id')::bigint
+          AND cr.student_id = (su->>'student_id')::uuid
+          AND cr.is_private = (su->>'is_private')::boolean
+      ) AS cleared
     FROM unnest(p_batch_updates) AS su
-    LEFT JOIN update_counts uc ON uc.class_id = (su->>'class_id')::bigint AND uc.gradebook_id = (su->>'gradebook_id')::bigint AND uc.student_id = (su->>'student_id')::uuid AND uc.is_private = (su->>'is_private')::boolean
+    LEFT JOIN update_counts uc ON
+      uc.class_id = (su->>'class_id')::bigint
+      AND uc.gradebook_id = (su->>'gradebook_id')::bigint
+      AND uc.student_id = (su->>'student_id')::uuid
+      AND uc.is_private = (su->>'is_private')::boolean
   ),
   debug_counts AS (
     SELECT
@@ -254,23 +309,57 @@ BEGIN
       (SELECT COUNT(*) FROM updates_with_context) AS version_matched_count_val,
       (SELECT COUNT(*) FROM updated_rows) AS updated_gcs_count_val,
       (SELECT COUNT(DISTINCT (class_id, gradebook_id, student_id, is_private)) FROM update_counts) AS unique_students_count_val,
-      (SELECT COUNT(*) FROM cleared_rows) AS cleared_state_count_val
+      (SELECT COUNT(*) FROM cleared_rows) AS cleared_state_count_val,
+      '[]'::jsonb AS cleared_rows_details
   ),
   final_results AS (
     SELECT
-      jsonb_agg(jsonb_build_object('class_id', class_id, 'gradebook_id', gradebook_id, 'student_id', student_id, 'is_private', is_private, 'message_ids', message_ids, 'updated_count', updated_count, 'version_matched', version_matched, 'cleared', cleared) ORDER BY student_id) AS results_jsonb,
-      (SELECT expanded_count_val FROM debug_counts LIMIT 1) AS ecv,
-      (SELECT version_matched_count_val FROM debug_counts LIMIT 1) AS vmcv,
-      (SELECT updated_gcs_count_val FROM debug_counts LIMIT 1) AS ugcv,
-      (SELECT unique_students_count_val FROM debug_counts LIMIT 1) AS uscv,
-      (SELECT cleared_state_count_val FROM debug_counts LIMIT 1) AS cscv
+      jsonb_agg(
+        jsonb_build_object(
+          'class_id', class_id,
+          'gradebook_id', gradebook_id,
+          'student_id', student_id,
+          'is_private', is_private,
+          'message_ids', message_ids,
+          'updated_count', updated_count,
+          'version_matched', version_matched,
+          'cleared', cleared
+        ) ORDER BY student_id
+      ) AS results_jsonb,
+      (SELECT expanded_count_val FROM debug_counts LIMIT 1) AS expanded_count_val,
+      (SELECT version_matched_count_val FROM debug_counts LIMIT 1) AS version_matched_count_val,
+      (SELECT updated_gcs_count_val FROM debug_counts LIMIT 1) AS updated_gcs_count_val,
+      (SELECT unique_students_count_val FROM debug_counts LIMIT 1) AS unique_students_count_val,
+      (SELECT cleared_state_count_val FROM debug_counts LIMIT 1) AS cleared_state_count_val,
+      (SELECT cleared_rows_details FROM debug_counts LIMIT 1) AS cleared_rows_details_val
     FROM student_results
   )
-  SELECT results_jsonb, ecv, vmcv, ugcv, uscv, cscv
-  INTO results, expanded_count, version_matched_count, updated_gcs_count, unique_students_count, cleared_state_count
+  SELECT
+    results_jsonb,
+    expanded_count_val,
+    version_matched_count_val,
+    updated_gcs_count_val,
+    unique_students_count_val,
+    cleared_state_count_val,
+    cleared_rows_details_val
+  INTO
+    results,
+    expanded_count,
+    version_matched_count,
+    updated_gcs_count,
+    unique_students_count,
+    cleared_state_count,
+    cleared_details
   FROM final_results;
 
-  -- Archive all messages
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 1: Expanded % update rows from input', expanded_count;
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 2: % rows matched version check (will be updated)', version_matched_count;
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 3: Updated % gradebook_column_students rows', updated_gcs_count;
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 4: Found % unique students with updates, preparing to clear recalc state', unique_students_count;
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 5: Cleared recalc state for % rows', cleared_state_count;
+
+  RAISE NOTICE '[update_gradebook_rows_batch] Step 6: Built results for % students', jsonb_array_length(results);
+
   SELECT ARRAY_AGG(DISTINCT msg_ids.msg_id) INTO message_ids_to_archive
   FROM (
     SELECT UNNEST(
@@ -283,11 +372,61 @@ BEGIN
   ) AS msg_ids;
 
   IF message_ids_to_archive IS NOT NULL AND array_length(message_ids_to_archive, 1) > 0 THEN
-    FOREACH msg_id IN ARRAY message_ids_to_archive LOOP
+    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: Archiving % messages (all messages from batch)', array_length(message_ids_to_archive, 1);
+    FOREACH msg_id IN ARRAY message_ids_to_archive
+    LOOP
       PERFORM pgmq_public.archive('gradebook_row_recalculate', msg_id);
     END LOOP;
+    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: Archived % messages', array_length(message_ids_to_archive, 1);
+  ELSE
+    RAISE NOTICE '[update_gradebook_rows_batch] Step 7: No messages to archive';
   END IF;
 
-  RETURN jsonb_build_object('results', results, 'expanded_count', expanded_count, 'version_matched_count', version_matched_count, 'updated_gcs_count', updated_gcs_count, 'unique_students_count', unique_students_count, 'cleared_state_count', cleared_state_count);
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'class_id', (sr->>'class_id')::bigint,
+        'gradebook_id', (sr->>'gradebook_id')::bigint,
+        'student_id', sr->>'student_id',
+        'is_private', (sr->>'is_private')::boolean
+      )
+    ),
+    '[]'::jsonb
+  ) INTO rows_to_reenqueue
+  FROM jsonb_array_elements(results) AS sr
+  WHERE (sr->>'version_matched')::boolean = false;
+
+  IF rows_to_reenqueue IS NOT NULL AND jsonb_array_length(rows_to_reenqueue) > 0 THEN
+    RAISE NOTICE '[update_gradebook_rows_batch] Step 8: Re-enqueueing % rows with version mismatches', jsonb_array_length(rows_to_reenqueue);
+    SELECT ARRAY_AGG(
+      jsonb_build_object(
+        'class_id', (sr->>'class_id')::bigint,
+        'gradebook_id', (sr->>'gradebook_id')::bigint,
+        'student_id', sr->>'student_id',
+        'is_private', (sr->>'is_private')::boolean
+      )
+    ) INTO messages_to_send
+    FROM jsonb_array_elements(rows_to_reenqueue) AS sr;
+
+    IF messages_to_send IS NOT NULL AND array_length(messages_to_send, 1) > 0 THEN
+      PERFORM pgmq_public.send_batch(
+        queue_name := 'gradebook_row_recalculate',
+        messages := messages_to_send
+      );
+      RAISE NOTICE '[update_gradebook_rows_batch] Step 8: Re-enqueued % messages', array_length(messages_to_send, 1);
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'results', results,
+    'expanded_count', expanded_count,
+    'version_matched_count', version_matched_count,
+    'updated_gcs_count', updated_gcs_count,
+    'unique_students_count', unique_students_count,
+    'cleared_state_count', cleared_state_count
+  );
 END;
 $$;
+
+COMMENT ON FUNCTION public.update_gradebook_rows_batch(jsonb[]) IS
+  'Batch updates gradebook rows and clears recalculation state. Issue #533: skip no-op column updates; clear state by student row without stale version match; result flags reflect actual clears.';

--- a/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
+++ b/supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql
@@ -1,17 +1,8 @@
--- Issue #533: Gradebook recalculation flakiness / stuck "recalculating" state.
+-- Gradebook batch RPC: skip no-op cell updates (reduces trigger churn) and keep
+-- full clearing/archive/re-enqueue behavior from 20251124233922_extend-more-rpc-timeouts.sql.
 --
--- Root cause: update_gradebook_rows_batch() updates gradebook_column_students,
--- which fires triggers that call enqueue_gradebook_row_recalculation() and can
--- bump gradebook_row_recalc_state.version before the batch clears state. The
--- clear step used expected_version, so it failed to clear; rows stayed dirty.
---
--- Fix 1: Skip no-op updates (IS DISTINCT FROM) so identical writes do not fire
---        triggers unnecessarily.
--- Fix 2: Clear recalc state by (class_id, gradebook_id, student_id, is_private)
---        without requiring version = expected_version after updates (worker
---        output for the batch is authoritative for that pass).
--- Fix 3: Report version_matched/cleared from cleared_rows (actual clears), not
---        from a post-hoc version equality check that can be false after triggers.
+-- enqueue_gradebook_row_recalculation: when a row is already recalculating, send a follow-up
+-- queue message but do not bump version (worker stability).
 
 CREATE OR REPLACE FUNCTION public.enqueue_gradebook_row_recalculation(
   p_class_id bigint,
@@ -242,7 +233,7 @@ BEGIN
     )
   ),
   cleared_rows AS (
-    UPDATE public.gradebook_row_recalc_state grs
+    UPDATE public.gradebook_row_recalc_state
     SET
       dirty = false,
       is_recalculating = false,
@@ -252,22 +243,24 @@ BEGIN
         astc.class_id,
         astc.gradebook_id,
         astc.student_id,
-        astc.is_private
+        astc.is_private,
+        astc.expected_version
       FROM all_students_to_clear astc
       ORDER BY astc.class_id, astc.gradebook_id, astc.student_id, astc.is_private
     ) ordered_astc
-    WHERE grs.class_id = ordered_astc.class_id
-      AND grs.gradebook_id = ordered_astc.gradebook_id
-      AND grs.student_id = ordered_astc.student_id
-      AND grs.is_private = ordered_astc.is_private
+    WHERE gradebook_row_recalc_state.class_id = ordered_astc.class_id
+      AND gradebook_row_recalc_state.gradebook_id = ordered_astc.gradebook_id
+      AND gradebook_row_recalc_state.student_id = ordered_astc.student_id
+      AND gradebook_row_recalc_state.is_private = ordered_astc.is_private
+      AND gradebook_row_recalc_state.version = ordered_astc.expected_version
     RETURNING
-      grs.class_id,
-      grs.gradebook_id,
-      grs.student_id,
-      grs.is_private,
-      grs.dirty,
-      grs.is_recalculating,
-      grs.version
+      gradebook_row_recalc_state.class_id,
+      gradebook_row_recalc_state.gradebook_id,
+      gradebook_row_recalc_state.student_id,
+      gradebook_row_recalc_state.is_private,
+      gradebook_row_recalc_state.dirty,
+      gradebook_row_recalc_state.is_recalculating,
+      gradebook_row_recalc_state.version
   ),
   student_results AS (
     SELECT DISTINCT
@@ -282,20 +275,28 @@ BEGIN
         '[]'::jsonb
       ) AS message_ids,
       COALESCE(uc.updated_count, 0) AS updated_count,
-      EXISTS (
-        SELECT 1 FROM cleared_rows cr
-        WHERE cr.class_id = (su->>'class_id')::bigint
-          AND cr.gradebook_id = (su->>'gradebook_id')::bigint
-          AND cr.student_id = (su->>'student_id')::uuid
-          AND cr.is_private = (su->>'is_private')::boolean
-      ) AS version_matched,
-      EXISTS (
-        SELECT 1 FROM cleared_rows cr
-        WHERE cr.class_id = (su->>'class_id')::bigint
-          AND cr.gradebook_id = (su->>'gradebook_id')::bigint
-          AND cr.student_id = (su->>'student_id')::uuid
-          AND cr.is_private = (su->>'is_private')::boolean
-      ) AS cleared
+      CASE
+        WHEN EXISTS (
+          SELECT 1 FROM public.gradebook_row_recalc_state rs
+          WHERE rs.class_id = (su->>'class_id')::bigint
+            AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+            AND rs.student_id = (su->>'student_id')::uuid
+            AND rs.is_private = (su->>'is_private')::boolean
+            AND rs.version = (su->>'expected_version')::bigint
+        ) THEN true
+        ELSE false
+      END AS version_matched,
+      CASE
+        WHEN EXISTS (
+          SELECT 1 FROM public.gradebook_row_recalc_state rs
+          WHERE rs.class_id = (su->>'class_id')::bigint
+            AND rs.gradebook_id = (su->>'gradebook_id')::bigint
+            AND rs.student_id = (su->>'student_id')::uuid
+            AND rs.is_private = (su->>'is_private')::boolean
+            AND rs.version = (su->>'expected_version')::bigint
+        ) THEN true
+        ELSE false
+      END AS cleared
     FROM unnest(p_batch_updates) AS su
     LEFT JOIN update_counts uc ON
       uc.class_id = (su->>'class_id')::bigint
@@ -428,5 +429,4 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.update_gradebook_rows_batch(jsonb[]) IS
-  'Batch updates gradebook rows and clears recalculation state. Issue #533: skip no-op column updates; clear state by student row without stale version match; result flags reflect actual clears.';
+COMMENT ON FUNCTION public.update_gradebook_rows_batch(jsonb[]) IS 'Batch updates gradebook rows and clears recalculation state. Skips no-op cell updates (IS DISTINCT FROM).';

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -446,6 +446,38 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await waitForVirtualizerIdle(page);
   });
 
+  test("Issue #533: gradebook recalc state is not stuck dirty/recalculating after scores settle", async () => {
+    const { data: gradebook, error: gradebookError } = await supabase
+      .from("gradebooks")
+      .select("id")
+      .eq("class_id", course.id)
+      .single();
+    if (gradebookError || !gradebook) {
+      throw new Error(`Failed to load gradebook: ${gradebookError?.message}`);
+    }
+
+    await expect(async () => {
+      const { data, error } = await supabase
+        .from("gradebook_row_recalc_state")
+        .select("student_id,dirty,is_recalculating")
+        .eq("class_id", course.id)
+        .eq("gradebook_id", gradebook.id)
+        .in(
+          "student_id",
+          students.map((s) => s.private_profile_id)
+        );
+      if (error) {
+        throw new Error(error.message);
+      }
+      for (const student of students) {
+        const row = (data ?? []).find((r) => r.student_id === student.private_profile_id);
+        if (!row) continue;
+        expect(row.dirty, `dirty for ${student.private_profile_id}`).toBe(false);
+        expect(row.is_recalculating, `is_recalculating for ${student.private_profile_id}`).toBe(false);
+      }
+    }).toPass({ timeout: 120_000 });
+  });
+
   test("Instructors can view comprehensive gradebook with real data", async ({ page }) => {
     // Verify the gradebook loads with all components
     await expect(page.getByText("Student Name")).toBeVisible();

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -446,36 +446,17 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await waitForVirtualizerIdle(page);
   });
 
-  test("Issue #533: gradebook recalc state is not stuck dirty/recalculating after scores settle", async () => {
-    const { data: gradebook, error: gradebookError } = await supabase
-      .from("gradebooks")
-      .select("id")
-      .eq("class_id", course.id)
-      .single();
-    if (gradebookError || !gradebook) {
-      throw new Error(`Failed to load gradebook: ${gradebookError?.message}`);
-    }
-
-    await expect(async () => {
-      const { data, error } = await supabase
-        .from("gradebook_row_recalc_state")
-        .select("student_id,dirty,is_recalculating")
-        .eq("class_id", course.id)
-        .eq("gradebook_id", gradebook.id)
-        .in(
-          "student_id",
-          students.map((s) => s.private_profile_id)
-        );
-      if (error) {
-        throw new Error(error.message);
-      }
-      for (const student of students) {
-        const row = (data ?? []).find((r) => r.student_id === student.private_profile_id);
-        if (!row) continue;
-        expect(row.dirty, `dirty for ${student.private_profile_id}`).toBe(false);
-        expect(row.is_recalculating, `is_recalculating for ${student.private_profile_id}`).toBe(false);
-      }
-    }).toPass({ timeout: 120_000 });
+  test("Issue #533: instructor can enter a decimal score in a manual gradebook cell", async ({ page }) => {
+    const studentName = students[0].private_profile_name;
+    await waitForVirtualizerIdle(page);
+    const getPartCell = () => getGridcellInRow(page, studentName, "Participation");
+    const partCell = await waitForStableLocator(page, getPartCell);
+    await partCell.click();
+    const scoreInput = page.locator('input[name="score"]');
+    await scoreInput.fill("50.5");
+    await expect(scoreInput).toHaveValue("50.5");
+    await page.getByRole("button", { name: /^Update$/ }).click();
+    await expect(partCell).toHaveText(/50\.5/);
   });
 
   test("Instructors can view comprehensive gradebook with real data", async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

[GitHub #533](https://github.com/pawtograder/platform/issues/533): instructors could not enter floating-point values in gradebook cells (e.g. `50.5`); the browser reported a validation error.

## Root cause

For `input type="number"`, the HTML default is **`step="1"`**, which **only allows integers** unless the step is `any` or a fractional step. `react-hook-form`’s `register()` spread can also **override** a `step` prop if `step` is placed before `{...register(...)}`.

## Fix

- **`overrideScoreForm.tsx`**: place `step="any"` **after** `{...register(...)}` for score and score override so decimals validate and submit correctly.
- **`whatIf.tsx`**: add `step="any"` to the What If numeric input.
- **`gradebookTable.tsx`**: add `step="any"` to Add/Edit column **Max Score** inputs.

## E2E

Opens **Participation**, enters `50.5`, and asserts the cell shows the decimal.

## Note on DB

No migration changes for #533. `supabase/migrations/20260327000000_fix_gradebook_noop_updates.sql` is left **as on `staging`** (earlier mistaken recalc/RPC edits on this branch were reverted).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80f0c692-0c14-418c-b8a6-9b6983c8f466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80f0c692-0c14-418c-b8a6-9b6983c8f466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gradebook numeric inputs now accept and preserve decimal values (step="any") across: the "What If" editor (no longer rounds displayed values), add/edit column dialogs, and manual score overrides—allowing instructors to enter and view precise scores (e.g., 50.5).

* **Tests**
  * Added an end-to-end test validating decimal score entry, update, and display in the gradebook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->