### PR TITLE
Fix discussion browse view post list height and nested scroll

### DIFF
--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -62,9 +62,18 @@ const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>)
         discussionBaseHref={discussionBaseHref}
         currentThread={currentThread}
       />
-      <Box flex="1" minH="0" overflow="auto" px={{ base: 3, md: 6 }} pt={{ base: 3, md: 6 }} pb="80px">
+      <Box
+        flex="1"
+        minH={0}
+        overflow="auto"
+        px={{ base: 3, md: 6 }}
+        pt={{ base: 3, md: 6 }}
+        pb="80px"
+        display="flex"
+        flexDirection="column"
+      >
         {threadId ? (
-          <Flex direction="row" gap={{ base: 3, lg: 6 }} align="stretch">
+          <Flex direction="row" gap={{ base: 3, lg: 6 }} align="stretch" flex="1" minH={0}>
             <Box
               flex={{ lg: showFullSidebar ? 4 : "unset" }}
               width={{ base: "52px", lg: showFullSidebar ? "auto" : "52px" }}
@@ -79,7 +88,7 @@ const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>)
                 }}
               />
             </Box>
-            <Box flex={{ lg: 8 }} minW={0}>
+            <Box flex={{ base: 1, lg: 8 }} minW={0} minH={0} display="flex" flexDirection="column">
               {children}
             </Box>
           </Flex>

--- a/app/course/[course_id]/discussion/layout.tsx
+++ b/app/course/[course_id]/discussion/layout.tsx
@@ -84,7 +84,9 @@ const DiscussionLayout = ({ children }: Readonly<{ children: React.ReactNode }>)
             </Box>
           </Flex>
         ) : (
-          children
+          <Box flex="1" minH={0} display="flex" flexDirection="column">
+            {children}
+          </Box>
         )}
       </Box>
     </Box>

--- a/app/course/[course_id]/discussion/page.tsx
+++ b/app/course/[course_id]/discussion/page.tsx
@@ -220,10 +220,10 @@ export default function DiscussionPage() {
 
   // My Feed
   return (
-    <Flex direction={{ base: "column", lg: "row" }} gap={{ base: 4, lg: 6 }} align="stretch">
-      <Box flex={{ lg: 8 }} minW={0}>
-        <Stack spaceY={4}>
-          <HStack justify="space-between" align="center">
+    <Flex direction={{ base: "column", lg: "row" }} gap={{ base: 4, lg: 6 }} align="stretch" flex="1" minH={0}>
+      <Box flex={{ base: 1, lg: 8 }} minW={0} minH={0} display="flex" flexDirection="column">
+        <Stack spaceY={4} flex="1" minH={0}>
+          <HStack justify="space-between" align="center" flexShrink={0}>
             <Heading size="md">My Feed</Heading>
             <TopicFollowMultiSelect
               topics={sortedTopics}
@@ -232,14 +232,28 @@ export default function DiscussionPage() {
             />
           </HStack>
 
-          <Box borderWidth="1px" borderColor="border.emphasized" bg="bg.panel" rounded="md" overflow="hidden">
+          <Box
+            borderWidth="1px"
+            borderColor="border.emphasized"
+            bg="bg.panel"
+            rounded="md"
+            overflow="hidden"
+            flex="1"
+            minH={0}
+            display="flex"
+            flexDirection="column"
+          >
             {feedThreads.length === 0 ? (
               <Text px="4" py="3" color="fg.muted" fontSize="sm">
                 Your feed is empty. Follow a topic (Browse Topics) or follow a post to see it here. Followed posts and
                 topics will appear in My Feed.
               </Text>
             ) : (
-              <VirtualizedPostRowList threadIds={feedThreads.map((t) => t.id)} courseId={Number(course_id)} />
+              <VirtualizedPostRowList
+                threadIds={feedThreads.map((t) => t.id)}
+                courseId={Number(course_id)}
+                fillHeight
+              />
             )}
           </Box>
         </Stack>

--- a/app/course/[course_id]/discussion/page.tsx
+++ b/app/course/[course_id]/discussion/page.tsx
@@ -7,6 +7,7 @@ import { TopicFollowMultiSelect } from "@/components/discussion/TopicFollowMulti
 import { useFollowedDiscussionTopicIds, useTopicFollowActions } from "@/hooks/useDiscussionTopicFollow";
 import { useCourseController, useDiscussionThreadTeasers, useDiscussionTopics } from "@/hooks/useCourseController";
 import { useTableControllerTableValues } from "@/lib/TableController";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Box, Flex, Heading, HStack, Stack, Text } from "@chakra-ui/react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -24,6 +25,19 @@ export default function DiscussionPage() {
   const controller = useCourseController();
   const topics = useDiscussionTopics();
   const threads = useDiscussionThreadTeasers();
+
+  const [discussionDataReady, setDiscussionDataReady] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([controller.discussionTopics.readyPromise, controller.discussionThreadTeasers.readyPromise]).then(
+      () => {
+        if (!cancelled) setDiscussionDataReady(true);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [controller]);
 
   const followedTopicIds = useFollowedDiscussionTopicIds();
   const { setTopicFollowStatusForId } = useTopicFollowActions();
@@ -112,6 +126,35 @@ export default function DiscussionPage() {
         return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
       });
   }, [q, selectedTopicId, threads]);
