### PR TITLE
fix(discussion): prevent accidental double posts on new forum threads

### DIFF
--- a/app/course/[course_id]/discussion/new/page.tsx
+++ b/app/course/[course_id]/discussion/new/page.tsx
@@ -9,7 +9,7 @@ import { useClassProfiles } from "@/hooks/useClassProfiles";
 import { useAssignments, useCourseController, useDiscussionTopics } from "@/hooks/useCourseController";
 import { Box, Fieldset, Flex, Heading, Icon, Input, Text, Separator } from "@chakra-ui/react";
 import { useParams, useRouter } from "next/navigation";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { FaChalkboardTeacher, FaQuestion, FaRegStickyNote, FaUser, FaUserSecret } from "react-icons/fa";
 import { TbWorld } from "react-icons/tb";
@@ -45,6 +45,13 @@ export default function NewDiscussionThread() {
     }
   });
 
+  /**
+   * Stays true after a successful create + router.push until unmount. RHF clears isSubmitting as soon as
+   * the submit handler promise resolves (right after push), which can re-enable the form before navigation finishes.
+   */
+  const [submitInFlight, setSubmitInFlight] = useState(false);
+  const formBusy = isSubmitting || submitInFlight;
+
   const topics = useDiscussionTopics();
   const assignments = useAssignments();
   const topicId = watch("topic_id");
@@ -76,6 +83,8 @@ export default function NewDiscussionThread() {
       return;
     }
     createInFlightRef.current = true;
+    setSubmitInFlight(true);
+    let navigationCommitted = false;
     try {
       // Prepare the thread data for creation
       const threadData = {
@@ -92,22 +101,29 @@ export default function NewDiscussionThread() {
       // Create the thread using TableController
       const createdThread = await discussionThreadTeasers.create(threadData);
 
-      // Navigate to the new thread (keep createInFlightRef true until unmount so slow navigations cannot double-post)
+      // Navigate to the new thread. RHF clears isSubmitting when this async function returns; keep
+      // submitInFlight + ref true until unmount so the form stays locked through slow client navigations.
       router.push(`/course/${course_id}/discussion/${createdThread.id}`);
+      navigationCommitted = true;
     } catch {
-      createInFlightRef.current = false;
       toaster.error({
         title: "Error creating discussion thread",
         description: "Please try again later."
       });
+    } finally {
+      // Clear only when we are not leaving the page (create failed or navigation did not start).
+      if (!navigationCommitted) {
+        createInFlightRef.current = false;
+        setSubmitInFlight(false);
+      }
     }
   });
   return (
     <Box p={{ base: "4", md: "0" }}>
       <Heading as="h1">New Discussion Thread</Heading>
       <Box maxW="4xl" w="100%">
-        <form onSubmit={onSubmit} aria-busy={isSubmitting}>
-          <Fieldset.Root bg="surface" disabled={isSubmitting}>
+        <form onSubmit={onSubmit} aria-busy={formBusy}>
+          <Fieldset.Root bg="surface" disabled={formBusy}>
             <Fieldset.Content w="100%">
               <Field
                 label="Topic"
@@ -375,7 +391,7 @@ export default function NewDiscussionThread() {
                         onChange={field.onChange}
                         value={field.value}
                         enableFilePicker={true}
-                        disabled={isSubmitting}
+                        disabled={formBusy}
                       />
                     );
                   }}
