### PR TITLE
Rename "Import Column" to "Import Columns"

### DIFF
--- a/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
+++ b/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
@@ -372,7 +372,7 @@ export default function ImportGradebookColumns() {
     >
       <Dialog.Trigger asChild>
         <Button variant="outline" size="sm" onClick={() => setDialogOpen(true)}>
-          <Icon as={FiUpload} mr={2} /> Import Column
+          <Icon as={FiUpload} mr={2} /> Import Columns
         </Button>
       </Dialog.Trigger>
       <Portal>

--- a/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
+++ b/app/course/[course_id]/manage/gradebook/importGradebookColumn.tsx
@@ -380,7 +380,7 @@ export default function ImportGradebookColumns() {
         <Dialog.Positioner>
           <Dialog.Content maxW={"100vw"} maxH={"100vh"} overflow={"auto"} width={"fit-content"}>
             <Dialog.Header>
-              <Dialog.Title>Import Gradebook Column</Dialog.Title>
+              <Dialog.Title>Import Gradebook Columns</Dialog.Title>
             </Dialog.Header>
             <Dialog.Body>
               <Toaster />

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -776,7 +776,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
 
     // Check action buttons
     await expect(page.getByRole("button", { name: "Download Gradebook" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Import Column" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Import Columns" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Add Column" })).toBeVisible();
 
     // Check that Student 1's assignments are showing grades, final grade is calculated
@@ -881,9 +881,9 @@ test.describe("Gradebook Page - Comprehensive", () => {
     }).toPass({ timeout: 60_000 });
   });
 
-  test("Import Column workflow creates a new column and populates scores", async ({ page }) => {
+  test("Import Columns workflow creates a new column and populates scores", async ({ page }) => {
     // Open import dialog
-    await page.getByRole("button", { name: "Import Column" }).click();
+    await page.getByRole("button", { name: "Import Columns" }).click();
 
     // Step 1: upload file
     const fileInput = page.locator('input[type="file"]');


### PR DESCRIPTION
I have been using this button successfully to import multiple columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the import button label from "Import Column" to "Import Columns" for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->