### PR TITLE
Add cleanup for mistaken individual assignment repositories

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/repositories/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/repositories/page.tsx
@@ -25,7 +25,16 @@ import {
 } from "@chakra-ui/react";
 import { ColumnDef, flexRender } from "@tanstack/react-table";
 import { Select } from "chakra-react-select";
-import { CheckIcon, RefreshCw, GitPullRequest, ShieldCheck } from "lucide-react";
+import {
+  DialogRoot,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+  DialogCloseTrigger
+} from "@/components/ui/dialog";
+import { CheckIcon, RefreshCw, GitPullRequest, ShieldCheck, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -326,6 +335,162 @@ function FixRepoPermissionsButton({
         </Box>
       )}
     </VStack>
+  );
+}
+
+const CLEANUP_CONFIRM_PHRASE = "CLEANUP";
+
+function CleanupIndividualReposButton({
+  courseId,
+  assignmentId,
+  tableController,
+  individualRepoCount
+}: {
+  courseId: number;
+  assignmentId: number;
+  tableController: TableController<"repositories", typeof joinedSelect, number> | undefined;
+  individualRepoCount: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<1 | 2>(1);
+  const [confirmText, setConfirmText] = useState("");
+  const [isRunning, setIsRunning] = useState(false);
+
+  const resetAndClose = () => {
+    setOpen(false);
+    setStep(1);
+    setConfirmText("");
+  };
+
+  const handleOpenChange = (details: { open: boolean }) => {
+    if (!details.open) {
+      setOpen(false);
+      setStep(1);
+      setConfirmText("");
+    }
+  };
+
+  const handleCleanup = async () => {
+    if (confirmText.trim() !== CLEANUP_CONFIRM_PHRASE) {
+      return;
+    }
+    const supabase = createClient();
+    setIsRunning(true);
+    try {
+      const { data, error } = await supabase.rpc("cleanup_individual_repositories_for_assignment", {
+        p_class_id: courseId,
+        p_assignment_id: assignmentId
+      });
+      if (error) throw error;
+      const result = data as { message?: string; summary?: Record<string, number> };
+      toaster.success({
+        title: "Cleanup started",
+        description: result.message ?? "Individual repositories were queued for archival."
+      });
+      resetAndClose();
+      await tableController?.refetchAll();
+    } catch (error) {
+      console.error(error);
+      toaster.error({
+        title: "Cleanup failed",
+        description: error instanceof Error ? error.message : "Could not clean up individual repositories."
+      });
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const disabledNoIndividuals = individualRepoCount === 0;
+
+  return (
+    <>
+      <Button
+        size="sm"
+        colorPalette="red"
+        variant="outline"
+        disabled={disabledNoIndividuals}
+        title={disabledNoIndividuals ? "There are no individual repositories for this assignment." : undefined}
+        onClick={() => {
+          setStep(1);
+          setConfirmText("");
+          setOpen(true);
+        }}
+      >
+        <Icon as={Trash2} boxSize={3.5} />
+        Cleanup individual repositories
+      </Button>
+
+      <DialogRoot open={open} onOpenChange={handleOpenChange}>
+        <DialogContent maxW="lg">
+          <DialogHeader>
+            <DialogTitle>Cleanup individual repositories</DialogTitle>
+            <DialogCloseTrigger />
+          </DialogHeader>
+          <DialogBody>
+            {step === 1 ? (
+              <VStack alignItems="flex-start" gap={3}>
+                <Text fontSize="sm">
+                  Use this when students were given both an individual repository and a group repository by mistake (for
+                  example, groups were configured after the assignment was released).
+                </Text>
+                <Text fontSize="sm" fontWeight="semibold">
+                  This will:
+                </Text>
+                <Box as="ul" pl={5} fontSize="sm" style={{ listStyleType: "disc" }}>
+                  <li>
+                    Archive {individualRepoCount} individual student repositor
+                    {individualRepoCount === 1 ? "y" : "ies"} on GitHub (async queue)
+                  </li>
+                  <li>Delete related submissions, grades, and workflow data from Pawtograder</li>
+                  <li>Remove the individual repository records (group repos are unchanged)</li>
+                </Box>
+                <Text fontSize="sm" color="red.600" _dark={{ color: "red.300" }}>
+                  This cannot be undone. Continue only if you are sure.
+                </Text>
+              </VStack>
+            ) : (
+              <VStack alignItems="stretch" gap={3}>
+                <Text fontSize="sm">
+                  Type <Code>{CLEANUP_CONFIRM_PHRASE}</Code> below to confirm. This runs the cleanup immediately.
+                </Text>
+                <Input
+                  placeholder={CLEANUP_CONFIRM_PHRASE}
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value)}
+                  autoComplete="off"
+                />
+              </VStack>
+            )}
+          </DialogBody>
+          <DialogFooter gap={2}>
+            {step === 1 ? (
+              <>
+                <Button variant="outline" onClick={resetAndClose}>
+                  Cancel
+                </Button>
+                <Button colorPalette="red" onClick={() => setStep(2)}>
+                  Continue
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="outline" onClick={() => setStep(1)} disabled={isRunning}>
+                  Back
+                </Button>
+                <Button
+                  colorPalette="red"
+                  loading={isRunning}
+                  disabled={confirmText.trim() !== CLEANUP_CONFIRM_PHRASE || isRunning}
+                  onClick={handleCleanup}
+                >
+                  Confirm cleanup
+                </Button>
+              </>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </DialogRoot>
+    </>
   );
 }
 
@@ -707,6 +872,11 @@ export default function RepositoriesPage() {
 
   const selectedCount = getSelectedRowModel().rows.length;
 
+  const individualRepoCount = useMemo(() => {
+    const rows = (data as unknown as RepositoryRow[]) ?? [];
+    return rows.filter((r) => r.assignment_group_id == null && r.profile_id != null).length;
+  }, [data]);
+
   return (
     <VStack w="100%">
       <VStack paddingBottom="55px" w="100%">
@@ -744,13 +914,21 @@ export default function RepositoriesPage() {
           </HStack>
         )}
         <Box overflowX="auto" maxW="100vw" maxH="100vh" overflowY="auto" w="100%">
-          <HStack justifyContent="space-between" alignItems="flex-start" w="100%" mb={2}>
+          <HStack justifyContent="space-between" alignItems="flex-start" w="100%" mb={2} flexWrap="wrap" gap={2}>
             <Heading size="sm">Repository Status</Heading>
-            <FixRepoPermissionsButton
-              courseId={Number(course_id)}
-              assignmentId={Number(assignment_id)}
-              tableController={repositories}
-            />
+            <HStack flexWrap="wrap" gap={2} justifyContent="flex-end">
+              <CleanupIndividualReposButton
+                courseId={Number(course_id)}
+                assignmentId={Number(assignment_id)}
+                tableController={repositories}
+                individualRepoCount={individualRepoCount}
+              />
+              <FixRepoPermissionsButton
+                courseId={Number(course_id)}
+                assignmentId={Number(assignment_id)}
+                tableController={repositories}
+              />
+            </HStack>
           </HStack>
           <Table.Root minW="0" w="100%">
             <Table.Header>

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/repositories/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/repositories/page.tsx
@@ -12,6 +12,8 @@ import {
   Box,
   Button,
   Code,
+  FieldLabel,
+  FieldRoot,
   Heading,
   HStack,
   Icon,
@@ -339,6 +341,7 @@ function FixRepoPermissionsButton({
 }
 
 const CLEANUP_CONFIRM_PHRASE = "CLEANUP";
+const CLEANUP_CONFIRM_INPUT_ID = "cleanup-individual-repos-confirm-input";
 
 function CleanupIndividualReposButton({
   courseId,
@@ -438,8 +441,8 @@ function CleanupIndividualReposButton({
                 </Text>
                 <Box as="ul" pl={5} fontSize="sm" style={{ listStyleType: "disc" }}>
                   <li>
-                    Archive {individualRepoCount} individual student repositor
-                    {individualRepoCount === 1 ? "y" : "ies"} on GitHub (async queue)
+                    Archive {individualRepoCount} individual student{" "}
+                    {individualRepoCount === 1 ? "repository" : "repositories"} on GitHub (async queue)
                   </li>
                   <li>Delete related submissions, grades, and workflow data from Pawtograder</li>
                   <li>Remove the individual repository records (group repos are unchanged)</li>
@@ -453,12 +456,16 @@ function CleanupIndividualReposButton({
                 <Text fontSize="sm">
                   Type <Code>{CLEANUP_CONFIRM_PHRASE}</Code> below to confirm. This runs the cleanup immediately.
                 </Text>
-                <Input
-                  placeholder={CLEANUP_CONFIRM_PHRASE}
-                  value={confirmText}
-                  onChange={(e) => setConfirmText(e.target.value)}
-                  autoComplete="off"
-                />
+                <FieldRoot gap={1.5}>
+                  <FieldLabel htmlFor={CLEANUP_CONFIRM_INPUT_ID}>{CLEANUP_CONFIRM_PHRASE}</FieldLabel>
+                  <Input
+                    id={CLEANUP_CONFIRM_INPUT_ID}
+                    placeholder={CLEANUP_CONFIRM_PHRASE}
+                    value={confirmText}
+                    onChange={(e) => setConfirmText(e.target.value)}
+                    autoComplete="off"
+                  />
+                </FieldRoot>
               </VStack>
             )}
           </DialogBody>

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -11358,6 +11358,10 @@ export type Database = {
         Returns: undefined;
       };
       cleanup_github_async_errors: { Args: never; Returns: undefined };
+      cleanup_individual_repositories_for_assignment: {
+        Args: { p_assignment_id: number; p_class_id: number };
+        Returns: Json;
+      };
       clear_all_incomplete_review_assignments: {
         Args: { p_assignment_id: number; p_class_id: number };
         Returns: Json;

--- a/supabase/migrations/20260417140000_cleanup_individual_assignment_repositories.sql
+++ b/supabase/migrations/20260417140000_cleanup_individual_assignment_repositories.sql
@@ -1,0 +1,250 @@
+-- Remove mistaken individual student repos when an assignment should be group-only.
+-- Archives repos via the async GitHub worker, then deletes local rows and submission data.
+
+CREATE OR REPLACE FUNCTION public.cleanup_individual_repositories_for_assignment(
+    p_class_id bigint,
+    p_assignment_id bigint
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_github_org text;
+    v_repo record;
+    v_org_name text;
+    v_repo_name text;
+    v_individual_repo_ids bigint[];
+    v_submission_ids bigint[];
+    v_enqueued integer := 0;
+    v_deleted_repos integer := 0;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+    IF NOT public.authorizeforclassinstructor(p_class_id) THEN
+        RAISE EXCEPTION 'Only instructors can clean up individual repositories';
+    END IF;
+
+    SELECT github_org INTO v_github_org
+    FROM public.classes
+    WHERE id = p_class_id;
+
+    IF v_github_org IS NULL OR v_github_org = '' THEN
+        RAISE EXCEPTION 'Course has no GitHub organization configured';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM public.assignments a
+        WHERE a.id = p_assignment_id AND a.class_id = p_class_id
+    ) THEN
+        RAISE EXCEPTION 'Assignment not found for this course';
+    END IF;
+
+    SELECT coalesce(array_agg(r.id), '{}')
+    INTO v_individual_repo_ids
+    FROM public.repositories r
+    WHERE r.class_id = p_class_id
+      AND r.assignment_id = p_assignment_id
+      AND r.assignment_group_id IS NULL
+      AND r.profile_id IS NOT NULL;
+
+    IF v_individual_repo_ids IS NULL OR cardinality(v_individual_repo_ids) = 0 THEN
+        RETURN jsonb_build_object(
+            'message', 'No individual repositories found for this assignment.',
+            'summary', jsonb_build_object(
+                'repositories_enqueued_for_archive', 0,
+                'repositories_deleted', 0,
+                'submissions_deleted', 0
+            )
+        );
+    END IF;
+
+    SELECT coalesce(array_agg(s.id), '{}')
+    INTO v_submission_ids
+    FROM public.submissions s
+    WHERE s.repository_id = ANY (v_individual_repo_ids);
+
+    -- Enqueue GitHub archive for each individual repo that exists on GitHub
+    FOR v_repo IN
+        SELECT r.id, r.repository, r.is_github_ready
+        FROM public.repositories r
+        WHERE r.id = ANY (v_individual_repo_ids)
+    LOOP
+        IF v_repo.repository IS NULL
+           OR v_repo.repository = ''
+           OR position('/' IN v_repo.repository) = 0
+        THEN
+            CONTINUE;
+        END IF;
+
+        v_org_name := split_part(v_repo.repository, '/', 1);
+        v_repo_name := split_part(v_repo.repository, '/', 2);
+
+        IF v_org_name IS NULL OR v_org_name = '' OR v_repo_name IS NULL OR v_repo_name = '' THEN
+            CONTINUE;
+        END IF;
+
+        IF v_org_name != v_github_org THEN
+            RAISE EXCEPTION 'Repository % org (%) does not match class github_org (%)',
+                v_repo.repository, v_org_name, v_github_org;
+        END IF;
+
+        IF coalesce(v_repo.is_github_ready, false) THEN
+            PERFORM public.enqueue_github_archive_repo(
+                p_class_id,
+                v_org_name,
+                v_repo_name,
+                'cleanup-individual-repos-' || v_repo.id::text
+            );
+            v_enqueued := v_enqueued + 1;
+        END IF;
+    END LOOP;
+
+    -- Delete submission graph for affected submissions (subset of delete_assignment_with_all_data)
+    IF v_submission_ids IS NOT NULL AND cardinality(v_submission_ids) > 0 THEN
+        UPDATE public.repository_check_runs rcr
+        SET target_submission_id = NULL
+        WHERE rcr.target_submission_id = ANY (v_submission_ids);
+
+        UPDATE public.grader_results gr
+        SET rerun_for_submission_id = NULL
+        WHERE gr.rerun_for_submission_id = ANY (v_submission_ids);
+
+        UPDATE public.assignment_leaderboard al
+        SET submission_id = NULL
+        WHERE al.submission_id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_regrade_request_comments srrc
+        USING public.submission_regrade_requests srr
+        WHERE srrc.submission_regrade_request_id = srr.id
+          AND srr.submission_id = ANY (v_submission_ids);
+
+        UPDATE public.submission_comments sc
+        SET regrade_request_id = NULL
+        WHERE sc.regrade_request_id IN (
+            SELECT id FROM public.submission_regrade_requests
+            WHERE submission_id = ANY (v_submission_ids)
+        );
+
+        UPDATE public.submission_file_comments sfc
+        SET regrade_request_id = NULL
+        WHERE sfc.regrade_request_id IN (
+            SELECT id FROM public.submission_regrade_requests
+            WHERE submission_id = ANY (v_submission_ids)
+        );
+
+        UPDATE public.submission_artifact_comments sac
+        SET regrade_request_id = NULL
+        WHERE sac.regrade_request_id IN (
+            SELECT id FROM public.submission_regrade_requests
+            WHERE submission_id = ANY (v_submission_ids)
+        );
+
+        DELETE FROM public.submission_regrade_requests
+        WHERE submission_id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_artifact_comments sac
+        USING public.submission_artifacts sa
+        JOIN public.submissions s ON sa.submission_id = s.id
+        WHERE sac.submission_artifact_id = sa.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_artifacts sa
+        USING public.submissions s
+        WHERE sa.submission_id = s.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_file_comments sfc
+        USING public.submission_files sf
+        JOIN public.submissions s ON sf.submission_id = s.id
+        WHERE sfc.submission_file_id = sf.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_files sf
+        USING public.submissions s
+        WHERE sf.submission_id = s.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_comments sc
+        USING public.submissions s
+        WHERE sc.submission_id = s.id
+          AND s.id = ANY (v_submission_ids)
+          AND sc.regrade_request_id IS NULL;
+
+        DELETE FROM public.grader_result_test_output grto
+        USING public.grader_result_tests grt
+        JOIN public.grader_results gr ON grt.grader_result_id = gr.id
+        JOIN public.submissions s ON gr.submission_id = s.id
+        WHERE grto.grader_result_test_id = grt.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.grader_result_tests grt
+        USING public.grader_results gr
+        JOIN public.submissions s ON gr.submission_id = s.id
+        WHERE grt.grader_result_id = gr.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.grader_result_output gro
+        USING public.grader_results gr
+        JOIN public.submissions s ON gr.submission_id = s.id
+        WHERE gro.grader_result_id = gr.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.grader_results gr
+        USING public.submissions s
+        WHERE gr.submission_id = s.id
+          AND s.id = ANY (v_submission_ids);
+
+        UPDATE public.submissions s
+        SET grading_review_id = NULL
+        WHERE s.id = ANY (v_submission_ids)
+          AND s.grading_review_id IS NOT NULL;
+
+        DELETE FROM public.review_assignments ra
+        WHERE ra.submission_id = ANY (v_submission_ids);
+
+        DELETE FROM public.submission_reviews sr
+        USING public.submissions s
+        WHERE sr.submission_id = s.id
+          AND s.id = ANY (v_submission_ids);
+
+        DELETE FROM public.submissions s
+        WHERE s.id = ANY (v_submission_ids);
+    END IF;
+
+    DELETE FROM public.repository_check_runs rcr
+    WHERE rcr.repository_id = ANY (v_individual_repo_ids);
+
+    DELETE FROM public.workflow_events we
+    WHERE we.repository_id = ANY (v_individual_repo_ids);
+
+    DELETE FROM public.workflow_run_error wre
+    WHERE wre.repository_id = ANY (v_individual_repo_ids);
+
+    DELETE FROM public.repositories r
+    WHERE r.id = ANY (v_individual_repo_ids);
+
+    GET DIAGNOSTICS v_deleted_repos = ROW_COUNT;
+
+    RETURN jsonb_build_object(
+        'message', format(
+            'Queued %s individual repositories for archival on GitHub and removed %s repository row(s) locally.',
+            v_enqueued,
+            v_deleted_repos
+        ),
+        'summary', jsonb_build_object(
+            'repositories_enqueued_for_archive', v_enqueued,
+            'repositories_deleted', v_deleted_repos,
+            'submissions_deleted', coalesce(cardinality(v_submission_ids), 0)::integer
+        )
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.cleanup_individual_repositories_for_assignment(bigint, bigint) FROM public;
+GRANT EXECUTE ON FUNCTION public.cleanup_individual_repositories_for_assignment(bigint, bigint) TO authenticated;
+
+COMMENT ON FUNCTION public.cleanup_individual_repositories_for_assignment IS
+'Instructors only: for an assignment, enqueue async GitHub archive for each individual (non-group) student repository, delete related submissions and workflow rows, then remove repository records.';

--- a/supabase/migrations/20260417140000_cleanup_individual_assignment_repositories.sql
+++ b/supabase/migrations/20260417140000_cleanup_individual_assignment_repositories.sql
@@ -19,6 +19,9 @@ DECLARE
     v_submission_ids bigint[];
     v_enqueued integer := 0;
     v_deleted_repos integer := 0;
+    v_repositories_skipped_unparseable integer := 0;
+    v_skipped_org_mismatch integer := 0;
+    v_skipped_org_mismatch_details jsonb := '[]'::jsonb;
 BEGIN
     IF auth.uid() IS NULL THEN
         RAISE EXCEPTION 'Not authenticated';
@@ -56,7 +59,10 @@ BEGIN
             'summary', jsonb_build_object(
                 'repositories_enqueued_for_archive', 0,
                 'repositories_deleted', 0,
-                'submissions_deleted', 0
+                'submissions_deleted', 0,
+                'repositories_skipped_unparseable', 0,
+                'skipped_org_mismatch', 0,
+                'skipped_org_mismatch_details', '[]'::jsonb
             )
         );
     END IF;
@@ -76,6 +82,7 @@ BEGIN
            OR v_repo.repository = ''
            OR position('/' IN v_repo.repository) = 0
         THEN
+            v_repositories_skipped_unparseable := v_repositories_skipped_unparseable + 1;
             CONTINUE;
         END IF;
 
@@ -83,12 +90,19 @@ BEGIN
         v_repo_name := split_part(v_repo.repository, '/', 2);
 
         IF v_org_name IS NULL OR v_org_name = '' OR v_repo_name IS NULL OR v_repo_name = '' THEN
+            v_repositories_skipped_unparseable := v_repositories_skipped_unparseable + 1;
             CONTINUE;
         END IF;
 
         IF v_org_name != v_github_org THEN
-            RAISE EXCEPTION 'Repository % org (%) does not match class github_org (%)',
-                v_repo.repository, v_org_name, v_github_org;
+            v_skipped_org_mismatch := v_skipped_org_mismatch + 1;
+            v_skipped_org_mismatch_details := v_skipped_org_mismatch_details || jsonb_build_array(
+                jsonb_build_object(
+                    'repository', v_repo.repository,
+                    'org_name', v_org_name
+                )
+            );
+            CONTINUE;
         END IF;
 
         IF coalesce(v_repo.is_github_ready, false) THEN
@@ -237,7 +251,10 @@ BEGIN
         'summary', jsonb_build_object(
             'repositories_enqueued_for_archive', v_enqueued,
             'repositories_deleted', v_deleted_repos,
-            'submissions_deleted', coalesce(cardinality(v_submission_ids), 0)::integer
+            'submissions_deleted', coalesce(cardinality(v_submission_ids), 0)::integer,
+            'repositories_skipped_unparseable', v_repositories_skipped_unparseable,
+            'skipped_org_mismatch', v_skipped_org_mismatch,
+            'skipped_org_mismatch_details', v_skipped_org_mismatch_details
         )
     );
 END;

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -11358,6 +11358,10 @@ export type Database = {
         Returns: undefined;
       };
       cleanup_github_async_errors: { Args: never; Returns: undefined };
+      cleanup_individual_repositories_for_assignment: {
+        Args: { p_assignment_id: number; p_class_id: number };
+        Returns: Json;
+      };
       clear_all_incomplete_review_assignments: {
         Args: { p_assignment_id: number; p_class_id: number };
         Returns: Json;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds **Cleanup individual repositories** on the Manage repositories page for an assignment. This targets the case where students end up with both an individual repo and a group repo because groups were set up after release.

## Behavior
- **Double confirmation**: warning step, then a second step requiring typing `CLEANUP`.
- **Server RPC** `cleanup_individual_repositories_for_assignment(p_class_id, p_assignment_id)` (instructors only):
  - Selects **individual** repos: `assignment_group_id IS NULL` and `profile_id IS NOT NULL`.
  - For each repo with `is_github_ready`, enqueues `enqueue_github_archive_repo` (same async worker path as other GitHub outbound work).
  - Deletes submission-related rows tied to those repositories (same ordering pattern as assignment deletion), clears FK pointers (`repository_check_runs.target_submission_id`, `grader_results.rerun_for_submission_id`, `assignment_leaderboard.submission_id`), removes workflow rows, then deletes `repository_check_runs` and `repositories` rows for those individuals.
- **UI** refetches the repository table after success.

## Notes
- Regenerated `SupabaseTypes.d.ts` entries for the new RPC (full `npm run client` still recommended after migrations land).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1015fa2f-9e97-4bd7-9bcc-8b38f181f331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1015fa2f-9e97-4bd7-9bcc-8b38f181f331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository cleanup functionality for individual assignments with a confirmation dialog requiring user verification.
  * New cleanup button in assignment management interface with safety checks and success notifications.
  * Automatic table refresh after cleanup completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/720)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->