### PR TITLE
fix: read recalc_state version AFTER upsert to prevent stuck rows

### DIFF
--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -178,38 +178,6 @@ async function processRowsAll(
         rows: rowsInput
       });
 
-      const versionsByStudent = new Map<string, number>();
-      {
-        let vFrom = 0;
-        const vPageSize = 1000;
-        while (true) {
-          const vTo = vFrom + vPageSize - 1;
-          const { data: verPage, error: verErr } = await adminSupabase
-            .from("gradebook_row_recalc_state")
-            .select("student_id, version, dirty, is_recalculating")
-            .eq("class_id", classId)
-            .eq("gradebook_id", gradebook_id)
-            .eq("is_private", is_private)
-            .order("student_id", { ascending: true })
-            .range(vFrom, vTo);
-          if (verErr) {
-            Sentry.captureException(verErr, gbScope);
-            break;
-          }
-          if (!verPage || verPage.length === 0) break;
-          for (const row of verPage as unknown as Array<{
-            student_id: string;
-            version: number;
-            dirty: boolean;
-            is_recalculating: boolean;
-          }>) {
-            versionsByStudent.set(row.student_id, row.version);
-          }
-          if (verPage.length < vPageSize) break;
-          vFrom += vPageSize;
-        }
-      }
-
       console.log(`Upserting ${rowEntries.length} rows for gradebook ${gradebook_id}`);
 
       // Track row keys being upserted for duplicate detection
@@ -268,6 +236,36 @@ async function processRowsAll(
         console.log(
           `[DEBUG] ${workerId} UPSERT: Successfully upserted ${rowEntries.length} rows for gradebook ${gradebook_id}`
         );
+      }
+
+      // Read versions AFTER the upsert so expected_version matches the
+      // post-upsert value. Reading before the upsert caused systematic
+      // version mismatches that left rows permanently stuck.
+      const versionsByStudent = new Map<string, number>();
+      {
+        let vFrom = 0;
+        const vPageSize = 1000;
+        while (true) {
+          const vTo = vFrom + vPageSize - 1;
+          const { data: verPage, error: verErr } = await adminSupabase
+            .from("gradebook_row_recalc_state")
+            .select("student_id, version")
+            .eq("class_id", classId)
+            .eq("gradebook_id", gradebook_id)
+            .eq("is_private", is_private)
+            .order("student_id", { ascending: true })
+            .range(vFrom, vTo);
+          if (verErr) {
+            Sentry.captureException(verErr, gbScope);
+            break;
+          }
+          if (!verPage || verPage.length === 0) break;
+          for (const row of verPage as unknown as Array<{ student_id: string; version: number }>) {
+            versionsByStudent.set(row.student_id, row.version);
+          }
+          if (verPage.length < vPageSize) break;
+          vFrom += vPageSize;
+        }
       }
 
       // Batch update all students in a single RPC call
@@ -430,23 +428,6 @@ async function processRowsAll(
         rows: rowsInputScoped
       });
 
-      const versionsByStudentScoped = new Map<string, number>();
-      {
-        const { data: verRows, error: verErr } = await adminSupabase
-          .from("gradebook_row_recalc_state")
-          .select("student_id, version")
-          .eq("class_id", classId)
-          .eq("gradebook_id", gradebook_id)
-          .eq("is_private", is_private)
-          .in("student_id", studentIds);
-        if (verErr) {
-          Sentry.captureException(verErr, gbScope);
-        }
-        for (const row of (verRows as unknown as Array<{ student_id: string; version: number }>) ?? []) {
-          versionsByStudentScoped.set(row.student_id, row.version);
-        }
-      }
-
       // Track row keys being upserted for duplicate detection
       const upsertRowKeysScoped = rowEntries.map((entry) => {
         const key = rowKey(classId, gradebook_id, entry.msg.message.student_id, is_private);
@@ -504,6 +485,27 @@ async function processRowsAll(
         console.log(
           `[DEBUG] ${workerId} UPSERT (scoped): Successfully upserted ${rowEntries.length} rows for gradebook ${gradebook_id}`
         );
+      }
+
+      // Read versions AFTER the upsert so expected_version matches the
+      // post-upsert value. Reading before the upsert caused systematic
+      // version mismatches: the upsert increments version, then the
+      // batch RPC tried to clear with the stale pre-upsert version.
+      const versionsByStudentScoped = new Map<string, number>();
+      {
+        const { data: verRows, error: verErr } = await adminSupabase
+          .from("gradebook_row_recalc_state")
+          .select("student_id, version")
+          .eq("class_id", classId)
+          .eq("gradebook_id", gradebook_id)
+          .eq("is_private", is_private)
+          .in("student_id", studentIds);
+        if (verErr) {
+          Sentry.captureException(verErr, gbScope);
+        }
+        for (const row of (verRows as unknown as Array<{ student_id: string; version: number }>) ?? []) {
+          versionsByStudentScoped.set(row.student_id, row.version);
+        }
       }
 
       // Batch update all students in a single RPC call


### PR DESCRIPTION
## Summary
- Fix systematic version mismatch in gradebook recalculation worker that left every processed row permanently stuck in `is_recalculating=true`

## Root cause
The worker read `version` from `gradebook_row_recalc_state` BEFORE upserting the same rows. The upsert's `ON CONFLICT DO UPDATE SET version = version + 1` incremented the version. The batch RPC then tried to clear rows with the pre-upsert `expected_version`, which always mismatched — leaving rows stuck forever.

## Fix
Move the version read to AFTER the upsert, in both the bulk and scoped code paths.

## Impact
- 100% failure rate on deployed Supabase (196+ stuck rows on fresh deployments)
- Passed locally because local Supabase processes everything synchronously
- Affected all gradebook score calculations going through the async recalculation queue

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the gradebook column recalculation process through improved database query efficiency. All existing functionality and error recovery behaviors remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->