### PR TITLE
feat(gradebook): expression validation + full-screen Expression Builder

### DIFF
--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -7,7 +7,7 @@ import {
   evaluateForStudent,
   evaluateRenderExpression,
   formatValueForOverlay,
-  type IntermediateValue,
+  type LineResult,
   type RenderExpressionResult,
   type ValidationResult
 } from "@/lib/gradebookExpressionTester";
@@ -319,45 +319,12 @@ export function ExpressionBuilder(props: Props) {
             renderExpression={renderExpression}
           />
 
-          {/* The editor + inline annotations share a border so they read as
-              one surface — the textarea is the input row, and every captured
-              subexpression is displayed below in source order with its value,
-              visually tied to the code. */}
-          <Box
-            borderWidth="1px"
-            borderColor={
-              validation.parseError || validation.dependencyError || validation.evaluation?.error
-                ? "red.500"
-                : validation.isValid && !validation.isEmpty
-                  ? "green.500"
-                  : "border.muted"
-            }
-            rounded="md"
-            bg="bg.subtle"
-            overflow="hidden"
-            data-testid="expression-builder-overlay"
-          >
-            <Textarea
-              id="scoreExpressionFull"
-              value={expression}
-              onChange={(e) => onExpressionChange(e.target.value)}
-              placeholder="Score Expression"
-              rows={Math.max(6, Math.min(12, expression.split("\n").length + 2))}
-              fontFamily="mono"
-              fontSize="sm"
-              border="none"
-              borderBottomWidth="1px"
-              borderBottomColor="border.subtle"
-              rounded="none"
-              bg="bg.panel"
-              _focus={{ boxShadow: "none", outline: "none" }}
-            />
-            <InlineAnnotations
-              validation={validation}
-              hasStudent={Boolean(selectedStudentId)}
-              expression={expression}
-            />
-          </Box>
+          <InlineLineAnnotatedEditor
+            expression={expression}
+            onExpressionChange={onExpressionChange}
+            validation={validation}
+            hasStudent={Boolean(selectedStudentId)}
+          />
 
           <ValidationStatus validation={validation} expression={expression} />
 
@@ -438,100 +405,179 @@ function FinalResultBadges({
 }
 
 /**
- * Inline annotations directly underneath the textarea. Each captured
- * subexpression renders as `source = value`, indented by AST containment
- * depth so nested calls read naturally as a breakdown of the expression
- * immediately above them.
+ * The full-screen editor surface. A monospace `<textarea>` is layered over a
+ * pre-rendered mirror that shows the same text line-by-line, plus a
+ * right-aligned `= value` annotation on every line that ends a top-level
+ * statement. Both layers share the same font metrics, padding, and line
+ * height so the cursor in the textarea lines up exactly with the values in
+ * the mirror; the textarea is transparent and painted on top, so the user
+ * edits normally while seeing per-line evaluations as inline hints.
  */
-function InlineAnnotations({
+function InlineLineAnnotatedEditor({
+  expression,
+  onExpressionChange,
   validation,
-  hasStudent,
-  expression
+  hasStudent
 }: {
+  expression: string;
+  onExpressionChange: (value: string) => void;
   validation: ValidationResult;
   hasStudent: boolean;
-  expression: string;
 }) {
   const evaluation = validation.evaluation;
 
-  if (!hasStudent) {
-    return (
-      <Box p={2} bg="bg.subtle">
-        <Text fontSize="xs" color="fg.muted">
-          Select a student on the left to see intermediate values and the final score.
-        </Text>
-      </Box>
-    );
-  }
-  if (!evaluation) return null;
-  if (evaluation.error && evaluation.intermediates.length === 0) {
-    return (
-      <Box p={2} bg="bg.subtle">
-        <Text fontSize="xs" color="red.500">
-          Evaluation error: {evaluation.error}
-        </Text>
-      </Box>
-    );
-  }
-  if (evaluation.intermediates.length === 0) {
-    // Pure-arithmetic expression with no subexpressions worth labelling.
-    return (
-      <Box p={2} bg="bg.subtle">
-        <Text fontSize="xs" color="fg.muted" fontFamily="mono">
-          {expression.trim()} = {evaluation.result}
-        </Text>
-      </Box>
-    );
-  }
-  const distinct = dedupeByStartEnd(evaluation.intermediates);
-  const levels = assignLevels(distinct);
-  const MAX_VISIBLE = 80;
-  const visible = distinct.slice(0, MAX_VISIBLE);
-  const hiddenCount = Math.max(0, distinct.length - MAX_VISIBLE);
+  // Build an O(1) lookup from line-index to annotation value.
+  const lineResultsByIndex = useMemo(() => {
+    const map = new Map<number, LineResult>();
+    for (const lr of evaluation?.lineResults ?? []) {
+      map.set(lr.lineIndex, lr);
+    }
+    return map;
+  }, [evaluation?.lineResults]);
+
+  const lines = useMemo(() => expression.split("\n"), [expression]);
+  const rows = Math.max(6, Math.min(24, lines.length + 2));
+
+  // Keep the textarea and the mirror in sync on scroll. The user might type
+  // more lines than the textarea's visible height, in which case both layers
+  // need to scroll together so the annotations stay aligned with the code.
+  const scrollSync = (e: React.UIEvent<HTMLTextAreaElement>) => {
+    if (mirrorRef.current) {
+      mirrorRef.current.scrollTop = e.currentTarget.scrollTop;
+      mirrorRef.current.scrollLeft = e.currentTarget.scrollLeft;
+    }
+  };
+  const mirrorRef = React.useRef<HTMLPreElement | null>(null);
+
+  const borderColor =
+    validation.parseError || validation.dependencyError || validation.evaluation?.error
+      ? "red.500"
+      : validation.isValid && !validation.isEmpty
+        ? "green.500"
+        : "border.muted";
+
   return (
-    <VStack align="stretch" gap={0} bg="bg.subtle" maxH="40vh" overflow="auto">
-      {visible.map((iv, idx) => (
-        <HStack
-          key={`${iv.start}-${iv.end}-${idx}`}
-          gap={2}
-          align="flex-start"
-          px={2}
+    <Box
+      position="relative"
+      borderWidth="1px"
+      borderColor={borderColor}
+      rounded="md"
+      bg="bg.panel"
+      overflow="hidden"
+      data-testid="expression-builder-overlay"
+    >
+      {/* Mirror layer: renders the user's text plus the per-line values. */}
+      <Box
+        as="pre"
+        ref={mirrorRef as React.RefObject<HTMLPreElement>}
+        aria-hidden="true"
+        position="absolute"
+        inset={0}
+        m={0}
+        px={3}
+        py={2}
+        fontFamily="mono"
+        fontSize="sm"
+        lineHeight="1.5"
+        color="fg"
+        whiteSpace="pre"
+        overflow="auto"
+        pointerEvents="none"
+      >
+        {lines.map((line, idx) => {
+          const lr = lineResultsByIndex.get(idx);
+          return (
+            <Box
+              key={idx}
+              as="div"
+              display="flex"
+              justifyContent="space-between"
+              gap={4}
+              data-testid={lr?.kind === "value" ? "expression-line-value" : undefined}
+            >
+              {/* The text content must match the textarea exactly — including
+                  trailing whitespace — so the invisible textarea text lines
+                  up underneath. Use a non-breaking content for empty lines
+                  so the div retains its height. */}
+              <Box as="span" color="transparent" whiteSpace="pre">
+                {line.length ? line : "\u200B"}
+              </Box>
+              {lr?.kind === "value" ? (
+                <Box
+                  as="span"
+                  color={lr.display === "undefined" ? "orange.500" : "green.600"}
+                  fontWeight="semibold"
+                  whiteSpace="pre"
+                  pl={2}
+                >
+                  {"= "}
+                  {lr.display}
+                </Box>
+              ) : lr?.kind === "error" ? (
+                <Box as="span" color="red.500" fontWeight="semibold" whiteSpace="pre" pl={2}>
+                  {"⚠ "}
+                  {lr.display}
+                </Box>
+              ) : null}
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Real editor: invisible background so the mirror shines through, but
+          the textarea itself holds the caret, selection, and IME focus. */}
+      <Box position="relative">
+        <Textarea
+          id="scoreExpressionFull"
+          value={expression}
+          onChange={(e) => onExpressionChange(e.target.value)}
+          onScroll={scrollSync}
+          placeholder="Score Expression"
+          rows={rows}
+          fontFamily="mono"
+          fontSize="sm"
+          lineHeight="1.5"
+          px={3}
+          py={2}
+          border="none"
+          rounded="none"
+          bg="transparent"
+          color="fg"
+          resize="vertical"
+          whiteSpace="pre"
+          overflow="auto"
+          spellCheck={false}
+          _focus={{ boxShadow: "none", outline: "none" }}
+          /* Hide the textarea's own text so only the mirror's per-line
+             layout (with its trailing annotations) is visible — the
+             textarea retains the caret and keeps accepting input. */
+          css={{
+            color: "transparent",
+            caretColor: "var(--chakra-colors-fg)",
+            "&::placeholder": { color: "var(--chakra-colors-fg-muted)" }
+          }}
+        />
+      </Box>
+
+      {!hasStudent && (
+        <Box
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          px={3}
           py={1}
-          borderBottomWidth={idx === visible.length - 1 && hiddenCount === 0 ? 0 : "1px"}
+          bg="bg.muted"
+          borderTopWidth="1px"
           borderColor="border.subtle"
-          _hover={{ bg: "bg.muted" }}
+          pointerEvents="none"
         >
-          <Text
-            fontSize="xs"
-            color="fg.muted"
-            fontFamily="mono"
-            flex="1"
-            wordBreak="break-all"
-            pl={`${(levels[idx] ?? 0) * 12}px`}
-          >
-            {iv.source}
+          <Text fontSize="xs" color="fg.muted">
+            Select a student to see per-line values.
           </Text>
-          <Badge
-            colorPalette={iv.error ? "red" : "blue"}
-            variant="subtle"
-            fontFamily="mono"
-            whiteSpace="normal"
-            maxW="55%"
-            textAlign="right"
-            fontSize="xs"
-          >
-            = {iv.display}
-          </Badge>
-        </HStack>
-      ))}
-      {hiddenCount > 0 && (
-        <HStack px={2} py={1} justifyContent="center" bg="bg.muted">
-          <Text fontSize="xs" color="fg.muted" fontStyle="italic">
-            {hiddenCount} more intermediate {hiddenCount === 1 ? "value" : "values"} hidden
-          </Text>
-        </HStack>
+        </Box>
       )}
-    </VStack>
+    </Box>
   );
 }
 
@@ -606,39 +652,6 @@ function ValidationStatus({ validation, expression }: { validation: ValidationRe
       </Text>
     </HStack>
   );
-}
-
-function dedupeByStartEnd(values: IntermediateValue[]): IntermediateValue[] {
-  const seen = new Map<string, IntermediateValue>();
-  for (const v of values) {
-    const key = `${v.start}:${v.end}:${v.source}`;
-    if (!seen.has(key)) seen.set(key, v);
-  }
-  return Array.from(seen.values()).sort((a, b) => {
-    if (a.start === b.start) return b.end - a.end;
-    return a.start - b.start;
-  });
-}
-
-function assignLevels(values: IntermediateValue[]): number[] {
-  // `values` is already sorted by start asc, then end desc (longer spans
-  // first), so a single-pass stack walk gives us the containment depth in
-  // O(n). Whenever the top of the stack no longer strictly contains the
-  // current entry, we pop it; the remaining stack size is the current depth.
-  const result: number[] = [];
-  const stack: IntermediateValue[] = [];
-  for (const value of values) {
-    while (stack.length > 0) {
-      const top = stack[stack.length - 1];
-      const strictlyContains =
-        top.start <= value.start && top.end >= value.end && !(top.start === value.start && top.end === value.end);
-      if (strictlyContains) break;
-      stack.pop();
-    }
-    result.push(stack.length);
-    stack.push(value);
-  }
-  return result;
 }
 
 /**

--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -1,0 +1,563 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import { toaster } from "@/components/ui/toaster";
+import { useAllStudentRoles } from "@/hooks/useCourseController";
+import { useGradebookController, useGradebookColumns } from "@/hooks/useGradebook";
+import {
+  evaluateForStudent,
+  formatValueForOverlay,
+  type IntermediateValue,
+  type ValidationResult
+} from "@/lib/gradebookExpressionTester";
+import { Badge, Box, Button, Code, Flex, HStack, Icon, Input, Text, Textarea, VStack } from "@chakra-ui/react";
+import type * as MathJSType from "mathjs";
+import React, { useEffect, useMemo, useState } from "react";
+import { LuArrowLeftRight, LuCheck, LuCircleAlert, LuMaximize2, LuMinimize2, LuUser } from "react-icons/lu";
+
+type MathJSNS = typeof MathJSType;
+
+export type ExpressionBuilderMode = "modal" | "fullscreen";
+
+type Props = {
+  expression: string;
+  onExpressionChange: (value: string) => void;
+  editingColumnId: number | null;
+  isExpanded: boolean;
+  onExpandToggle: () => void;
+  math: MathJSNS | null;
+  /**
+   * Called whenever the validation result changes. Parent can use this to
+   * disable the Save button when validation fails.
+   */
+  onValidationChange?: (result: ValidationResult) => void;
+};
+
+function useLoadedMathJS() {
+  const [math, setMath] = useState<MathJSNS | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    import("mathjs").then((mod) => {
+      if (!cancelled) setMath(mod);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return math;
+}
+
+/**
+ * Expression builder panel. Provides:
+ *  - Live parse / dependency validation of the entered score expression.
+ *  - An optional full-screen mode which adds a student-picker and evaluates
+ *    the expression against that student, overlaying intermediate values on
+ *    every subexpression.
+ */
+export function ExpressionBuilder(props: Props) {
+  const { expression, onExpressionChange, editingColumnId, isExpanded, onExpandToggle, onValidationChange } = props;
+  const gradebookController = useGradebookController();
+  const gradebookColumns = useGradebookColumns();
+  const fallbackMath = useLoadedMathJS();
+  const math = props.math ?? fallbackMath;
+  const students = useAllStudentRoles();
+  const [selectedStudentId, setSelectedStudentId] = useState<string>("");
+  const [studentFilter, setStudentFilter] = useState<string>("");
+
+  const sortedStudents = useMemo(() => {
+    const sorted = [...students].sort((a, b) => {
+      const aName = a.profiles?.name || a.profiles?.short_name || "";
+      const bName = b.profiles?.name || b.profiles?.short_name || "";
+      return aName.localeCompare(bName);
+    });
+    if (!studentFilter.trim()) return sorted;
+    const q = studentFilter.toLowerCase();
+    return sorted.filter((s) => {
+      const name = (s.profiles?.name || s.profiles?.short_name || "").toLowerCase();
+      const email = (s.users?.email || "").toLowerCase();
+      return name.includes(q) || email.includes(q);
+    });
+  }, [students, studentFilter]);
+
+  // Default to the first student when we enter full-screen mode.
+  useEffect(() => {
+    if (!isExpanded) return;
+    if (!selectedStudentId && sortedStudents.length > 0) {
+      setSelectedStudentId(sortedStudents[0].private_profile_id);
+    }
+  }, [isExpanded, sortedStudents, selectedStudentId]);
+
+  // Recompute when the set of column slugs changes so dependency validation
+  // stays current if another instructor adds/removes a column in the background.
+  const gradebookColumnsKey = useMemo(
+    () => gradebookColumns.map((c) => `${c.id}:${c.slug ?? ""}`).join("|"),
+    [gradebookColumns]
+  );
+  const validation = useMemo<ValidationResult>(() => {
+    if (!math) {
+      return {
+        isValid: true,
+        isEmpty: expression.trim().length === 0,
+        parseError: null,
+        dependencyError: null,
+        evaluation: null
+      };
+    }
+    try {
+      return evaluateForStudent({
+        math,
+        gradebookController,
+        expression,
+        studentId: isExpanded ? selectedStudentId : "",
+        editingColumnId,
+        captureIntermediates: isExpanded
+      });
+    } catch (e) {
+      return {
+        isValid: false,
+        isEmpty: expression.trim().length === 0,
+        parseError: e instanceof Error ? e.message : String(e),
+        dependencyError: null,
+        evaluation: null
+      };
+    }
+    // gradebookColumnsKey is intentionally a dep so validation updates when
+    // columns are added/removed in the background.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [math, gradebookController, expression, selectedStudentId, editingColumnId, isExpanded, gradebookColumnsKey]);
+
+  useEffect(() => {
+    onValidationChange?.(validation);
+  }, [validation, onValidationChange]);
+
+  const selectedStudent = students.find((s) => s.private_profile_id === selectedStudentId);
+
+  if (!isExpanded) {
+    return (
+      <VStack align="stretch" gap={1}>
+        <HStack justifyContent="space-between">
+          <Label htmlFor="scoreExpression">Score Expression</Label>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={onExpandToggle}
+            title="Open full-screen expression builder"
+          >
+            <Icon as={LuMaximize2} mr={1} /> Expression Builder
+          </Button>
+        </HStack>
+        <Textarea
+          id="scoreExpression"
+          value={expression}
+          onChange={(e) => onExpressionChange(e.target.value)}
+          placeholder="Score Expression"
+          rows={4}
+          fontFamily="mono"
+          fontSize="sm"
+          borderColor={
+            validation.parseError || validation.dependencyError || validation.evaluation?.error
+              ? "red.500"
+              : validation.isValid && !validation.isEmpty
+                ? "green.500"
+                : undefined
+          }
+        />
+        <ValidationStatus validation={validation} expression={expression} />
+      </VStack>
+    );
+  }
+
+  return (
+    <VStack align="stretch" gap={3} w="100%">
+      <HStack justifyContent="space-between" wrap="wrap" gap={2}>
+        <HStack gap={2}>
+          <Icon as={LuArrowLeftRight} color="fg.muted" />
+          <Text fontWeight="semibold">Expression Builder</Text>
+          <Text fontSize="sm" color="fg.muted">
+            Edit your expression, pick a student, and see intermediate values evaluated against their grade book.
+          </Text>
+        </HStack>
+        <Button type="button" size="xs" variant="outline" onClick={onExpandToggle}>
+          <Icon as={LuMinimize2} mr={1} /> Collapse
+        </Button>
+      </HStack>
+
+      <Flex gap={4} direction={{ base: "column", lg: "row" }} align="stretch" flex={1}>
+        {/* Left: Student picker */}
+        <Box
+          flex="0 0 280px"
+          borderWidth="1px"
+          borderColor="border.muted"
+          rounded="md"
+          p={3}
+          bg="bg.muted"
+          overflow="auto"
+          maxH={{ base: "200px", lg: "65vh" }}
+        >
+          <HStack mb={2}>
+            <Icon as={LuUser} color="fg.muted" />
+            <Text fontSize="sm" fontWeight="semibold">
+              Test against student
+            </Text>
+          </HStack>
+          <Input
+            placeholder="Search name or email…"
+            value={studentFilter}
+            onChange={(e) => setStudentFilter(e.target.value)}
+            size="sm"
+            mb={2}
+          />
+          <VStack align="stretch" gap={0.5}>
+            {sortedStudents.length === 0 && (
+              <Text color="fg.muted" fontSize="sm">
+                No students match this search.
+              </Text>
+            )}
+            {sortedStudents.map((s) => {
+              const displayName = s.profiles?.name || s.profiles?.short_name || "Unknown";
+              const isSelected = s.private_profile_id === selectedStudentId;
+              return (
+                <Button
+                  key={s.private_profile_id}
+                  onClick={() => setSelectedStudentId(s.private_profile_id)}
+                  size="xs"
+                  variant={isSelected ? "solid" : "ghost"}
+                  colorPalette={isSelected ? "green" : "gray"}
+                  justifyContent="flex-start"
+                  textAlign="left"
+                  title={s.users?.email ?? ""}
+                >
+                  {displayName}
+                </Button>
+              );
+            })}
+          </VStack>
+        </Box>
+
+        {/* Middle: Expression editor + overlay */}
+        <VStack flex="1" align="stretch" gap={2} minW={0}>
+          <Label htmlFor="scoreExpressionFull">Score Expression</Label>
+          <Textarea
+            id="scoreExpressionFull"
+            value={expression}
+            onChange={(e) => onExpressionChange(e.target.value)}
+            placeholder="Score Expression"
+            rows={10}
+            fontFamily="mono"
+            fontSize="sm"
+            borderColor={
+              validation.parseError || validation.dependencyError || validation.evaluation?.error
+                ? "red.500"
+                : validation.isValid && !validation.isEmpty
+                  ? "green.500"
+                  : undefined
+            }
+          />
+          <ValidationStatus validation={validation} expression={expression} />
+
+          <Box
+            mt={2}
+            borderWidth="1px"
+            borderColor="border.muted"
+            rounded="md"
+            p={3}
+            bg="bg.subtle"
+            overflow="auto"
+            maxH="40vh"
+            data-testid="expression-builder-overlay"
+          >
+            <HStack mb={2} justifyContent="space-between" gap={2} wrap="wrap">
+              <Text fontSize="sm" fontWeight="semibold">
+                Annotated expression{" "}
+                {selectedStudent && (
+                  <Text as="span" color="fg.muted" fontWeight="normal">
+                    — {selectedStudent.profiles?.name || selectedStudent.profiles?.short_name}
+                  </Text>
+                )}
+              </Text>
+              {validation.evaluation && !validation.evaluation.error && (
+                <Badge colorPalette="green" variant="subtle">
+                  Result: {validation.evaluation.result}
+                </Badge>
+              )}
+            </HStack>
+            <AnnotatedExpressionView validation={validation} expression={expression} />
+          </Box>
+        </VStack>
+
+        {/* Right: List of intermediates */}
+        <Box
+          flex="0 0 320px"
+          borderWidth="1px"
+          borderColor="border.muted"
+          rounded="md"
+          p={3}
+          bg="bg.muted"
+          overflow="auto"
+          maxH={{ base: "200px", lg: "65vh" }}
+        >
+          <Text fontSize="sm" fontWeight="semibold" mb={2}>
+            Intermediate values
+          </Text>
+          {!selectedStudentId && (
+            <Text fontSize="sm" color="fg.muted">
+              Select a student to see live evaluation.
+            </Text>
+          )}
+          {validation.evaluation &&
+            validation.evaluation.intermediates.length === 0 &&
+            !validation.evaluation.error && (
+              <Text fontSize="sm" color="fg.muted">
+                No intermediate subexpressions.
+              </Text>
+            )}
+          {validation.evaluation?.error && (
+            <Text fontSize="sm" color="red.500">
+              Cannot evaluate: {validation.evaluation.error}
+            </Text>
+          )}
+          {validation.evaluation && (
+            <VStack align="stretch" gap={2}>
+              {validation.evaluation.intermediates.slice(0, 80).map((iv, idx) => (
+                <Box
+                  key={`${iv.start}-${iv.end}-${idx}`}
+                  borderWidth="1px"
+                  borderColor={iv.error ? "red.300" : "border.muted"}
+                  rounded="sm"
+                  p={2}
+                  bg="bg.panel"
+                >
+                  <Code fontSize="xs" wordBreak="break-all" whiteSpace="pre-wrap" bg="transparent" color="fg.muted">
+                    {iv.source}
+                  </Code>
+                  <Text fontSize="xs" fontWeight="semibold" color={iv.error ? "red.500" : "fg"}>
+                    = {iv.display}
+                  </Text>
+                </Box>
+              ))}
+            </VStack>
+          )}
+          {validation.evaluation?.incompleteValues && (
+            <Box mt={3} borderWidth="1px" borderColor="orange.300" rounded="sm" p={2} bg="orange.50">
+              <Text fontSize="xs" fontWeight="semibold" color="orange.700">
+                Incomplete dependencies
+              </Text>
+              {(validation.evaluation.incompleteValues.missing?.gradebook_columns?.length ?? 0) > 0 && (
+                <Text fontSize="xs" color="orange.700">
+                  Missing: {validation.evaluation.incompleteValues.missing!.gradebook_columns!.join(", ")}
+                </Text>
+              )}
+              {(validation.evaluation.incompleteValues.not_released?.gradebook_columns?.length ?? 0) > 0 && (
+                <Text fontSize="xs" color="orange.700">
+                  Not released: {validation.evaluation.incompleteValues.not_released!.gradebook_columns!.join(", ")}
+                </Text>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Flex>
+    </VStack>
+  );
+}
+
+function ValidationStatus({ validation, expression }: { validation: ValidationResult; expression: string }) {
+  if (validation.isEmpty) {
+    return (
+      <Text fontSize="xs" color="fg.muted">
+        No expression set — this column can be hand-graded.
+      </Text>
+    );
+  }
+  if (validation.parseError) {
+    return (
+      <HStack gap={1} color="red.500" data-testid="expression-parse-error">
+        <Icon as={LuCircleAlert} />
+        <Text fontSize="xs" fontWeight="semibold">
+          Parse error:
+        </Text>
+        <Text fontSize="xs">{validation.parseError}</Text>
+      </HStack>
+    );
+  }
+  if (validation.dependencyError) {
+    return (
+      <HStack gap={1} color="red.500" align="flex-start" data-testid="expression-dependency-error">
+        <Icon as={LuCircleAlert} mt="2px" />
+        <VStack align="stretch" gap={0}>
+          <Text fontSize="xs" fontWeight="semibold">
+            Dependency error:
+          </Text>
+          <Text fontSize="xs" whiteSpace="pre-wrap">
+            {validation.dependencyError}
+          </Text>
+        </VStack>
+      </HStack>
+    );
+  }
+  if (validation.evaluation?.error) {
+    return (
+      <HStack gap={1} color="red.500" align="flex-start" data-testid="expression-eval-error">
+        <Icon as={LuCircleAlert} mt="2px" />
+        <VStack align="stretch" gap={0}>
+          <Text fontSize="xs" fontWeight="semibold">
+            Evaluation error for selected student:
+          </Text>
+          <Text fontSize="xs" whiteSpace="pre-wrap">
+            {validation.evaluation.error}
+          </Text>
+        </VStack>
+      </HStack>
+    );
+  }
+  if (validation.evaluation && !validation.evaluation.error) {
+    return (
+      <HStack gap={1} color="green.600" data-testid="expression-ok">
+        <Icon as={LuCheck} />
+        <Text fontSize="xs">
+          Evaluates to{" "}
+          <Text as="span" fontWeight="semibold">
+            {validation.evaluation.result}
+          </Text>{" "}
+          for the selected student.
+        </Text>
+      </HStack>
+    );
+  }
+  return (
+    <HStack gap={1} color="green.600" data-testid="expression-ok-syntax">
+      <Icon as={LuCheck} />
+      <Text fontSize="xs">
+        Expression parses ({expression.length} chars). Open the Expression Builder to test on a real student.
+      </Text>
+    </HStack>
+  );
+}
+
+/**
+ * Renders the expression with every captured subexpression highlighted and
+ * overlaid with its evaluated value.
+ */
+function AnnotatedExpressionView({ validation, expression }: { validation: ValidationResult; expression: string }) {
+  const evaluation = validation.evaluation;
+
+  if (!evaluation) {
+    return (
+      <Code whiteSpace="pre-wrap" wordBreak="break-all" fontSize="sm" bg="transparent">
+        {expression || (
+          <Text as="span" color="fg.muted">
+            (empty expression)
+          </Text>
+        )}
+      </Code>
+    );
+  }
+
+  // Build a simple "line by intermediate" rendering: for each distinct
+  // intermediate, show the source → value, indented by AST depth so nested
+  // calls line up under their parents.
+  // For the inline overlay, render the expression once then list the
+  // intermediate values underneath, grouped by depth inferred from their
+  // source length (longer = outer).
+  const distinct = dedupeByStartEnd(evaluation.intermediates);
+  const levels = assignLevels(distinct);
+
+  return (
+    <VStack align="stretch" gap={1}>
+      <Code
+        fontSize="sm"
+        bg="transparent"
+        whiteSpace="pre-wrap"
+        wordBreak="break-all"
+        borderWidth="1px"
+        borderColor="border.subtle"
+        rounded="sm"
+        p={2}
+      >
+        {expression}
+      </Code>
+      <VStack align="stretch" gap={0.5}>
+        {distinct.map((iv, idx) => (
+          <HStack key={`${iv.start}-${iv.end}-${idx}`} gap={2} align="flex-start" pl={`${(levels[idx] ?? 0) * 12}px`}>
+            <Text fontSize="xs" color="fg.muted" fontFamily="mono" flex="1" wordBreak="break-all">
+              {iv.source}
+            </Text>
+            <Badge
+              colorPalette={iv.error ? "red" : "blue"}
+              variant="subtle"
+              fontFamily="mono"
+              whiteSpace="normal"
+              maxW="50%"
+              textAlign="right"
+            >
+              {iv.display}
+            </Badge>
+          </HStack>
+        ))}
+        {distinct.length === 0 && !evaluation.error && (
+          <Text fontSize="xs" color="fg.muted">
+            Final value: {evaluation.result}
+          </Text>
+        )}
+      </VStack>
+    </VStack>
+  );
+}
+
+function dedupeByStartEnd(values: IntermediateValue[]): IntermediateValue[] {
+  const seen = new Map<string, IntermediateValue>();
+  for (const v of values) {
+    const key = `${v.start}:${v.end}:${v.source}`;
+    if (!seen.has(key)) seen.set(key, v);
+  }
+  return Array.from(seen.values()).sort((a, b) => {
+    if (a.start === b.start) return b.end - a.end;
+    return a.start - b.start;
+  });
+}
+
+function assignLevels(values: IntermediateValue[]): number[] {
+  // Greedy interval containment: level = deepest nesting of earlier entries
+  // whose range strictly contains this one.
+  const result: number[] = [];
+  for (let i = 0; i < values.length; i++) {
+    let depth = 0;
+    for (let j = 0; j < i; j++) {
+      const a = values[j];
+      const b = values[i];
+      if (a.start <= b.start && a.end >= b.end && !(a.start === b.start && a.end === b.end)) {
+        depth = Math.max(depth, (result[j] ?? 0) + 1);
+      }
+    }
+    result.push(depth);
+  }
+  return result;
+}
+
+/**
+ * Convenience helper used by parent dialogs when they want to guard their
+ * onSubmit against invalid expressions. Returns `true` if the expression
+ * should be blocked from saving.
+ */
+export function shouldBlockSave(validation: ValidationResult | null): boolean {
+  if (!validation) return false;
+  if (validation.isEmpty) return false;
+  if (validation.parseError) return true;
+  if (validation.dependencyError) return true;
+  // Evaluation errors are only shown when a student is selected; don't block
+  // save just because one student's data trips the expression, but do surface
+  // the warning.
+  return false;
+}
+
+export function useExpressionValidationToaster(validation: ValidationResult | null) {
+  // Re-exported for parents that want to show a toast when the user
+  // attempts to save an invalid expression.
+  void validation;
+  return (message: string) => {
+    toaster.error({ title: "Invalid score expression", description: message });
+  };
+}
+
+// Re-export helpers so consumers don't need to dip into the tester module.
+export { formatValueForOverlay };

--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -2,7 +2,7 @@
 
 import { Label } from "@/components/ui/label";
 import { useAllStudentRoles } from "@/hooks/useCourseController";
-import { useGradebookController, useGradebookColumns } from "@/hooks/useGradebook";
+import { useGradebookColumns, useGradebookController, useGradebookExpressionPrefix } from "@/hooks/useGradebook";
 import {
   evaluateForStudent,
   evaluateRenderExpression,
@@ -183,9 +183,10 @@ export function ExpressionBuilder(props: Props) {
   const selectedStudent = students.find((s) => s.private_profile_id === selectedStudentId);
 
   // Evaluate the render expression against the current final score so the
-  // preview can show both forms side-by-side. We read `expression_prefix` off
-  // the controller since it's prepended to every column's render expression.
-  const expressionPrefix = gradebookController.expressionPrefix ?? "";
+  // preview can show both forms side-by-side. Subscribe to
+  // `gradebooks.expression_prefix` (prepended to every render expression) so
+  // the preview re-renders if another instructor edits the prefix.
+  const expressionPrefix = useGradebookExpressionPrefix();
   const rawScore =
     validation.evaluation && !validation.evaluation.error && typeof validation.evaluation.rawResult === "number"
       ? (validation.evaluation.rawResult as number)
@@ -484,16 +485,19 @@ function InlineAnnotations({
   }
   const distinct = dedupeByStartEnd(evaluation.intermediates);
   const levels = assignLevels(distinct);
+  const MAX_VISIBLE = 80;
+  const visible = distinct.slice(0, MAX_VISIBLE);
+  const hiddenCount = Math.max(0, distinct.length - MAX_VISIBLE);
   return (
     <VStack align="stretch" gap={0} bg="bg.subtle" maxH="40vh" overflow="auto">
-      {distinct.slice(0, 80).map((iv, idx) => (
+      {visible.map((iv, idx) => (
         <HStack
           key={`${iv.start}-${iv.end}-${idx}`}
           gap={2}
           align="flex-start"
           px={2}
           py={1}
-          borderBottomWidth={idx === distinct.length - 1 ? 0 : "1px"}
+          borderBottomWidth={idx === visible.length - 1 && hiddenCount === 0 ? 0 : "1px"}
           borderColor="border.subtle"
           _hover={{ bg: "bg.muted" }}
         >
@@ -520,6 +524,13 @@ function InlineAnnotations({
           </Badge>
         </HStack>
       ))}
+      {hiddenCount > 0 && (
+        <HStack px={2} py={1} justifyContent="center" bg="bg.muted">
+          <Text fontSize="xs" color="fg.muted" fontStyle="italic">
+            {hiddenCount} more intermediate {hiddenCount === 1 ? "value" : "values"} hidden
+          </Text>
+        </HStack>
+      )}
     </VStack>
   );
 }
@@ -649,6 +660,9 @@ export function shouldBlockSave(validation: ValidationResult | null, expression?
   if (validation.isEmpty) return false;
   if (validation.parseError) return true;
   if (validation.dependencyError) return true;
+  // Cover the "math still loading / failed to load" case where the synthetic
+  // result flags isValid=false with no parse/dependency error attached.
+  if (!validation.isValid) return true;
   // Evaluation errors are only shown when a student is selected; don't block
   // save just because one student's data trips the expression, but do surface
   // the warning.

--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -5,11 +5,13 @@ import { useAllStudentRoles } from "@/hooks/useCourseController";
 import { useGradebookController, useGradebookColumns } from "@/hooks/useGradebook";
 import {
   evaluateForStudent,
+  evaluateRenderExpression,
   formatValueForOverlay,
   type IntermediateValue,
+  type RenderExpressionResult,
   type ValidationResult
 } from "@/lib/gradebookExpressionTester";
-import { Badge, Box, Button, Code, Flex, HStack, Icon, Input, Text, Textarea, VStack } from "@chakra-ui/react";
+import { Badge, Box, Button, Flex, HStack, Icon, Input, Text, Textarea, VStack } from "@chakra-ui/react";
 import type * as MathJSType from "mathjs";
 import React, { useEffect, useMemo, useState } from "react";
 import { LuArrowLeftRight, LuCheck, LuCircleAlert, LuMaximize2, LuMinimize2, LuUser } from "react-icons/lu";
@@ -25,6 +27,15 @@ type Props = {
   isExpanded: boolean;
   onExpandToggle: () => void;
   math: MathJSNS | null;
+  /**
+   * Column-level context used by the preview. The render expression and max
+   * score drive the "Rendered" preview below the editor; when both are
+   * provided and non-empty we show the final evaluation result in both its
+   * raw numeric form and the way the gradebook cell would actually render
+   * (e.g. "B-", "✔️", a bespoke label).
+   */
+  renderExpression?: string | null;
+  maxScore?: number | null;
   /**
    * Called whenever the validation result changes. Parent can use this to
    * disable the Save button when validation fails.
@@ -62,7 +73,16 @@ function useLoadedMathJS(): { math: MathJSNS | null; loadError: string | null } 
  *    every subexpression.
  */
 export function ExpressionBuilder(props: Props) {
-  const { expression, onExpressionChange, editingColumnId, isExpanded, onExpandToggle, onValidationChange } = props;
+  const {
+    expression,
+    onExpressionChange,
+    editingColumnId,
+    isExpanded,
+    onExpandToggle,
+    renderExpression,
+    maxScore,
+    onValidationChange
+  } = props;
   const gradebookController = useGradebookController();
   const gradebookColumns = useGradebookColumns();
   const { math: fallbackMath, loadError: mathLoadError } = useLoadedMathJS();
@@ -161,6 +181,19 @@ export function ExpressionBuilder(props: Props) {
   }, [validation, onValidationChange]);
 
   const selectedStudent = students.find((s) => s.private_profile_id === selectedStudentId);
+
+  // Evaluate the render expression against the current final score so the
+  // preview can show both forms side-by-side. We read `expression_prefix` off
+  // the controller since it's prepended to every column's render expression.
+  const expressionPrefix = gradebookController.expressionPrefix ?? "";
+  const rawScore =
+    validation.evaluation && !validation.evaluation.error && typeof validation.evaluation.rawResult === "number"
+      ? (validation.evaluation.rawResult as number)
+      : undefined;
+  const renderExpressionResult: RenderExpressionResult | null = useMemo(() => {
+    if (!math) return null;
+    return evaluateRenderExpression(math, expressionPrefix, renderExpression, rawScore, maxScore ?? undefined);
+  }, [math, expressionPrefix, renderExpression, rawScore, maxScore]);
 
   if (!isExpanded) {
     return (
@@ -265,111 +298,70 @@ export function ExpressionBuilder(props: Props) {
           </VStack>
         </Box>
 
-        {/* Middle: Expression editor + overlay */}
+        {/* Right side: a unified editor — the textarea flows into the list of
+            intermediate values directly below, with the final result (and its
+            rendered form, if a render expression is set) surfaced right above
+            the textarea so the reader's eye lands on it first. */}
         <VStack flex="1" align="stretch" gap={2} minW={0}>
-          <Label htmlFor="scoreExpressionFull">Score Expression</Label>
-          <Textarea
-            id="scoreExpressionFull"
-            value={expression}
-            onChange={(e) => onExpressionChange(e.target.value)}
-            placeholder="Score Expression"
-            rows={10}
-            fontFamily="mono"
-            fontSize="sm"
+          <HStack justifyContent="space-between" gap={2} wrap="wrap">
+            <Label htmlFor="scoreExpressionFull">Score Expression</Label>
+            {selectedStudent && (
+              <Text fontSize="xs" color="fg.muted">
+                Testing against {selectedStudent.profiles?.name || selectedStudent.profiles?.short_name}
+              </Text>
+            )}
+          </HStack>
+
+          <FinalResultBadges
+            validation={validation}
+            renderExpressionResult={renderExpressionResult}
+            renderExpression={renderExpression}
+          />
+
+          {/* The editor + inline annotations share a border so they read as
+              one surface — the textarea is the input row, and every captured
+              subexpression is displayed below in source order with its value,
+              visually tied to the code. */}
+          <Box
+            borderWidth="1px"
             borderColor={
               validation.parseError || validation.dependencyError || validation.evaluation?.error
                 ? "red.500"
                 : validation.isValid && !validation.isEmpty
                   ? "green.500"
-                  : undefined
+                  : "border.muted"
             }
-          />
-          <ValidationStatus validation={validation} expression={expression} />
-
-          <Box
-            mt={2}
-            borderWidth="1px"
-            borderColor="border.muted"
             rounded="md"
-            p={3}
             bg="bg.subtle"
-            overflow="auto"
-            maxH="40vh"
+            overflow="hidden"
             data-testid="expression-builder-overlay"
           >
-            <HStack mb={2} justifyContent="space-between" gap={2} wrap="wrap">
-              <Text fontSize="sm" fontWeight="semibold">
-                Annotated expression{" "}
-                {selectedStudent && (
-                  <Text as="span" color="fg.muted" fontWeight="normal">
-                    — {selectedStudent.profiles?.name || selectedStudent.profiles?.short_name}
-                  </Text>
-                )}
-              </Text>
-              {validation.evaluation && !validation.evaluation.error && (
-                <Badge colorPalette="green" variant="subtle">
-                  Result: {validation.evaluation.result}
-                </Badge>
-              )}
-            </HStack>
-            <AnnotatedExpressionView validation={validation} expression={expression} />
+            <Textarea
+              id="scoreExpressionFull"
+              value={expression}
+              onChange={(e) => onExpressionChange(e.target.value)}
+              placeholder="Score Expression"
+              rows={Math.max(6, Math.min(12, expression.split("\n").length + 2))}
+              fontFamily="mono"
+              fontSize="sm"
+              border="none"
+              borderBottomWidth="1px"
+              borderBottomColor="border.subtle"
+              rounded="none"
+              bg="bg.panel"
+              _focus={{ boxShadow: "none", outline: "none" }}
+            />
+            <InlineAnnotations
+              validation={validation}
+              hasStudent={Boolean(selectedStudentId)}
+              expression={expression}
+            />
           </Box>
-        </VStack>
 
-        {/* Right: List of intermediates */}
-        <Box
-          flex="0 0 320px"
-          borderWidth="1px"
-          borderColor="border.muted"
-          rounded="md"
-          p={3}
-          bg="bg.muted"
-          overflow="auto"
-          maxH={{ base: "200px", lg: "65vh" }}
-        >
-          <Text fontSize="sm" fontWeight="semibold" mb={2}>
-            Intermediate values
-          </Text>
-          {!selectedStudentId && (
-            <Text fontSize="sm" color="fg.muted">
-              Select a student to see live evaluation.
-            </Text>
-          )}
-          {validation.evaluation &&
-            validation.evaluation.intermediates.length === 0 &&
-            !validation.evaluation.error && (
-              <Text fontSize="sm" color="fg.muted">
-                No intermediate subexpressions.
-              </Text>
-            )}
-          {validation.evaluation?.error && (
-            <Text fontSize="sm" color="red.500">
-              Cannot evaluate: {validation.evaluation.error}
-            </Text>
-          )}
-          {validation.evaluation && (
-            <VStack align="stretch" gap={2}>
-              {validation.evaluation.intermediates.slice(0, 80).map((iv, idx) => (
-                <Box
-                  key={`${iv.start}-${iv.end}-${idx}`}
-                  borderWidth="1px"
-                  borderColor={iv.error ? "red.300" : "border.muted"}
-                  rounded="sm"
-                  p={2}
-                  bg="bg.panel"
-                >
-                  <Code fontSize="xs" wordBreak="break-all" whiteSpace="pre-wrap" bg="transparent" color="fg.muted">
-                    {iv.source}
-                  </Code>
-                  <Text fontSize="xs" fontWeight="semibold" color={iv.error ? "red.500" : "fg"}>
-                    = {iv.display}
-                  </Text>
-                </Box>
-              ))}
-            </VStack>
-          )}
+          <ValidationStatus validation={validation} expression={expression} />
+
           {validation.evaluation?.incompleteValues && (
-            <Box mt={3} borderWidth="1px" borderColor="orange.300" rounded="sm" p={2} bg="orange.50">
+            <Box borderWidth="1px" borderColor="orange.300" rounded="sm" p={2} bg="orange.50">
               <Text fontSize="xs" fontWeight="semibold" color="orange.700">
                 Incomplete dependencies
               </Text>
@@ -385,8 +377,149 @@ export function ExpressionBuilder(props: Props) {
               )}
             </Box>
           )}
-        </Box>
+        </VStack>
       </Flex>
+    </VStack>
+  );
+}
+
+/**
+ * Renders two side-by-side badges showing the final score and, if a render
+ * expression is set, its rendered form too (e.g. `81.5` and `B-`).
+ */
+function FinalResultBadges({
+  validation,
+  renderExpressionResult,
+  renderExpression
+}: {
+  validation: ValidationResult;
+  renderExpressionResult: RenderExpressionResult | null;
+  renderExpression?: string | null;
+}) {
+  const hasScore = !!validation.evaluation && !validation.evaluation.error;
+  const scoreText = hasScore ? validation.evaluation!.result : "—";
+  const hasRender = Boolean((renderExpression ?? "").trim());
+  return (
+    <HStack gap={2} wrap="wrap" data-testid="expression-builder-result-badges">
+      <Badge colorPalette={hasScore ? "green" : "gray"} variant="subtle" fontSize="sm" px={2} py={1}>
+        <Text as="span" color="fg.muted" fontWeight="normal" mr={1}>
+          Score
+        </Text>
+        <Text as="span" fontWeight="semibold" fontFamily="mono">
+          {scoreText}
+        </Text>
+      </Badge>
+      {hasRender && (
+        <Badge
+          colorPalette={
+            renderExpressionResult?.kind === "ok" ? "purple" : renderExpressionResult?.kind === "error" ? "red" : "gray"
+          }
+          variant="subtle"
+          fontSize="sm"
+          px={2}
+          py={1}
+          data-testid="expression-builder-rendered-badge"
+        >
+          <Text as="span" color="fg.muted" fontWeight="normal" mr={1}>
+            Rendered
+          </Text>
+          <Text as="span" fontWeight="semibold" fontFamily="mono">
+            {renderExpressionResult?.kind === "ok"
+              ? renderExpressionResult.rendered
+              : renderExpressionResult?.kind === "error"
+                ? `error: ${renderExpressionResult.message}`
+                : "—"}
+          </Text>
+        </Badge>
+      )}
+    </HStack>
+  );
+}
+
+/**
+ * Inline annotations directly underneath the textarea. Each captured
+ * subexpression renders as `source = value`, indented by AST containment
+ * depth so nested calls read naturally as a breakdown of the expression
+ * immediately above them.
+ */
+function InlineAnnotations({
+  validation,
+  hasStudent,
+  expression
+}: {
+  validation: ValidationResult;
+  hasStudent: boolean;
+  expression: string;
+}) {
+  const evaluation = validation.evaluation;
+
+  if (!hasStudent) {
+    return (
+      <Box p={2} bg="bg.subtle">
+        <Text fontSize="xs" color="fg.muted">
+          Select a student on the left to see intermediate values and the final score.
+        </Text>
+      </Box>
+    );
+  }
+  if (!evaluation) return null;
+  if (evaluation.error && evaluation.intermediates.length === 0) {
+    return (
+      <Box p={2} bg="bg.subtle">
+        <Text fontSize="xs" color="red.500">
+          Evaluation error: {evaluation.error}
+        </Text>
+      </Box>
+    );
+  }
+  if (evaluation.intermediates.length === 0) {
+    // Pure-arithmetic expression with no subexpressions worth labelling.
+    return (
+      <Box p={2} bg="bg.subtle">
+        <Text fontSize="xs" color="fg.muted" fontFamily="mono">
+          {expression.trim()} = {evaluation.result}
+        </Text>
+      </Box>
+    );
+  }
+  const distinct = dedupeByStartEnd(evaluation.intermediates);
+  const levels = assignLevels(distinct);
+  return (
+    <VStack align="stretch" gap={0} bg="bg.subtle" maxH="40vh" overflow="auto">
+      {distinct.slice(0, 80).map((iv, idx) => (
+        <HStack
+          key={`${iv.start}-${iv.end}-${idx}`}
+          gap={2}
+          align="flex-start"
+          px={2}
+          py={1}
+          borderBottomWidth={idx === distinct.length - 1 ? 0 : "1px"}
+          borderColor="border.subtle"
+          _hover={{ bg: "bg.muted" }}
+        >
+          <Text
+            fontSize="xs"
+            color="fg.muted"
+            fontFamily="mono"
+            flex="1"
+            wordBreak="break-all"
+            pl={`${(levels[idx] ?? 0) * 12}px`}
+          >
+            {iv.source}
+          </Text>
+          <Badge
+            colorPalette={iv.error ? "red" : "blue"}
+            variant="subtle"
+            fontFamily="mono"
+            whiteSpace="normal"
+            maxW="55%"
+            textAlign="right"
+            fontSize="xs"
+          >
+            = {iv.display}
+          </Badge>
+        </HStack>
+      ))}
     </VStack>
   );
 }
@@ -461,76 +594,6 @@ function ValidationStatus({ validation, expression }: { validation: ValidationRe
         Expression parses ({expression.length} chars). Open the Expression Builder to test on a real student.
       </Text>
     </HStack>
-  );
-}
-
-/**
- * Renders the expression with every captured subexpression highlighted and
- * overlaid with its evaluated value.
- */
-function AnnotatedExpressionView({ validation, expression }: { validation: ValidationResult; expression: string }) {
-  const evaluation = validation.evaluation;
-
-  if (!evaluation) {
-    return (
-      <Code whiteSpace="pre-wrap" wordBreak="break-all" fontSize="sm" bg="transparent">
-        {expression || (
-          <Text as="span" color="fg.muted">
-            (empty expression)
-          </Text>
-        )}
-      </Code>
-    );
-  }
-
-  // Build a simple "line by intermediate" rendering: for each distinct
-  // intermediate, show the source → value, indented by AST depth so nested
-  // calls line up under their parents.
-  // For the inline overlay, render the expression once then list the
-  // intermediate values underneath, grouped by depth inferred from their
-  // source length (longer = outer).
-  const distinct = dedupeByStartEnd(evaluation.intermediates);
-  const levels = assignLevels(distinct);
-
-  return (
-    <VStack align="stretch" gap={1}>
-      <Code
-        fontSize="sm"
-        bg="transparent"
-        whiteSpace="pre-wrap"
-        wordBreak="break-all"
-        borderWidth="1px"
-        borderColor="border.subtle"
-        rounded="sm"
-        p={2}
-      >
-        {expression}
-      </Code>
-      <VStack align="stretch" gap={0.5}>
-        {distinct.map((iv, idx) => (
-          <HStack key={`${iv.start}-${iv.end}-${idx}`} gap={2} align="flex-start" pl={`${(levels[idx] ?? 0) * 12}px`}>
-            <Text fontSize="xs" color="fg.muted" fontFamily="mono" flex="1" wordBreak="break-all">
-              {iv.source}
-            </Text>
-            <Badge
-              colorPalette={iv.error ? "red" : "blue"}
-              variant="subtle"
-              fontFamily="mono"
-              whiteSpace="normal"
-              maxW="50%"
-              textAlign="right"
-            >
-              {iv.display}
-            </Badge>
-          </HStack>
-        ))}
-        {distinct.length === 0 && !evaluation.error && (
-          <Text fontSize="xs" color="fg.muted">
-            Final value: {evaluation.result}
-          </Text>
-        )}
-      </VStack>
-    </VStack>
   );
 }
 

--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Label } from "@/components/ui/label";
-import { toaster } from "@/components/ui/toaster";
 import { useAllStudentRoles } from "@/hooks/useCourseController";
 import { useGradebookController, useGradebookColumns } from "@/hooks/useGradebook";
 import {
@@ -33,18 +32,26 @@ type Props = {
   onValidationChange?: (result: ValidationResult) => void;
 };
 
-function useLoadedMathJS() {
+function useLoadedMathJS(): { math: MathJSNS | null; loadError: string | null } {
   const [math, setMath] = useState<MathJSNS | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
-    import("mathjs").then((mod) => {
-      if (!cancelled) setMath(mod);
-    });
+    import("mathjs")
+      .then((mod) => {
+        if (!cancelled) setMath(mod);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // eslint-disable-next-line no-console -- surface chunk-load failures to the devtools console.
+        console.error("Failed to load mathjs for expression builder", err);
+        setLoadError(err instanceof Error ? err.message : String(err));
+      });
     return () => {
       cancelled = true;
     };
   }, []);
-  return math;
+  return { math, loadError };
 }
 
 /**
@@ -58,7 +65,7 @@ export function ExpressionBuilder(props: Props) {
   const { expression, onExpressionChange, editingColumnId, isExpanded, onExpandToggle, onValidationChange } = props;
   const gradebookController = useGradebookController();
   const gradebookColumns = useGradebookColumns();
-  const fallbackMath = useLoadedMathJS();
+  const { math: fallbackMath, loadError: mathLoadError } = useLoadedMathJS();
   const math = props.math ?? fallbackMath;
   const students = useAllStudentRoles();
   const [selectedStudentId, setSelectedStudentId] = useState<string>("");
@@ -94,10 +101,24 @@ export function ExpressionBuilder(props: Props) {
     [gradebookColumns]
   );
   const validation = useMemo<ValidationResult>(() => {
+    const isEmpty = expression.trim().length === 0;
+    if (mathLoadError) {
+      return {
+        // A non-empty expression cannot be validated if mathjs failed to load,
+        // so we block save to err on the safe side.
+        isValid: isEmpty,
+        isEmpty,
+        parseError: `Unable to load expression evaluator: ${mathLoadError}`,
+        dependencyError: null,
+        evaluation: null
+      };
+    }
     if (!math) {
       return {
-        isValid: true,
-        isEmpty: expression.trim().length === 0,
+        // Same reasoning as above: treat "mathjs still loading" as blocking
+        // for non-empty expressions rather than briefly showing Save enabled.
+        isValid: isEmpty,
+        isEmpty,
         parseError: null,
         dependencyError: null,
         evaluation: null
@@ -124,7 +145,16 @@ export function ExpressionBuilder(props: Props) {
     // gradebookColumnsKey is intentionally a dep so validation updates when
     // columns are added/removed in the background.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [math, gradebookController, expression, selectedStudentId, editingColumnId, isExpanded, gradebookColumnsKey]);
+  }, [
+    math,
+    mathLoadError,
+    gradebookController,
+    expression,
+    selectedStudentId,
+    editingColumnId,
+    isExpanded,
+    gradebookColumnsKey
+  ]);
 
   useEffect(() => {
     onValidationChange?.(validation);
@@ -194,7 +224,6 @@ export function ExpressionBuilder(props: Props) {
           bg="bg.muted"
           overflow="auto"
           maxH={{ base: "200px", lg: "65vh" }}
-          data-testid="expression-builder-student-picker"
         >
           <HStack mb={2}>
             <Icon as={LuUser} color="fg.muted" />
@@ -518,19 +547,22 @@ function dedupeByStartEnd(values: IntermediateValue[]): IntermediateValue[] {
 }
 
 function assignLevels(values: IntermediateValue[]): number[] {
-  // Greedy interval containment: level = deepest nesting of earlier entries
-  // whose range strictly contains this one.
+  // `values` is already sorted by start asc, then end desc (longer spans
+  // first), so a single-pass stack walk gives us the containment depth in
+  // O(n). Whenever the top of the stack no longer strictly contains the
+  // current entry, we pop it; the remaining stack size is the current depth.
   const result: number[] = [];
-  for (let i = 0; i < values.length; i++) {
-    let depth = 0;
-    for (let j = 0; j < i; j++) {
-      const a = values[j];
-      const b = values[i];
-      if (a.start <= b.start && a.end >= b.end && !(a.start === b.start && a.end === b.end)) {
-        depth = Math.max(depth, (result[j] ?? 0) + 1);
-      }
+  const stack: IntermediateValue[] = [];
+  for (const value of values) {
+    while (stack.length > 0) {
+      const top = stack[stack.length - 1];
+      const strictlyContains =
+        top.start <= value.start && top.end >= value.end && !(top.start === value.start && top.end === value.end);
+      if (strictlyContains) break;
+      stack.pop();
     }
-    result.push(depth);
+    result.push(stack.length);
+    stack.push(value);
   }
   return result;
 }
@@ -539,9 +571,18 @@ function assignLevels(values: IntermediateValue[]): number[] {
  * Convenience helper used by parent dialogs when they want to guard their
  * onSubmit against invalid expressions. Returns `true` if the expression
  * should be blocked from saving.
+ *
+ * Pass the raw expression string so we can treat the "validation not yet
+ * computed" case as blocking for non-empty expressions (otherwise Save would
+ * briefly be enabled between the dialog opening and the first
+ * `onValidationChange` from ExpressionBuilder).
  */
-export function shouldBlockSave(validation: ValidationResult | null): boolean {
-  if (!validation) return false;
+export function shouldBlockSave(validation: ValidationResult | null, expression?: string): boolean {
+  if (!validation) {
+    // No validation yet — block only if there is something to validate.
+    const raw = expression?.trim() ?? "";
+    return raw.length > 0;
+  }
   if (validation.isEmpty) return false;
   if (validation.parseError) return true;
   if (validation.dependencyError) return true;
@@ -549,15 +590,6 @@ export function shouldBlockSave(validation: ValidationResult | null): boolean {
   // save just because one student's data trips the expression, but do surface
   // the warning.
   return false;
-}
-
-export function useExpressionValidationToaster(validation: ValidationResult | null) {
-  // Re-exported for parents that want to show a toast when the user
-  // attempts to save an invalid expression.
-  void validation;
-  return (message: string) => {
-    toaster.error({ title: "Invalid score expression", description: message });
-  };
 }
 
 // Re-export helpers so consumers don't need to dip into the tester module.

--- a/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
+++ b/app/course/[course_id]/manage/gradebook/expressionBuilder.tsx
@@ -194,6 +194,7 @@ export function ExpressionBuilder(props: Props) {
           bg="bg.muted"
           overflow="auto"
           maxH={{ base: "200px", lg: "65vh" }}
+          data-testid="expression-builder-student-picker"
         >
           <HStack mb={2}>
             <Icon as={LuUser} color="fg.muted" />

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -114,7 +114,7 @@ import {
 } from "react-icons/lu";
 import { TbEye, TbEyeOff, TbFilter } from "react-icons/tb";
 import { WhatIf } from "../../gradebook/whatIf";
-import { ExpressionBuilder, shouldBlockSave } from "./expressionBuilder";
+import { ExpressionBuilder, shouldBlockSave } from "@/app/course/[course_id]/manage/gradebook/expressionBuilder";
 import type { ValidationResult } from "@/lib/gradebookExpressionTester";
 import GradebookCell from "./gradebookCell";
 import { GradebookPopoverProvider, useGradebookPopover } from "./GradebookPopoverProvider";
@@ -870,19 +870,19 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                     <>
                       <Label htmlFor="scoreExpression">Score Expression</Label>
                       {/*
-                        The HTML `disabled` attribute causes the browser to
-                        omit the field from form submission, which in turn
-                        makes react-hook-form hand back `undefined` for
-                        `scoreExpression` on submit. Passing `disabled: true`
-                        through `register()` keeps the value in the form
-                        state while still making the textarea read-only, so
-                        downstream `extractAndValidateDependencies(...)` and
-                        the Refine update call still see the persisted
-                        `assignments(...)` expression.
+                        Use `readOnly` instead of `disabled` — a bare HTML
+                        `disabled` attribute tells the browser to omit the
+                        field from form submission (react-hook-form then
+                        hands `undefined` back to `onSubmit`, which would
+                        wipe the persisted `assignments(...)` expression
+                        when the instructor saves a metadata-only edit).
+                        `readOnly` keeps the field non-editable while still
+                        letting react-hook-form read the registered value.
                       */}
                       <Textarea
                         id="scoreExpression"
-                        {...register("scoreExpression", { disabled: true })}
+                        readOnly
+                        {...register("scoreExpression")}
                         placeholder="Score Expression"
                         rows={4}
                       />

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -693,7 +693,14 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   if (!columnId) return null;
   if (!column) throw new Error(`Column ${columnId} not found`);
 
-  const canEditScoreExpression = scoreExpression && scoreExpression.startsWith("assignments(") ? false : true;
+  // Pin the "is this column assignment-backed?" gate to the column's
+  // PERSISTED score expression, not the live-watched form value. Otherwise
+  // the moment an instructor types `assignments(` while editing a regular
+  // column, `canEditScoreExpression` flips to `false`, ExpressionBuilder
+  // unmounts mid-edit, and the instructor loses the full-screen state
+  // (expanded mode, selected student, and the mathjs / intermediate
+  // annotations that had already loaded).
+  const canEditScoreExpression = !(column.score_expression?.startsWith("assignments(") ?? false);
 
   const onSubmit = async (data: FieldValues) => {
     // When the score expression is not user-editable (assignment-backed

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -687,6 +687,10 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
         showCalculatedRanges: column.show_calculated_ranges ?? false,
         instructorOnly: column.instructor_only ?? false
       });
+      // Clear any ValidationResult cached from a previously-edited column so
+      // a stale error state can't briefly gate the Save button before
+      // ExpressionBuilder's first `onValidationChange` fires for the new one.
+      setValidation(null);
     }
   }, [columnId, column, reset]);
 

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -869,10 +869,20 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                   ) : (
                     <>
                       <Label htmlFor="scoreExpression">Score Expression</Label>
+                      {/*
+                        The HTML `disabled` attribute causes the browser to
+                        omit the field from form submission, which in turn
+                        makes react-hook-form hand back `undefined` for
+                        `scoreExpression` on submit. Passing `disabled: true`
+                        through `register()` keeps the value in the form
+                        state while still making the textarea read-only, so
+                        downstream `extractAndValidateDependencies(...)` and
+                        the Refine update call still see the persisted
+                        `assignments(...)` expression.
+                      */}
                       <Textarea
                         id="scoreExpression"
-                        disabled
-                        {...register("scoreExpression")}
+                        {...register("scoreExpression", { disabled: true })}
                         placeholder="Score Expression"
                         rows={4}
                       />

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -581,7 +581,7 @@ function AddColumnDialog() {
                     onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
                     math={null}
                     renderExpression={renderExpressionValue}
-                    maxScore={typeof maxScoreValue === "number" ? maxScoreValue : Number(maxScoreValue) || null}
+                    maxScore={Number.isFinite(Number(maxScoreValue)) ? Number(maxScoreValue) : null}
                     onValidationChange={setValidation}
                   />
                   {errors.scoreExpression && (
@@ -668,7 +668,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
     }
   });
 
-  const scoreExpression = watch("scoreExpression");
+  const scoreExpression = watch("scoreExpression") ?? "";
   const renderExpressionValue = watch("renderExpression") ?? "";
   const maxScoreValue = watch("maxScore");
   const [isExpressionBuilderExpanded, setIsExpressionBuilderExpanded] = useState(false);
@@ -696,7 +696,12 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   const canEditScoreExpression = scoreExpression && scoreExpression.startsWith("assignments(") ? false : true;
 
   const onSubmit = async (data: FieldValues) => {
-    if (shouldBlockSave(validation, data.scoreExpression)) {
+    // When the score expression is not user-editable (assignment-backed
+    // columns), ExpressionBuilder is not mounted, so `validation` never
+    // updates. Skipping the client-side guard in that case lets instructors
+    // save metadata-only edits (name, description, max_score, etc.); the
+    // server-side extractAndValidateDependencies below still runs.
+    if (canEditScoreExpression && shouldBlockSave(validation, data.scoreExpression)) {
       toaster.error({
         title: "Invalid score expression",
         description: validation?.parseError || validation?.dependencyError || "Fix the score expression before saving."
@@ -842,7 +847,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                 <Box>
                   {canEditScoreExpression ? (
                     <ExpressionBuilder
-                      expression={scoreExpression ?? ""}
+                      expression={scoreExpression}
                       onExpressionChange={(val) =>
                         setValue("scoreExpression", val, { shouldDirty: true, shouldValidate: true })
                       }
@@ -851,7 +856,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                       onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
                       math={null}
                       renderExpression={renderExpressionValue}
-                      maxScore={typeof maxScoreValue === "number" ? maxScoreValue : Number(maxScoreValue) || null}
+                      maxScore={Number.isFinite(Number(maxScoreValue)) ? Number(maxScoreValue) : null}
                       onValidationChange={setValidation}
                     />
                   ) : (
@@ -910,7 +915,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                     type="submit"
                     colorPalette="green"
                     loading={isLoading}
-                    disabled={shouldBlockSave(validation, scoreExpression)}
+                    disabled={canEditScoreExpression && shouldBlockSave(validation, scoreExpression)}
                   >
                     Save
                   </Button>

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -437,7 +437,7 @@ function AddColumnDialog() {
   }, [isOpen, reset]);
 
   const onSubmit = async (data: FieldValues) => {
-    if (shouldBlockSave(validation)) {
+    if (shouldBlockSave(validation, data.scoreExpression)) {
       toaster.error({
         title: "Invalid score expression",
         description: validation?.parseError || validation?.dependencyError || "Fix the expression before saving."
@@ -603,7 +603,12 @@ function AddColumnDialog() {
                   </Checkbox>
                 </Box>
                 <HStack justifyContent="flex-end">
-                  <Button type="submit" colorPalette="green" loading={isLoading} disabled={shouldBlockSave(validation)}>
+                  <Button
+                    type="submit"
+                    colorPalette="green"
+                    loading={isLoading}
+                    disabled={shouldBlockSave(validation, scoreExpression)}
+                  >
                     Save
                   </Button>
                   <Button type="button" variant="ghost" onClick={onClose}>
@@ -685,7 +690,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   const canEditScoreExpression = scoreExpression && scoreExpression.startsWith("assignments(") ? false : true;
 
   const onSubmit = async (data: FieldValues) => {
-    if (shouldBlockSave(validation)) {
+    if (shouldBlockSave(validation, data.scoreExpression)) {
       toaster.error({
         title: "Invalid score expression",
         description: validation?.parseError || validation?.dependencyError || "Fix the score expression before saving."
@@ -893,7 +898,12 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                   </Text>
                 )}
                 <HStack justifyContent="flex-end">
-                  <Button type="submit" colorPalette="green" loading={isLoading} disabled={shouldBlockSave(validation)}>
+                  <Button
+                    type="submit"
+                    colorPalette="green"
+                    loading={isLoading}
+                    disabled={shouldBlockSave(validation, scoreExpression)}
+                  >
                     Save
                   </Button>
                   <Button type="button" variant="ghost" onClick={onClose}>

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -424,6 +424,8 @@ function AddColumnDialog() {
     }
   });
   const scoreExpression = watch("scoreExpression") ?? "";
+  const renderExpressionValue = watch("renderExpression") ?? "";
+  const maxScoreValue = watch("maxScore");
   const [isExpressionBuilderExpanded, setIsExpressionBuilderExpanded] = useState(false);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
 
@@ -578,6 +580,8 @@ function AddColumnDialog() {
                     isExpanded={isExpressionBuilderExpanded}
                     onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
                     math={null}
+                    renderExpression={renderExpressionValue}
+                    maxScore={typeof maxScoreValue === "number" ? maxScoreValue : Number(maxScoreValue) || null}
                     onValidationChange={setValidation}
                   />
                   {errors.scoreExpression && (
@@ -665,6 +669,8 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   });
 
   const scoreExpression = watch("scoreExpression");
+  const renderExpressionValue = watch("renderExpression") ?? "";
+  const maxScoreValue = watch("maxScore");
   const [isExpressionBuilderExpanded, setIsExpressionBuilderExpanded] = useState(false);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
 
@@ -844,6 +850,8 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                       isExpanded={isExpressionBuilderExpanded}
                       onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
                       math={null}
+                      renderExpression={renderExpressionValue}
+                      maxScore={typeof maxScoreValue === "number" ? maxScoreValue : Number(maxScoreValue) || null}
                       onValidationChange={setValidation}
                     />
                   ) : (

--- a/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
+++ b/app/course/[course_id]/manage/gradebook/gradebookTable.tsx
@@ -114,6 +114,8 @@ import {
 } from "react-icons/lu";
 import { TbEye, TbEyeOff, TbFilter } from "react-icons/tb";
 import { WhatIf } from "../../gradebook/whatIf";
+import { ExpressionBuilder, shouldBlockSave } from "./expressionBuilder";
+import type { ValidationResult } from "@/lib/gradebookExpressionTester";
 import GradebookCell from "./gradebookCell";
 import { GradebookPopoverProvider, useGradebookPopover } from "./GradebookPopoverProvider";
 import ImportGradebookColumn from "./importGradebookColumn";
@@ -407,6 +409,8 @@ function AddColumnDialog() {
     register,
     handleSubmit,
     reset,
+    setValue,
+    watch,
     formState: { errors }
   } = useForm<FormValues>({
     defaultValues: {
@@ -419,16 +423,27 @@ function AddColumnDialog() {
       instructorOnly: false
     }
   });
-  const scoreExpressionRegister = register("scoreExpression");
+  const scoreExpression = watch("scoreExpression") ?? "";
+  const [isExpressionBuilderExpanded, setIsExpressionBuilderExpanded] = useState(false);
+  const [validation, setValidation] = useState<ValidationResult | null>(null);
 
   // Reset form when dialog opens/closes
   useEffect(() => {
     if (!isOpen) {
       reset();
+      setIsExpressionBuilderExpanded(false);
+      setValidation(null);
     }
   }, [isOpen, reset]);
 
   const onSubmit = async (data: FieldValues) => {
+    if (shouldBlockSave(validation)) {
+      toaster.error({
+        title: "Invalid score expression",
+        description: validation?.parseError || validation?.dependencyError || "Fix the expression before saving."
+      });
+      return;
+    }
     setIsLoading(true);
     try {
       const dependencies = gradebookController.extractAndValidateDependencies(data.scoreExpression ?? "", -1);
@@ -471,7 +486,13 @@ function AddColumnDialog() {
   };
 
   return (
-    <Dialog.Root open={isOpen} size={"md"} placement={"center"} lazyMount unmountOnExit>
+    <Dialog.Root
+      open={isOpen}
+      size={isExpressionBuilderExpanded ? "cover" : "md"}
+      placement={"center"}
+      lazyMount
+      unmountOnExit
+    >
       <Dialog.Trigger asChild>
         <Button variant="surface" size="sm" colorPalette="green" onClick={() => setIsOpen(true)}>
           <Icon as={FiPlus} mr={2} /> Add Column
@@ -480,7 +501,7 @@ function AddColumnDialog() {
       <Portal>
         <Dialog.Backdrop />
         <Dialog.Positioner>
-          <Dialog.Content>
+          <Dialog.Content maxW={isExpressionBuilderExpanded ? "100vw" : undefined}>
             <Dialog.Header>
               <Dialog.Title>Add Column</Dialog.Title>
             </Dialog.Header>
@@ -548,8 +569,17 @@ function AddColumnDialog() {
                   )}
                 </Box>
                 <Box>
-                  <Label htmlFor="scoreExpression">Score Expression</Label>
-                  <Textarea id="scoreExpression" {...scoreExpressionRegister} placeholder="Score Expression" rows={4} />
+                  <ExpressionBuilder
+                    expression={scoreExpression}
+                    onExpressionChange={(val) =>
+                      setValue("scoreExpression", val, { shouldDirty: true, shouldValidate: true })
+                    }
+                    editingColumnId={null}
+                    isExpanded={isExpressionBuilderExpanded}
+                    onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
+                    math={null}
+                    onValidationChange={setValidation}
+                  />
                   {errors.scoreExpression && (
                     <Text color="red.500" fontSize="sm">
                       {errors.scoreExpression.message as string}
@@ -573,7 +603,7 @@ function AddColumnDialog() {
                   </Checkbox>
                 </Box>
                 <HStack justifyContent="flex-end">
-                  <Button type="submit" colorPalette="green" loading={isLoading}>
+                  <Button type="submit" colorPalette="green" loading={isLoading} disabled={shouldBlockSave(validation)}>
                     Save
                   </Button>
                   <Button type="button" variant="ghost" onClick={onClose}>
@@ -613,6 +643,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
     handleSubmit,
     reset,
     setError,
+    setValue,
     watch,
     formState: { errors }
   } = useForm<FormValues>({
@@ -629,6 +660,8 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   });
 
   const scoreExpression = watch("scoreExpression");
+  const [isExpressionBuilderExpanded, setIsExpressionBuilderExpanded] = useState(false);
+  const [validation, setValidation] = useState<ValidationResult | null>(null);
 
   useEffect(() => {
     if (column) {
@@ -646,14 +679,19 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
     }
   }, [columnId, column, reset]);
 
-  const scoreExpressionRegister = register("scoreExpression");
-
   if (!columnId) return null;
   if (!column) throw new Error(`Column ${columnId} not found`);
 
   const canEditScoreExpression = scoreExpression && scoreExpression.startsWith("assignments(") ? false : true;
 
   const onSubmit = async (data: FieldValues) => {
+    if (shouldBlockSave(validation)) {
+      toaster.error({
+        title: "Invalid score expression",
+        description: validation?.parseError || validation?.dependencyError || "Fix the score expression before saving."
+      });
+      return;
+    }
     toaster.create({
       title: "Saving...",
       description: "This may take a few seconds to recalculate...",
@@ -708,13 +746,19 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
   };
 
   return (
-    <Dialog.Root open={true} size={"md"} placement={"center"} lazyMount unmountOnExit>
+    <Dialog.Root
+      open={true}
+      size={isExpressionBuilderExpanded ? "cover" : "md"}
+      placement={"center"}
+      lazyMount
+      unmountOnExit
+    >
       <Portal>
         <Dialog.Backdrop />
         <Dialog.Positioner>
-          <Dialog.Content>
+          <Dialog.Content maxW={isExpressionBuilderExpanded ? "100vw" : undefined}>
             <Dialog.Header>
-              <Dialog.Title>Edit Column</Dialog.Title>
+              <Dialog.Title>Edit Column{isExpressionBuilderExpanded ? " — Expression Builder" : ""}</Dialog.Title>
             </Dialog.Header>
             <Dialog.Body as="form" onSubmit={handleSubmit(onSubmit)}>
               <VStack gap={3} align="stretch">
@@ -785,14 +829,30 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                   )}
                 </Box>
                 <Box>
-                  <Label htmlFor="scoreExpression">Score Expression</Label>
-                  <Textarea
-                    id="scoreExpression"
-                    disabled={!canEditScoreExpression}
-                    {...scoreExpressionRegister}
-                    placeholder="Score Expression"
-                    rows={4}
-                  />
+                  {canEditScoreExpression ? (
+                    <ExpressionBuilder
+                      expression={scoreExpression ?? ""}
+                      onExpressionChange={(val) =>
+                        setValue("scoreExpression", val, { shouldDirty: true, shouldValidate: true })
+                      }
+                      editingColumnId={columnId}
+                      isExpanded={isExpressionBuilderExpanded}
+                      onExpandToggle={() => setIsExpressionBuilderExpanded((prev) => !prev)}
+                      math={null}
+                      onValidationChange={setValidation}
+                    />
+                  ) : (
+                    <>
+                      <Label htmlFor="scoreExpression">Score Expression</Label>
+                      <Textarea
+                        id="scoreExpression"
+                        disabled
+                        {...register("scoreExpression")}
+                        placeholder="Score Expression"
+                        rows={4}
+                      />
+                    </>
+                  )}
                   {errors.scoreExpression && (
                     <Text color="red.500" fontSize="sm">
                       {errors.scoreExpression.message as string}
@@ -833,7 +893,7 @@ function EditColumnDialog({ columnId, onClose }: { columnId: number; onClose: ()
                   </Text>
                 )}
                 <HStack justifyContent="flex-end">
-                  <Button type="submit" colorPalette="green" loading={isLoading}>
+                  <Button type="submit" colorPalette="green" loading={isLoading} disabled={shouldBlockSave(validation)}>
                     Save
                   </Button>
                   <Button type="button" variant="ghost" onClick={onClose}>

--- a/hooks/useGradebook.tsx
+++ b/hooks/useGradebook.tsx
@@ -1505,6 +1505,11 @@ export class GradebookController {
     this._assignments = assignments;
   }
 
+  /** Expression prefix from `gradebooks.expression_prefix`, prepended to every column's render expression. */
+  public get expressionPrefix() {
+    return this._expression_prefix;
+  }
+
   // Removed old subscription methods - use TableController directly
 
   // Subscribe to a specific student/column pair using the new controller

--- a/hooks/useGradebook.tsx
+++ b/hooks/useGradebook.tsx
@@ -130,6 +130,34 @@ export function useGradebookColumns() {
   return columns;
 }
 
+/**
+ * Subscribes to changes in `gradebooks.expression_prefix` so any component
+ * that depends on the prefix (e.g. the Expression Builder's render-expression
+ * preview) re-renders when the prefix is edited elsewhere. Without this a
+ * component would read `GradebookController.expressionPrefix` on first render
+ * and then drift when the value changed, because only the controller's
+ * cell-renderer cache listens to the underlying `gradebook_row` updates.
+ */
+export function useGradebookExpressionPrefix() {
+  const gradebookController = useGradebookController();
+  const [prefix, setPrefix] = useState<string>(gradebookController.expressionPrefix);
+  useEffect(() => {
+    const { unsubscribe, data } = gradebookController.gradebook_row.list((rows) => {
+      // Read the prefix directly from the freshly-listed rows rather than
+      // relying on the controller's cached `_expression_prefix` — subscriber
+      // ordering between this callback and the controller's own hydration
+      // callback is not guaranteed, and we want to render the newest value
+      // either way.
+      const row = rows.find((r) => r.id === gradebookController.gradebook_id) ?? rows[0];
+      setPrefix(row?.expression_prefix ?? "");
+    });
+    const row = data.find((r) => r.id === gradebookController.gradebook_id) ?? data[0];
+    setPrefix(row?.expression_prefix ?? "");
+    return unsubscribe;
+  }, [gradebookController]);
+  return prefix;
+}
+
 export function useGradebookColumn(column_id: number) {
   const gradebookController = useGradebookController();
   const [column, setColumn] = useState<GradebookColumn | undefined>(

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -528,6 +528,17 @@ export function evaluateRenderExpression(
       }
       return "Error";
     }) as ImportFunction;
+    // Mirror the security guards used by the live gradebook cell renderer in
+    // `GradebookController._getSharedMath()`: block MathJS surface that could
+    // let a render expression redefine operators, pull arbitrary modules, or
+    // reshape the parser. This keeps the preview behaviour aligned with what
+    // the rendered cell will actually do, so instructors can't save an
+    // expression here that the real renderer would reject at runtime.
+    for (const name of ["import", "createUnit", "reviver", "resolve"]) {
+      imports[name] = (() => {
+        throw new Error(`${name} is not allowed`);
+      }) as ImportFunction;
+    }
     localMath.import(imports, { override: true });
 
     const full = (prefix ? prefix + "\n" : "") + raw;
@@ -701,19 +712,64 @@ export function evaluateForStudent(params: {
       `\\b(${CONTEXT_FUNCTIONS.map((fn) => fn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\(context,\\s*`,
       "g"
     );
-    // Use the parsed AST's own `toString()` as the haystack for position
-    // lookups instead of the user's raw input. mathjs normalises string
-    // literals (e.g. single → double quotes) when stringifying, so the
-    // subnode `pretty` strings only match reliably against the same
-    // normalised form — using the raw `trimmed` input produces `-1` spans
-    // for any expression that contains a quoted slug.
-    const canonicalExpression = parsed.toString().replace(contextArgStrip, "$1(");
+    // `start`/`end` on each intermediate need to be positions in the USER'S
+    // raw input (`trimmed`) so the UI can overlay annotations on the exact
+    // substring the user typed. MathJS's `node.toString()` normalises
+    // formatting (single → double quotes, canonical operator spacing, etc.),
+    // so the `pretty` we derive from `node.toString()` may not be a literal
+    // substring of `trimmed`. We try a few variants to locate it, and fall
+    // back to `-1` when no mapping exists — that's the documented contract
+    // and the UI falls back cleanly (the per-line annotation path doesn't
+    // depend on positions at all).
+    //
     // Walk source positions greedily so repeated subexpressions (e.g.
     // `gradebook_columns("hw-1") + gradebook_columns("hw-1")`) get DISTINCT
-    // spans. Without this, `indexOf(pretty)` always hands back the first
-    // occurrence, both instances land on `start=0` / `end=len(pretty)`, and
-    // the dedupe loop below collapses them into one entry.
+    // spans: `indexOf(pretty)` alone would always return the first
+    // occurrence, collapsing both instances into one dedup entry.
     const nextSearchFromBySource = new Map<string, number>();
+    /**
+     * Locate `pretty` inside the user's raw input (`trimmed`) starting at
+     * `searchFrom`. Returns `{ start, end }` indices into `trimmed`, or
+     * `{ start: -1, end: -1 }` when no mapping exists. Tries three
+     * progressively more forgiving matches so mathjs's formatting
+     * normalisation (e.g. `'hw-1'` → `"hw-1"`, `score*2` → `score * 2`)
+     * doesn't drop otherwise-valid spans.
+     */
+    const findRawSpan = (pretty: string, searchFrom: number): { start: number; end: number } => {
+      // 1. Literal match against the user's typed text.
+      let idx = trimmed.indexOf(pretty, searchFrom);
+      if (idx >= 0) return { start: idx, end: idx + pretty.length };
+      // 2. Swap mathjs-canonical double quotes for single quotes — common
+      //    when the user typed `'hw-1'` but mathjs stringified as `"hw-1"`.
+      if (pretty.includes('"')) {
+        const singleQuoted = pretty.replace(/"/g, "'");
+        idx = trimmed.indexOf(singleQuoted, searchFrom);
+        if (idx >= 0) return { start: idx, end: idx + singleQuoted.length };
+      }
+      // 3. Strip all whitespace and compare, character-by-character,
+      //    tolerating different whitespace in `trimmed`. This catches
+      //    `score*2` ↔ `score * 2`-style operator-spacing normalisation
+      //    without needing a second parser. Returns the exact raw span
+      //    (including any whitespace inside the matching run).
+      const squished = pretty.replace(/\s+/g, "");
+      if (squished !== pretty && squished.length > 0) {
+        for (let start = searchFrom; start + squished.length <= trimmed.length; start++) {
+          let i = start;
+          let j = 0;
+          while (i < trimmed.length && j < squished.length) {
+            if (/\s/.test(trimmed[i])) {
+              i++;
+              continue;
+            }
+            if (trimmed[i] !== squished[j]) break;
+            i++;
+            j++;
+          }
+          if (j === squished.length) return { start, end: i };
+        }
+      }
+      return { start: -1, end: -1 };
+    };
     for (const node of collectNodes(transformed)) {
       if (!shouldCaptureNode(node)) continue;
       let source: string;
@@ -731,9 +787,9 @@ export function evaluateForStudent(params: {
       const pretty = source.replace(contextArgStrip, "$1(");
 
       const searchFrom = nextSearchFromBySource.get(pretty) ?? 0;
-      const idx = canonicalExpression.indexOf(pretty, searchFrom);
-      if (idx >= 0) {
-        nextSearchFromBySource.set(pretty, idx + pretty.length);
+      const span = findRawSpan(pretty, searchFrom);
+      if (span.start >= 0) {
+        nextSearchFromBySource.set(pretty, span.end);
       }
       let value: unknown;
       let nodeError: string | undefined;
@@ -745,8 +801,8 @@ export function evaluateForStudent(params: {
       intermediates.push({
         source: pretty,
         nodeType: node.type,
-        start: idx,
-        end: idx >= 0 ? idx + pretty.length : -1,
+        start: span.start,
+        end: span.end,
         display: nodeError ? `error: ${nodeError}` : formatValueForOverlay(value),
         raw: value,
         error: nodeError

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -69,6 +69,21 @@ export type EvaluationResult = {
   intermediates: IntermediateValue[];
 };
 
+function maybeUnwrapMatrix(value: unknown): unknown {
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    // mathjs DenseMatrix exposes a toArray() method
+    if (typeof obj.toArray === "function") {
+      try {
+        return (obj.toArray as () => unknown)();
+      } catch {
+        /* fall through */
+      }
+    }
+  }
+  return value;
+}
+
 /** Short, safe stringification for overlays (`mean(...) = 87.5`). */
 export function formatValueForOverlay(value: unknown): string {
   if (value === undefined) return "undefined";
@@ -83,15 +98,16 @@ export function formatValueForOverlay(value: unknown): string {
     return JSON.stringify(value);
   }
   if (typeof value === "boolean") return value ? "true" : "false";
-  if (Array.isArray(value)) {
-    if (value.length === 0) return "[]";
-    if (value.length > 4) {
-      return `[${value.slice(0, 4).map(formatValueForOverlay).join(", ")}, … ${value.length - 4} more]`;
+  const unwrapped = maybeUnwrapMatrix(value);
+  if (Array.isArray(unwrapped)) {
+    if (unwrapped.length === 0) return "[]";
+    if (unwrapped.length > 4) {
+      return `[${unwrapped.slice(0, 4).map(formatValueForOverlay).join(", ")}, … ${unwrapped.length - 4} more]`;
     }
-    return `[${value.map(formatValueForOverlay).join(", ")}]`;
+    return `[${unwrapped.map(formatValueForOverlay).join(", ")}]`;
   }
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
+  if (typeof unwrapped === "object" && unwrapped !== null) {
+    const obj = unwrapped as Record<string, unknown>;
     // GradebookExpressionValue-like object
     if ("score" in obj && "column_slug" in obj) {
       const score = obj["score"];
@@ -108,14 +124,14 @@ export function formatValueForOverlay(value: unknown): string {
       }
     }
     try {
-      const json = JSON.stringify(value);
+      const json = JSON.stringify(unwrapped);
       if (json.length <= 80) return json;
       return json.slice(0, 77) + "…";
     } catch {
       return "[object]";
     }
   }
-  return String(value);
+  return String(unwrapped);
 }
 
 /**
@@ -385,15 +401,31 @@ export function evaluateForStudent(params: {
     }
   };
 
+  /** mathjs `ResultSet` shape is `{ entries: unknown[] }`, but plain Arrays
+   * also own an `entries()` method via `Array.prototype`, so we must guard
+   * `Array.isArray(...)` first. Without this guard every array-returning
+   * expression (e.g. `gradebook_columns("assignment-*")`) would be rewritten
+   * to `undefined`. */
+  const unwrapResultSet = (value: unknown): unknown => {
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      "entries" in (value as Record<string, unknown>)
+    ) {
+      const entries = (value as { entries: unknown }).entries;
+      if (Array.isArray(entries)) {
+        return entries.length > 0 ? entries[entries.length - 1] : undefined;
+      }
+    }
+    return value;
+  };
+
   let rawResult: unknown;
   let resultStr = "";
   let evalError: string | null = null;
   try {
-    rawResult = transformed.evaluate({ context });
-    if (typeof rawResult === "object" && rawResult !== null && "entries" in (rawResult as Record<string, unknown>)) {
-      const entries = (rawResult as { entries: unknown[] }).entries;
-      rawResult = entries.length > 0 ? entries[entries.length - 1] : undefined;
-    }
+    rawResult = unwrapResultSet(transformed.evaluate({ context }));
     resultStr = formatValueForOverlay(rawResult);
   } catch (e) {
     evalError = e instanceof Error ? e.message : String(e);
@@ -423,11 +455,7 @@ export function evaluateForStudent(params: {
       let value: unknown;
       let nodeError: string | undefined;
       try {
-        value = node.evaluate({ context });
-        if (value && typeof value === "object" && "entries" in (value as Record<string, unknown>)) {
-          const entries = (value as { entries: unknown[] }).entries;
-          value = entries.length > 0 ? entries[entries.length - 1] : undefined;
-        }
+        value = unwrapResultSet(node.evaluate({ context }));
       } catch (e) {
         nodeError = e instanceof Error ? e.message : String(e);
       }

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -145,7 +145,10 @@ type MathJSInstance = ReturnType<MathJSNS["create"]>;
 function shouldCaptureNode(node: MathNode): boolean {
   const t = node.type;
   // Skip pure leaves (constants / bare symbol lookups) — the overlay for
-  // `score * 2` should not repeat the constant `2` next to itself.
+  // `score * 2` should not repeat the constant `2` next to itself. We also
+  // skip `FunctionAssignmentNode` (e.g. `f(x) = ...`) because its value is a
+  // function reference, not a scalar worth displaying, and we never recurse
+  // into its body either (see `collectNodes`).
   return (
     t === "FunctionNode" ||
     t === "OperatorNode" ||
@@ -159,12 +162,21 @@ function shouldCaptureNode(node: MathNode): boolean {
   );
 }
 
-/** Ordered walk of the AST. */
+/** Ordered walk of the AST. Descendants of a `FunctionAssignmentNode` (the
+ *  body of a lambda like `f(x) = x.score > 0`) are intentionally skipped:
+ *  their free variables (`x` here) are bound inside the lambda and have no
+ *  meaningful value in the outer evaluation scope, so trying to evaluate them
+ *  produces misleading "Undefined symbol x" errors. The lambda itself — and
+ *  the top-level call that receives it, e.g. `countif(gradebook_columns(...),
+ *  f(x) = ...)` — is still captured. */
 function collectNodes(root: MathNode): MathNode[] {
   const out: MathNode[] = [];
-  root.traverse((node) => {
+  const walk = (node: MathNode) => {
     out.push(node);
-  });
+    if (node.type === "FunctionAssignmentNode") return;
+    (node as unknown as { forEach?: (cb: (child: MathNode) => void) => void }).forEach?.(walk);
+  };
+  walk(root);
   return out;
 }
 

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -1,0 +1,476 @@
+"use client";
+/**
+ * Gradebook expression validation and debugging helpers.
+ *
+ * Parses a score expression, validates dependencies against the set of loaded
+ * gradebook columns / assignments, and evaluates the expression for a concrete
+ * student by reusing the same math imports that the server-side recalculator
+ * and the client-side what-if evaluator use. Returns:
+ *   - parse errors (mathjs `parse(...)` threw)
+ *   - dependency errors (unknown slug, cycle, etc.)
+ *   - the final score (report_only policy) for the student, or the eval error
+ *   - intermediate values for every subexpression in the AST so the Expression
+ *     Builder can overlay them on top of the editor.
+ */
+import type { GradebookColumnWithEntries } from "@/utils/supabase/DatabaseTypes";
+import {
+  addCommonExpressionFunctions,
+  COMMON_CONTEXT_FUNCTIONS
+} from "@/supabase/functions/gradebook-column-recalculate/expression/commonMathFunctions";
+import {
+  dedupeIncompleteValues,
+  pushMissingDependenciesToContext,
+  type IncompleteValuesAdvice
+} from "@/supabase/functions/gradebook-column-recalculate/expression/shared";
+import type { FunctionNode, MathNode } from "mathjs";
+import { minimatch } from "minimatch";
+import type { GradebookController } from "@/hooks/useGradebook";
+
+const CONTEXT_FUNCTIONS = [...COMMON_CONTEXT_FUNCTIONS, "gradebook_columns", "assignments"];
+
+export type IntermediateValue = {
+  /** Original substring of the expression (e.g. `mean(gradebook_columns("hw-*"))`) */
+  source: string;
+  /** 0-indexed start/end position in the original expression string */
+  start: number;
+  end: number;
+  /** The mathjs node type (FunctionNode, OperatorNode, …) */
+  nodeType: string;
+  /** Short printable form of the evaluated value; trimmed to keep overlays small */
+  display: string;
+  /** Raw value for debugging / tooltip reveal */
+  raw?: unknown;
+  /** Error message if evaluating this subtree threw */
+  error?: string;
+};
+
+export type ValidationResult = {
+  /** true when the expression parses and all dependency slugs resolve */
+  isValid: boolean;
+  /** "" or empty string counts as valid (no score expression) */
+  isEmpty: boolean;
+  parseError: string | null;
+  dependencyError: string | null;
+  /** Populated when a student row has been evaluated */
+  evaluation: EvaluationResult | null;
+};
+
+export type EvaluationResult = {
+  studentId: string;
+  /** Scalar (or best-effort string) of the full expression */
+  result: string;
+  /** Raw result for later processing */
+  rawResult: unknown;
+  /** Any incomplete values encountered during the (report_only) run */
+  incompleteValues: IncompleteValuesAdvice | null;
+  /** Runtime error, if evaluation threw */
+  error: string | null;
+  /** Per-subnode evaluation results, in source order */
+  intermediates: IntermediateValue[];
+};
+
+/** Short, safe stringification for overlays (`mean(...) = 87.5`). */
+export function formatValueForOverlay(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return String(value);
+    if (Number.isInteger(value)) return value.toString();
+    return Number(value.toFixed(4)).toString();
+  }
+  if (typeof value === "string") {
+    if (value.length > 40) return JSON.stringify(value.slice(0, 37) + "…");
+    return JSON.stringify(value);
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    if (value.length > 4) {
+      return `[${value.slice(0, 4).map(formatValueForOverlay).join(", ")}, … ${value.length - 4} more]`;
+    }
+    return `[${value.map(formatValueForOverlay).join(", ")}]`;
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    // GradebookExpressionValue-like object
+    if ("score" in obj && "column_slug" in obj) {
+      const score = obj["score"];
+      const maxScore = obj["max_score"];
+      const slug = obj["column_slug"];
+      const scoreStr = formatValueForOverlay(score);
+      const maxStr = maxScore !== undefined ? `/${formatValueForOverlay(maxScore)}` : "";
+      return `${slug}=${scoreStr}${maxStr}`;
+    }
+    if ("entries" in obj) {
+      const entries = (obj as { entries: unknown[] }).entries;
+      if (Array.isArray(entries) && entries.length > 0) {
+        return formatValueForOverlay(entries[entries.length - 1]);
+      }
+    }
+    try {
+      const json = JSON.stringify(value);
+      if (json.length <= 80) return json;
+      return json.slice(0, 77) + "…";
+    } catch {
+      return "[object]";
+    }
+  }
+  return String(value);
+}
+
+/**
+ * We accept the full mathjs namespace (`import * as mathjs from "mathjs"`) so
+ * we can call `create(...)` to spin up a fresh instance. The caller is
+ * expected to dynamically import mathjs to keep it out of the main bundle.
+ */
+type MathJSNS = typeof import("mathjs");
+type MathJSInstance = ReturnType<MathJSNS["create"]>;
+
+function shouldCaptureNode(node: MathNode): boolean {
+  const t = node.type;
+  // Skip pure leaves (constants / bare symbol lookups) — the overlay for
+  // `score * 2` should not repeat the constant `2` next to itself.
+  return (
+    t === "FunctionNode" ||
+    t === "OperatorNode" ||
+    t === "ParenthesisNode" ||
+    t === "AccessorNode" ||
+    t === "ConditionalNode" ||
+    t === "ArrayNode" ||
+    t === "RangeNode" ||
+    t === "AssignmentNode" ||
+    t === "BlockNode"
+  );
+}
+
+/** Ordered walk of the AST. */
+function collectNodes(root: MathNode): MathNode[] {
+  const out: MathNode[] = [];
+  root.traverse((node) => {
+    out.push(node);
+  });
+  return out;
+}
+
+type DepsMap = {
+  assignments?: number[];
+  gradebook_columns?: number[];
+};
+
+/**
+ * Returns the set of slugs referenced anywhere in the expression AST that do
+ * NOT resolve to a known gradebook column / assignment, plus an "unresolvable"
+ * flag for cycles.
+ */
+export function validateExpressionString(
+  math: MathJSNS,
+  gradebookController: GradebookController,
+  expression: string,
+  editingColumnId: number | null
+): { parseError: string | null; dependencyError: string | null; deps: DepsMap | null } {
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    return { parseError: null, dependencyError: null, deps: null };
+  }
+  let node: MathNode;
+  try {
+    node = math.parse(trimmed);
+  } catch (e) {
+    return {
+      parseError: e instanceof Error ? e.message : String(e),
+      dependencyError: null,
+      deps: null
+    };
+  }
+
+  try {
+    const deps = gradebookController.extractAndValidateDependencies(trimmed, editingColumnId ?? -1) as DepsMap | null;
+    // Check AST-wide for references we should support.
+    void node;
+    return { parseError: null, dependencyError: null, deps };
+  } catch (e) {
+    return {
+      parseError: null,
+      dependencyError: e instanceof Error ? e.message : String(e),
+      deps: null
+    };
+  }
+}
+
+type ColumnWithEntries = GradebookColumnWithEntries;
+
+/**
+ * Build the import map that mirrors `useGradebookWhatIf.recalculate` but with
+ * a much simpler, read-only lookup against the current persisted row for the
+ * given student (no what-if overrides are applied).
+ *
+ * All functions receive a leading `context` argument that the AST transform
+ * injects before evaluation.
+ */
+function buildImports(
+  math: MathJSInstance,
+  gradebookController: GradebookController,
+  studentId: string,
+  isPrivateCalculation: boolean
+) {
+  type ImportFunction = (...args: never[]) => unknown;
+  const imports: Record<string, ImportFunction> = {};
+  const allColumns = gradebookController.columns as ColumnWithEntries[];
+
+  imports["gradebook_columns"] = ((
+    context: {
+      incomplete_values: IncompleteValuesAdvice | null;
+      incomplete_values_policy: "report_only" | "assume_max" | "assume_zero";
+    },
+    slugInput: string | string[]
+  ) => {
+    const findOne = (slug: string) => {
+      const matchingColumns = allColumns.filter((c) => c.slug && minimatch(c.slug, slug));
+      if (!matchingColumns.length) return null;
+
+      const scoreForColumn = (colId: number) => {
+        const thisColumn = allColumns.find((c) => c.id === colId);
+        if (!thisColumn) throw new Error(`Column ${colId} not found`);
+        const columnStudent = gradebookController.getGradebookColumnStudent(colId, studentId);
+
+        let score: number | null = null;
+        let released = columnStudent?.released ?? false;
+        let is_missing = columnStudent?.is_missing ?? true;
+        if (columnStudent?.score_override !== null && columnStudent?.score_override !== undefined) {
+          score = columnStudent.score_override;
+          is_missing = false;
+          released = true;
+        } else if (columnStudent?.score !== null && columnStudent?.score !== undefined) {
+          score = columnStudent.score;
+        }
+
+        const ret = {
+          score: score,
+          score_override: columnStudent?.score_override ?? null,
+          is_missing,
+          is_droppable: columnStudent?.is_droppable ?? true,
+          is_excused: columnStudent?.is_excused ?? false,
+          max_score: thisColumn.max_score ?? 0,
+          column_slug: thisColumn.slug ?? "",
+          is_private: columnStudent?.is_private ?? false,
+          incomplete_values: columnStudent?.incomplete_values ?? null,
+          released
+        };
+        // Propagate not_released / missing for report_only policy so the
+        // caller can see which slugs caused undefined intermediates.
+        if (!ret.released && ret.score === null && !ret.is_private) {
+          if (!context.incomplete_values) context.incomplete_values = {};
+          if (!context.incomplete_values.not_released) context.incomplete_values.not_released = {};
+          if (!context.incomplete_values.not_released.gradebook_columns) {
+            context.incomplete_values.not_released.gradebook_columns = [];
+          }
+          context.incomplete_values.not_released.gradebook_columns.push(ret.column_slug);
+        }
+        pushMissingDependenciesToContext(context as { incomplete_values: IncompleteValuesAdvice | null }, ret);
+        return ret;
+      };
+
+      if (matchingColumns.length === 1 && !slug.includes("*")) {
+        return scoreForColumn(matchingColumns[0].id);
+      }
+      return matchingColumns.map((c) => scoreForColumn(c.id));
+    };
+
+    if (Array.isArray(slugInput)) {
+      return slugInput.map(findOne);
+    }
+    const ret = findOne(slugInput);
+    if (ret && !slugInput.includes("*")) return ret;
+    if (Array.isArray(ret)) return ret;
+    return [ret];
+  }) as ImportFunction;
+
+  imports["assignments"] = ((_context: unknown, slugInput: string | string[]) => {
+    const assignments = (() => {
+      try {
+        return gradebookController.assignments ?? [];
+      } catch {
+        return [];
+      }
+    })();
+    const findOne = (slug: string) => {
+      const match = assignments.filter((a) => a.slug && minimatch(a.slug, slug));
+      if (!match.length) return null;
+      return match[0].total_points ?? null;
+    };
+    if (Array.isArray(slugInput)) return slugInput.map(findOne);
+    return findOne(slugInput);
+  }) as ImportFunction;
+
+  addCommonExpressionFunctions(imports, {
+    includeSecurityGuards: false,
+    enforcePrivateCalculationMatch: false
+  });
+  math.import(imports, { override: true });
+  void isPrivateCalculation;
+  return imports;
+}
+
+/**
+ * Parse, validate, and evaluate an expression against a student. Uses the
+ * `report_only` incomplete-values policy so missing dependencies surface
+ * rather than being silently coerced.
+ */
+export function evaluateForStudent(params: {
+  math: MathJSNS;
+  gradebookController: GradebookController;
+  expression: string;
+  studentId: string;
+  editingColumnId: number | null;
+  captureIntermediates?: boolean;
+}): ValidationResult {
+  const { math, gradebookController, expression, studentId, editingColumnId } = params;
+  const trimmed = expression.trim();
+  if (!trimmed) {
+    return {
+      isValid: true,
+      isEmpty: true,
+      parseError: null,
+      dependencyError: null,
+      evaluation: null
+    };
+  }
+
+  const { parseError, dependencyError } = validateExpressionString(math, gradebookController, trimmed, editingColumnId);
+  if (parseError) {
+    return { isValid: false, isEmpty: false, parseError, dependencyError: null, evaluation: null };
+  }
+  if (dependencyError) {
+    return { isValid: false, isEmpty: false, parseError: null, dependencyError, evaluation: null };
+  }
+
+  if (!studentId) {
+    return {
+      isValid: true,
+      isEmpty: false,
+      parseError: null,
+      dependencyError: null,
+      evaluation: null
+    };
+  }
+
+  // Build a fresh math instance to avoid polluting the shared one used by
+  // render expressions.
+  const localMath: MathJSInstance = math.create(math.all, {});
+  buildImports(localMath, gradebookController, studentId, false);
+
+  const parsed = localMath.parse(trimmed);
+  const transformed = parsed.transform((node: MathNode) => {
+    if (node.type === "FunctionNode") {
+      const fn = node as FunctionNode;
+      if (CONTEXT_FUNCTIONS.includes(fn.fn.name)) {
+        const SymbolNodeCtor = (localMath as unknown as { SymbolNode: new (name: string) => MathNode }).SymbolNode;
+        const contextSymbol = new SymbolNodeCtor("context");
+        const newArgs: MathNode[] = [contextSymbol, ...fn.args];
+        fn.args = newArgs;
+      }
+    }
+    return node;
+  });
+
+  const context = {
+    student_id: studentId,
+    is_private_calculation: false,
+    incomplete_values: {} as IncompleteValuesAdvice,
+    incomplete_values_policy: "report_only" as const,
+    class_id: gradebookController.class_id,
+    scope: {
+      setTag: () => {},
+      addBreadcrumb: () => {}
+    }
+  };
+
+  let rawResult: unknown;
+  let resultStr = "";
+  let evalError: string | null = null;
+  try {
+    rawResult = transformed.evaluate({ context });
+    if (typeof rawResult === "object" && rawResult !== null && "entries" in (rawResult as Record<string, unknown>)) {
+      const entries = (rawResult as { entries: unknown[] }).entries;
+      rawResult = entries.length > 0 ? entries[entries.length - 1] : undefined;
+    }
+    resultStr = formatValueForOverlay(rawResult);
+  } catch (e) {
+    evalError = e instanceof Error ? e.message : String(e);
+  }
+
+  const intermediates: IntermediateValue[] = [];
+  if (params.captureIntermediates !== false) {
+    for (const node of collectNodes(transformed)) {
+      if (!shouldCaptureNode(node)) continue;
+      let source: string;
+      try {
+        source = node.toString();
+      } catch {
+        source = node.type;
+      }
+      // Strip the leading `context, ` the transform injected for known context
+      // functions so the displayed source matches what the user typed.
+      const pretty = source
+        .replace(/^mean\(context, /, "mean(")
+        .replace(/^sum\(context, /, "sum(")
+        .replace(/^countif\(context, /, "countif(")
+        .replace(/^drop_lowest\(context, /, "drop_lowest(")
+        .replace(/^gradebook_columns\(context, /, "gradebook_columns(")
+        .replace(/^assignments\(context, /, "assignments(");
+
+      const idx = trimmed.indexOf(pretty);
+      let value: unknown;
+      let nodeError: string | undefined;
+      try {
+        value = node.evaluate({ context });
+        if (value && typeof value === "object" && "entries" in (value as Record<string, unknown>)) {
+          const entries = (value as { entries: unknown[] }).entries;
+          value = entries.length > 0 ? entries[entries.length - 1] : undefined;
+        }
+      } catch (e) {
+        nodeError = e instanceof Error ? e.message : String(e);
+      }
+      intermediates.push({
+        source: pretty,
+        nodeType: node.type,
+        start: idx,
+        end: idx >= 0 ? idx + pretty.length : -1,
+        display: nodeError ? `error: ${nodeError}` : formatValueForOverlay(value),
+        raw: value,
+        error: nodeError
+      });
+    }
+    // Deduplicate identical (source,start) entries that the tree walk can emit
+    // (e.g. BlockNode + its single child both match the whole expression).
+    const seen = new Set<string>();
+    for (let i = intermediates.length - 1; i >= 0; i--) {
+      const key = `${intermediates[i].start}:${intermediates[i].end}:${intermediates[i].source}`;
+      if (seen.has(key)) intermediates.splice(i, 1);
+      else seen.add(key);
+    }
+  }
+
+  const deduped = dedupeIncompleteValues(context.incomplete_values);
+  const hasMeaningful =
+    (deduped?.missing?.gradebook_columns?.length ?? 0) > 0 ||
+    (deduped?.not_released?.gradebook_columns?.length ?? 0) > 0;
+
+  return {
+    isValid: evalError === null,
+    isEmpty: false,
+    parseError: null,
+    dependencyError: null,
+    evaluation: {
+      studentId,
+      result: evalError ? "" : resultStr,
+      rawResult,
+      incompleteValues: hasMeaningful ? deduped! : null,
+      error: evalError,
+      intermediates: intermediates.sort((a, b) => {
+        if (a.start === b.start) return b.end - a.end; // longer spans first
+        return a.start - b.start;
+      })
+    }
+  };
+}

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -256,7 +256,14 @@ export function mapLinesToBlocks(
       result.push({ kind: "blank" });
       continue;
     }
-    if (depth === 0 && !inString) {
+    // Only promote a newline-at-depth-0 into a statement terminator when
+    // the line did NOT already end with an explicit `;`. Otherwise we'd
+    // double-count the same statement — mathjs treats `T = 10;\n` as a
+    // single statement, so a stray extra advance here would desynchronise
+    // `blockIndex` from `blockEntries` and the line would get a spurious
+    // `undefined` overlay from `blockEntries[blockIndex]` being out of
+    // range.
+    if (depth === 0 && !inString && !endedStatement) {
       // Newline at top level → end of a statement.
       assignedBlock = blockIndex;
       blockIndex++;
@@ -675,27 +682,40 @@ export function evaluateForStudent(params: {
   let rawResult: unknown;
   let resultStr = "";
   let evalError: string | null = null;
-  /** Raw per-block values from the top-level `ResultSet.entries`, if the
-   *  expression parsed as a `BlockNode`. Used to annotate each line of the
-   *  editor with the value of the statement that ends there. */
+  /** Raw per-block values, one per top-level statement in source order. We
+   *  evaluate each block individually in a shared scope so that even
+   *  semicolon-suppressed statements (e.g. `T = 930;`) — which mathjs
+   *  normally omits from `ResultSet.entries` — still produce a value for
+   *  the overlay. */
   let blockEntries: unknown[] = [];
   try {
-    const topLevel = transformed.evaluate({ context });
-    if (
-      topLevel &&
-      typeof topLevel === "object" &&
-      !Array.isArray(topLevel) &&
-      "entries" in (topLevel as Record<string, unknown>)
-    ) {
-      const entries = (topLevel as { entries: unknown }).entries;
-      if (Array.isArray(entries)) {
-        blockEntries = entries;
-        rawResult = entries.length > 0 ? entries[entries.length - 1] : undefined;
-      } else {
-        rawResult = unwrapResultSet(topLevel);
+    const topLevelAny = transformed as unknown as {
+      type?: string;
+      blocks?: Array<{ node: MathNode }>;
+    };
+    if (topLevelAny.type === "BlockNode" && Array.isArray(topLevelAny.blocks)) {
+      // Evaluate each top-level statement in a shared `scope` so that
+      // assignments from earlier statements (e.g. `T = 930`) are visible to
+      // later ones (e.g. `T * 2`). `context` is still read from the same
+      // synthetic object we passed to the AST transform.
+      const scope = { context };
+      for (const block of topLevelAny.blocks) {
+        try {
+          const v = unwrapResultSet(block.node.evaluate(scope));
+          blockEntries.push(v);
+        } catch (blockErr) {
+          // An error in any block stops evaluation — record the message on
+          // `evalError` so the UI surfaces it once, and push a sentinel for
+          // this block so the block-index alignment stays correct.
+          evalError = blockErr instanceof Error ? blockErr.message : String(blockErr);
+          blockEntries.push(undefined);
+          break;
+        }
       }
+      rawResult = blockEntries.length > 0 ? blockEntries[blockEntries.length - 1] : undefined;
     } else {
-      rawResult = unwrapResultSet(topLevel);
+      // Single-expression (non-block) input.
+      rawResult = unwrapResultSet(transformed.evaluate({ context }));
       blockEntries = [rawResult];
     }
     resultStr = formatValueForOverlay(rawResult);

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -323,6 +323,117 @@ function buildImports(math: MathJSInstance, gradebookController: GradebookContro
 }
 
 /**
+ * Breakpoints used by the default gradebook render helpers (`letter`,
+ * `check`, `checkOrX`). Mirrors the tables in `useGradebook._getSharedMath`.
+ * Keeping them here keeps the tester self-contained — the expression builder
+ * can evaluate a column's render expression without touching the shared math
+ * instance that powers the live gradebook cells (and without waiting for the
+ * controller to have wired one up yet, which matters on Add Column).
+ */
+const LETTER_BREAKPOINTS: Array<{ score: number; letter: string }> = [
+  { score: 93, letter: "A" },
+  { score: 90, letter: "A-" },
+  { score: 87, letter: "B+" },
+  { score: 83, letter: "B" },
+  { score: 80, letter: "B-" },
+  { score: 77, letter: "C+" },
+  { score: 73, letter: "C" },
+  { score: 70, letter: "C-" },
+  { score: 67, letter: "D+" },
+  { score: 63, letter: "D" },
+  { score: 60, letter: "D-" },
+  { score: 0, letter: "F" }
+];
+const CHECK_BREAKPOINTS: Array<{ score: number; mark: string }> = [
+  { score: 90, mark: "✔️+" },
+  { score: 80, mark: "✔️" },
+  { score: 70, mark: "✔️-" },
+  { score: 0, mark: "❌" }
+];
+
+export type RenderExpressionResult =
+  | { kind: "empty" }
+  | { kind: "ok"; rendered: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Evaluate a column's render expression against a final score. Reuses the
+ * `letter`, `check`, `checkOrX`, and `customLabel` helpers exposed in the
+ * live gradebook so the builder's preview matches the rendered cell.
+ *
+ * @param prefix The gradebook's `expression_prefix` (may be empty).
+ * @param renderExpression The user's render expression. Empty/null → `empty`.
+ * @param score Final numeric score of the column (undefined → "(N/A)"-like).
+ * @param maxScore Max score of the column.
+ */
+export function evaluateRenderExpression(
+  math: MathJSNS,
+  prefix: string,
+  renderExpression: string | null | undefined,
+  score: number | undefined,
+  maxScore: number | undefined
+): RenderExpressionResult {
+  const raw = (renderExpression ?? "").trim();
+  if (!raw) return { kind: "empty" };
+  try {
+    const localMath: MathJSInstance = math.create(math.all, {});
+    type ImportFunction = (...args: never[]) => unknown;
+    const imports: Record<string, ImportFunction> = {};
+    imports["letter"] = ((s: number | undefined, m: number | undefined) => {
+      if (s === undefined) return "(N/A)";
+      const normalized = 100 * (s / (m ?? 100));
+      const hit = LETTER_BREAKPOINTS.find((b) => normalized >= b.score);
+      return hit ? hit.letter : "F";
+    }) as ImportFunction;
+    imports["check"] = ((s: number | undefined, m: number | undefined) => {
+      if (s === undefined) return "(N/A)";
+      const normalized = 100 * (s / (m ?? 100));
+      const hit = CHECK_BREAKPOINTS.find((b) => normalized >= b.score);
+      return hit ? hit.mark : "❌";
+    }) as ImportFunction;
+    imports["checkOrX"] = ((s: number | undefined, m: number | undefined) => {
+      if (s === undefined) return "(N/A)";
+      const normalized = 100 * (s / (m ?? 1));
+      return normalized > 0 ? "✔️" : "❌";
+    }) as ImportFunction;
+    imports["customLabel"] = ((value: number | undefined, breakpoints: { toArray?: () => unknown[] } | unknown) => {
+      if (value === undefined) return "(N/A)";
+      const arr = Array.isArray(breakpoints)
+        ? breakpoints
+        : breakpoints && typeof (breakpoints as { toArray?: () => unknown[] }).toArray === "function"
+          ? (breakpoints as { toArray: () => unknown[] }).toArray()
+          : [];
+      for (const pair of arr as [number, string][]) {
+        const [s, label] = pair;
+        if (value >= s) return label;
+      }
+      return "Error";
+    }) as ImportFunction;
+    localMath.import(imports, { override: true });
+
+    const full = (prefix ? prefix + "\n" : "") + raw;
+    const expr = localMath.parse(full);
+    const compiled = expr.compile();
+    const ret = compiled.evaluate({ score, max_score: maxScore });
+    const unwrapped =
+      ret && typeof ret === "object" && !Array.isArray(ret) && "entries" in (ret as Record<string, unknown>)
+        ? (() => {
+            const entries = (ret as { entries: unknown }).entries;
+            return Array.isArray(entries) && entries.length > 0 ? entries[entries.length - 1] : undefined;
+          })()
+        : ret;
+    if (unwrapped === undefined || unwrapped === null) return { kind: "ok", rendered: "-" };
+    if (typeof unwrapped === "number") {
+      if (!Number.isFinite(unwrapped)) return { kind: "ok", rendered: String(unwrapped) };
+      return { kind: "ok", rendered: Number(unwrapped.toFixed(4)).toString() };
+    }
+    return { kind: "ok", rendered: String(unwrapped) };
+  } catch (e) {
+    return { kind: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
  * Parse, validate, and evaluate an expression against a student. Uses the
  * `report_only` incomplete-values policy so missing dependencies surface
  * rather than being silently coerced.

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -188,9 +188,12 @@ export function validateExpressionString(
   if (!trimmed) {
     return { parseError: null, dependencyError: null, deps: null };
   }
-  let node: MathNode;
+  // Attempt a parse first so we can distinguish a syntax error from a
+  // dependency error. `extractAndValidateDependencies` also parses internally
+  // but throws a single merged error, which the UI presents under the wrong
+  // category.
   try {
-    node = math.parse(trimmed);
+    math.parse(trimmed);
   } catch (e) {
     return {
       parseError: e instanceof Error ? e.message : String(e),
@@ -201,8 +204,6 @@ export function validateExpressionString(
 
   try {
     const deps = gradebookController.extractAndValidateDependencies(trimmed, editingColumnId ?? -1) as DepsMap | null;
-    // Check AST-wide for references we should support.
-    void node;
     return { parseError: null, dependencyError: null, deps };
   } catch (e) {
     return {
@@ -223,12 +224,7 @@ type ColumnWithEntries = GradebookColumnWithEntries;
  * All functions receive a leading `context` argument that the AST transform
  * injects before evaluation.
  */
-function buildImports(
-  math: MathJSInstance,
-  gradebookController: GradebookController,
-  studentId: string,
-  isPrivateCalculation: boolean
-) {
+function buildImports(math: MathJSInstance, gradebookController: GradebookController, studentId: string) {
   type ImportFunction = (...args: never[]) => unknown;
   const imports: Record<string, ImportFunction> = {};
   const allColumns = gradebookController.columns as ColumnWithEntries[];
@@ -323,7 +319,6 @@ function buildImports(
     enforcePrivateCalculationMatch: false
   });
   math.import(imports, { override: true });
-  void isPrivateCalculation;
   return imports;
 }
 
@@ -373,21 +368,36 @@ export function evaluateForStudent(params: {
   // Build a fresh math instance to avoid polluting the shared one used by
   // render expressions.
   const localMath: MathJSInstance = math.create(math.all, {});
-  buildImports(localMath, gradebookController, studentId, false);
+  buildImports(localMath, gradebookController, studentId);
 
   const parsed = localMath.parse(trimmed);
-  const transformed = parsed.transform((node: MathNode) => {
-    if (node.type === "FunctionNode") {
-      const fn = node as FunctionNode;
+  // For every context-aware function call, prepend the `context` symbol to
+  // the argument list.
+  //
+  // mathjs's `Node.transform(cb)` stops recursing once the callback returns a
+  // DIFFERENT node (see node_modules/mathjs/lib/esm/expression/node/Node.js),
+  // so if we naively `return new FunctionNode(...)` for the outer `sum(...)`
+  // the inner `gradebook_columns(...)` never gets its context prepended and
+  // fails at runtime with a bogus "invalid pattern" error. We recurse
+  // manually so both levels get rewritten, and we build fresh `FunctionNode`s
+  // rather than mutating `.args` in place to avoid corrupting any AST that
+  // mathjs may have cached.
+  const SymbolNodeCtor = (localMath as unknown as { SymbolNode: new (name: string) => MathNode }).SymbolNode;
+  const FunctionNodeCtor = (localMath as unknown as { FunctionNode: new (fn: unknown, args: MathNode[]) => MathNode })
+    .FunctionNode;
+  const injectContextArg = (node: MathNode): MathNode => {
+    // Recurse into children first so inner calls also get transformed.
+    const mapped = (node as unknown as { map: (cb: (child: MathNode) => MathNode) => MathNode }).map(injectContextArg);
+    if (mapped.type === "FunctionNode") {
+      const fn = mapped as FunctionNode;
       if (CONTEXT_FUNCTIONS.includes(fn.fn.name)) {
-        const SymbolNodeCtor = (localMath as unknown as { SymbolNode: new (name: string) => MathNode }).SymbolNode;
         const contextSymbol = new SymbolNodeCtor("context");
-        const newArgs: MathNode[] = [contextSymbol, ...fn.args];
-        fn.args = newArgs;
+        return new FunctionNodeCtor(fn.fn, [contextSymbol, ...fn.args]);
       }
     }
-    return node;
-  });
+    return mapped;
+  };
+  const transformed = injectContextArg(parsed);
 
   const context = {
     student_id: studentId,
@@ -441,15 +451,17 @@ export function evaluateForStudent(params: {
       } catch {
         source = node.type;
       }
-      // Strip the leading `context, ` the transform injected for known context
-      // functions so the displayed source matches what the user typed.
-      const pretty = source
-        .replace(/^mean\(context, /, "mean(")
-        .replace(/^sum\(context, /, "sum(")
-        .replace(/^countif\(context, /, "countif(")
-        .replace(/^drop_lowest\(context, /, "drop_lowest(")
-        .replace(/^gradebook_columns\(context, /, "gradebook_columns(")
-        .replace(/^assignments\(context, /, "assignments(");
+      // Strip every `context, ` the transform injected for context-aware
+      // functions so the displayed source matches what the user typed. This
+      // must be global (not anchored) because nested calls like
+      // `sum(gradebook_columns("hw-*"))` stringify to
+      // `sum(context, gradebook_columns(context, "hw-*"))` and we need to
+      // clean both levels.
+      const contextArgStrip = new RegExp(
+        `\\b(${CONTEXT_FUNCTIONS.map((fn) => fn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\(context,\\s*`,
+        "g"
+      );
+      const pretty = source.replace(contextArgStrip, "$1(");
 
       const idx = trimmed.indexOf(pretty);
       let value: unknown;

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -44,6 +44,24 @@ export type IntermediateValue = {
   error?: string;
 };
 
+/**
+ * Per-input-line annotation used by the inline preview. For each line of the
+ * user's typed expression we report either:
+ *   - `kind: "value"` — this line ENDS a top-level statement (e.g. `T = 930`
+ *     or the final `])` of a multi-line `case_when([...])`), and `display` is
+ *     the short-form evaluated value of that statement.
+ *   - `kind: "continuation"` — this line is mid-statement (e.g. a line in the
+ *     middle of a multi-line matrix literal). No value to show yet.
+ *   - `kind: "blank"` — empty or whitespace-only line.
+ *   - `kind: "error"` — the statement ending on this line threw during eval;
+ *     `display` is the error message.
+ */
+export type LineResult =
+  | { kind: "value"; lineIndex: number; blockIndex: number; display: string; raw?: unknown }
+  | { kind: "continuation"; lineIndex: number; blockIndex: number }
+  | { kind: "blank"; lineIndex: number }
+  | { kind: "error"; lineIndex: number; blockIndex: number; display: string };
+
 export type ValidationResult = {
   /** true when the expression parses and all dependency slugs resolve */
   isValid: boolean;
@@ -67,6 +85,12 @@ export type EvaluationResult = {
   error: string | null;
   /** Per-subnode evaluation results, in source order */
   intermediates: IntermediateValue[];
+  /**
+   * Per-input-line annotations, one per `\n`-separated line of the raw
+   * expression text. Used by the Expression Builder to render an inline
+   * `= value` overlay on the line that ends each statement.
+   */
+  lineResults: LineResult[];
 };
 
 function maybeUnwrapMatrix(value: unknown): unknown {
@@ -160,6 +184,89 @@ function shouldCaptureNode(node: MathNode): boolean {
     t === "AssignmentNode" ||
     t === "BlockNode"
   );
+}
+
+/**
+ * Walk the user's raw expression character-by-character, tracking bracket
+ * depth and string state, and assign each `\n`-separated input line to a
+ * top-level statement (block) index. Returns, per input line:
+ *   `{ kind: "end", blockIndex }` — the line ENDS a top-level statement.
+ *   `{ kind: "mid", blockIndex }` — the line is mid-statement.
+ *   `{ kind: "blank" }` — whitespace/comment only.
+ *
+ * Matches mathjs's parse behaviour: newline at bracket-depth 0 terminates a
+ * statement, so does `;` at depth 0. Tracks `"` / `'` string literals and
+ * backslash-escapes so braces inside strings don't affect depth. `#`
+ * starts a line comment.
+ */
+export function mapLinesToBlocks(
+  expression: string
+): Array<{ kind: "end"; blockIndex: number } | { kind: "mid"; blockIndex: number } | { kind: "blank" }> {
+  const lines = expression.split("\n");
+  const result: Array<{ kind: "end"; blockIndex: number } | { kind: "mid"; blockIndex: number } | { kind: "blank" }> =
+    [];
+  let depth = 0;
+  let blockIndex = 0;
+  let inString = false;
+  let stringChar = "";
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let hasContent = false;
+    let endedStatement = false;
+    let assignedBlock = blockIndex;
+    for (let j = 0; j < line.length; j++) {
+      const ch = line[j];
+      if (inString) {
+        if (ch === "\\") {
+          j++;
+          continue;
+        }
+        if (ch === stringChar) inString = false;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        inString = true;
+        stringChar = ch;
+        hasContent = true;
+        continue;
+      }
+      if (ch === "#") break; // mathjs line comment
+      if (ch === "(" || ch === "[" || ch === "{") {
+        depth++;
+        hasContent = true;
+        continue;
+      }
+      if (ch === ")" || ch === "]" || ch === "}") {
+        depth--;
+        hasContent = true;
+        continue;
+      }
+      if (/\s/.test(ch)) continue;
+      if (ch === ";" && depth === 0) {
+        assignedBlock = blockIndex;
+        blockIndex++;
+        endedStatement = true;
+        hasContent = true;
+        continue;
+      }
+      hasContent = true;
+    }
+    if (!hasContent) {
+      result.push({ kind: "blank" });
+      continue;
+    }
+    if (depth === 0 && !inString) {
+      // Newline at top level → end of a statement.
+      assignedBlock = blockIndex;
+      blockIndex++;
+      endedStatement = true;
+    }
+    result.push(
+      endedStatement ? { kind: "end", blockIndex: assignedBlock } : { kind: "mid", blockIndex: assignedBlock }
+    );
+  }
+  return result;
 }
 
 /** Ordered walk of the AST. Descendants of a `FunctionAssignmentNode` (the
@@ -557,8 +664,29 @@ export function evaluateForStudent(params: {
   let rawResult: unknown;
   let resultStr = "";
   let evalError: string | null = null;
+  /** Raw per-block values from the top-level `ResultSet.entries`, if the
+   *  expression parsed as a `BlockNode`. Used to annotate each line of the
+   *  editor with the value of the statement that ends there. */
+  let blockEntries: unknown[] = [];
   try {
-    rawResult = unwrapResultSet(transformed.evaluate({ context }));
+    const topLevel = transformed.evaluate({ context });
+    if (
+      topLevel &&
+      typeof topLevel === "object" &&
+      !Array.isArray(topLevel) &&
+      "entries" in (topLevel as Record<string, unknown>)
+    ) {
+      const entries = (topLevel as { entries: unknown }).entries;
+      if (Array.isArray(entries)) {
+        blockEntries = entries;
+        rawResult = entries.length > 0 ? entries[entries.length - 1] : undefined;
+      } else {
+        rawResult = unwrapResultSet(topLevel);
+      }
+    } else {
+      rawResult = unwrapResultSet(topLevel);
+      blockEntries = [rawResult];
+    }
     resultStr = formatValueForOverlay(rawResult);
   } catch (e) {
     evalError = e instanceof Error ? e.message : String(e);
@@ -641,6 +769,36 @@ export function evaluateForStudent(params: {
     (deduped?.missing?.gradebook_columns?.length ?? 0) > 0 ||
     (deduped?.not_released?.gradebook_columns?.length ?? 0) > 0;
 
+  // Walk the raw expression text and decide, for each input line, whether it
+  // ends a statement — if so we pair it with the corresponding entry from
+  // `blockEntries` so the UI can render an inline `= value` annotation.
+  const lineMap = mapLinesToBlocks(expression);
+  const lineResults: LineResult[] = lineMap.map((entry, lineIndex) => {
+    if (entry.kind === "blank") return { kind: "blank", lineIndex } as const;
+    if (entry.kind === "mid") {
+      return { kind: "continuation", lineIndex, blockIndex: entry.blockIndex } as const;
+    }
+    // kind === "end"
+    if (evalError) {
+      // If evaluation threw, only the statement that threw should report the
+      // error. We don't know which one, but annotating the last-evaluated
+      // line with the error is a reasonable approximation.
+      const isLastBlock = entry.blockIndex === lineMap.filter((l) => l.kind === "end").length - 1;
+      if (isLastBlock) {
+        return { kind: "error", lineIndex, blockIndex: entry.blockIndex, display: evalError } as const;
+      }
+      return { kind: "continuation", lineIndex, blockIndex: entry.blockIndex } as const;
+    }
+    const rawValue = entry.blockIndex < blockEntries.length ? blockEntries[entry.blockIndex] : undefined;
+    return {
+      kind: "value",
+      lineIndex,
+      blockIndex: entry.blockIndex,
+      display: formatValueForOverlay(rawValue),
+      raw: rawValue
+    } as const;
+  });
+
   return {
     isValid: evalError === null,
     isEmpty: false,
@@ -655,7 +813,8 @@ export function evaluateForStudent(params: {
       intermediates: intermediates.sort((a, b) => {
         if (a.start === b.start) return b.end - a.end; // longer spans first
         return a.start - b.start;
-      })
+      }),
+      lineResults
     }
   };
 }

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -855,17 +855,30 @@ export function evaluateForStudent(params: {
       return { kind: "continuation", lineIndex, blockIndex: entry.blockIndex } as const;
     }
     // kind === "end"
+    // Per-block evaluation (above) breaks on the first throwing block and
+    // pushes an `undefined` sentinel for it, so:
+    //   - blockIndex < blockEntries.length - 1 → successfully evaluated,
+    //     show its cached value;
+    //   - blockIndex === blockEntries.length - 1 → either the only
+    //     successful block OR the throwing one (we use `evalError` to
+    //     decide);
+    //   - blockIndex >= blockEntries.length → block never ran (earlier
+    //     statement threw and stopped evaluation); stay as a continuation.
     if (evalError) {
-      // If evaluation threw, only the statement that threw should report the
-      // error. We don't know which one, but annotating the last-evaluated
-      // line with the error is a reasonable approximation.
-      const isLastBlock = entry.blockIndex === lineMap.filter((l) => l.kind === "end").length - 1;
-      if (isLastBlock) {
+      const throwingBlockIndex = blockEntries.length - 1;
+      if (entry.blockIndex === throwingBlockIndex) {
         return { kind: "error", lineIndex, blockIndex: entry.blockIndex, display: evalError } as const;
       }
+      if (entry.blockIndex > throwingBlockIndex) {
+        return { kind: "continuation", lineIndex, blockIndex: entry.blockIndex } as const;
+      }
+      // Earlier block that completed successfully before the throw — still
+      // show its captured value. Fall through to the value case below.
+    }
+    if (entry.blockIndex >= blockEntries.length) {
       return { kind: "continuation", lineIndex, blockIndex: entry.blockIndex } as const;
     }
-    const rawValue = entry.blockIndex < blockEntries.length ? blockEntries[entry.blockIndex] : undefined;
+    const rawValue = blockEntries[entry.blockIndex];
     return {
       kind: "value",
       lineIndex,

--- a/lib/gradebookExpressionTester.ts
+++ b/lib/gradebookExpressionTester.ts
@@ -566,6 +566,26 @@ export function evaluateForStudent(params: {
 
   const intermediates: IntermediateValue[] = [];
   if (params.captureIntermediates !== false) {
+    // Hoisted so it's compiled once per evaluateForStudent call instead of
+    // once per captured node. The CONTEXT_FUNCTIONS list is a hard-coded
+    // constant, so the regex is fully static — no ReDoS surface.
+    const contextArgStrip = new RegExp(
+      `\\b(${CONTEXT_FUNCTIONS.map((fn) => fn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\(context,\\s*`,
+      "g"
+    );
+    // Use the parsed AST's own `toString()` as the haystack for position
+    // lookups instead of the user's raw input. mathjs normalises string
+    // literals (e.g. single → double quotes) when stringifying, so the
+    // subnode `pretty` strings only match reliably against the same
+    // normalised form — using the raw `trimmed` input produces `-1` spans
+    // for any expression that contains a quoted slug.
+    const canonicalExpression = parsed.toString().replace(contextArgStrip, "$1(");
+    // Walk source positions greedily so repeated subexpressions (e.g.
+    // `gradebook_columns("hw-1") + gradebook_columns("hw-1")`) get DISTINCT
+    // spans. Without this, `indexOf(pretty)` always hands back the first
+    // occurrence, both instances land on `start=0` / `end=len(pretty)`, and
+    // the dedupe loop below collapses them into one entry.
+    const nextSearchFromBySource = new Map<string, number>();
     for (const node of collectNodes(transformed)) {
       if (!shouldCaptureNode(node)) continue;
       let source: string;
@@ -580,13 +600,13 @@ export function evaluateForStudent(params: {
       // `sum(gradebook_columns("hw-*"))` stringify to
       // `sum(context, gradebook_columns(context, "hw-*"))` and we need to
       // clean both levels.
-      const contextArgStrip = new RegExp(
-        `\\b(${CONTEXT_FUNCTIONS.map((fn) => fn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\(context,\\s*`,
-        "g"
-      );
       const pretty = source.replace(contextArgStrip, "$1(");
 
-      const idx = trimmed.indexOf(pretty);
+      const searchFrom = nextSearchFromBySource.get(pretty) ?? 0;
+      const idx = canonicalExpression.indexOf(pretty, searchFrom);
+      if (idx >= 0) {
+        nextSearchFromBySource.set(pretty, idx + pretty.length);
+      }
       let value: unknown;
       let nodeError: string | undefined;
       try {
@@ -606,6 +626,8 @@ export function evaluateForStudent(params: {
     }
     // Deduplicate identical (source,start) entries that the tree walk can emit
     // (e.g. BlockNode + its single child both match the whole expression).
+    // Repeated subexpressions with DIFFERENT start offsets (thanks to the
+    // greedy search above) stay distinct.
     const seen = new Set<string>();
     for (let i = intermediates.length - 1; i >= 0; i--) {
       const key = `${intermediates[i].start}:${intermediates[i].end}:${intermediates[i].source}`;

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -940,6 +940,102 @@ test.describe("Gradebook Page - Comprehensive", () => {
     // This column is not included in final grade so don't check that it updates
   });
 
+  test("Expression Builder: live validation, full-screen mode, and per-student evaluation", async ({ page }) => {
+    // Uses the Add Column dialog (creates a new column so it's safe even in
+    // the serial suite). Covers:
+    //   1. Live parse validation (invalid syntax).
+    //   2. Dependency validation (unknown slug) blocks save.
+    //   3. A valid expression enables save.
+    //   4. Full-screen Expression Builder opens, shows a student picker, and
+    //      evaluates the expression against a specific student with live
+    //      intermediate values.
+    await page.getByRole("button", { name: "Add Column" }).click();
+
+    const addDialog = page.getByRole("dialog").filter({ hasText: "Add Column" });
+    await expect(addDialog).toBeVisible();
+
+    await addDialog.getByLabel("Name").fill("Validated Column");
+    await addDialog.getByLabel("Max Score").fill("100");
+    await addDialog.getByLabel("Slug").fill("validated-column");
+
+    const scoreTextarea = addDialog.getByLabel("Score Expression");
+    await expect(scoreTextarea).toBeVisible();
+    const saveButton = addDialog.getByRole("button", { name: /^Save$/ });
+
+    // --- (1) Parse error ---
+    await scoreTextarea.fill("((1 +");
+    await expect(page.getByTestId("expression-parse-error")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("expression-parse-error")).toContainText(/Parse error/i);
+    // Clicking Save while the expression is invalid must not close the dialog
+    // or create a column. The button is rendered with `disabled={true}` on
+    // Chakra when validation fails, but we belt-and-suspenders click it.
+    await saveButton.click({ force: true }).catch(() => {
+      /* Chakra may mark the button as disabled, which blocks the click. */
+    });
+    await expect(addDialog).toBeVisible();
+
+    // --- (2) Dependency error ---
+    await scoreTextarea.fill('mean(gradebook_columns("does-not-exist-xyz"))');
+    await expect(page.getByTestId("expression-dependency-error")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("expression-dependency-error")).toContainText(/Invalid dependency/i);
+    await saveButton.click({ force: true }).catch(() => {});
+    await expect(addDialog).toBeVisible();
+
+    // --- (3) Valid arithmetic expression ---
+    await scoreTextarea.fill("1 + 2 * 3");
+    await expect(page.getByTestId("expression-ok-syntax")).toBeVisible({ timeout: 10_000 });
+
+    // --- (4) Full-screen expression builder ---
+    await addDialog.getByRole("button", { name: /Expression Builder/i }).click();
+    // The overlay region is rendered only in expanded mode.
+    await expect(page.getByTestId("expression-builder-overlay")).toBeVisible({ timeout: 10_000 });
+
+    // The student picker auto-selects the first student; verify that at least
+    // one student button is visible, and that we can pick a specific one.
+    const studentPicker = page.getByTestId("expression-builder-student-picker");
+    await expect(studentPicker).toBeVisible();
+    const studentButton = studentPicker.getByRole("button", { name: students[0].private_profile_name });
+    await expect(studentButton).toBeVisible();
+    await studentButton.click();
+
+    // With a valid expression and a selected student, we should see a green
+    // evaluation status and a "Result: …" badge inside the overlay.
+    await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("expression-builder-overlay")).toContainText(/Result:\s*7/);
+
+    // Switch to an expression that uses a real gradebook_columns slug and
+    // assert that the intermediate-values panel renders the inner call.
+    // The helper creates a `participation` manual column which is in the
+    // beforeAll fixture above.
+    const fullScreenTextarea = page.getByLabel("Score Expression").first();
+    await fullScreenTextarea.fill('gradebook_columns("participation")');
+    await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
+    // The intermediate overlay panel should mention the dependency slug it
+    // just resolved (participation=…/…) rather than "undefined".
+    await expect(page.getByTestId("expression-builder-overlay")).toContainText(/participation/);
+    await expect(page.getByTestId("expression-builder-overlay")).not.toContainText(/undefined/);
+
+    // Introducing a parse error in the full-screen mode should still surface
+    // the inline error and keep Save disabled.
+    await fullScreenTextarea.fill("((1 +");
+    await expect(page.getByTestId("expression-parse-error")).toBeVisible({ timeout: 10_000 });
+
+    // Collapse back, close the dialog. No column is actually created.
+    await page.getByRole("button", { name: /Collapse/i }).click();
+    await expect(page.getByTestId("expression-builder-overlay")).toBeHidden();
+
+    await addDialog.getByRole("button", { name: /^Cancel$/ }).click();
+    await expect(addDialog).toBeHidden();
+
+    // Sanity: no column named "Validated Column" leaked into the DB.
+    const { data: leaked } = await supabase
+      .from("gradebook_columns")
+      .select("id")
+      .eq("class_id", course.id)
+      .eq("slug", "validated-column");
+    expect(leaked ?? []).toHaveLength(0);
+  });
+
   // test("Student What If page allows simulating grades and shows released grades", async ({ page }) => {
   //   // Log in as a student and navigate to the student gradebook
   //   // Didn't want to make another test suite with a different beforEach just for a single test

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -996,9 +996,18 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await studentButton.click();
 
     // With a valid expression and a selected student, we should see a green
-    // evaluation status and a "Result: …" badge inside the overlay.
+    // evaluation status and a "Score: …" badge at the top of the editor.
     await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId("expression-builder-overlay")).toContainText(/Result:\s*7/);
+    await expect(page.getByTestId("expression-builder-result-badges")).toContainText(/Score\s*7/);
+    // No render expression yet — only the Score badge is shown.
+    await expect(page.getByTestId("expression-builder-rendered-badge")).toHaveCount(0);
+
+    // Setting a render expression should light up the second badge with the
+    // rendered form alongside the raw score. With score=7 and max_score=100
+    // the default `letter(score)` renders as "F".
+    await addDialog.getByLabel("Render Expression").fill("letter(score)");
+    await expect(page.getByTestId("expression-builder-rendered-badge")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("expression-builder-rendered-badge")).toContainText(/Rendered\s*F/);
 
     // Switch to an expression that uses a real gradebook_columns slug and
     // assert that the intermediate-values panel renders the inner call. Scope

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -998,6 +998,10 @@ test.describe("Gradebook Page - Comprehensive", () => {
     // With a valid expression and a selected student, we should see a green
     // evaluation status and a "Score: …" badge at the top of the editor.
     await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
+    // Wait for the result-badges container to render before asserting its
+    // text — it mounts as soon as the Expression Builder expands, which is a
+    // separate re-render from the one that flips `expression-ok` visible.
+    await expect(page.getByTestId("expression-builder-result-badges")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("expression-builder-result-badges")).toContainText(/Score\s*7/);
     // No render expression yet — only the Score badge is shown.
     await expect(page.getByTestId("expression-builder-rendered-badge")).toHaveCount(0);

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -966,36 +966,33 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await scoreTextarea.fill("((1 +");
     await expect(page.getByTestId("expression-parse-error")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("expression-parse-error")).toContainText(/Parse error/i);
-    // Clicking Save while the expression is invalid must not close the dialog
-    // or create a column. The button is rendered with `disabled={true}` on
-    // Chakra when validation fails, but we belt-and-suspenders click it.
-    await saveButton.click({ force: true }).catch(() => {
-      /* Chakra may mark the button as disabled, which blocks the click. */
-    });
-    await expect(addDialog).toBeVisible();
+    // Save must be disabled while the expression is unparseable — asserting
+    // the disabled state explicitly (rather than clicking and swallowing the
+    // failure) fails loud if the guard ever regresses.
+    await expect(saveButton).toBeDisabled();
 
     // --- (2) Dependency error ---
     await scoreTextarea.fill('mean(gradebook_columns("does-not-exist-xyz"))');
     await expect(page.getByTestId("expression-dependency-error")).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId("expression-dependency-error")).toContainText(/Invalid dependency/i);
-    await saveButton.click({ force: true }).catch(() => {});
-    await expect(addDialog).toBeVisible();
+    await expect(saveButton).toBeDisabled();
 
     // --- (3) Valid arithmetic expression ---
     await scoreTextarea.fill("1 + 2 * 3");
     await expect(page.getByTestId("expression-ok-syntax")).toBeVisible({ timeout: 10_000 });
+    await expect(saveButton).toBeEnabled();
 
     // --- (4) Full-screen expression builder ---
     await addDialog.getByRole("button", { name: /Expression Builder/i }).click();
     // The overlay region is rendered only in expanded mode.
     await expect(page.getByTestId("expression-builder-overlay")).toBeVisible({ timeout: 10_000 });
 
-    // The student picker auto-selects the first student; verify that at least
-    // one student button is visible, and that we can pick a specific one.
-    const studentPicker = page.getByTestId("expression-builder-student-picker");
-    await expect(studentPicker).toBeVisible();
-    const studentButton = studentPicker.getByRole("button", { name: students[0].private_profile_name });
-    await expect(studentButton).toBeVisible();
+    // The student picker auto-selects the first student; scope the button
+    // lookup to the dialog so we don't match any instructor/grader UI still
+    // rendered underneath. Student names in this fixture are globally unique
+    // inside the dialog.
+    const studentButton = addDialog.getByRole("button", { name: students[0].private_profile_name });
+    await expect(studentButton).toBeVisible({ timeout: 10_000 });
     await studentButton.click();
 
     // With a valid expression and a selected student, we should see a green
@@ -1004,10 +1001,11 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await expect(page.getByTestId("expression-builder-overlay")).toContainText(/Result:\s*7/);
 
     // Switch to an expression that uses a real gradebook_columns slug and
-    // assert that the intermediate-values panel renders the inner call.
-    // The helper creates a `participation` manual column which is in the
-    // beforeAll fixture above.
-    const fullScreenTextarea = page.getByLabel("Score Expression").first();
+    // assert that the intermediate-values panel renders the inner call. Scope
+    // to the full-screen id so we don't hit the compact-mode textarea if both
+    // are ever mounted simultaneously.
+    const fullScreenTextarea = addDialog.locator("#scoreExpressionFull");
+    await expect(fullScreenTextarea).toBeVisible();
     await fullScreenTextarea.fill('gradebook_columns("participation")');
     await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
     // The intermediate overlay panel should mention the dependency slug it
@@ -1015,12 +1013,30 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await expect(page.getByTestId("expression-builder-overlay")).toContainText(/participation/);
     await expect(page.getByTestId("expression-builder-overlay")).not.toContainText(/undefined/);
 
+    // Nested context-aware calls (regression guard): the `context` arg
+    // injected by the AST transform must be stripped globally from every
+    // level of the stringified source, not just the outermost call, AND the
+    // transform has to recurse into children so the inner `gradebook_columns`
+    // also receives the `context` symbol (mathjs's own `transform()` stops
+    // recursing the moment the callback returns a new node). We use a glob
+    // so `gradebook_columns(...)` returns an array that `mean` accepts.
+    await fullScreenTextarea.fill('mean(gradebook_columns("*"))');
+    await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("expression-builder-overlay")).not.toContainText(/context,/);
+    // The inner call must resolve (not "invalid pattern"), proving both
+    // levels of the AST received the injected context symbol.
+    await expect(page.getByTestId("expression-builder-overlay")).not.toContainText(/invalid pattern/);
+
     // Introducing a parse error in the full-screen mode should still surface
     // the inline error and keep Save disabled.
     await fullScreenTextarea.fill("((1 +");
     await expect(page.getByTestId("expression-parse-error")).toBeVisible({ timeout: 10_000 });
 
-    // Collapse back, close the dialog. No column is actually created.
+    // Collapse back. Note: the expression state is shared between the compact
+    // and full-screen textareas, so the invalid `((1 +` from above is
+    // intentionally left in place — the subsequent Cancel closes the dialog
+    // and discards it. Any future edit that closes via Save/Escape should
+    // reset the textarea first or this will leak into whatever reopens it.
     await page.getByRole("button", { name: /Collapse/i }).click();
     await expect(page.getByTestId("expression-builder-overlay")).toBeHidden();
 

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -1036,6 +1036,20 @@ test.describe("Gradebook Page - Comprehensive", () => {
     // levels of the AST received the injected context symbol.
     await expect(page.getByTestId("expression-builder-overlay")).not.toContainText(/invalid pattern/);
 
+    // Multi-line expressions get one inline annotation per statement.
+    // Typing three assignments followed by their sum should produce four
+    // `= value` annotations inside the editor.
+    await fullScreenTextarea.fill("A = 10\nB = 20\nC = A + B\nC * 2");
+    await expect(page.getByTestId("expression-ok")).toBeVisible({ timeout: 10_000 });
+    const lineValues = page.getByTestId("expression-line-value");
+    await expect(lineValues).toHaveCount(4);
+    // The overlay should carry the final value for each statement.
+    const overlayText = await page.getByTestId("expression-builder-overlay").innerText();
+    expect(overlayText).toContain("= 10");
+    expect(overlayText).toContain("= 20");
+    expect(overlayText).toContain("= 30");
+    expect(overlayText).toContain("= 60");
+
     // Introducing a parse error in the full-screen mode should still surface
     // the inline error and keep Save disabled.
     await fullScreenTextarea.fill("((1 +");

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -1,0 +1,651 @@
+/**
+ * Unit tests for `evaluateForStudent` — the core of the Expression Builder.
+ *
+ * These tests assert that a broad cross-section of real production score
+ * expressions (taken verbatim from `tests/e2e/gradebook-calculations.test.tsx`)
+ * evaluate to the expected final value AND produce the expected intermediate
+ * values, so that:
+ *   1. The values shown in the UI overlay are correct.
+ *   2. The `context` argument injection (AST transform recursion) works at
+ *      every nesting level.
+ *   3. The `.score` accessor, glob slug matching, `gradebook_columns()`
+ *      single-vs-array return shape, lambdas, and `assume_max` / `report_only`
+ *      policies all behave like the server-side recalculator.
+ *
+ * We stand up an in-memory fake `GradebookController` just rich enough to
+ * satisfy the expression machinery — `columns`, `getGradebookColumnStudent`,
+ * `assignments`, `class_id`, and `extractAndValidateDependencies` — so the
+ * tests don't need a live Supabase / Next.js environment.
+ */
+import * as mathjs from "mathjs";
+import { minimatch } from "minimatch";
+
+import { evaluateForStudent, formatValueForOverlay, type IntermediateValue } from "@/lib/gradebookExpressionTester";
+import type { GradebookColumnStudent } from "@/utils/supabase/DatabaseTypes";
+
+type ColumnSpec = {
+  id: number;
+  slug: string;
+  name: string;
+  max_score: number;
+  score_expression?: string | null;
+  dependencies?: { gradebook_columns?: number[]; assignments?: number[] } | null;
+};
+
+type StudentEntry = {
+  score?: number | null;
+  score_override?: number | null;
+  is_missing?: boolean;
+  is_excused?: boolean;
+  is_droppable?: boolean;
+  is_private?: boolean;
+  released?: boolean;
+};
+
+type AssignmentSpec = {
+  id: number;
+  slug: string;
+  total_points: number | null;
+};
+
+/**
+ * Shape-compatible stand-in for `GradebookController` — we intentionally
+ * strip it down to the surface that `evaluateForStudent` touches. The real
+ * controller is cast through `as unknown as GradebookController` at the call
+ * site.
+ */
+function createFakeController(params: {
+  class_id?: number;
+  columns: ColumnSpec[];
+  assignments?: AssignmentSpec[];
+  /** Per-student, per-slug entries. Missing entries are treated as missing. */
+  entries: Record<string, Record<string, StudentEntry>>;
+}) {
+  const { class_id = 1, columns, assignments = [], entries } = params;
+  const columnById = new Map(columns.map((c) => [c.id, c]));
+  const columnBySlug = new Map(columns.map((c) => [c.slug, c]));
+
+  return {
+    class_id,
+    get columns() {
+      return columns;
+    },
+    get assignments() {
+      return assignments;
+    },
+    /** Mirrors GradebookController.getGradebookColumnStudent's `GradebookColumnStudent | undefined` return. */
+    getGradebookColumnStudent(column_id: number, student_id: string): GradebookColumnStudent | undefined {
+      const col = columnById.get(column_id);
+      if (!col) return undefined;
+      const e = entries[student_id]?.[col.slug];
+      if (!e) return undefined;
+      return {
+        id: column_id,
+        class_id,
+        created_at: "",
+        updated_at: "",
+        gradebook_column_id: column_id,
+        gradebook_id: 1,
+        is_droppable: e.is_droppable ?? true,
+        is_excused: e.is_excused ?? false,
+        is_missing: e.is_missing ?? false,
+        is_private: e.is_private ?? true,
+        is_recalculating: false,
+        released: e.released ?? true,
+        score: e.score ?? null,
+        score_override: e.score_override ?? null,
+        score_override_note: null,
+        student_id,
+        incomplete_values: null
+      } as unknown as GradebookColumnStudent;
+    },
+    /**
+     * Minimal port of the real `extractAndValidateDependencies`: parse the
+     * expression, walk any `gradebook_columns(...)` / `assignments(...)`
+     * calls with string-literal args, and error out if the slug doesn't
+     * match anything in the fixture. Keeps the test self-contained (no need
+     * to import the full GradebookController).
+     */
+    extractAndValidateDependencies(expr: string, column_id: number) {
+      const errors: string[] = [];
+      const deps: { gradebook_columns: Set<number>; assignments: Set<number> } = {
+        gradebook_columns: new Set(),
+        assignments: new Set()
+      };
+      const node = mathjs.parse(expr);
+      node.traverse((n) => {
+        if (n.type !== "FunctionNode") return;
+        const fn = n as mathjs.FunctionNode;
+        if (fn.fn.name !== "gradebook_columns" && fn.fn.name !== "assignments") return;
+        const arg = fn.args[0];
+        if (!arg || arg.type !== "ConstantNode") return;
+        const val = (arg as mathjs.ConstantNode).value;
+        if (typeof val !== "string") return;
+        if (fn.fn.name === "gradebook_columns") {
+          const matches = columns.filter((c) => minimatch(c.slug, val));
+          if (matches.length === 0) errors.push(`Invalid dependency: ${val} for function gradebook_columns`);
+          else matches.forEach((c) => deps.gradebook_columns.add(c.id));
+        } else {
+          const matches = assignments.filter((a) => a.slug && minimatch(a.slug, val));
+          if (matches.length === 0) errors.push(`Invalid dependency: ${val} for function assignments`);
+          else matches.forEach((a) => deps.assignments.add(a.id));
+        }
+      });
+      if (column_id !== -1 && deps.gradebook_columns.has(column_id)) {
+        errors.push("Cycle detected in score expression");
+      }
+      if (errors.length > 0) throw new Error(errors.join("\n"));
+      const out: { gradebook_columns?: number[]; assignments?: number[] } = {};
+      if (deps.gradebook_columns.size > 0) out.gradebook_columns = [...deps.gradebook_columns];
+      if (deps.assignments.size > 0) out.assignments = [...deps.assignments];
+      return Object.keys(out).length > 0 ? out : null;
+    },
+    // Unused by `evaluateForStudent`, but keep the ref available for future tests.
+    _columnBySlug: columnBySlug
+  };
+}
+
+type FakeController = ReturnType<typeof createFakeController>;
+
+/** Run an expression against the fake controller and return the evaluation. */
+function runExpression(controller: FakeController, expression: string, studentId: string) {
+  const result = evaluateForStudent({
+    math: mathjs,
+    // The tester only touches the subset of GradebookController we faked.
+    gradebookController: controller as unknown as Parameters<typeof evaluateForStudent>[0]["gradebookController"],
+    expression,
+    studentId,
+    editingColumnId: null,
+    captureIntermediates: true
+  });
+  return result;
+}
+
+/**
+ * Locate the first intermediate whose post-`context`-strip source equals
+ * `source`. Returns the display / numeric score for readable assertions.
+ */
+function findIntermediate(intermediates: IntermediateValue[], source: string): IntermediateValue | undefined {
+  return intermediates.find((iv) => iv.source === source);
+}
+
+describe("Expression Builder — evaluateForStudent", () => {
+  describe("fixture 1 (weighted average + cascading final grade)", () => {
+    // Mirrors gradebook-calculations.test.tsx fixture 1.
+    //   HW columns: leaf-hw1=80, leaf-hw2=70, leaf-hw3=90 (all max 100)
+    //   Participation: leaf-part=85
+    //   calc-hw-avg = mean(gradebook_columns('leaf-hw*'))  → 80.0
+    //   calc-final  = gradebook_columns('calc-hw-avg') * 0.7 + gradebook_columns('leaf-part') * 0.3
+    //                ≈ 80 * 0.7 + 85 * 0.3 = 81.5
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "leaf-hw1", name: "HW 1", max_score: 100 },
+        { id: 2, slug: "leaf-hw2", name: "HW 2", max_score: 100 },
+        { id: 3, slug: "leaf-hw3", name: "HW 3", max_score: 100 },
+        { id: 4, slug: "leaf-part", name: "Participation", max_score: 100 },
+        {
+          id: 5,
+          slug: "calc-hw-avg",
+          name: "HW Avg",
+          max_score: 100,
+          score_expression: "mean(gradebook_columns('leaf-hw*'))",
+          dependencies: { gradebook_columns: [1, 2, 3] }
+        }
+      ],
+      entries: {
+        alice: {
+          "leaf-hw1": { score: 80 },
+          "leaf-hw2": { score: 70 },
+          "leaf-hw3": { score: 90 },
+          "leaf-part": { score: 85 },
+          // calc-hw-avg is stored on the row, but the builder reads it via
+          // the expression, not the stored score, so we can leave it 0 here
+          // without affecting the test — or set it to the expected 80.
+          "calc-hw-avg": { score: 80 }
+        }
+      }
+    });
+
+    test("mean over glob slug evaluates to weighted average and yields a numeric overlay", () => {
+      const r = runExpression(controller, "mean(gradebook_columns('leaf-hw*'))", "alice");
+      expect(r.isValid).toBe(true);
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(80, 5);
+      expect(r.evaluation?.result).toBe("80");
+
+      // NB: mathjs `node.toString()` canonicalises string literals to
+      // double quotes, so intermediate sources use `"..."` even though the
+      // user may have typed `'...'`. Every expectation below reflects the
+      // canonical double-quoted form.
+      const inner = findIntermediate(r.evaluation!.intermediates, `gradebook_columns("leaf-hw*")`);
+      expect(inner).toBeDefined();
+      expect(inner?.error).toBeUndefined();
+      // The inner call resolves to an array of 3 GradebookExpressionValue objects.
+      expect(Array.isArray(inner?.raw)).toBe(true);
+      expect((inner?.raw as unknown[]).length).toBe(3);
+      // The overlay pretty-prints GradebookExpressionValues as `slug=score/max`.
+      expect(inner?.display).toMatch(/leaf-hw1=80\/100/);
+      expect(inner?.display).toMatch(/leaf-hw2=70\/100/);
+      expect(inner?.display).toMatch(/leaf-hw3=90\/100/);
+    });
+
+    test("weighted average final grade composes single-column lookups, multiplies, and adds", () => {
+      const expr = "gradebook_columns('calc-hw-avg') * 0.7 + gradebook_columns('leaf-part') * 0.3";
+      const r = runExpression(controller, expr, "alice");
+      expect(r.isValid).toBe(true);
+      expect(r.evaluation?.error).toBeNull();
+      // 80 * 0.7 + 85 * 0.3 = 81.5
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(81.5, 5);
+
+      const im = r.evaluation!.intermediates;
+      // Both single-slug lookups should appear in intermediates and resolve.
+      const hwAvg = findIntermediate(im, `gradebook_columns("calc-hw-avg")`);
+      const part = findIntermediate(im, `gradebook_columns("leaf-part")`);
+      expect(hwAvg?.display).toMatch(/calc-hw-avg=80\/100/);
+      expect(part?.display).toMatch(/leaf-part=85\/100/);
+
+      // The two multiplications should also be captured with numeric results.
+      const left = findIntermediate(im, `gradebook_columns("calc-hw-avg") * 0.7`);
+      const right = findIntermediate(im, `gradebook_columns("leaf-part") * 0.3`);
+      expect(Number(left?.raw)).toBeCloseTo(56, 5);
+      expect(Number(right?.raw)).toBeCloseTo(25.5, 5);
+    });
+  });
+
+  describe("fixture 2 (max of a glob and .score accessor)", () => {
+    // Mirrors fixture 2:
+    //   classes-a=3, classes-b=4  → max=4
+    //   lists-a=2,   lists-b=4    → max=4
+    //   topic = (topic-classes.score + topic-lists.score) / 2 → (4+4)/2 = 4
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "classes-a", name: "Classes A", max_score: 4 },
+        { id: 2, slug: "classes-b", name: "Classes B", max_score: 4 },
+        { id: 3, slug: "lists-a", name: "Lists A", max_score: 4 },
+        { id: 4, slug: "lists-b", name: "Lists B", max_score: 4 },
+        {
+          id: 5,
+          slug: "topic-classes",
+          name: "Topic Classes",
+          max_score: 4,
+          score_expression: "max(gradebook_columns('classes*'))",
+          dependencies: { gradebook_columns: [1, 2] }
+        },
+        {
+          id: 6,
+          slug: "topic-lists",
+          name: "Topic Lists",
+          max_score: 4,
+          score_expression: "max(gradebook_columns('lists*'))",
+          dependencies: { gradebook_columns: [3, 4] }
+        }
+      ],
+      entries: {
+        alice: {
+          "classes-a": { score: 3 },
+          "classes-b": { score: 4 },
+          "lists-a": { score: 2 },
+          "lists-b": { score: 4 },
+          "topic-classes": { score: 4 },
+          "topic-lists": { score: 4 }
+        }
+      }
+    });
+
+    test("max() over glob returns the highest .score of the matched columns", () => {
+      const r = runExpression(controller, "max(gradebook_columns('classes*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(4);
+      const inner = findIntermediate(r.evaluation!.intermediates, `gradebook_columns("classes*")`);
+      expect(inner?.display).toMatch(/classes-a=3\/4/);
+      expect(inner?.display).toMatch(/classes-b=4\/4/);
+    });
+
+    test("`.score` accessor on single-slug call supports manual arithmetic", () => {
+      const expr = "(gradebook_columns('topic-classes').score + gradebook_columns('topic-lists').score) / 2";
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(4, 5);
+
+      const im = r.evaluation!.intermediates;
+      const leftAccess = findIntermediate(im, `gradebook_columns("topic-classes").score`);
+      const rightAccess = findIntermediate(im, `gradebook_columns("topic-lists").score`);
+      expect(Number(leftAccess?.raw)).toBe(4);
+      expect(Number(rightAccess?.raw)).toBe(4);
+    });
+  });
+
+  describe("fixture 3 (countif with lambda)", () => {
+    // Lab 1/2/4 = 1 (completed), Lab 3 = 0 (not).  countif(lab*, x.score > 0) → 3
+    // Skill A=2 (meets), B=1 (approaches), C=0 (does not meet)
+    //   countif(skill*, x.score == 2) → 1
+    //   countif(skill*, x.score == 1) → 1
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "lab-1", name: "Lab 1", max_score: 1 },
+        { id: 2, slug: "lab-2", name: "Lab 2", max_score: 1 },
+        { id: 3, slug: "lab-3", name: "Lab 3", max_score: 1 },
+        { id: 4, slug: "lab-4", name: "Lab 4", max_score: 1 },
+        { id: 5, slug: "skill-a", name: "Skill A", max_score: 2 },
+        { id: 6, slug: "skill-b", name: "Skill B", max_score: 2 },
+        { id: 7, slug: "skill-c", name: "Skill C", max_score: 2 }
+      ],
+      entries: {
+        alice: {
+          "lab-1": { score: 1 },
+          "lab-2": { score: 1 },
+          "lab-3": { score: 0 },
+          "lab-4": { score: 1 },
+          "skill-a": { score: 2 },
+          "skill-b": { score: 1 },
+          "skill-c": { score: 0 }
+        }
+      }
+    });
+
+    test("countif over lab glob with a truthy predicate counts completed labs", () => {
+      const r = runExpression(controller, "countif(gradebook_columns('lab*'), f(x) = x.score > 0)", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(3);
+      expect(r.evaluation?.result).toBe("3");
+    });
+
+    test("countif over skill glob with an equality predicate counts 'meets' skills", () => {
+      const r = runExpression(controller, "countif(gradebook_columns('skill*'), f(x) = x.score == 2)", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(1);
+    });
+
+    test("countif with a different predicate counts 'approaching' skills on the same data", () => {
+      const r = runExpression(controller, "countif(gradebook_columns('skill*'), f(x) = x.score == 1)", "alice");
+      expect(Number(r.evaluation?.rawResult)).toBe(1);
+    });
+  });
+
+  describe("fixture 4 (additive via .score with score_override)", () => {
+    // hw-total (override = 92) + curve-adj (score = 3) → 95
+    // Score overrides on a dependency must take precedence over `.score`.
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "hw-total", name: "HW Total", max_score: 100 },
+        { id: 2, slug: "curve-adj", name: "Curve", max_score: 20 }
+      ],
+      entries: {
+        alice: {
+          "hw-total": { score: 88, score_override: 92 },
+          "curve-adj": { score: 3 }
+        }
+      }
+    });
+
+    test("score_override on a dependency wins over the persisted score", () => {
+      const r = runExpression(
+        controller,
+        "gradebook_columns('hw-total').score + gradebook_columns('curve-adj').score",
+        "alice"
+      );
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(95);
+
+      const hw = findIntermediate(r.evaluation!.intermediates, `gradebook_columns("hw-total")`);
+      // The GradebookExpressionValue raw carries the overridden score.
+      expect((hw?.raw as { score: number }).score).toBe(92);
+    });
+  });
+
+  describe("fixture 5 (chained calculated → calculated)", () => {
+    //   quiz-1=80, quiz-2=70, quiz-3=90 → avg=80
+    //   calc-quiz-avg=80
+    //   calc-quiz-bonus = calc-quiz-avg * 0.9 + 10 = 82
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "quiz-1", name: "Q1", max_score: 100 },
+        { id: 2, slug: "quiz-2", name: "Q2", max_score: 100 },
+        { id: 3, slug: "quiz-3", name: "Q3", max_score: 100 },
+        {
+          id: 4,
+          slug: "calc-quiz-avg",
+          name: "Quiz Avg",
+          max_score: 100,
+          score_expression: "mean(gradebook_columns('quiz*'))",
+          dependencies: { gradebook_columns: [1, 2, 3] }
+        }
+      ],
+      entries: {
+        alice: {
+          "quiz-1": { score: 80 },
+          "quiz-2": { score: 70 },
+          "quiz-3": { score: 90 },
+          "calc-quiz-avg": { score: 80 }
+        }
+      }
+    });
+
+    test("chained calculated-column lookup plus constant evaluates correctly", () => {
+      const r = runExpression(controller, "gradebook_columns('calc-quiz-avg') * 0.9 + 10", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(82, 5);
+
+      const im = r.evaluation!.intermediates;
+      const times = findIntermediate(im, `gradebook_columns("calc-quiz-avg") * 0.9`);
+      expect(Number(times?.raw)).toBeCloseTo(72, 5);
+    });
+  });
+
+  describe("context injection recurses through nested calls", () => {
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "hw-1", name: "HW1", max_score: 100 },
+        { id: 2, slug: "hw-2", name: "HW2", max_score: 100 },
+        { id: 3, slug: "hw-3", name: "HW3", max_score: 100 }
+      ],
+      entries: {
+        alice: {
+          "hw-1": { score: 90 },
+          "hw-2": { score: 70 },
+          "hw-3": { score: 80 }
+        }
+      }
+    });
+
+    test("nested mean(gradebook_columns(...)) resolves without `invalid pattern`", () => {
+      // Regression guard: if the transform stopped recursing after returning
+      // a new outer node, the inner `gradebook_columns` would be called
+      // without the `context` arg and minimatch would throw "invalid pattern".
+      const r = runExpression(controller, "mean(gradebook_columns('hw-*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(80, 5);
+      for (const iv of r.evaluation!.intermediates) {
+        expect(iv.display).not.toMatch(/invalid pattern/);
+      }
+    });
+
+    test("overlay source strips the injected `context` arg at every nesting level", () => {
+      const r = runExpression(controller, "sum(gradebook_columns('hw-*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      for (const iv of r.evaluation!.intermediates) {
+        // Overlay must show what the user typed — the synthesized `context`
+        // symbol must be stripped from every level of the stringified AST.
+        expect(iv.source).not.toMatch(/\bcontext\b/);
+      }
+    });
+  });
+
+  describe("parse and dependency errors", () => {
+    const controller = createFakeController({
+      columns: [{ id: 1, slug: "hw-1", name: "HW1", max_score: 100 }],
+      entries: { alice: { "hw-1": { score: 90 } } }
+    });
+
+    test("a syntax error surfaces as a parseError (no evaluation attempted)", () => {
+      const r = runExpression(controller, "((1 +", "alice");
+      expect(r.isValid).toBe(false);
+      expect(r.parseError).toBeTruthy();
+      expect(r.dependencyError).toBeNull();
+      expect(r.evaluation).toBeNull();
+    });
+
+    test("an unknown slug surfaces as a dependencyError", () => {
+      const r = runExpression(controller, "mean(gradebook_columns('does-not-exist'))", "alice");
+      expect(r.isValid).toBe(false);
+      expect(r.parseError).toBeNull();
+      expect(r.dependencyError).toMatch(/Invalid dependency/);
+      expect(r.evaluation).toBeNull();
+    });
+
+    test("empty expression is treated as valid-empty", () => {
+      const r = runExpression(controller, "", "alice");
+      expect(r.isValid).toBe(true);
+      expect(r.isEmpty).toBe(true);
+      expect(r.evaluation).toBeNull();
+    });
+  });
+
+  describe("incomplete values and missing data", () => {
+    // hw-1 has a score, hw-2 is NOT released and has no score → should surface
+    // as `not_released` in the report-only pass.
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "hw-1", name: "HW1", max_score: 100 },
+        { id: 2, slug: "hw-2", name: "HW2", max_score: 100 }
+      ],
+      entries: {
+        alice: {
+          "hw-1": { score: 80 },
+          "hw-2": { released: false, is_private: false }
+        }
+      }
+    });
+
+    test("a not-released dependency shows up in incompleteValues under report_only", () => {
+      const r = runExpression(controller, "mean(gradebook_columns('hw-*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const slugs = r.evaluation?.incompleteValues?.not_released?.gradebook_columns ?? [];
+      expect(slugs).toContain("hw-2");
+    });
+  });
+
+  describe("drop_lowest preserves dropped semantics", () => {
+    // 4 labs, one failed (score 0) — drop_lowest(labs, 1) then mean should
+    // ignore the dropped entry.
+    //   kept: lab-1=100, lab-2=80, lab-4=90  → weighted mean 100*(100+80+90)/(100*3) = 90
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "lab-1", name: "Lab 1", max_score: 100 },
+        { id: 2, slug: "lab-2", name: "Lab 2", max_score: 100 },
+        { id: 3, slug: "lab-3", name: "Lab 3", max_score: 100 },
+        { id: 4, slug: "lab-4", name: "Lab 4", max_score: 100 }
+      ],
+      entries: {
+        alice: {
+          "lab-1": { score: 100 },
+          "lab-2": { score: 80 },
+          "lab-3": { score: 0 },
+          "lab-4": { score: 90 }
+        }
+      }
+    });
+
+    test("mean(drop_lowest(...)) drops the lowest-ratio entry", () => {
+      const r = runExpression(controller, "mean(drop_lowest(gradebook_columns('lab-*'), 1))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBeCloseTo(90, 5);
+
+      const dropNode = findIntermediate(r.evaluation!.intermediates, `drop_lowest(gradebook_columns("lab-*"), 1)`);
+      expect(dropNode).toBeDefined();
+      // After drop_lowest the array has 3 entries, not 4 — lab-3 (ratio 0) is
+      // dropped.
+      expect(Array.isArray(dropNode?.raw)).toBe(true);
+      expect((dropNode?.raw as unknown[]).length).toBe(3);
+      expect(dropNode?.display).not.toMatch(/lab-3=/);
+      expect(dropNode?.display).toMatch(/lab-1=100\/100/);
+    });
+  });
+
+  describe("assignments(...) lookup", () => {
+    // `assignments("slug")` returns the total_points of the assignment. Used
+    // for columns backed by an assignment grade.
+    const controller = createFakeController({
+      columns: [{ id: 1, slug: "final", name: "Final", max_score: 100 }],
+      assignments: [
+        { id: 1, slug: "final-exam", total_points: 95 },
+        { id: 2, slug: "final-project", total_points: 87 }
+      ],
+      entries: {}
+    });
+
+    test("assignments('slug') returns the total_points and is visible in the overlay", () => {
+      const r = runExpression(controller, "assignments('final-exam')", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(95);
+      const inner = findIntermediate(r.evaluation!.intermediates, `assignments("final-exam")`);
+      expect(inner?.raw).toBe(95);
+    });
+  });
+
+  describe("boundary / edge-case expressions", () => {
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "hw-1", name: "HW1", max_score: 100 },
+        { id: 2, slug: "hw-2", name: "HW2", max_score: 100 }
+      ],
+      entries: {
+        alice: {
+          "hw-1": { score: 50 },
+          "hw-2": { score: 100 }
+        }
+      }
+    });
+
+    test("sum over an array of single-slug lookups delegates to .score", () => {
+      // sum([a, b]) on GradebookExpressionValue objects. This is the
+      // `scoreA + scoreB` pattern written with the shared aggregate.
+      const r = runExpression(controller, "sum(gradebook_columns('hw-*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(150);
+    });
+
+    test("pure-arithmetic expression (no dependencies) evaluates without touching the controller", () => {
+      const r = runExpression(controller, "1 + 2 * 3", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(Number(r.evaluation?.rawResult)).toBe(7);
+      // The user's typed expression has no context-aware calls, so the
+      // intermediates must be free of any `context` references.
+      for (const iv of r.evaluation!.intermediates) {
+        expect(iv.source).not.toMatch(/context/);
+      }
+    });
+
+    test("intermediate sources preserve positional info within the expression string", () => {
+      // Positions should be ascending and within bounds of the typed string.
+      const expr = "mean(gradebook_columns('hw-*')) + 5";
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      for (const iv of r.evaluation!.intermediates) {
+        if (iv.start !== -1) {
+          expect(iv.start).toBeGreaterThanOrEqual(0);
+          expect(iv.end).toBeGreaterThan(iv.start);
+          expect(iv.end).toBeLessThanOrEqual(expr.length);
+        }
+      }
+    });
+  });
+
+  describe("formatValueForOverlay agrees with the evaluator output", () => {
+    // Sanity check: the string shown in `result` should equal
+    // `formatValueForOverlay(rawResult)` for the same value.
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "hw-1", name: "HW1", max_score: 100 },
+        { id: 2, slug: "hw-2", name: "HW2", max_score: 100 }
+      ],
+      entries: { alice: { "hw-1": { score: 80 }, "hw-2": { score: 60 } } }
+    });
+
+    test("result string matches formatValueForOverlay of the raw result", () => {
+      const r = runExpression(controller, "mean(gradebook_columns('hw-*'))", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      expect(r.evaluation?.result).toBe(formatValueForOverlay(r.evaluation?.rawResult));
+    });
+  });
+});

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -666,6 +666,25 @@ describe("Expression Builder — evaluateForStudent", () => {
       }
     });
 
+    test("repeated identical subexpressions receive distinct source spans", () => {
+      // Regression: `trimmed.indexOf(pretty)` used to always find the first
+      // occurrence, so both copies of `gradebook_columns('hw-1')` below would
+      // land on `start=0` / `end=24` and the dedup loop would collapse them
+      // into one entry — the second instance would disappear from the
+      // annotated view entirely.
+      const r = runExpression(controller, "gradebook_columns('hw-1') + gradebook_columns('hw-1')", "alice");
+      expect(r.evaluation?.error).toBeNull();
+      // Both inner calls must appear with strictly-increasing start offsets.
+      const hits = r.evaluation!.intermediates.filter((iv) => iv.source === `gradebook_columns("hw-1")`);
+      expect(hits.length).toBe(2);
+      expect(hits[0].start).toBeGreaterThanOrEqual(0);
+      expect(hits[1].start).toBeGreaterThan(hits[0].start);
+      expect(hits[1].end).toBeGreaterThan(hits[0].end);
+      // Both land on the same `GradebookExpressionValue` shape and score.
+      expect((hits[0].raw as { score: number }).score).toBe(50);
+      expect((hits[1].raw as { score: number }).score).toBe(50);
+    });
+
     test("intermediate sources preserve positional info within the expression string", () => {
       // Positions should be ascending and within bounds of the typed string.
       const expr = "mean(gradebook_columns('hw-*')) + 5";

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -882,5 +882,33 @@ case_when([
       // And the overall `result` of the expression is the last block's value.
       expect(r.evaluation!.result).toBe("11");
     });
+
+    test("runtime error attribution pins to the block that threw, not the last source line", () => {
+      // Regression: the previous error-annotation branch used
+      //   `entry.blockIndex === lineMap.filter(l => l.kind === "end").length - 1`
+      // which measured "how many lines END a block" in the user's source —
+      // that's almost always the LAST line, even when the throwing block
+      // was one of the earlier ones.  With per-block evaluation that stops
+      // on the first error, the real throwing block is
+      // `blockEntries.length - 1`.
+      //
+      // `sum` throws on non-array input ("Sum called with non-array value").
+      // Line 1 runs and assigns T = 930, then line 2 throws. The error
+      // should be attributed to line 2, not to line 3 (which never ran).
+      const expr = `T = gradebook_columns('final-course-total').score
+BAD = sum(T)
+GOOD = T * 2`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeTruthy();
+      const lines = r.evaluation!.lineResults;
+      expect(lines[0]).toMatchObject({ kind: "value", display: "930" });
+      expect(lines[1].kind).toBe("error");
+      expect(lines[2].kind).toBe("continuation");
+      // And the error message must refer to `sum`, not to the harmless
+      // multiplication on line 3.
+      if (lines[1].kind === "error") {
+        expect(lines[1].display).toMatch(/Sum.*non-array/i);
+      }
+    });
   });
 });

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -717,4 +717,115 @@ describe("Expression Builder — evaluateForStudent", () => {
       expect(r.evaluation?.result).toBe(formatValueForOverlay(r.evaluation?.rawResult));
     });
   });
+
+  describe("per-line annotations for multi-line expressions", () => {
+    // Rebuilds the real production workflow: a long block expression that
+    // uses top-level `let`-style assignments and ends in a `case_when(...)`
+    // that spans multiple lines. The Expression Builder renders the value of
+    // each statement inline on the line that ENDS it, and leaves
+    // continuation lines (e.g. rows of a multi-line matrix literal) blank.
+    const controller = createFakeController({
+      columns: [
+        { id: 1, slug: "final-course-total", name: "Final Total", max_score: 1000 },
+        { id: 2, slug: "final-individual-assignments", name: "Indiv", max_score: 300 },
+        { id: 3, slug: "final-group-assignments", name: "Group", max_score: 200 },
+        { id: 4, slug: "final-exams", name: "Exams", max_score: 400 },
+        { id: 5, slug: "final-labs", name: "Labs", max_score: 12 },
+        { id: 6, slug: "final-participation", name: "Part", max_score: 50 }
+      ],
+      entries: {
+        alice: {
+          "final-course-total": { score: 930 },
+          "final-individual-assignments": { score: 260 },
+          "final-group-assignments": { score: 170 },
+          "final-exams": { score: 300 },
+          "final-labs": { score: 11 },
+          "final-participation": { score: 45 }
+        }
+      }
+    });
+
+    test("`T = 930` style single-line statements get their value on the same line", () => {
+      const expr = `T = gradebook_columns('final-course-total').score
+IND = gradebook_columns('final-individual-assignments').score
+T + IND`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const lines = r.evaluation!.lineResults;
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toMatchObject({ kind: "value", lineIndex: 0, display: "930" });
+      expect(lines[1]).toMatchObject({ kind: "value", lineIndex: 1, display: "260" });
+      expect(lines[2]).toMatchObject({ kind: "value", lineIndex: 2, display: "1190" });
+    });
+
+    test("case_when spanning multiple lines only annotates the closing `])`", () => {
+      const expr = `T = gradebook_columns('final-course-total').score
+case_when([
+  largerEq(T, 900), 10;
+  largerEq(T, 800), 8;
+  true, 0
+])`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const lines = r.evaluation!.lineResults;
+      expect(lines).toHaveLength(6);
+      // Line 0: T = 930
+      expect(lines[0]).toMatchObject({ kind: "value", lineIndex: 0, display: "930" });
+      // Lines 1-4: inside the case_when literal — continuation, no value
+      for (const i of [1, 2, 3, 4]) {
+        expect(lines[i].kind).toBe("continuation");
+      }
+      // Line 5: closing `])` — the case_when evaluates to 10 (largerEq(930, 900))
+      expect(lines[5]).toMatchObject({ kind: "value", lineIndex: 5, display: "10" });
+    });
+
+    test("blank lines in the editor are flagged as blank (no value, no continuation)", () => {
+      const expr = `T = gradebook_columns('final-course-total').score
+
+T * 2`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const lines = r.evaluation!.lineResults;
+      expect(lines[0].kind).toBe("value");
+      expect(lines[1].kind).toBe("blank");
+      expect(lines[2]).toMatchObject({ kind: "value", display: "1860" });
+    });
+
+    test("full production-style grade-boundary block evaluates cleanly end-to-end", () => {
+      // Trimmed from the user-supplied expression in the spec. Alice has
+      // T=930, IND=260, GRP=170, EXM=300, LABS=11, PART=45 → all A-ok
+      // thresholds pass, so A_ok=1 and case_when picks the `T>=930, 11` row.
+      const expr = `T = gradebook_columns('final-course-total').score
+IND = gradebook_columns('final-individual-assignments').score
+GRP = gradebook_columns('final-group-assignments').score
+EXM = gradebook_columns('final-exams').score
+LABS = gradebook_columns('final-labs').score
+PART = gradebook_columns('final-participation').score
+A_ok = largerEq(T, 900) * largerEq(IND, 240) * largerEq(GRP, 160) * largerEq(EXM, 280) * largerEq(LABS, 11) * largerEq(PART, 40)
+case_when([
+  A_ok * largerEq(T, 930), 11;
+  A_ok * largerEq(T, 900), 10;
+  true, 0
+])`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const lines = r.evaluation!.lineResults;
+      // 7 `X = ...` statements (lines 0-6) each annotated, then a 4-line
+      // case_when(...) with the last line (line 10) carrying the final value.
+      expect(lines[0]).toMatchObject({ kind: "value", display: "930" });
+      expect(lines[1]).toMatchObject({ kind: "value", display: "260" });
+      expect(lines[2]).toMatchObject({ kind: "value", display: "170" });
+      expect(lines[3]).toMatchObject({ kind: "value", display: "300" });
+      expect(lines[4]).toMatchObject({ kind: "value", display: "11" });
+      expect(lines[5]).toMatchObject({ kind: "value", display: "45" });
+      expect(lines[6]).toMatchObject({ kind: "value", display: "1" }); // A_ok
+      expect(lines[7].kind).toBe("continuation"); // case_when([
+      expect(lines[8].kind).toBe("continuation"); //   A_ok * largerEq(T, 930), 11;
+      expect(lines[9].kind).toBe("continuation"); //   A_ok * largerEq(T, 900), 10;
+      expect(lines[10].kind).toBe("continuation"); //   true, 0
+      expect(lines[11]).toMatchObject({ kind: "value", display: "11" }); // ])
+      // And the overall `result` of the expression is the last block's value.
+      expect(r.evaluation!.result).toBe("11");
+    });
+  });
 });

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -360,6 +360,56 @@ describe("Expression Builder — evaluateForStudent", () => {
       const r = runExpression(controller, "countif(gradebook_columns('skill*'), f(x) = x.score == 1)", "alice");
       expect(Number(r.evaluation?.rawResult)).toBe(1);
     });
+
+    test("subexpressions inside a lambda body are never captured as intermediates", () => {
+      // The lambda `f(x) = not x.is_missing and x.score > 0` binds `x` inside
+      // its body. Evaluating `x.score > 0` at the outer scope throws
+      // "Undefined symbol x", so the preview must NOT descend into the
+      // lambda. It should still show the top-level call itself and the
+      // sibling `gradebook_columns(...)` arg alongside it.
+      const r = runExpression(
+        controller,
+        "countif(gradebook_columns('lab*'), f(x) = not x.is_missing and x.score > 0)",
+        "alice"
+      );
+      expect(r.evaluation?.error).toBeNull();
+      const im = r.evaluation!.intermediates;
+
+      // The lambda itself is skipped.
+      expect(im.find((iv) => iv.nodeType === "FunctionAssignmentNode")).toBeUndefined();
+
+      // Inner x.is_missing / x.score / x.score > 0 / not x.is_missing / the
+      // combining `and` are all inside the lambda body — none should leak in
+      // as standalone intermediates.  Check that no intermediate's source
+      // EQUALS one of those lambda-body subexpressions (the top-level
+      // countif source naturally contains the lambda as a substring — that's
+      // fine; what we're guarding against is the individual inner nodes
+      // showing up as their own entries).
+      const lambdaBodies = new Set([
+        "x.is_missing",
+        "x.score",
+        "x.score > 0",
+        "not x.is_missing",
+        "not x.is_missing and x.score > 0"
+      ]);
+      for (const iv of im) {
+        expect(lambdaBodies.has(iv.source)).toBe(false);
+      }
+      // And none of them should be reporting an "Undefined symbol x" error.
+      for (const iv of im) {
+        expect(iv.display).not.toMatch(/Undefined symbol/i);
+      }
+
+      // The top-level `countif(...)` and its `gradebook_columns('lab*')` arg
+      // ARE captured (they evaluate cleanly in the outer scope).
+      const countifCall = im.find((iv) => iv.source.startsWith("countif("));
+      expect(countifCall).toBeDefined();
+      expect(Number(countifCall?.raw)).toBe(3);
+
+      const gbcArg = findIntermediate(im, `gradebook_columns("lab*")`);
+      expect(gbcArg).toBeDefined();
+      expect(Array.isArray(gbcArg?.raw)).toBe(true);
+    });
   });
 
   describe("fixture 4 (additive via .score with score_override)", () => {

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -698,6 +698,32 @@ describe("Expression Builder — evaluateForStudent", () => {
         }
       }
     });
+
+    test("start/end map back to the RAW typed input, not the mathjs-canonical form", () => {
+      // Regression: mathjs `node.toString()` normalises `score*2` →
+      // `score * 2`, single quotes → double quotes, etc.  The tester should
+      // still report positions inside the user's exact textarea text, so the
+      // UI can overlay annotations under the right characters (and so
+      // `iv.end <= expression.length` holds even for compact input).
+      const expr = "gradebook_columns('hw-1').score*2";
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      for (const iv of r.evaluation!.intermediates) {
+        if (iv.start === -1) continue;
+        expect(iv.start).toBeGreaterThanOrEqual(0);
+        expect(iv.end).toBeGreaterThan(iv.start);
+        // Hard constraint from the reviewer: spans must fit inside the
+        // user-typed string.
+        expect(iv.end).toBeLessThanOrEqual(expr.length);
+      }
+      // `gradebook_columns('hw-1')` appears at index 0 with single quotes in
+      // the typed input — even though mathjs stringifies it with double
+      // quotes. The tester must locate it anyway.
+      const innerCall = r.evaluation!.intermediates.find((iv) => iv.source === `gradebook_columns("hw-1")`);
+      expect(innerCall).toBeDefined();
+      expect(innerCall?.start).toBe(0);
+      expect(innerCall?.end).toBe("gradebook_columns('hw-1')".length);
+    });
   });
 
   describe("formatValueForOverlay agrees with the evaluator output", () => {

--- a/tests/unit/gradebook-expression-builder.test.ts
+++ b/tests/unit/gradebook-expression-builder.test.ts
@@ -817,6 +817,35 @@ T * 2`;
       expect(lines[2]).toMatchObject({ kind: "value", display: "1860" });
     });
 
+    test("lines that end with an explicit `;` don't double-advance the block counter", () => {
+      // Regression: the previous version counted BOTH the `;` AND the
+      // newline at depth 0 as statement terminators, so `T = 930;\n` would
+      // advance the block counter twice while mathjs only produced ONE
+      // entry in `ResultSet.entries`. The line would then pull a stale /
+      // out-of-range value from `blockEntries` — typically `undefined`.
+      //
+      // This was especially noticeable for inline semicolons on the same
+      // line as a newline, e.g.:
+      //
+      //   T = gradebook_columns('final-course-total').score;
+      //   T * 2
+      //
+      // which should show `T = … = 930` on the first line and `T * 2 =
+      // 1860` on the second — not `undefined` anywhere.
+      const expr = `T = gradebook_columns('final-course-total').score;
+T * 2`;
+      const r = runExpression(controller, expr, "alice");
+      expect(r.evaluation?.error).toBeNull();
+      const lines = r.evaluation!.lineResults;
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toMatchObject({ kind: "value", display: "930" });
+      expect(lines[1]).toMatchObject({ kind: "value", display: "1860" });
+      // And the stored block count should match the number of value lines,
+      // not double it.
+      const valueLines = lines.filter((l) => l.kind === "value");
+      expect(valueLines).toHaveLength(2);
+    });
+
     test("full production-style grade-boundary block evaluates cleanly end-to-end", () => {
       // Trimmed from the user-supplied expression in the spec. Alice has
       // T=930, IND=260, GRP=170, EXM=300, LABS=11, PART=45 → all A-ok

--- a/tests/unit/gradebook-expression-tester.test.ts
+++ b/tests/unit/gradebook-expression-tester.test.ts
@@ -1,0 +1,78 @@
+import { formatValueForOverlay } from "@/lib/gradebookExpressionTester";
+
+describe("gradebook expression tester helpers", () => {
+  describe("formatValueForOverlay", () => {
+    test("formats primitives", () => {
+      expect(formatValueForOverlay(undefined)).toBe("undefined");
+      expect(formatValueForOverlay(null)).toBe("null");
+      expect(formatValueForOverlay(42)).toBe("42");
+      expect(formatValueForOverlay(3.14159)).toBe("3.1416");
+      expect(formatValueForOverlay(true)).toBe("true");
+    });
+
+    test("formats plain arrays without collapsing to undefined", () => {
+      // Regression: `"entries" in arr` is true for plain arrays because
+      // Array.prototype.entries exists. We must not mistake plain arrays
+      // for mathjs ResultSets.
+      expect(formatValueForOverlay([1, 2, 3])).toBe("[1, 2, 3]");
+      expect(formatValueForOverlay([])).toBe("[]");
+    });
+
+    test("formats long arrays with an ellipsis", () => {
+      expect(formatValueForOverlay([1, 2, 3, 4, 5, 6])).toBe("[1, 2, 3, 4, … 2 more]");
+    });
+
+    test("formats GradebookExpressionValue-like objects", () => {
+      const value = {
+        score: 80,
+        max_score: 100,
+        column_slug: "hw-1",
+        score_override: null,
+        is_missing: false,
+        is_droppable: false,
+        is_excused: false,
+        is_private: false
+      };
+      expect(formatValueForOverlay(value)).toBe("hw-1=80/100");
+    });
+
+    test("formats arrays of GradebookExpressionValue-like objects", () => {
+      const values = [
+        {
+          score: 80,
+          max_score: 100,
+          column_slug: "hw-1",
+          score_override: null,
+          is_missing: false,
+          is_droppable: false,
+          is_excused: false,
+          is_private: false
+        },
+        {
+          score: 90,
+          max_score: 100,
+          column_slug: "hw-2",
+          score_override: null,
+          is_missing: false,
+          is_droppable: false,
+          is_excused: false,
+          is_private: false
+        }
+      ];
+      expect(formatValueForOverlay(values)).toBe("[hw-1=80/100, hw-2=90/100]");
+    });
+
+    test("unwraps mathjs DenseMatrix-style values via toArray()", () => {
+      const fakeMatrix = {
+        toArray: () => [1, 2, 3]
+      };
+      expect(formatValueForOverlay(fakeMatrix)).toBe("[1, 2, 3]");
+    });
+
+    test("unwraps ResultSet-style values", () => {
+      // ResultSet is `{ entries: unknown[] }` with no other own array behavior.
+      const resultSet = { entries: [1, 2, 42] };
+      expect(formatValueForOverlay(resultSet)).toBe("42");
+    });
+  });
+});

--- a/tests/unit/gradebook-expression-tester.test.ts
+++ b/tests/unit/gradebook-expression-tester.test.ts
@@ -145,5 +145,19 @@ describe("gradebook expression tester helpers", () => {
       expect(r.kind).toBe("error");
       if (r.kind === "error") expect(r.message).toBeTruthy();
     });
+
+    test("dangerous MathJS surface (import / createUnit / reviver / resolve) is blocked", () => {
+      // Mirrors the live gradebook renderer's security guard in
+      // GradebookController._getSharedMath(); the preview must reject the
+      // same names so an instructor can't save an expression here that the
+      // rendered cell would throw on at runtime.
+      for (const name of ["import", "createUnit", "reviver", "resolve"]) {
+        const r = evaluateRenderExpression(mathjs, "", `${name}("foo")`, 80, 100);
+        expect(r.kind).toBe("error");
+        if (r.kind === "error") {
+          expect(r.message).toMatch(new RegExp(`${name}\\b.*not allowed`));
+        }
+      }
+    });
   });
 });

--- a/tests/unit/gradebook-expression-tester.test.ts
+++ b/tests/unit/gradebook-expression-tester.test.ts
@@ -1,4 +1,5 @@
-import { formatValueForOverlay } from "@/lib/gradebookExpressionTester";
+import * as mathjs from "mathjs";
+import { evaluateRenderExpression, formatValueForOverlay } from "@/lib/gradebookExpressionTester";
 
 describe("gradebook expression tester helpers", () => {
   describe("formatValueForOverlay", () => {
@@ -79,6 +80,70 @@ describe("gradebook expression tester helpers", () => {
       // ResultSet is `{ entries: unknown[] }` with no other own array behavior.
       const resultSet = { entries: [1, 2, 42] };
       expect(formatValueForOverlay(resultSet)).toBe("42");
+    });
+  });
+
+  describe("evaluateRenderExpression", () => {
+    test("empty render expression is reported as empty, not an error", () => {
+      const r = evaluateRenderExpression(mathjs, "", "", 80, 100);
+      expect(r.kind).toBe("empty");
+      const r2 = evaluateRenderExpression(mathjs, "", null, 80, 100);
+      expect(r2.kind).toBe("empty");
+    });
+
+    test("default `round(score, 2)` pattern evaluates to a trimmed numeric", () => {
+      const r = evaluateRenderExpression(mathjs, "", "round(score, 2)", 81.5, 100);
+      expect(r.kind).toBe("ok");
+      if (r.kind === "ok") expect(r.rendered).toBe("81.5");
+    });
+
+    test("`letter(score)` maps a raw score to the expected letter grade", () => {
+      const r = evaluateRenderExpression(mathjs, "", "letter(score)", 81.5, 100);
+      expect(r.kind).toBe("ok");
+      if (r.kind === "ok") expect(r.rendered).toBe("B-");
+
+      const r2 = evaluateRenderExpression(mathjs, "", "letter(score)", 95, 100);
+      if (r2.kind === "ok") expect(r2.rendered).toBe("A");
+
+      const r3 = evaluateRenderExpression(mathjs, "", "letter(score)", 55, 100);
+      if (r3.kind === "ok") expect(r3.rendered).toBe("F");
+    });
+
+    test("`check(score)` maps scores to emoji check marks based on breakpoints", () => {
+      const ok = evaluateRenderExpression(mathjs, "", "check(score)", 95, 100);
+      expect(ok.kind).toBe("ok");
+      if (ok.kind === "ok") expect(ok.rendered).toContain("✔");
+      const bad = evaluateRenderExpression(mathjs, "", "check(score)", 10, 100);
+      if (bad.kind === "ok") expect(bad.rendered).toBe("❌");
+    });
+
+    test("`checkOrX(score)` returns ✔️ for any positive score", () => {
+      const ok = evaluateRenderExpression(mathjs, "", "checkOrX(score)", 1, 100);
+      expect(ok.kind).toBe("ok");
+      if (ok.kind === "ok") expect(ok.rendered).toBe("✔️");
+      const zero = evaluateRenderExpression(mathjs, "", "checkOrX(score)", 0, 100);
+      if (zero.kind === "ok") expect(zero.rendered).toBe("❌");
+    });
+
+    test("`expression_prefix` is prepended so helper defs from the prefix are visible", () => {
+      // The expression_prefix is a block of mathjs that runs before the
+      // render expression. We simulate a prefix that defines a custom helper.
+      const prefix = "halve(x) = x / 2";
+      const r = evaluateRenderExpression(mathjs, prefix, "halve(score)", 80, 100);
+      expect(r.kind).toBe("ok");
+      if (r.kind === "ok") expect(r.rendered).toBe("40");
+    });
+
+    test("undefined score renders without crashing", () => {
+      const r = evaluateRenderExpression(mathjs, "", "letter(score)", undefined, 100);
+      expect(r.kind).toBe("ok");
+      if (r.kind === "ok") expect(r.rendered).toBe("(N/A)");
+    });
+
+    test("syntax error in render expression surfaces as `error`", () => {
+      const r = evaluateRenderExpression(mathjs, "", "((letter(score)", 80, 100);
+      expect(r.kind).toBe("error");
+      if (r.kind === "error") expect(r.message).toBeTruthy();
     });
   });
 });

--- a/tests/unit/gradebook-expression-tester.test.ts
+++ b/tests/unit/gradebook-expression-tester.test.ts
@@ -10,6 +10,12 @@ describe("gradebook expression tester helpers", () => {
       expect(formatValueForOverlay(true)).toBe("true");
     });
 
+    test("formats non-finite numbers (NaN / Infinity)", () => {
+      expect(formatValueForOverlay(NaN)).toBe("NaN");
+      expect(formatValueForOverlay(Infinity)).toBe("Infinity");
+      expect(formatValueForOverlay(-Infinity)).toBe("-Infinity");
+    });
+
     test("formats plain arrays without collapsing to undefined", () => {
       // Regression: `"entries" in arr` is true for plain arrays because
       // Array.prototype.entries exists. We must not mistake plain arrays


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Instructors previously had to author gradebook `score_expression`s in a 4-line textarea with zero feedback. This PR adds:

1. **Live validation** on the Add/Edit Column dialogs:
   - Parse the expression with mathjs as the user types.
   - Validate slug references & cycle detection via the existing `extractAndValidateDependencies`.
   - Inline error messages, a colored border, and the Save button is disabled until the expression parses and all dependency slugs resolve.

2. **Full-screen Expression Builder** — a new "Expression Builder" button on the Edit Column modal expands it to full-screen, adding:
   - A **student picker** (search + list) to choose whose gradebook row the expression should be tested against.
   - **Live evaluation** of the expression for the selected student using the same expression machinery the client What-If evaluator / server recalculator use (`addCommonExpressionFunctions` + `pushMissingDependenciesToContext` + context-function AST transform).
   - **Per-line inline annotations** — the textarea renders each line of the user's expression with a right-aligned `= value` overlay on the same line as the statement that ended there. Multi-line statements (e.g. a `case_when([...])` spanning 10+ lines) only annotate the closing `])`; continuation rows stay blank. Lambda bodies are skipped.
   - **Final-score badges above the editor** — a "Score" badge shows the raw numeric result; if the column has a render expression set, a second "Rendered" badge shows the rendered form alongside.
   - An **incomplete-values panel** that surfaces missing / not-released dependencies picked up during evaluation (report-only policy).

## Walkthrough

### Per-line inline values in the full-screen editor

[Score Expression editor with per-line = value annotations. Each assignment line shows its value on the right; the multi-line case_when(\[...\]) matrix only annotates the final \]) with the computed score.](https://cursor.com/agents/bc-c81a3167-b336-4a55-b642-9985aa91d178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F13_inline_per_line_values.png)

### Score + Rendered badges

[Score and Rendered badges side-by-side when a render expression is set.](https://cursor.com/agents/bc-c81a3167-b336-4a55-b642-9985aa91d178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F11_inline_score_and_rendered.png)

## Testing

### Unit tests — 56 passing

- ✅ `npx jest tests/unit/gradebook-expression-builder.test.ts tests/unit/gradebook-expression-tester.test.ts tests/unit/gradebook-expression-shared.test.ts`
- 27 tests exercising every score-expression pattern in `tests/e2e/gradebook-calculations.test.tsx`, plus per-line annotations, lambda-body skipping, repeated-subexpression spans, nested context injection, and a full production-style grade-boundary block from the spec.
- New tests for the latest round of CodeRabbit fixes: raw-span mapping with `score*2`-style compact input; security guards in `evaluateRenderExpression` for `import`/`createUnit`/`reviver`/`resolve`.

### E2E test — reliably passes locally on prod build

Run on a fresh local Supabase + a `PORT=3001 npm run start` production build (8 consecutive passes):

```
=== CHROMIUM (prod build of c23ecc7b) ===
  ✓ Run 1: 17.2s   ✓ Run 2: 18.9s   ✓ Run 3: 17.0s
  ✓ Run 4: 17.2s   ✓ Run 5: 17.1s

=== WEBKIT ===
  ✓ Run 1: 21.6s   ✓ Run 2: 21.7s   ✓ Run 3: 19.6s
```

[e2e_local_8_consecutive_passes.log](https://cursor.com/agents/bc-c81a3167-b336-4a55-b642-9985aa91d178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fe2e_local_8_consecutive_passes.log)

### ⚠️ CI `Deploy Branch Preview` failure is a Coolify deploy-cache issue, not a code bug

[ci_infra_stale_deploy_proof.md](https://cursor.com/agents/bc-c81a3167-b336-4a55-b642-9985aa91d178/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_infra_stale_deploy_proof.md)

**Root cause:** Coolify reports every redeploy as "finished" within 10 seconds but does NOT actually swap the running container. The deployed preview `cursor-gradebook-expression-builder-d178.dev.pawtograder.net` has been serving the very first image pushed for this branch (`sha-bd1242d3`, `main-app-486fd5c34841bf4f.js`) since the second commit, even though every subsequent commit pushed a new image to GHCR with different chunk hashes.

Evidence (reproducible with `curl` + `docker pull`):

```
# Deployed preview is still serving bd1242d3's chunks
$ curl -s https://cursor-gradebook-expression-builder-d178.dev.pawtograder.net/ \
    | grep -oE '_next/static/chunks/main-app-[a-f0-9]*\.js'
_next/static/chunks/main-app-486fd5c34841bf4f.js

# This is sha-bd1242d3 (first commit, OLD UI)
$ docker pull ghcr.io/pawtograder/platform-frontend:sha-bd1242d
$ docker run --rm ghcr.io/pawtograder/platform-frontend:sha-bd1242d \
    sh -c "ls /app/.next/static/chunks/ | grep main-app-"
main-app-486fd5c34841bf4f.js   ← matches deployed

# Latest image (sha-c23ecc7b, my current HEAD)
$ docker pull ghcr.io/pawtograder/platform-frontend:sha-c23ecc7
$ docker run --rm ghcr.io/pawtograder/platform-frontend:sha-c23ecc7 \
    sh -c "ls /app/.next/static/chunks/ | grep main-app-"
main-app-97749102ab5fb3b2.js   ← NOT served, but correctly built with:
                               ← `InlineLineAnnotatedEditor`
                               ← `expression-builder-result-badges`
```

Each of the 10 deploys since the first successful one logs:

```
Deploying frontend app r11vv0m8x6sl33dt5mni1bnl with image ghcr.io/pawtograder/platform-frontend:sha-<new>
Waiting for deployment <uuid> to finish
Deployment <uuid> for app r11vv0m8x6sl33dt5mni1bnl is finished
Skipping Discord webhook - this is a redeploy of existing service
```

…but the container's served chunks never change.

**Corroborating evidence:** The `staging` branch's own `Deploy Branch Preview` runs are also failing with the same element-not-found timeout pattern. Even already-merged PRs (#719) had `deploy: FAILURE`. This is a platform-level bug that affects the whole repo, not something this PR can fix.

**Fix path (outside the PR):** either
- Force-delete this branch's Coolify service via the Coolify admin UI (the action's `cleanupByName` path) so the next deploy creates a fresh service; or
- Upgrade `pawtograder/coolify-supabase-deployment-action@main` to pass `force: true` to `deployByTagOrUuid` (the Coolify API already supports it) so each redeploy does a clean pull.

### Other checks

- ✅ `npx tsc --noEmit` (only pre-existing unrelated error in `tests/e2e/gradebook-calculations.test.tsx`).
- ✅ `npx prettier --check` / `npx eslint` clean on touched files.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c81a3167-b336-4a55-b642-9985aa91d178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c81a3167-b336-4a55-b642-9985aa91d178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expression Builder: modal and fullscreen editor with live validation, student picker, per-line inline annotations/overlay, rendered-score badges, and save-blocking for invalid expressions
  * New evaluation tooling for expression validation, per-student evaluation, and overlay formatting
  * Hook to surface expression prefix updates to validation/rendering

* **UX**
  * Dialog sizing and Save button behavior updated when builder is expanded; Save is disabled with invalid/unavailable validation

* **Tests**
  * New unit and E2E coverage for formatting, render evaluation, live validation, fullscreen flow, and per-student evaluation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->