### PR TITLE
Fix finalize_submission_early granting free extensions when late tokens are active

### DIFF
--- a/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
+++ b/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
@@ -105,7 +105,29 @@ BEGIN
     hours_to_subtract := -1 * EXTRACT(EPOCH FROM (effective_due_date - utc_now)) / 3600;
     minutes_to_subtract := -1 * (EXTRACT(EPOCH FROM (effective_due_date - utc_now)) % 3600) / 60;
 
-    -- Insert the negative due date exception
+    -- Get the active submission id for this profile
+    SELECT id INTO this_active_submission_id
+    FROM public.submissions
+    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id) OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
+    AND assignment_id = this_assignment_id
+    AND is_active = true
+    LIMIT 1;
+
+    -- If active submission does not exist, abort
+    IF this_active_submission_id IS NULL THEN
+        RETURN json_build_object('success', false, 'error', 'No active submission found');
+    END IF;
+
+    -- Check if there's already a review assignment for this student for this assignment
+    IF EXISTS (
+        SELECT 1 FROM review_assignments
+        WHERE assignment_id = this_assignment.id
+        AND assignee_profile_id = this_profile_id
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Self review already assigned');
+    END IF;
+
+    -- Insert the negative due date exception only after validation checks pass
     IF this_group_id IS NOT NULL THEN
         INSERT INTO assignment_due_date_exceptions (
             class_id,
@@ -142,28 +164,6 @@ BEGIN
             minutes_to_subtract,
             0
         );
-    END IF;
-
-    -- Get the active submission id for this profile
-    SELECT id INTO this_active_submission_id
-    FROM public.submissions
-    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id) OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
-    AND assignment_id = this_assignment_id
-    AND is_active = true
-    LIMIT 1;
-
-    -- If active submission does not exist, abort
-    IF this_active_submission_id IS NULL THEN
-        RETURN json_build_object('success', false, 'error', 'No active submission found');
-    END IF;
-
-    -- Check if there's already a review assignment for this student for this assignment
-    IF EXISTS (
-        SELECT 1 FROM review_assignments
-        WHERE assignment_id = this_assignment.id
-        AND assignee_profile_id = this_profile_id
-    ) THEN
-        RETURN json_build_object('success', false, 'error', 'Self review already assigned');
     END IF;
 
     -- Create or get existing submission review
@@ -358,6 +358,9 @@ BEGIN
     RETURN NEW;
 END;
 $function$;
+
+ALTER FUNCTION public.apply_extensions_to_new_assignment()
+  SET search_path = public, pg_temp;
 
 CREATE OR REPLACE FUNCTION public.create_assignment_exceptions_from_extension()
 RETURNS trigger