@@ -384,9 +400,9 @@ export default function NewDiscussionThread() {
             </Fieldset.Content>
             <Button
               type="submit"
-              loading={isSubmitting}
+              loading={formBusy}
               loadingText="Posting…"
-              disabled={isSubmitting}
+              disabled={formBusy}
               w="100%"
               colorPalette="green"
             >

--- a/app/course/[course_id]/discussion/new/page.tsx
+++ b/app/course/[course_id]/discussion/new/page.tsx
@@ -9,7 +9,7 @@ import { useClassProfiles } from "@/hooks/useClassProfiles";
 import { useAssignments, useCourseController, useDiscussionTopics } from "@/hooks/useCourseController";
 import { Box, Fieldset, Flex, Heading, Icon, Input, Text, Separator } from "@chakra-ui/react";
 import { useParams, useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { FaChalkboardTeacher, FaQuestion, FaRegStickyNote, FaUser, FaUserSecret } from "react-icons/fa";
 import { TbWorld } from "react-icons/tb";
@@ -28,6 +28,8 @@ export default function NewDiscussionThread() {
   const router = useRouter();
   const { private_profile_id, public_profile_id, public_profile } = useClassProfiles();
   const { discussionThreadTeasers } = useCourseController();
+  /** Blocks duplicate submits before React re-renders (double-clicks, rapid Enter). */
+  const createInFlightRef = useRef(false);
 
   const {
     handleSubmit,
@@ -70,6 +72,10 @@ export default function NewDiscussionThread() {
   }, [topics]);
 
   const onSubmit = handleSubmit(async (data) => {
+    if (createInFlightRef.current) {
+      return;
+    }
+    createInFlightRef.current = true;
     try {
       // Prepare the thread data for creation
       const threadData = {
@@ -86,9 +92,10 @@ export default function NewDiscussionThread() {
       // Create the thread using TableController
       const createdThread = await discussionThreadTeasers.create(threadData);
 
-      // Navigate to the new thread
+      // Navigate to the new thread (keep createInFlightRef true until unmount so slow navigations cannot double-post)
       router.push(`/course/${course_id}/discussion/${createdThread.id}`);
     } catch {
+      createInFlightRef.current = false;
       toaster.error({
         title: "Error creating discussion thread",
         description: "Please try again later."
@@ -99,8 +106,8 @@ export default function NewDiscussionThread() {
     <Box p={{ base: "4", md: "0" }}>
       <Heading as="h1">New Discussion Thread</Heading>
       <Box maxW="4xl" w="100%">
-        <form onSubmit={onSubmit}>
-          <Fieldset.Root bg="surface">
+        <form onSubmit={onSubmit} aria-busy={isSubmitting}>
+          <Fieldset.Root bg="surface" disabled={isSubmitting}>
             <Fieldset.Content w="100%">
               <Field
                 label="Topic"
@@ -368,13 +375,21 @@ export default function NewDiscussionThread() {
                         onChange={field.onChange}
                         value={field.value}
                         enableFilePicker={true}
+                        disabled={isSubmitting}
                       />
                     );
                   }}
                 />
               </Field>
             </Fieldset.Content>
-            <Button type="submit" loading={isSubmitting} disabled={isSubmitting} w="100%" colorPalette="green">
+            <Button
+              type="submit"
+              loading={isSubmitting}
+              loadingText="Posting…"
+              disabled={isSubmitting}
+              w="100%"
+              colorPalette="green"
+            >
               Submit
             </Button>
           </Fieldset.Root>

--- a/components/ui/message-input.tsx
+++ b/components/ui/message-input.tsx
@@ -59,6 +59,10 @@ type MessageInputProps = React.ComponentProps<typeof MDEditor> & {
    * @default true (files are inserted inline by default)
    */
   inlineFileUpload?: boolean;
+  /**
+   * When true, the editor and toolbar are non-interactive (e.g. parent form is submitting).
+   */
+  disabled?: boolean;
 };
 
 export default function MessageInput(props: MessageInputProps) {
@@ -82,6 +86,7 @@ export default function MessageInput(props: MessageInputProps) {
     uploadFolder = "discussion",
     maxCodeLines = 300,
     inlineFileUpload = true, // Default to inline mode
+    disabled: disabledProp = false,
     ...editorProps
   } = props;
   const { course_id } = useParams();
@@ -373,7 +378,17 @@ export default function MessageInput(props: MessageInputProps) {
   );
   if (singleLine) {
     return (
-      <VStack align="stretch" spaceY="0" p="0" gap="2" w="100%" ref={containerRef} position="relative">
+      <VStack
+        align="stretch"
+        spaceY="0"
+        p="0"
+        gap="2"
+        w="100%"
+        ref={containerRef}
+        position="relative"
+        opacity={disabledProp ? 0.65 : 1}
+        pointerEvents={disabledProp ? "none" : "auto"}
+      >
         {showMarkdownPreview && (
           <Box width="100%" p="2" bg="bg.muted" border={"1px solid"} borderColor="border.subtle" rounded="md" m="0">
             <Markdown>{value}</Markdown>
@@ -383,7 +398,7 @@ export default function MessageInput(props: MessageInputProps) {
         <Textarea
           p="2"
           width="100%"
-          disabled={isSending}
+          disabled={isSending || disabledProp}
           aria-label={ariaLabel ?? placeholder ?? "Reply..."}
           placeholder={placeholder ?? "Reply..."}
           m="0"
@@ -433,6 +448,9 @@ export default function MessageInput(props: MessageInputProps) {
             }
             if (e.key === "Enter" && !(e.shiftKey || e.metaKey || !enterToSend)) {
               e.preventDefault();
+              if (disabledProp) {
+                return;
+              }
               if ((value?.trim() === "" || !value) && !allowEmptyMessage) {
                 toaster.create({
                   title: "Empty message",
@@ -495,6 +513,7 @@ export default function MessageInput(props: MessageInputProps) {
                   size="xs"
                   colorPalette={anonymousMode ? "red" : "teal"}
                   p={0}
+                  disabled={disabledProp}
                 >
                   <FaUserSecret />
                 </Button>
@@ -509,6 +528,7 @@ export default function MessageInput(props: MessageInputProps) {
                   size="xs"
                   colorPalette="teal"
                   p={0}
+                  disabled={disabledProp}
                 >
                   <FaPaperclip />
                 </Button>
@@ -522,6 +542,7 @@ export default function MessageInput(props: MessageInputProps) {
                 size="xs"
                 colorPalette="teal"
                 p={0}
+                disabled={disabledProp}
               >
                 <TbMathFunction />
               </Button>
@@ -545,6 +566,7 @@ export default function MessageInput(props: MessageInputProps) {
                     colorPalette="teal"
                     p={0}
                     onClick={() => setShowGiphyPicker(!showGiphyPicker)}
+                    disabled={disabledProp}
                   >
                     GIF
                   </Button>
@@ -574,6 +596,7 @@ export default function MessageInput(props: MessageInputProps) {
                   size="xs"
                   colorPalette="teal"
                   p={0}
+                  disabled={disabledProp}
                 >
                   <FaSmile />
                 </Button>
@@ -583,11 +606,11 @@ export default function MessageInput(props: MessageInputProps) {
           <Box>
             <Field.Root orientation="horizontal">
               <Field.Label fontSize="xs">{sendButtonText ? `Enter to ${sendButtonText}` : "Enter to send"}</Field.Label>
-              <Checkbox checked={enterToSend} onChange={() => setEnterToSend(!enterToSend)} />
+              <Checkbox checked={enterToSend} onChange={() => setEnterToSend(!enterToSend)} disabled={disabledProp} />
             </Field.Root>
           </Box>
           {onClose && (
-            <Button aria-label="Close" onClick={onClose} variant="ghost" size="xs" ml={2}>
+            <Button aria-label="Close" onClick={onClose} variant="ghost" size="xs" ml={2} disabled={disabledProp}>
               {closeButtonText ?? "Close"}
             </Button>
           )}
@@ -597,6 +620,9 @@ export default function MessageInput(props: MessageInputProps) {
               aria-label={props.sendButtonText ? props.sendButtonText : "Send message"}
               onClick={async () => {
                 if (!sendMessage) {
+                  return;
+                }
+                if (disabledProp) {
                   return;
                 }
                 if ((value?.trim() === "" || !value) && !allowEmptyMessage) {
@@ -627,6 +653,7 @@ export default function MessageInput(props: MessageInputProps) {
               colorPalette="green"
               size="xs"
               m={2}
+              disabled={disabledProp}
             >
               {props.sendButtonText ? props.sendButtonText : "Send"}
             </Button>
@@ -636,7 +663,17 @@ export default function MessageInput(props: MessageInputProps) {
     );
   }
   return (
-    <VStack align="stretch" spaceY="0" p="0" gap="0" w="100%" ref={containerRef} position="relative">
+    <VStack
+      align="stretch"
+      spaceY="0"
+      p="0"
+      gap="0"
+      w="100%"
+      ref={containerRef}
+      position="relative"
+      opacity={disabledProp ? 0.65 : 1}
+      pointerEvents={disabledProp ? "none" : "auto"}
+    >
       <MDEditor
         ref={mdEditorRef}
         value={value}
@@ -676,7 +713,7 @@ export default function MessageInput(props: MessageInputProps) {
           }
         }}
         textareaProps={{
-          disabled: isSending,
+          disabled: isSending || disabledProp,
           onKeyDown: handleKeyDown,
           onInput: (e) => {
             // Update cursor position on every keystroke
@@ -740,6 +777,7 @@ export default function MessageInput(props: MessageInputProps) {
                 size="xs"
                 colorPalette={anonymousMode ? "red" : "teal"}
                 p={0}
+                disabled={disabledProp}
               >
                 <FaUserSecret />
               </Button>
@@ -754,6 +792,7 @@ export default function MessageInput(props: MessageInputProps) {
                 size="xs"
                 colorPalette="teal"
                 p={0}
+                disabled={disabledProp}
               >
                 <FaPaperclip />
               </Button>
@@ -767,6 +806,7 @@ export default function MessageInput(props: MessageInputProps) {
               size="xs"
               colorPalette="teal"
               p={0}
+              disabled={disabledProp}
             >
               <TbMathFunction />
             </Button>
@@ -790,6 +830,7 @@ export default function MessageInput(props: MessageInputProps) {
                   colorPalette="teal"
                   p={0}
                   onClick={() => setShowGiphyPicker(!showGiphyPicker)}
+                  disabled={disabledProp}
                 >
                   GIF
                 </Button>
@@ -819,6 +860,7 @@ export default function MessageInput(props: MessageInputProps) {
                 size="xs"
                 colorPalette="teal"
                 p={0}
+                disabled={disabledProp}
               >
                 <FaSmile />
               </Button>
@@ -826,7 +868,7 @@ export default function MessageInput(props: MessageInputProps) {
           )}
         </HStack>
         {onClose && (
-          <Button aria-label="Close" onClick={onClose} variant="ghost" size="xs" ml={2}>
+          <Button aria-label="Close" onClick={onClose} variant="ghost" size="xs" ml={2} disabled={disabledProp}>
             {closeButtonText ?? "Close"}
           </Button>
         )}
@@ -835,6 +877,9 @@ export default function MessageInput(props: MessageInputProps) {
             loading={isSending}
             aria-label="Send message"
             onClick={async () => {
+              if (disabledProp) {
+                return;
+              }
               if ((value?.trim() === "" || !value) && !allowEmptyMessage) {
                 toaster.create({
                   title: "Empty message",
@@ -863,6 +908,7 @@ export default function MessageInput(props: MessageInputProps) {
             colorPalette="green"
             size="xs"
             ml={2}
+            disabled={disabledProp}
           >
             {props.sendButtonText ? props.sendButtonText : "Send"}
           </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Students were accidentally creating duplicate forum threads when submitting a new post. The submit button showed a spinner, but the markdown editor and other controls stayed interactive during the async create, and rapid double-clicks could race before React Hook Form flipped `isSubmitting`.

## Changes
- **New thread form** (`app/course/[course_id]/discussion/new/page.tsx`):
  - Synchronous `createInFlightRef` guard so a second submit is ignored immediately.
  - **`submitInFlight` state** + **`formBusy = isSubmitting || submitInFlight`**: RHF sets `isSubmitting` back to false when the async handler promise resolves (right after `router.push()` returns), which could re-enable the form before the client finishes navigating; `submitInFlight` stays true after a successful push until unmount. On failure, `finally` clears both the ref and `submitInFlight`.
  - `Fieldset.Root`, `MessageInput`, `aria-busy`, and submit button use **`formBusy`**.
  - Submit button shows `Posting…` while loading.

- **MessageInput** (`components/ui/message-input.tsx`): optional `disabled` prop that dims the editor and uses `pointer-events: none` on the MDEditor layout (and single-line layout) so the body cannot be edited while the parent form is posting; toolbar buttons respect the same state.

## Testing
- `npm run format` and `npm run lint` (pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e871939-2951-4d2c-88d6-5abf66c5003e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e871939-2951-4d2c-88d6-5abf66c5003e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discussion form now provides clear posting feedback, disables inputs while submitting, and remains locked through navigation to avoid re-enabling mid-post.
  * Message input component supports a disabled state with visual dimming and disables all input and toolbar actions to prevent interaction while busy.

* **Bug Fixes**
  * Prevents duplicate thread submissions from rapid or repeated submit actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->