### PR TITLE
Unify grade.yml workflow SHA mismatch error message

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -53,7 +53,7 @@ import {
 import { useActiveReviewAssignmentId } from "@/hooks/useSubmissionReview";
 import { useUserProfile } from "@/hooks/useUserProfiles";
 import { activateSubmission } from "@/lib/edgeFunctions";
-import { submissionHasGraderOutput } from "@/lib/submissionHasGraderOutput";
+import { graderResultsHasAutograderTestsOrOutput, submissionHasGraderOutput } from "@/lib/submissionHasGraderOutput";
 import { createClient } from "@/utils/supabase/client";
 import { GraderResultTestExtraData } from "@/utils/supabase/DatabaseTypes";
 import { Icon } from "@chakra-ui/react";
@@ -1331,6 +1331,21 @@ function TestResults() {
   const totalMaxScore = testResults?.reduce((acc, test) => acc + (test.max_score || 0), 0);
   const { matches } = useErrorPinMatches(submission.id);
   const hasBuildError = submission.grader_results?.lint_output === "Gradle build failed";
+  const hasRealAutograderOutput = graderResultsHasAutograderTestsOrOutput(submission.grader_results);
+
+  if (!hasRealAutograderOutput) {
+    return (
+      <Box>
+        <Heading size="md" mt={2}>
+          Automated Check Results
+        </Heading>
+        <Text fontSize="sm" color="text.muted" mt={2}>
+          No automated test results for this submission. Open the Results tab to see submission status or any reported
+          errors.
+        </Text>
+      </Box>
+    );
+  }
 
   // Get all unique error pin matches for prominent display on build errors
   const getAllMatches = () => {
@@ -1610,6 +1625,7 @@ function UnGradedGradingSummary() {
   const submission = useSubmission();
   const { assignment } = useAssignmentController();
   const gradingRubric = useRubric("grading-review");
+  const hasRealAutograderOutput = graderResultsHasAutograderTestsOrOutput(submission.grader_results);
   const graderResultsMaxScore = submission.grader_results?.max_score;
   const totalMaxScore = assignment.total_points;
   const isCapped = gradingRubric?.cap_score_to_assignment_points ?? false;
@@ -1633,9 +1649,17 @@ function UnGradedGradingSummary() {
           <Text as="span" fontWeight="bold">
             Automated Checks:
           </Text>{" "}
-          {graderResultsMaxScore} points, results shown below.
+          {hasRealAutograderOutput ? (
+            <>{graderResultsMaxScore} points, results shown below.</>
+          ) : (
+            <>
+              No automated score recorded for this submission yet (the autograder may not have finished or produced
+              tests). See the Results tab for status.
+            </>
+          )}
         </List.Item>
-        {!isCapped &&
+        {hasRealAutograderOutput &&
+          !isCapped &&
           graderResultsMaxScore !== undefined &&
           totalMaxScore !== null &&
           graderResultsMaxScore > totalMaxScore && (

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/results/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/results/page.tsx
@@ -44,6 +44,24 @@ import { ErrorPinCallout } from "@/components/discussion/ErrorPinCallout";
 import { AIHelpSubmissionErrorButton } from "@/components/ai-help/AIHelpSubmissionErrorButton";
 import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 
+/** When create-submission already recorded a user-visible message (e.g. grade.yml mismatch), hide the generic missing-grader-result row. */
+function filterWorkflowRunErrorsForDisplay<
+  T extends { data?: unknown; is_private?: boolean | null; id?: string | number }
+>(errors: T[]): T[] {
+  const hasUserVisibleType = errors.some((e) => {
+    const d = e.data;
+    return d !== null && typeof d === "object" && "type" in d && (d as { type?: string }).type === "user_visible_error";
+  });
+  if (!hasUserVisibleType) return errors;
+  return errors.filter((e) => {
+    const d = e.data;
+    if (d !== null && typeof d === "object" && "error_type" in d) {
+      return (d as { error_type?: string }).error_type !== "missing_grader_result";
+    }
+    return true;
+  });
+}
+
 function LLMHintButton({ testId, onHintGenerated }: { testId: number; onHintGenerated: (hint: string) => void }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -833,7 +851,7 @@ export default function GraderResults() {
     return <Box>No grader results found</Box>;
   }
   if (query.data.data.workflow_run_error && query.data.data.workflow_run_error.length > 0) {
-    const errors = query.data.data.workflow_run_error;
+    const errors = filterWorkflowRunErrorsForDisplay(query.data.data.workflow_run_error);
 
     // Check if any errors are user-visible
     const hasUserVisibleErrors = errors.some((error) => !error.is_private);

--- a/lib/submissionHasGraderOutput.ts
+++ b/lib/submissionHasGraderOutput.ts
@@ -1,4 +1,37 @@
 /**
+ * True when the grader produced something we can score or display as real autograder output:
+ * tests, non-empty lint/build log, or captured stdout/stderr rows.
+ *
+ * Does **not** treat `errors` alone as sufficient — placeholder rows inserted when a workflow
+ * ends without a real grader run often only set `errors` and still get the DB default `max_score`
+ * (e.g. 100), which must not drive the rubric sidebar "Automated Checks: … points" line.
+ */
+export function graderResultsHasAutograderTestsOrOutput(
+  graderResults:
+    | {
+        grader_result_tests?: unknown[] | null;
+        lint_output?: string | null;
+        grader_result_output?: unknown[] | null;
+      }
+    | null
+    | undefined
+): boolean {
+  if (!graderResults) {
+    return false;
+  }
+  if ((graderResults.grader_result_tests?.length ?? 0) > 0) {
+    return true;
+  }
+  if ((graderResults.lint_output?.trim().length ?? 0) > 0) {
+    return true;
+  }
+  if ((graderResults.grader_result_output?.length ?? 0) > 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Whether a submission had autograder activity worth showing on the Results tab.
  * Covers tests, lint/build logs, captured grader stdout/stderr rows, structured `errors` JSON,
  * and optional `build_failures` / `build_failure_summary` if present on the row.

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -27,6 +27,23 @@ import { Buffer } from "node:buffer";
 import { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
 import * as Sentry from "npm:@sentry/deno";
 
+const GRADE_WORKFLOW_PATH = ".github/workflows/grade.yml";
+
+/**
+ * User-facing explanation when the student's workflow file hash does not match the course handout.
+ * Same text is shown to students (API error) and recorded for instructors (workflow_run_error).
+ */
+function formatGradeYmlWorkflowMismatchMessage(syncedRepoSha: string | null): string {
+  const restoreOneLiner = syncedRepoSha?.trim()
+    ? `git checkout ${syncedRepoSha.trim()} -- ${GRADE_WORKFLOW_PATH}`
+    : `git checkout $(git rev-list --max-parents=0 HEAD | tail -n 1) -- ${GRADE_WORKFLOW_PATH}`;
+  return [
+    `Your ${GRADE_WORKFLOW_PATH} file does not match the expected contents for this assignment (it may have been edited, or your copy may differ from the handout).`,
+    "Restore the file from your repository's initial commit, then commit and push. From your assignment repo:",
+    restoreOneLiner
+  ].join(" ");
+}
+
 function sha256Hex(buf: Uint8Array): string {
   const hash = createHash("sha256");
   hash.update(buf);
@@ -1177,18 +1194,18 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         ) {
           scope.setTag("hash_in_db", config.workflow_sha);
           scope.setTag("hash_in_student_repo", hashStr);
-          const errorMessage = `.github/workflows/grade.yml SHA does not match expected value. This file must be the same in student repos as in the grader repo for security reasons. SHA on student repo: ${hashStr} !== SHA in database: ${config.workflow_sha}.`;
+          const mismatchMessage = formatGradeYmlWorkflowMismatchMessage(repoData.synced_repo_sha);
           Sentry.captureMessage("workflow sha mismatch", scope);
           if (isGraderOrInstructor) {
             await recordWorkflowRunError({
-              name: `.github/workflows/grade.yml SHA is different from that in handout!!! You are a grader or instructor, so this submission is permitted. But, if a student has this same workflow file, they will get a big nasty error. Please be sure to update the handout to match this repo's workflow, which will avoid this error.`,
+              name: mismatchMessage,
               data: {
                 type: "security_error"
               },
               is_private: true
             });
           } else {
-            throw new SecurityError(errorMessage);
+            throw new SecurityError(mismatchMessage);
           }
         }
         const pawtograderConfig = config.config as unknown as PawtograderConfig;

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -1200,12 +1200,12 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
             await recordWorkflowRunError({
               name: mismatchMessage,
               data: {
-                type: "security_error"
+                type: "user_visible_error"
               },
-              is_private: true
+              is_private: false
             });
           } else {
-            throw new SecurityError(mismatchMessage);
+            throw new UserVisibleError(mismatchMessage, 400);
           }
         }
         const pawtograderConfig = config.config as unknown as PawtograderConfig;

--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -1259,6 +1259,22 @@ async function handleWorkflowCompletionErrors(
         scope.setTag(`submission_${submission.id}_has_grader_result`, hasGraderResult.toString());
 
         if (!hasGraderResult) {
+          const { data: userVisibleErrRows, error: userVisibleErrLookupError } = await adminSupabase
+            .from("workflow_run_error")
+            .select("id")
+            .eq("repository_id", repositoryId)
+            .eq("run_number", workflowRun.id)
+            .eq("run_attempt", workflowRun.run_attempt)
+            .eq("data->>type", "user_visible_error")
+            .limit(1);
+          if (userVisibleErrLookupError) {
+            Sentry.captureException(userVisibleErrLookupError, scope);
+          }
+          if (userVisibleErrRows && userVisibleErrRows.length > 0) {
+            scope.setTag("missing_grader_result_skipped", "user_visible_error_present");
+            continue;
+          }
+
           const sentryMessage = "Workflow terminated without creating a grader result.";
           const userErrorMessage =
             "The grading container failed to terminate cleanly. This may indicate that the grading script ran out of memory or encountered an unexpected error. Please contact your instructor for assistance.";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When autograder submission failed because `.github/workflows/grade.yml` did not match the expected hash, students saw a terse "security" style message and instructors saw a different warning in workflow run errors.

## Changes

- **Single message** for both paths: students (API response) and instructors/graders (`workflow_run_error` record) use the same text.
- **Clear explanation**: the workflow file must match the handout; restore from the repo’s initial commit, then commit and push.
- **One-liner**: when `repositories.synced_repo_sha` is set, the message includes  
  `git checkout <synced_repo_sha> -- .github/workflows/grade.yml`.  
  If that SHA is missing, it falls back to  
  `git checkout $(git rev-list --max-parents=0 HEAD | tail -n 1) -- .github/workflows/grade.yml`.
- **User-visible error (not SecurityError)**: mismatch is thrown as `UserVisibleError` with HTTP 400 so the response body surfaces the full message to GitHub Actions / clients. Instructor path records `user_visible_error` and is not private.
- **No duplicate “missing grader result”**: `github-repo-webhook` skips creating the synthetic `missing_grader_result` workflow error when a `user_visible_error` already exists for the same run. The student submission results page also filters out `missing_grader_result` when a `user_visible_error` is present (covers older duplicate rows).
- **Rubric sidebar**: placeholder `grader_results` rows (errors-only, DB default `max_score` e.g. 100) no longer show “Automated Checks: 100 points, results shown below” or misleading `Automated Check Results (0/0)`. New helper `graderResultsHasAutograderTestsOrOutput` requires real tests, non-empty lint, or grader output rows.

## Testing

- `npm run format`
- Deno not available in this environment; no `deno check` run locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ab77f8-76d1-4de8-9e17-0581219166c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ab77f8-76d1-4de8-9e17-0581219166c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