--- a/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
+++ b/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
@@ -1,0 +1,434 @@
+-- Centralized advisory lock helpers for assignment_due_date_exceptions write paths.
+CREATE OR REPLACE FUNCTION public.assignment_due_date_exception_lock_key(
+    _assignment_id bigint,
+    _student_id uuid,
+    _assignment_group_id bigint
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$
+    SELECT hashtextextended(
+        'assignment_due_date_exceptions:' || _assignment_id::text || ':' || COALESCE(_assignment_group_id::text, _student_id::text, 'no-subject'),
+        0
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.acquire_assignment_due_date_exception_lock(
+    _assignment_id bigint,
+    _student_id uuid,
+    _assignment_group_id bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(
+        public.assignment_due_date_exception_lock_key(_assignment_id, _student_id, _assignment_group_id)
+    );
+END;
+$$;
+
+-- Re-define finalize_submission_early to use the shared lock helper.
+CREATE OR REPLACE FUNCTION "public"."finalize_submission_early"("this_assignment_id" bigint, "this_profile_id" uuid)
+RETURNS json
+LANGUAGE "plpgsql" SECURITY DEFINER
+AS $$
+DECLARE
+    this_assignment public.assignments;
+    this_group_id bigint;
+    this_self_review_setting public.assignment_self_review_settings;
+    this_active_submission_id bigint;
+    existing_submission_review_id bigint;
+    hours_to_subtract integer;
+    minutes_to_subtract integer;
+    utc_now TIMESTAMP := date_trunc('minute', now() + interval '59 second');
+    effective_due_date timestamp with time zone;
+BEGIN
+    -- Get the assignment first
+    SELECT * INTO this_assignment FROM public.assignments WHERE id = this_assignment_id;
+
+    -- Check if assignment exists
+    IF this_assignment.id IS NULL THEN
+        RETURN json_build_object('success', false, 'error', 'Assignment not found');
+    END IF;
+
+    -- Confirm this is a private profile for a student in this class, else abort
+    IF NOT EXISTS (
+        SELECT 1 FROM user_roles
+        WHERE private_profile_id = this_profile_id
+        AND role = 'student'
+        AND class_id = this_assignment.class_id
+        AND user_id = auth.uid()
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Not authorized');
+    END IF;
+
+    -- Get the group of the student for this assignment
+    SELECT assignment_group_id INTO this_group_id
+    FROM public.assignment_groups_members
+    WHERE profile_id = this_profile_id
+    AND class_id = this_assignment.class_id
+    AND assignment_id = this_assignment.id
+    LIMIT 1;
+
+    -- Serialize all finalize attempts for this assignment + group/profile tuple.
+    PERFORM public.acquire_assignment_due_date_exception_lock(this_assignment_id, this_profile_id, this_group_id);
+
+    -- Get the self review setting
+    SELECT * INTO this_self_review_setting
+    FROM public.assignment_self_review_settings
+    WHERE id = this_assignment.self_review_setting_id;
+
+    -- If self reviews are not enabled for this assignment, abort
+    IF this_self_review_setting.enabled IS NOT TRUE THEN
+        RETURN json_build_object('success', false, 'error', 'Self reviews not enabled for this assignment');
+    END IF;
+
+    -- Check if there's already a negative due date exception (already finalized)
+    IF EXISTS (
+        SELECT 1 FROM assignment_due_date_exceptions
+        WHERE assignment_id = this_assignment_id
+        AND (
+            (student_id = this_profile_id AND hours < 0) OR
+            (assignment_group_id = this_group_id AND hours < 0)
+        )
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Submission already finalized');
+    END IF;
+
+    -- Get the effective due date (lab-based or regular)
+    effective_due_date := public.calculate_effective_due_date(this_assignment_id, this_profile_id);
+
+    -- Calculate hours and minutes to subtract from the effective due date
+    hours_to_subtract := -1 * EXTRACT(EPOCH FROM (effective_due_date - utc_now)) / 3600;
+    minutes_to_subtract := -1 * (EXTRACT(EPOCH FROM (effective_due_date - utc_now)) % 3600) / 60;
+
+    -- Insert the negative due date exception
+    IF this_group_id IS NOT NULL THEN
+        INSERT INTO assignment_due_date_exceptions (
+            class_id,
+            assignment_id,
+            assignment_group_id,
+            creator_id,
+            hours,
+            minutes,
+            tokens_consumed
+        ) VALUES (
+            this_assignment.class_id,
+            this_assignment_id,
+            this_group_id,
+            this_profile_id,
+            hours_to_subtract,
+            minutes_to_subtract,
+            0
+        );
+    ELSE
+        INSERT INTO assignment_due_date_exceptions (
+            class_id,
+            assignment_id,
+            student_id,
+            creator_id,
+            hours,
+            minutes,
+            tokens_consumed
+        ) VALUES (
+            this_assignment.class_id,
+            this_assignment_id,
+            this_profile_id,
+            this_profile_id,
+            hours_to_subtract,
+            minutes_to_subtract,
+            0
+        );
+    END IF;
+
+    -- Get the active submission id for this profile
+    SELECT id INTO this_active_submission_id
+    FROM public.submissions
+    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id) OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
+    AND assignment_id = this_assignment_id
+    AND is_active = true
+    LIMIT 1;
+
+    -- If active submission does not exist, abort
+    IF this_active_submission_id IS NULL THEN
+        RETURN json_build_object('success', false, 'error', 'No active submission found');
+    END IF;
+
+    -- Check if there's already a review assignment for this student for this assignment
+    IF EXISTS (
+        SELECT 1 FROM review_assignments
+        WHERE assignment_id = this_assignment.id
+        AND assignee_profile_id = this_profile_id
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Self review already assigned');
+    END IF;
+
+    -- Create or get existing submission review
+    SELECT id INTO existing_submission_review_id
+    FROM public.submission_reviews
+    WHERE submission_id = this_active_submission_id
+    AND class_id = this_assignment.class_id
+    AND rubric_id = this_assignment.self_review_rubric_id
+    LIMIT 1;
+
+    IF existing_submission_review_id IS NULL THEN
+        INSERT INTO submission_reviews (total_score, released, tweak, class_id, submission_id, name, rubric_id)
+        VALUES (0, false, 0, this_assignment.class_id, this_active_submission_id, 'Self Review', this_assignment.self_review_rubric_id)
+        RETURNING id INTO existing_submission_review_id;
+    END IF;
+
+    -- Create the review assignment using the effective due date
+    INSERT INTO review_assignments (
+        due_date,
+        assignee_profile_id,
+        submission_id,
+        submission_review_id,
+        assignment_id,
+        rubric_id,
+        class_id
+    ) VALUES (
+        utc_now + (INTERVAL '1 hour' * this_self_review_setting.deadline_offset),
+        this_profile_id,
+        this_active_submission_id,
+        existing_submission_review_id,
+        this_assignment.id,
+        this_assignment.self_review_rubric_id,
+        this_assignment.class_id
+    );
+
+    RETURN json_build_object('success', true, 'message', 'Submission finalized and self review assigned');
+END;
+$$;
+
+-- Harden extension authorization checks used by RLS with the same lock key.
+CREATE OR REPLACE FUNCTION public.authorize_to_create_own_due_date_extension(_student_id uuid, _assignment_group_id bigint, _assignment_id bigint, _class_id bigint, _creator_id uuid, _hours_to_extend integer, _tokens_consumed integer)
+RETURNS boolean
+LANGUAGE plpgsql
+VOLATILE SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+declare
+  tokens_used_this_assignment int;
+  tokens_used_all_assignments int;
+  tokens_remaining int;
+  tokens_needed int;
+  max_tokens_for_assignment int;
+  private_profile_id uuid;
+  existing_negative_exception boolean;
+begin
+
+  -- Validate that the declared number of tokens consumed is correct
+  -- Use numeric division to avoid integer division truncation before ceil()
+  tokens_needed := ceil(_hours_to_extend::numeric / 24);
+  if tokens_needed != _tokens_consumed then
+    return false;
+  end if;
+
+  select public.user_roles.private_profile_id from public.user_roles where user_id = auth.uid() and class_id = _class_id into private_profile_id;
+  -- Make sure student is in the class and the creator of the extension
+  if private_profile_id is null or private_profile_id != _creator_id then
+    return false;
+  end if;
+
+  -- Serialize checks for this assignment + group/profile tuple against concurrent inserts.
+  perform public.acquire_assignment_due_date_exception_lock(_assignment_id, _student_id, _assignment_group_id);
+
+  -- Check if there's already a negative exception for this student/assignment_group + assignment + class
+  -- Prevent ANY additional exception in that case
+    select exists (
+      select 1 from public.assignment_due_date_exceptions adde
+      where (
+        (_student_id is not null and adde.student_id is not null and _student_id = adde.student_id) or
+        (_assignment_group_id is not null and adde.assignment_group_id is not null and _assignment_group_id = adde.assignment_group_id)
+      )
+      and adde.assignment_id = _assignment_id
+      and adde.class_id = _class_id
+      and adde.hours < 0
+    ) into existing_negative_exception;
+
+    if existing_negative_exception then
+      return false;
+    end if;
+
+  select late_tokens_per_student from public.classes where id = _class_id into tokens_remaining;
+
+  -- Make sure that the student is in the assignment group or matches the student_id
+  if _assignment_group_id is not null then
+    if not exists (select 1 from public.assignment_groups_members where assignment_group_id = _assignment_group_id and profile_id = private_profile_id) then
+      return false;
+    end if;
+    select coalesce(sum(tokens_consumed), 0) from public.assignment_due_date_exceptions where assignment_group_id = _assignment_group_id and assignment_id = _assignment_id into tokens_used_this_assignment;
+  else
+    if private_profile_id != _student_id then
+      return false;
+    end if;
+      select coalesce(sum(tokens_consumed), 0) from public.assignment_due_date_exceptions where student_id = _student_id and assignment_id = _assignment_id into tokens_used_this_assignment;
+  end if;
+
+  -- Calculate total tokens used across all assignments for this student
+  -- Join with assignment_groups_members to get all assignment groups the student is in
+  select coalesce(sum(adde.tokens_consumed), 0)
+  from public.assignment_due_date_exceptions adde
+  left join public.assignment_groups_members agm on agm.assignment_group_id = adde.assignment_group_id
+  where adde.student_id = _student_id
+     or agm.profile_id = private_profile_id
+  into tokens_used_all_assignments;
+
+  if tokens_used_all_assignments + tokens_needed > tokens_remaining then
+    return false;
+  end if;
+
+  -- Verify assignment exists and belongs to the specified class before checking max_late_tokens
+  select max_late_tokens from public.assignments where id=_assignment_id and class_id=_class_id into max_tokens_for_assignment;
+
+  -- If assignment doesn't exist or class_id doesn't match, reject the request
+  if max_tokens_for_assignment IS NULL then
+    return false;
+  end if;
+
+  if tokens_used_this_assignment + tokens_needed > max_tokens_for_assignment then
+    return false;
+  end if;
+
+  return true;
+end;
+$function$;
+
+-- Harden extension fan-out functions that previously used NOT EXISTS + INSERT without locks.
+CREATE OR REPLACE FUNCTION public.apply_extensions_to_new_assignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+    v_creator_profile_id uuid;
+    v_extension_row record;
+BEGIN
+    SELECT private_profile_id INTO v_creator_profile_id
+    FROM user_roles
+    WHERE user_id = auth.uid()
+      AND class_id = NEW.class_id
+      AND disabled = false
+    LIMIT 1;
+
+    IF v_creator_profile_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    FOR v_extension_row IN
+        SELECT sde.student_id, sde.hours
+        FROM student_deadline_extensions sde
+        WHERE sde.class_id = NEW.class_id
+          AND (sde.includes_lab = true OR NEW.minutes_due_after_lab IS NULL)
+    LOOP
+        PERFORM public.acquire_assignment_due_date_exception_lock(NEW.id, v_extension_row.student_id, NULL);
+
+        IF NOT EXISTS (
+            SELECT 1
+            FROM assignment_due_date_exceptions ade
+            WHERE ade.assignment_id = NEW.id
+              AND ade.student_id = v_extension_row.student_id
+        ) THEN
+            INSERT INTO assignment_due_date_exceptions (
+                assignment_id,
+                student_id,
+                class_id,
+                creator_id,
+                hours,
+                minutes,
+                tokens_consumed,
+                note
+            )
+            VALUES (
+                NEW.id,
+                v_extension_row.student_id,
+                NEW.class_id,
+                v_creator_profile_id,
+                v_extension_row.hours,
+                0,
+                0,
+                'Instructor-granted extension for all assignments in class'
+            );
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.create_assignment_exceptions_from_extension()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+    v_creator_profile_id uuid;
+    v_assignment_row record;
+BEGIN
+    SELECT private_profile_id INTO v_creator_profile_id
+    FROM user_roles
+    WHERE user_id = auth.uid()
+      AND class_id = NEW.class_id
+      AND disabled = false
+    LIMIT 1;
+
+    IF v_creator_profile_id IS NULL THEN
+        SELECT private_profile_id INTO v_creator_profile_id
+        FROM user_roles
+        WHERE class_id = NEW.class_id
+          AND role IN ('instructor', 'admin')
+          AND disabled = false
+        LIMIT 1;
+
+        IF v_creator_profile_id IS NULL THEN
+            RAISE WARNING 'No suitable profile found for creating extension exceptions in class %', NEW.class_id;
+            RETURN NEW;
+        END IF;
+    END IF;
+
+    FOR v_assignment_row IN
+        SELECT a.id
+        FROM assignments a
+        WHERE a.class_id = NEW.class_id
+          AND a.archived_at IS NULL
+          AND (NEW.includes_lab = true OR a.minutes_due_after_lab IS NULL)
+    LOOP
+        PERFORM public.acquire_assignment_due_date_exception_lock(v_assignment_row.id, NEW.student_id, NULL);
+
+        IF NOT EXISTS (
+            SELECT 1 FROM assignment_due_date_exceptions ade
+            WHERE ade.assignment_id = v_assignment_row.id
+              AND ade.student_id = NEW.student_id
+        ) THEN
+            INSERT INTO assignment_due_date_exceptions (
+                assignment_id,
+                student_id,
+                class_id,
+                creator_id,
+                hours,
+                minutes,
+                tokens_consumed,
+                note
+            )
+            VALUES (
+                v_assignment_row.id,
+                NEW.student_id,
+                NEW.class_id,
+                v_creator_profile_id,
+                NEW.hours,
+                0,
+                0,
+                'Instructor-granted extension for all assignments in class'
+            );
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$function$;
+
+ALTER FUNCTION public.create_assignment_exceptions_from_extension()
+  SET search_path = public, pg_temp;

--- a/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
+++ b/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
@@ -34,6 +34,7 @@ $$;
 CREATE OR REPLACE FUNCTION "public"."finalize_submission_early"("this_assignment_id" bigint, "this_profile_id" uuid)
 RETURNS json
 LANGUAGE "plpgsql" SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
     this_assignment public.assignments;
@@ -258,7 +259,7 @@ begin
       )
       and adde.assignment_id = _assignment_id
       and adde.class_id = _class_id
-      and adde.hours < 0
+      and (adde.hours < 0 or (adde.hours = 0 and adde.minutes < 0))
     ) into existing_negative_exception;
 
     if existing_negative_exception then

--- a/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
+++ b/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
@@ -86,24 +86,36 @@ BEGIN
         RETURN json_build_object('success', false, 'error', 'Self reviews not enabled for this assignment');
     END IF;
 
-    -- Check if there's already a negative due date exception (already finalized)
+    -- Check if there's already a finalize exception (negative hours) for this student/group.
     IF EXISTS (
         SELECT 1 FROM assignment_due_date_exceptions
         WHERE assignment_id = this_assignment_id
         AND (
-            (student_id = this_profile_id AND hours < 0) OR
-            (assignment_group_id = this_group_id AND hours < 0)
+            student_id = this_profile_id OR
+            (this_group_id IS NOT NULL AND assignment_group_id = this_group_id)
         )
+        AND (hours < 0 OR (hours = 0 AND minutes < 0))
     ) THEN
         RETURN json_build_object('success', false, 'error', 'Submission already finalized');
     END IF;
 
-    -- Get the effective due date (lab-based or regular)
-    effective_due_date := public.calculate_effective_due_date(this_assignment_id, this_profile_id);
+    -- Get the FINAL due date including all existing extensions (late tokens, instructor grants, etc.)
+    -- calculate_effective_due_date only returns the base date; calculate_final_due_date includes extensions.
+    effective_due_date := public.calculate_final_due_date(this_assignment_id, this_profile_id, this_group_id);
 
-    -- Calculate hours and minutes to subtract from the effective due date
+    -- Reject if the student is at or past their actual deadline
+    IF utc_now >= effective_due_date THEN
+        RETURN json_build_object('success', false, 'error', 'Cannot finalize early after the due date has passed');
+    END IF;
+
+    -- Calculate hours and minutes to subtract from the final due date
     hours_to_subtract := -1 * EXTRACT(EPOCH FROM (effective_due_date - utc_now)) / 3600;
     minutes_to_subtract := -1 * (EXTRACT(EPOCH FROM (effective_due_date - utc_now)) % 3600) / 60;
+
+    -- Safety net: the result must always be negative (moving the deadline earlier)
+    IF hours_to_subtract >= 0 AND minutes_to_subtract >= 0 THEN
+        RETURN json_build_object('success', false, 'error', 'Cannot finalize early after the due date has passed');
+    END IF;
 
     -- Get the active submission id for this profile
     SELECT id INTO this_active_submission_id

--- a/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
+++ b/supabase/migrations/20260413234500_due_date_exception_advisory_locks.sql
@@ -44,7 +44,7 @@ DECLARE
     existing_submission_review_id bigint;
     hours_to_subtract integer;
     minutes_to_subtract integer;
-    utc_now TIMESTAMP := date_trunc('minute', now() + interval '59 second');
+    utc_now TIMESTAMP WITH TIME ZONE := date_trunc('minute', now() + interval '59 second');
     effective_due_date timestamp with time zone;
 BEGIN
     -- Get the assignment first

--- a/tests/e2e/finalize-submission-early-group-rpc.spec.ts
+++ b/tests/e2e/finalize-submission-early-group-rpc.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+import { addDays } from "date-fns";
+import {
+  createAuthenticatedClient,
+  createClass,
+  createUserInClass,
+  insertAssignment,
+  insertPreBakedSubmission,
+  supabase
+} from "./TestingUtils";
+import type { TestingUser } from "./TestingUtils";
+
+type FinalizeSubmissionResponse = {
+  success: boolean;
+  error?: string;
+  message?: string;
+};
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("finalize_submission_early RPC for group assignments", () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  let classId: number;
+  let assignmentId: number;
+  let assignmentGroupId: number;
+  let studentA: TestingUser;
+  let studentB: TestingUser;
+
+  test.beforeAll(async () => {
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const course = await createClass({ name: `E2E Finalize Group RPC ${suffix}` });
+    classId = course.id;
+
+    studentA = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Finalize Student A ${suffix}`,
+      email: `e2e-finalize-a-${suffix}@pawtograder.net`
+    });
+    studentB = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Finalize Student B ${suffix}`,
+      email: `e2e-finalize-b-${suffix}@pawtograder.net`
+    });
+
+    const assignment = await insertAssignment({
+      class_id: classId,
+      due_date: addDays(new Date(), 7).toISOString(),
+      name: `E2E Finalize Group Assignment ${suffix}`,
+      assignment_slug: `e2e-finalize-group-${suffix}`,
+      group_config: "groups",
+      min_group_size: 1,
+      max_group_size: 4,
+      group_formation_deadline: addDays(new Date(), 7).toISOString()
+    });
+    assignmentId = assignment.id;
+
+    const { data: assignmentGroup, error: assignmentGroupError } = await supabase
+      .from("assignment_groups")
+      .insert({
+        assignment_id: assignmentId,
+        class_id: classId,
+        name: `e2e-finalize-group-${suffix}`
+      })
+      .select("id")
+      .single();
+    if (assignmentGroupError || !assignmentGroup) {
+      throw new Error(`Failed to create assignment group: ${assignmentGroupError?.message ?? "unknown error"}`);
+    }
+    assignmentGroupId = assignmentGroup.id;
+
+    const { error: membersError } = await supabase.from("assignment_groups_members").insert([
+      {
+        assignment_group_id: assignmentGroupId,
+        assignment_id: assignmentId,
+        class_id: classId,
+        added_by: studentA.private_profile_id,
+        profile_id: studentA.private_profile_id
+      },
+      {
+        assignment_group_id: assignmentGroupId,
+        assignment_id: assignmentId,
+        class_id: classId,
+        added_by: studentA.private_profile_id,
+        profile_id: studentB.private_profile_id
+      }
+    ]);
+    if (membersError) {
+      throw new Error(`Failed to add group members: ${membersError.message}`);
+    }
+
+    await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      assignment_group_id: assignmentGroupId,
+      student_profile_id: studentA.private_profile_id,
+      repositorySuffix: suffix
+    });
+  });
+
+  test("only one group member can successfully finalize early via direct RPC", async () => {
+    const studentAClient = await createAuthenticatedClient(studentA);
+    const studentBClient = await createAuthenticatedClient(studentB);
+
+    const [firstAttempt, secondAttempt] = await Promise.all([
+      studentAClient.rpc("finalize_submission_early", {
+        this_assignment_id: assignmentId,
+        this_profile_id: studentA.private_profile_id
+      }),
+      studentBClient.rpc("finalize_submission_early", {
+        this_assignment_id: assignmentId,
+        this_profile_id: studentB.private_profile_id
+      })
+    ]);
+
+    expect([firstAttempt.error, secondAttempt.error].filter(Boolean)).toHaveLength(0);
+
+    const responses: FinalizeSubmissionResponse[] = [
+      firstAttempt.data as FinalizeSubmissionResponse,
+      secondAttempt.data as FinalizeSubmissionResponse
+    ];
+    const successfulResponses = responses.filter((response) => response?.success);
+    const failedResponses = responses.filter((response) => !response?.success);
+
+    expect(successfulResponses).toHaveLength(1);
+    expect(failedResponses).toHaveLength(1);
+    expect(failedResponses[0]?.error ?? failedResponses[0]?.message).toBe("Submission already finalized");
+
+    const { data: exceptions, error: exceptionsError } = await supabase
+      .from("assignment_due_date_exceptions")
+      .select("id, assignment_group_id, student_id, hours, minutes")
+      .eq("assignment_id", assignmentId);
+
+    expect(exceptionsError).toBeNull();
+    expect(exceptions).toHaveLength(1);
+    expect(exceptions?.[0]?.assignment_group_id).toBe(assignmentGroupId);
+    expect(exceptions?.[0]?.student_id).toBeNull();
+
+    const hasPositiveExtension = (exceptions ?? []).some(
+      (exception) => exception.hours > 0 || (exception.hours === 0 && exception.minutes > 0)
+    );
+    expect(hasPositiveExtension).toBe(false);
+  });
+});

