### PR TITLE
Fix: sync GitHub repos when instructors edit assignment groups

### DIFF
--- a/supabase/migrations/20260417130000_sync_repos_on_assignment_group_changes.sql
+++ b/supabase/migrations/20260417130000_sync_repos_on_assignment_group_changes.sql
@@ -1,0 +1,104 @@
+-- When a group assignment is released before groups exist, students get individual repos from
+-- create_all_repos_for_assignment (release trigger / cron). Later, when instructors create groups
+-- or move students, nothing re-invoked repo creation. Re-queue repo sync when groups or
+-- membership change for an already-released group/both assignment so new group repos are created.
+
+CREATE OR REPLACE FUNCTION public.sync_repos_after_assignment_group_change()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_assignment_id bigint;
+  v_class_id bigint;
+  v_group_config public.assignment_group_mode;
+  v_release timestamptz;
+  v_template text;
+BEGIN
+  IF TG_TABLE_NAME = 'assignment_groups' THEN
+    IF TG_OP = 'DELETE' THEN
+      v_assignment_id := OLD.assignment_id;
+      v_class_id := OLD.class_id;
+    ELSE
+      v_assignment_id := NEW.assignment_id;
+      v_class_id := NEW.class_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'assignment_groups_members' THEN
+    IF TG_OP = 'DELETE' THEN
+      v_assignment_id := OLD.assignment_id;
+      v_class_id := OLD.class_id;
+    ELSE
+      v_assignment_id := NEW.assignment_id;
+      v_class_id := NEW.class_id;
+    END IF;
+  ELSE
+    RAISE WARNING 'sync_repos_after_assignment_group_change: unexpected table %', TG_TABLE_NAME;
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  SELECT a.group_config, a.release_date, a.template_repo
+  INTO v_group_config, v_release, v_template
+  FROM public.assignments a
+  WHERE a.id = v_assignment_id AND a.class_id = v_class_id;
+
+  IF v_group_config IS NULL THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF v_group_config NOT IN ('groups', 'both') THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF v_template IS NULL OR v_template = '' THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF v_release IS NULL OR v_release > now() THEN
+    IF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RAISE NOTICE 'sync_repos_after_assignment_group_change: enqueue repos for assignment_id=%, class_id=% (source=% %)',
+    v_assignment_id, v_class_id, TG_TABLE_NAME, TG_OP;
+
+  PERFORM public.create_all_repos_for_assignment(v_class_id, v_assignment_id, false);
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.sync_repos_after_assignment_group_change() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.sync_repos_after_assignment_group_change() TO postgres;
+
+COMMENT ON FUNCTION public.sync_repos_after_assignment_group_change() IS
+  'After groups or membership change, enqueue repo creation/sync for released group/both assignments (new groups get repos without toggling release date).';
+
+DROP TRIGGER IF EXISTS trigger_sync_repos_on_assignment_groups_change ON public.assignment_groups;
+CREATE TRIGGER trigger_sync_repos_on_assignment_groups_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.assignment_groups
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_repos_after_assignment_group_change();
+
+DROP TRIGGER IF EXISTS trigger_sync_repos_on_assignment_groups_members_change ON public.assignment_groups_members;
+CREATE TRIGGER trigger_sync_repos_on_assignment_groups_members_change
+  AFTER INSERT OR UPDATE OR DELETE ON public.assignment_groups_members
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_repos_after_assignment_group_change();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

For group assignments (`group_config` `groups` or `both`), repos are created when the assignment is released (and via related triggers/cron). If the assignment was released **before** any groups existed, students correctly received **individual** repos. When instructors later created or edited groups / membership, **no code path** re-ran `create_all_repos_for_assignment`, so **group repos were never enqueued**. The workaround was toggling the release date so the assignment trigger fired again.

## Solution

Add PostgreSQL `AFTER INSERT OR UPDATE OR DELETE` triggers on `assignment_groups` and `assignment_groups_members` that call `public.create_all_repos_for_assignment(class_id, assignment_id, false)` when:

- The assignment has `group_config` in (`groups`, `both`)
- `template_repo` is set
- `release_date` is in the past (assignment is released)

This reuses the existing enqueue logic (same as release handling): it creates missing group repos, enqueues individual repos for students not in a group where needed, and syncs permissions.

## Migration

- `supabase/migrations/20260417130000_sync_repos_on_assignment_group_changes.sql`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-986a9517-3455-4f95-8e9b-65698c30ec3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-986a9517-3455-4f95-8e9b-65698c30ec3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repositories now automatically synchronize when assignment group membership changes, streamlining group-based assignment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->