### PR TITLE
Allow grading comments after review completion; restrict edits when released

### DIFF
--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -11168,6 +11168,10 @@ export type Database = {
         Args: { submission_review_id: number };
         Returns: boolean;
       };
+      authorize_for_submission_review_comment_writable: {
+        Args: { submission_review_id: number };
+        Returns: boolean;
+      };
       authorize_for_submission_reviewable: {
         Args: {
           requested_submission_id: number;

--- a/supabase/migrations/20260417120000_authorize_submission_review_writable_after_complete.sql
+++ b/supabase/migrations/20260417120000_authorize_submission_review_writable_after_complete.sql
@@ -1,0 +1,304 @@
+-- Comment RLS: allow graders/instructors to insert/update/delete comments after a
+-- submission_review or review_assignment is marked complete. The only hard stop for
+-- graders remains release (issue #446). submission_review row updates stay gated by
+-- authorize_for_submission_review_writable (completed submission_review).
+
+CREATE OR REPLACE FUNCTION public.authorize_for_submission_review_comment_writable(submission_review_id bigint)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+begin
+    return (
+        select exists (
+            select 1
+            from submission_reviews sr
+            left join review_assignments ra
+                on ra.submission_review_id = sr.id
+            left join user_roles ur on ur.private_profile_id = ra.assignee_profile_id and ur.class_id = sr.class_id
+            where sr.id = authorize_for_submission_review_comment_writable.submission_review_id
+              and ur.user_id = auth.uid()
+        )
+    );
+end;
+$function$;
+
+COMMENT ON FUNCTION public.authorize_for_submission_review_comment_writable(bigint) IS
+  'True when the current user has a review_assignment for this submission_review, regardless of submission_review.completed_at. Used by comment INSERT/UPDATE RLS; release restrictions are separate.';
+
+CREATE OR REPLACE FUNCTION public.authorize_for_submission_review_writable(submission_review_id bigint)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+begin
+    -- Only write to a submission review row if there is a review assignment for the user and the review is not done.
+    return (
+        select exists (
+            select 1
+            from submission_reviews sr
+            left join review_assignments ra
+                on ra.submission_review_id = sr.id
+            left join user_roles ur on ur.private_profile_id = ra.assignee_profile_id and ur.class_id = sr.class_id
+            where sr.id = authorize_for_submission_review_writable.submission_review_id
+              and sr.completed_at is null
+              and ur.user_id = auth.uid()
+        )
+    );
+end;
+$function$;
+
+-- Issue #446 policies: use comment-specific auth for graders so completed reviews still allow comment edits.
+DROP POLICY IF EXISTS "Instructors always; others only own comment if review not released" ON public.submission_comments;
+DROP POLICY IF EXISTS "Instructors always; others only own comment if review not released" ON public.submission_file_comments;
+DROP POLICY IF EXISTS "Instructors always; others only own comment if review not released" ON public.submission_artifact_comments;
+
+CREATE POLICY "Instructors always; others only own comment if review not released"
+ON public.submission_comments
+AS PERMISSIVE
+FOR UPDATE
+TO public
+USING (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+)
+WITH CHECK (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY "Instructors always; others only own comment if review not released"
+ON public.submission_file_comments
+AS PERMISSIVE
+FOR UPDATE
+TO public
+USING (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_file_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_file_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+)
+WITH CHECK (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_file_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_file_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+);
+
+CREATE POLICY "Instructors always; others only own comment if review not released"
+ON public.submission_artifact_comments
+AS PERMISSIVE
+FOR UPDATE
+TO public
+USING (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_artifact_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_artifact_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+)
+WITH CHECK (
+  public.authorizeforclassinstructor(class_id)
+  OR (
+    public.authorizeforprofile(author)
+    AND (
+      submission_review_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM public.submission_reviews sr
+        WHERE sr.id = submission_artifact_comments.submission_review_id
+          AND sr.released = false
+          AND (
+            public.authorize_for_submission_review_comment_writable(submission_artifact_comments.submission_review_id)
+            OR (
+              NOT public.authorizeforclassgrader(class_id)
+              AND sr.completed_at IS NULL
+            )
+          )
+      )
+    )
+  )
+);
+
+COMMENT ON POLICY "Instructors always; others only own comment if review not released" ON public.submission_comments IS
+  'Instructors may update any comment. Graders may update only their own rows while the review is unreleased and they have a review assignment (even if the submission_review is complete). Students may update only their own rows while the review is unreleased and not completed. NULL submission_review_id keeps prior behavior for non-review comments.';
+COMMENT ON POLICY "Instructors always; others only own comment if review not released" ON public.submission_file_comments IS
+  'Instructors may update any comment. Graders may update only their own rows while the review is unreleased and they have a review assignment (even if the submission_review is complete). Students may update only their own rows while the review is unreleased and not completed. NULL submission_review_id keeps prior behavior for non-review comments.';
+COMMENT ON POLICY "Instructors always; others only own comment if review not released" ON public.submission_artifact_comments IS
+  'Instructors may update any comment. Graders may update only their own rows while the review is unreleased and they have a review assignment (even if the submission_review is complete). Students may update only their own rows while the review is unreleased and not completed. NULL submission_review_id keeps prior behavior for non-review comments.';
+
+-- INSERT policies: keep hard_deadline enforcement after due_date, but do not block
+-- inserts solely because the review_assignment was marked completed.
+
+DROP POLICY IF EXISTS "insert for self with deadline check" ON public.submission_comments;
+DROP POLICY IF EXISTS "insert for self with deadline check" ON public.submission_file_comments;
+DROP POLICY IF EXISTS "insert for self with deadline check" ON public.submission_artifact_comments;
+
+CREATE POLICY "insert for self with deadline check" ON public.submission_comments
+    FOR INSERT
+    WITH CHECK (
+        public.authorizeforprofile(author)
+        AND (
+            public.authorizeforclassgrader(class_id)
+            OR (
+                (submission_review_id IS NULL)
+                AND public.authorize_for_submission(submission_id)
+            )
+            OR (
+                public.authorize_for_submission_review_comment_writable(submission_review_id)
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM public.review_assignments ra
+                    WHERE ra.submission_review_id = submission_comments.submission_review_id
+                      AND ra.assignee_profile_id IN (
+                          SELECT up.private_profile_id
+                          FROM public.user_privileges up
+                          WHERE up.user_id = auth.uid()
+                      )
+                      AND ra.due_date < NOW()
+                      AND ra.hard_deadline = true
+                )
+            )
+        )
+    );
+
+CREATE POLICY "insert for self with deadline check" ON public.submission_file_comments
+    FOR INSERT
+    WITH CHECK (
+        public.authorizeforprofile(author)
+        AND (
+            public.authorizeforclassgrader(class_id)
+            OR (
+                (submission_review_id IS NULL)
+                AND public.authorize_for_submission(submission_id)
+            )
+            OR (
+                public.authorize_for_submission_review_comment_writable(submission_review_id)
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM public.review_assignments ra
+                    WHERE ra.submission_review_id = submission_file_comments.submission_review_id
+                      AND ra.assignee_profile_id IN (
+                          SELECT up.private_profile_id
+                          FROM public.user_privileges up
+                          WHERE up.user_id = auth.uid()
+                      )
+                      AND ra.due_date < NOW()
+                      AND ra.hard_deadline = true
+                )
+            )
+        )
+    );
+
+CREATE POLICY "insert for self with deadline check" ON public.submission_artifact_comments
+    FOR INSERT
+    WITH CHECK (
+        public.authorizeforprofile(author)
+        AND (
+            public.authorizeforclassgrader(class_id)
+            OR (
+                (submission_review_id IS NULL)
+                AND public.authorize_for_submission(submission_id)
+            )
+            OR (
+                public.authorize_for_submission_review_comment_writable(submission_review_id)
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM public.review_assignments ra
+                    WHERE ra.submission_review_id = submission_artifact_comments.submission_review_id
+                      AND ra.assignee_profile_id IN (
+                          SELECT up.private_profile_id
+                          FROM public.user_privileges up
+                          WHERE up.user_id = auth.uid()
+                      )
+                      AND ra.due_date < NOW()
+                      AND ra.hard_deadline = true
+                )
+            )
+        )
+    );

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -11168,6 +11168,10 @@ export type Database = {
         Args: { submission_review_id: number };
         Returns: boolean;
       };