+
+  if (!discussionDataReady) {
+    return (
+      <Box flex="1" minH={0} display="flex" flexDirection="column" aria-busy="true" aria-live="polite">
+        <Flex direction={{ base: "column", lg: "row" }} gap={{ base: 4, lg: 6 }} flex="1" minH={0} align="stretch">
+          <Box flex={{ lg: 4 }} minW={0}>
+            <Stack spaceY={2}>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} height="72px" borderRadius="md" />
+              ))}
+            </Stack>
+          </Box>
+          <Box flex={{ base: 1, lg: 8 }} minW={0} display="flex" flexDirection="column">
+            <Skeleton height="32px" width="min(240px, 55%)" mb="4" borderRadius="md" />
+            <Box
+              flex="1"
+              minH="min(320px, 50dvh)"
+              borderWidth="1px"
+              borderColor="border.emphasized"
+              rounded="md"
+              overflow="hidden"
+            >
+              <Skeleton height="100%" minH="200px" borderRadius="md" />
+            </Box>
+          </Box>
+        </Flex>
+      </Box>
+    );
+  }
 
   if (view === "browse") {
     return (

--- a/app/course/[course_id]/discussion/page.tsx
+++ b/app/course/[course_id]/discussion/page.tsx
@@ -26,14 +26,20 @@ export default function DiscussionPage() {
   const topics = useDiscussionTopics();
   const threads = useDiscussionThreadTeasers();
 
-  const [discussionDataReady, setDiscussionDataReady] = useState(false);
+  const [discussionDataReady, setDiscussionDataReady] = useState(
+    () => controller.discussionTopics.ready && controller.discussionThreadTeasers.ready
+  );
   useEffect(() => {
     let cancelled = false;
-    void Promise.all([controller.discussionTopics.readyPromise, controller.discussionThreadTeasers.readyPromise]).then(
-      () => {
+    void Promise.all([controller.discussionTopics.readyPromise, controller.discussionThreadTeasers.readyPromise])
+      .then(() => {
         if (!cancelled) setDiscussionDataReady(true);
-      }
-    );
+      })
+      .catch((err: unknown) => {
+        // eslint-disable-next-line no-console -- surface load failures; page must not stay on skeleton forever
+        console.error("DiscussionPage: failed waiting for discussion data", err);
+        if (!cancelled) setDiscussionDataReady(true);
+      });
     return () => {
       cancelled = true;
     };

--- a/app/course/[course_id]/discussion/page.tsx
+++ b/app/course/[course_id]/discussion/page.tsx
@@ -115,13 +115,8 @@ export default function DiscussionPage() {
 
   if (view === "browse") {
     return (
-      <Box
-        // On desktop, turn browse view into a split-pane with independent scroll areas.
-        height={{ base: "auto", lg: "100%" }}
-        minH={0}
-        overflow={{ base: "visible", lg: "hidden" }}
-      >
-        <Flex direction={{ base: "column", lg: "row" }} gap={{ base: 4, lg: 6 }} align="stretch" height="100%" minH={0}>
+      <Box flex="1" minH={0} display="flex" flexDirection="column">
+        <Flex direction={{ base: "column", lg: "row" }} gap={{ base: 4, lg: 6 }} align="stretch" flex="1" minH={0}>
           <Box flex={{ lg: 4 }} minW={0} overflowY={{ base: "visible", lg: "auto" }} minH={0}>
             <Stack spaceY={1}>
               {sortedTopics.map((t) => (
@@ -146,7 +141,7 @@ export default function DiscussionPage() {
             </Stack>
           </Box>
 
-          <Box flex={{ lg: 8 }} minW={0} minH={0} display="flex" flexDirection="column">
+          <Box flex={{ base: 1, lg: 8 }} minW={0} minH={0} display="flex" flexDirection="column">
             <HStack justify="space-between" align="center" mb="4" flexShrink={0}>
               <Heading size="md">{selectedTopic?.topic ?? "Select a topic"}</Heading>
             </HStack>
@@ -158,23 +153,21 @@ export default function DiscussionPage() {
               rounded="md"
               overflow="hidden"
               minH={0}
+              flex="1"
               display="flex"
               flexDirection="column"
             >
-              <Box
-                overflowY={
-                  browseThreads.length > 24 ? { base: "visible", lg: "visible" } : { base: "visible", lg: "auto" }
-                }
-                minH={0}
-              >
-                {browseThreads.length === 0 ? (
-                  <Text px="4" py="3" color="fg.muted" fontSize="sm">
-                    No posts match your criteria.
-                  </Text>
-                ) : (
-                  <VirtualizedPostRowList threadIds={browseThreads.map((t) => t.id)} courseId={Number(course_id)} />
-                )}
-              </Box>
+              {browseThreads.length === 0 ? (
+                <Text px="4" py="3" color="fg.muted" fontSize="sm">
+                  No posts match your criteria.
+                </Text>
+              ) : (
+                <VirtualizedPostRowList
+                  threadIds={browseThreads.map((t) => t.id)}
+                  courseId={Number(course_id)}
+                  fillHeight
+                />
+              )}
             </Box>
           </Box>
         </Flex>

--- a/components/discussion/VirtualizedPostRowList.tsx
+++ b/components/discussion/VirtualizedPostRowList.tsx
@@ -11,9 +11,14 @@ const VIRTUALIZE_THRESHOLD = 24;
 type Props = {
   threadIds: number[];
   courseId: number;
-  /** Max height of the scroll region (Chakra token or CSS length). */
+  /** Max height of the scroll region (Chakra token or CSS length). Ignored when `fillHeight` is true. */
   maxHeight?: string;
   estimateRowHeight?: number;
+  /**
+   * When true, the virtualized list grows with the parent flex column (e.g. browse-by-topic)
+   * instead of using a capped max-height and its own tiny scroll viewport.
+   */
+  fillHeight?: boolean;
 };
 
 /**
@@ -24,7 +29,8 @@ export function VirtualizedPostRowList({
   threadIds,
   courseId,
   maxHeight = "min(70vh, 560px)",
-  estimateRowHeight = DEFAULT_ROW_HEIGHT
+  estimateRowHeight = DEFAULT_ROW_HEIGHT,
+  fillHeight = false
 }: Props) {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -46,7 +52,12 @@ export function VirtualizedPostRowList({
   }
 
   return (
-    <Box ref={parentRef} overflowY="auto" maxH={maxHeight} minH="120px" css={{ contain: "strict" }}>
+    <Box
+      ref={parentRef}
+      overflowY="auto"
+      {...(fillHeight ? { flex: 1, minH: 0, minW: 0 } : { maxH: maxHeight, minH: "120px" })}
+      css={{ contain: "strict" }}
+    >
       <Box height={`${rowVirtualizer.getTotalSize()}px`} position="relative" width="100%">
         {rowVirtualizer.getVirtualItems().map((vi) => (
           <Box

--- a/components/discussion/VirtualizedPostRowList.tsx
+++ b/components/discussion/VirtualizedPostRowList.tsx
@@ -32,31 +32,31 @@ export function VirtualizedPostRowList({
   estimateRowHeight = DEFAULT_ROW_HEIGHT,
   fillHeight = false
 }: Props) {
-  const parentRef = useRef<HTMLDivElement>(null);
+  const listRootRef = useRef<HTMLDivElement>(null);
 
   const rowVirtualizer = useVirtualizer({
     count: threadIds.length,
-    getScrollElement: () => parentRef.current,
+    getScrollElement: () => listRootRef.current,
     estimateSize: () => estimateRowHeight,
     overscan: 6
   });
 
   if (threadIds.length <= VIRTUALIZE_THRESHOLD) {
     return (
-      <>
+      <Box ref={listRootRef} width="100%" {...(fillHeight ? { flex: 1, minH: 0, minW: 0, overflowY: "auto" } : {})}>
         {threadIds.map((id) => (
           <PostRow key={id} threadId={id} href={`/course/${courseId}/discussion/${id}`} />
         ))}
-      </>
+      </Box>
     );
   }
 
   return (
     <Box
-      ref={parentRef}
+      ref={listRootRef}
       overflowY="auto"
       {...(fillHeight ? { flex: 1, minH: 0, minW: 0 } : { maxH: maxHeight, minH: "120px" })}
-      css={{ contain: "strict" }}
+      css={{ contain: "layout paint" }}
     >
       <Box height={`${rowVirtualizer.getTotalSize()}px`} position="relative" width="100%">
         {rowVirtualizer.getVirtualItems().map((vi) => (

--- a/hooks/useCourseController.tsx
+++ b/hooks/useCourseController.tsx
@@ -279,7 +279,9 @@ type DiscussionThreadTeaser = Pick<
 
 export function useDiscussionThreadTeasers() {
   const controller = useCourseController();
-  const [teasers, setTeasers] = useState<DiscussionThreadTeaser[]>([]);
+  const [teasers, setTeasers] = useState<DiscussionThreadTeaser[]>(
+    () => controller.discussionThreadTeasers.list().data as DiscussionThreadTeaser[]
+  );
   useEffect(() => {
     const { data, unsubscribe } = controller.discussionThreadTeasers.list((data) => {
       setTeasers(data as DiscussionThreadTeaser[]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Browse Topics showed **skeleton / empty / “Loading…”** flashes because:
1. `useDiscussionThreadTeasers` started as `[]` and only synced in `useEffect`, so the first client render could show **“No posts”** or **PostRow “Loading…”** even after SSR had data.
2. There was no explicit wait for `TableController` hydration before painting the discussion index.

## Changes
- **`useDiscussionThreadTeasers`:** Initialize state from `controller.discussionThreadTeasers.list().data` (same pattern as `useDiscussionTopics` uses `.rows`).
- **Discussion index page:** `Promise.all(discussionTopics.readyPromise, discussionThreadTeasers.readyPromise)` then render; until then show a **two-column skeleton** with `aria-busy="true"` for assistive tech.

## Verification
Local dev + full-page capture after wait for loaded content (no skeleton, no “Loading…” in rows). Artifact: `/opt/cursor/artifacts/discussion-browse-loaded-AFTER.png` on the agent run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-828eb2ed-4df4-4dfe-8807-46ab60178144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-828eb2ed-4df4-4dfe-8807-46ab60178144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading placeholders that display while discussion data is being fetched.

* **Improvements**
  * Enhanced layout consistency and flexibility across discussion views.
  * Improved scroll behavior and container sizing for discussion lists to fill available space more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->