--- a/tests/e2e/finalize-submission-early-group-rpc.spec.ts
+++ b/tests/e2e/finalize-submission-early-group-rpc.spec.ts
@@ -7,8 +7,8 @@ import {
   insertAssignment,
   insertPreBakedSubmission,
   supabase
-} from "./TestingUtils";
-import type { TestingUser } from "./TestingUtils";
+} from "@/tests/e2e/TestingUtils";
+import type { TestingUser } from "@/tests/e2e/TestingUtils";
 
 type FinalizeSubmissionResponse = {
   success: boolean;

--- a/tests/e2e/finalize-submission-early-group-rpc.spec.ts
+++ b/tests/e2e/finalize-submission-early-group-rpc.spec.ts
@@ -100,33 +100,28 @@ test.describe("finalize_submission_early RPC for group assignments", () => {
     });
   });
 
-  test("only one group member can successfully finalize early via direct RPC", async () => {
+  test("only one group member can successfully finalize early via direct RPC burst", async () => {
     const studentAClient = await createAuthenticatedClient(studentA);
     const studentBClient = await createAuthenticatedClient(studentB);
 
-    const [firstAttempt, secondAttempt] = await Promise.all([
-      studentAClient.rpc("finalize_submission_early", {
+    const attempts = Array.from({ length: 6 }, (_, idx) =>
+      (idx % 2 === 0 ? studentAClient : studentBClient).rpc("finalize_submission_early", {
         this_assignment_id: assignmentId,
-        this_profile_id: studentA.private_profile_id
-      }),
-      studentBClient.rpc("finalize_submission_early", {
-        this_assignment_id: assignmentId,
-        this_profile_id: studentB.private_profile_id
+        this_profile_id: idx % 2 === 0 ? studentA.private_profile_id : studentB.private_profile_id
       })
-    ]);
+    );
+    const results = await Promise.all(attempts);
+    expect(results.map((result) => result.error).filter(Boolean)).toHaveLength(0);
 
-    expect([firstAttempt.error, secondAttempt.error].filter(Boolean)).toHaveLength(0);
-
-    const responses: FinalizeSubmissionResponse[] = [
-      firstAttempt.data as FinalizeSubmissionResponse,
-      secondAttempt.data as FinalizeSubmissionResponse
-    ];
+    const responses: FinalizeSubmissionResponse[] = results.map((result) => result.data as FinalizeSubmissionResponse);
     const successfulResponses = responses.filter((response) => response?.success);
     const failedResponses = responses.filter((response) => !response?.success);
 
     expect(successfulResponses).toHaveLength(1);
-    expect(failedResponses).toHaveLength(1);
-    expect(failedResponses[0]?.error ?? failedResponses[0]?.message).toBe("Submission already finalized");
+    expect(failedResponses).toHaveLength(responses.length - 1);
+    expect(
+      failedResponses.every((response) => (response.error ?? response.message) === "Submission already finalized")
+    ).toBe(true);
 
     const { data: exceptions, error: exceptionsError } = await supabase
       .from("assignment_due_date_exceptions")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a direct-RPC E2E burst test for `finalize_submission_early` on grouped assignments to stress concurrent callers
- remediate `finalize_submission_early` race by taking a transaction-scoped advisory lock keyed by assignment + group/profile identity
- audit and remediate additional due-date-exception race paths with the same lock key derivation
  - add shared helpers: `assignment_due_date_exception_lock_key(...)` and `acquire_assignment_due_date_exception_lock(...)`
  - apply lock to `authorize_to_create_own_due_date_extension(...)` to serialize RLS check path against concurrent inserts
  - apply lock in extension fan-out trigger functions (`apply_extensions_to_new_assignment`, `create_assignment_exceptions_from_extension`) around NOT EXISTS + INSERT writes
- address review feedback:
  - use `@/tests/e2e/TestingUtils` imports in E2E
  - move finalize validations (`active submission` and existing `review_assignments`) before writing negative due-date exception rows
  - set `search_path = public, pg_temp` on security-definer functions (including `finalize_submission_early` and `apply_extensions_to_new_assignment`)
  - align negative-exception predicate in `authorize_to_create_own_due_date_extension` with finalize logic (`hours < 0 OR (hours = 0 AND minutes < 0)`)
  - align timestamp types in finalize logic by making `utc_now` timezone-aware (`TIMESTAMP WITH TIME ZONE`) to match `effective_due_date`

## Testing
- `npm run format`
- `sudo env PATH="/home/ubuntu/.nvm/versions/node/v22.22.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" npx supabase db reset`
- `BASE_URL=http://localhost:3000 npx playwright test tests/e2e/finalize-submission-early-group-rpc.spec.ts --project=chromium`

## Audit notes
- `assignment_due_date_exceptions` has no uniqueness guard on `(assignment_id, assignment_group_id)` or `(assignment_id, student_id)`, so check-then-insert code paths must serialize explicitly
- highest-risk sites were all due-date exception write paths using `NOT EXISTS`/pre-check logic without locks; those are now lock-serialized on the shared key
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2523fd89-3edd-4a54-a7d7-030f7b7e5f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2523fd89-3edd-4a54-a7d7-030f7b7e5f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Serialize concurrent early-finalize operations for group submissions to prevent duplicate due-date exceptions, ensuring a single group-level exception is created and that recorded extensions are not positive by mistake.
* **Tests**
  * Added an end-to-end test validating concurrent finalize flows for group assignments: multiple concurrent attempts yield one success, expected failures for others, and correct exception row creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->