### PR TITLE
Fix auto-recalculate of submission grade totals when a rubric check score changes

### DIFF
--- a/supabase/migrations/20260328000000_fix_rubric_check_points_recompute.sql
+++ b/supabase/migrations/20260328000000_fix_rubric_check_points_recompute.sql
@@ -39,6 +39,7 @@ BEGIN
         WHERE rubric_check_id = NEW.id AND deleted_at IS NULL
       ) AS subq
       WHERE subq.submission_review_id IS NOT NULL
+      ORDER BY subq.submission_review_id
     LOOP
       PERFORM public._submission_review_recompute_scores(v_review_id);
     END LOOP;

--- a/supabase/migrations/20260328000000_fix_rubric_check_points_recompute.sql
+++ b/supabase/migrations/20260328000000_fix_rubric_check_points_recompute.sql
@@ -1,0 +1,52 @@
+-- rubric_checks.points cascade updates comment rows inside a trigger at depth 1;
+-- comment INSERT/UPDATE triggers call submissionreviewrecompute() at depth 2, which
+-- returns early (pg_trigger_depth guard) and never recomputes submission_reviews totals.
+-- After cascading points, directly call _submission_review_recompute_scores for each
+-- affected submission review (non-deleted comments only, matching score aggregation).
+
+CREATE OR REPLACE FUNCTION public.handle_rubric_check_points_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_review_id bigint;
+BEGIN
+  IF NEW.points IS DISTINCT FROM OLD.points THEN
+    UPDATE public.submission_comments
+    SET points = NEW.points
+    WHERE rubric_check_id = NEW.id;
+
+    UPDATE public.submission_file_comments
+    SET points = NEW.points
+    WHERE rubric_check_id = NEW.id;
+
+    UPDATE public.submission_artifact_comments
+    SET points = NEW.points
+    WHERE rubric_check_id = NEW.id;
+
+    FOR v_review_id IN
+      SELECT DISTINCT subq.submission_review_id
+      FROM (
+        SELECT submission_review_id FROM public.submission_comments
+        WHERE rubric_check_id = NEW.id AND deleted_at IS NULL
+        UNION
+        SELECT submission_review_id FROM public.submission_file_comments
+        WHERE rubric_check_id = NEW.id AND deleted_at IS NULL
+        UNION
+        SELECT submission_review_id FROM public.submission_artifact_comments
+        WHERE rubric_check_id = NEW.id AND deleted_at IS NULL
+      ) AS subq
+      WHERE subq.submission_review_id IS NOT NULL
+    LOOP
+      PERFORM public._submission_review_recompute_scores(v_review_id);
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_rubric_check_points_update() IS
+  'Cascade rubric_checks.points to comment rows; then recompute each affected submission_review via _submission_review_recompute_scores (avoids nested trigger depth skip).';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updates to rubric check points now properly cascade changes to all related submission comments and automatically recalculate scores for affected submission reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->