### PR TITLE
Fix flaky gradebook E2E: scope release menu to Participation column

### DIFF
--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -987,7 +987,10 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await tableRegion.evaluate((el) => {
       el.scrollLeft = el.scrollWidth;
     });
-    await tableRegion.locator('button[aria-label="Column options"]').last().click();
+    // Scroll area order is not guaranteed to match visual order; target Participation explicitly
+    // (`.last()` would hit the rightmost column, e.g. instructor-only test column, not Participation).
+    const participationHeader = tableRegion.locator('[role="columnheader"]').filter({ hasText: /^Participation/ });
+    await participationHeader.getByRole("button", { name: "Column options" }).click();
     const releaseItem = page.getByRole("menuitem", { name: "Release Column", exact: true });
     await releaseItem.click();
 
@@ -1086,7 +1089,8 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await tableRegion2.evaluate((el) => {
       el.scrollLeft = el.scrollWidth;
     });
-    await tableRegion2.locator('button[aria-label="Column options"]').last().click();
+    const participationHeader2 = tableRegion2.locator('[role="columnheader"]').filter({ hasText: /^Participation/ });
+    await participationHeader2.getByRole("button", { name: "Column options" }).click();
     const unreleaseItem = page.getByRole("menuitem", { name: "Unrelease Column", exact: true });
     await unreleaseItem.click();
     //Wait for the column to unrelease


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI Playwright runs were intermittently failing on `Manual column release/unrelease controls student visibility (individual)` with `publicRecord.score` staying `null` while the private row had the expected score.

## Root cause

After scrolling the instructor gradebook horizontally, the test clicked `button[aria-label="Column options"]` with `.last()`. In the virtualized header row, DOM order does not match the visual rightmost column; the last matching control was often **not** Participation (e.g. the instructor-only column added earlier in the suite), so **Release Column** ran on the wrong column. Participation stayed unreleased, so public `gradebook_column_students` rows never synced.

## Fix

Target the menu button inside the `columnheader` that contains the Participation title, for both release and unrelease.

## Verification

- Local prod build: `NEXT_PUBLIC_PAWTOGRADER_WEB_URL=http://localhost:3001`, `rm -rf .next && npm run build`, `PORT=3001 npm run start`, `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/gradebook.test.tsx --project=chromium` (full serial file; all 9 tests passed).

No assertion relaxations and no added waits.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-203da443-26f9-4bc8-96c6-95485fb9d678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-203da443-26f9-4bc8-96c6-95485fb9d678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