+      authorize_for_submission_review_comment_writable: {
+        Args: { submission_review_id: number };
+        Returns: boolean;
+      };
       authorize_for_submission_reviewable: {
         Args: {
           requested_submission_id: number;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Graders and instructors were blocked from creating or editing submission review comments after a submission review (or review assignment) was marked complete, because RLS reused `authorize_for_submission_review_writable`, which requires `submission_reviews.completed_at IS NULL`. Insert policies also blocked new comments when the assignee's `review_assignments.completed_at` was set.

## Changes

- Add `authorize_for_submission_review_comment_writable(submission_review_id)` — true when the user has a `review_assignment` for that review, **without** requiring an incomplete submission review.
- Keep `authorize_for_submission_review_writable` as-is for **`submission_reviews` row updates** (still requires incomplete review for non-instructors).
- Update issue #446 UPDATE policies on `submission_comments`, `submission_file_comments`, and `submission_artifact_comments` to use the new function for the grader path.
- Update INSERT policies (`insert for self with deadline check`) to use the new function and **drop the `review_assignments.completed_at IS NOT NULL` branch** from the NOT EXISTS guard; **hard deadline** (`due_date` + `hard_deadline`) behavior is unchanged.
- Regenerate `Database` RPC types for the new function in `SupabaseTypes.d.ts` (app + edge copy).

## Behavior

- **Completed review / assignment:** graders with an assignment can still add/edit/delete comments (subject to existing UI rules) as long as the review is **not released**.
- **Released:** non-instructors still cannot edit/delete per existing policies.
- **Submission review metadata:** graders still cannot update `submission_reviews` after completion via the old writable check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ef08c40-5d57-4680-8578-6e9bacb26bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ef08c40-5d57-4680-8578-6e9bacb26bb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated submission review comment permissions to allow instructors full editing access to all comments
  * Enabled reviewers to edit their own comments after review submission
  * Refined access controls for comment creation and modification based on user roles and review status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->