### PR TITLE
Clear TA messaging when grading feedback is released

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
@@ -38,7 +38,7 @@ import {
   useRubricParts,
   useRubricWithParts
 } from "@/hooks/useAssignment";
-import { useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
+import { useIsGrader, useIsGraderOrInstructor, useIsInstructor } from "@/hooks/useClassProfiles";
 import { useAssignmentGroupWithMembers, useCourseController } from "@/hooks/useCourseController";
 import {
   computeRubricAnnotationTargetMetaFromParts,
@@ -57,6 +57,7 @@ import {
 } from "@/hooks/useSubmission";
 import { useActiveReviewAssignmentId, useActiveRubricId } from "@/hooks/useSubmissionReview";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import { useFindTableControllerValue } from "@/lib/TableController";
 import { createClient } from "@/utils/supabase/client";
 import {
@@ -467,6 +468,8 @@ function ArtifactCommentsForm({
   }
   const reviewContext = useSubmissionReviewOrGradingReview(submission.grading_review_id);
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const [eventuallyVisible, setEventuallyVisible] = useState(true);
   const submissionController = useSubmissionController();
 
@@ -474,21 +477,42 @@ function ArtifactCommentsForm({
     async (message: string, author_id: string) => {
       const finalSubmissionReviewId = submissionReviewId ?? reviewContext?.id;
 
-      await submissionController.submission_artifact_comments.create({
-        submission_id: submission.id,
-        submission_artifact_id: artifact.id,
-        class_id: submission.class_id,
-        author: author_id,
-        comment: message,
-        submission_review_id: finalSubmissionReviewId ?? null,
-        released: reviewContext ? reviewContext.released : true,
-        eventually_visible: eventuallyVisible,
-        rubric_check_id: null,
-        points: null,
-        regrade_request_id: null
-      });
+      try {
+        await submissionController.submission_artifact_comments.create({
+          submission_id: submission.id,
+          submission_artifact_id: artifact.id,
+          class_id: submission.class_id,
+          author: author_id,
+          comment: message,
+          submission_review_id: finalSubmissionReviewId ?? null,
+          released: reviewContext ? reviewContext.released : true,
+          eventually_visible: eventuallyVisible,
+          rubric_check_id: null,
+          points: null,
+          regrade_request_id: null
+        });
+      } catch (error: unknown) {
+        toaster.error({
+          title: "Could not save comment",
+          description: getStudentFacingErrorMessage(error, {
+            releasedReviewGraderBlocked:
+              isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(reviewContext?.released)
+          })
+        });
+        throw error;
+      }
     },
-    [submissionController, submission, artifact, reviewContext, eventuallyVisible, submissionReviewId]
+    [
+      submissionController,
+      submission,
+      artifact,
+      reviewContext,
+      eventuallyVisible,
+      submissionReviewId,
+      isGraderOrInstructor,
+      isInstructor,
+      isTaOnly
+    ]
   );
 
   return (
@@ -531,6 +555,8 @@ function ArtifactCheckPopover({
     throw new Error("No grading review ID found");
   }
   const reviewContext = useSubmissionReviewOrGradingReview(submission.grading_review_id);
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const rubric = useRubricWithParts(reviewContext?.rubric_id);
   const rubricCriteria = useRubricCriteriaByRubric(rubric?.id);
   const rubricChecks = useRubricChecksByRubric(rubric?.id);
@@ -787,8 +813,18 @@ function ArtifactCheckPopover({
                       regrade_request_id: null,
                       target_student_profile_id: targetEff.targetId
                     };
-                    await submissionController.submission_artifact_comments.create(values);
-                    setIsOpen(false);
+                    try {
+                      await submissionController.submission_artifact_comments.create(values);
+                      setIsOpen(false);
+                    } catch (error: unknown) {
+                      toaster.error({
+                        title: "Could not save annotation",
+                        description: getStudentFacingErrorMessage(error, {
+                          releasedReviewGraderBlocked:
+                            isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(reviewContext?.released)
+                        })
+                      });
+                    }
                   }}
                 />
               </>

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
@@ -463,10 +463,14 @@ function ArtifactCommentsForm({
   defaultValue: string;
   submissionReviewId?: number;
 }) {
-  if (!submission.grading_review_id) {
+  const fallbackGradingReviewId = submission.grading_review_id;
+  if (!fallbackGradingReviewId) {
     throw new Error("No grading review ID found");
   }
-  const reviewContext = useSubmissionReviewOrGradingReview(submission.grading_review_id);
+  const effectiveSubmissionReviewId = submissionReviewId ?? fallbackGradingReviewId;
+  const reviewContext = useSubmissionReviewOrGradingReview(effectiveSubmissionReviewId);
+  const finalSubmissionReviewId = reviewContext?.id ?? effectiveSubmissionReviewId;
+  const releasedForWrite = finalSubmissionReviewId === reviewContext?.id ? Boolean(reviewContext?.released) : true;
   const isGraderOrInstructor = useIsGraderOrInstructor();
   const isInstructor = useIsInstructor();
   const isTaOnly = useIsGrader();
@@ -475,8 +479,6 @@ function ArtifactCommentsForm({
 
   const postComment = useCallback(
     async (message: string, author_id: string) => {
-      const finalSubmissionReviewId = submissionReviewId ?? reviewContext?.id;
-
       try {
         await submissionController.submission_artifact_comments.create({
           submission_id: submission.id,
@@ -484,8 +486,8 @@ function ArtifactCommentsForm({
           class_id: submission.class_id,
           author: author_id,
           comment: message,
-          submission_review_id: finalSubmissionReviewId ?? null,
-          released: reviewContext ? reviewContext.released : true,
+          submission_review_id: finalSubmissionReviewId,
+          released: releasedForWrite,
           eventually_visible: eventuallyVisible,
           rubric_check_id: null,
           points: null,
@@ -495,8 +497,7 @@ function ArtifactCommentsForm({
         toaster.error({
           title: "Could not save comment",
           description: getStudentFacingErrorMessage(error, {
-            releasedReviewGraderBlocked:
-              isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(reviewContext?.released)
+            releasedReviewGraderBlocked: isGraderOrInstructor && !isInstructor && isTaOnly && releasedForWrite
           })
         });
         throw error;
@@ -506,9 +507,9 @@ function ArtifactCommentsForm({
       submissionController,
       submission,
       artifact,
-      reviewContext,
+      releasedForWrite,
       eventuallyVisible,
-      submissionReviewId,
+      finalSubmissionReviewId,
       isGraderOrInstructor,
       isInstructor,
       isTaOnly
@@ -551,10 +552,14 @@ function ArtifactCheckPopover({
   submissionReviewId?: number;
 }) {
   const submission = useSubmission();
-  if (!submission.grading_review_id) {
+  const fallbackGradingReviewId = submission.grading_review_id;
+  if (!fallbackGradingReviewId) {
     throw new Error("No grading review ID found");
   }
-  const reviewContext = useSubmissionReviewOrGradingReview(submission.grading_review_id);
+  const effectiveSubmissionReviewId = submissionReviewId ?? fallbackGradingReviewId;
+  const reviewContext = useSubmissionReviewOrGradingReview(effectiveSubmissionReviewId);
+  const finalSubmissionReviewId = reviewContext?.id ?? effectiveSubmissionReviewId;
+  const releasedForWrite = finalSubmissionReviewId === reviewContext?.id ? Boolean(reviewContext?.released) : true;
   const isInstructor = useIsInstructor();
   const isTaOnly = useIsGrader();
   const rubric = useRubricWithParts(reviewContext?.rubric_id);
@@ -780,8 +785,6 @@ function ArtifactCheckPopover({
                       commentText = selectedSubOption.comment + (commentText ? "\n" + commentText : "");
                     }
 
-                    const finalSubmissionReviewId = submissionReviewId ?? reviewContext?.id;
-
                     if (!finalSubmissionReviewId && selectedCheckOption.check?.id) {
                       toaster.error({
                         title: "Error saving comment",
@@ -806,9 +809,9 @@ function ArtifactCheckPopover({
                       submission_id: submission.id,
                       submission_artifact_id: artifact.id,
                       author: profile_id,
-                      released: reviewContext ? reviewContext.released : true,
+                      released: releasedForWrite,
                       points: points ?? null,
-                      submission_review_id: finalSubmissionReviewId ?? null,
+                      submission_review_id: finalSubmissionReviewId,
                       eventually_visible: eventuallyVisible,
                       regrade_request_id: null,
                       target_student_profile_id: targetEff.targetId
@@ -821,7 +824,7 @@ function ArtifactCheckPopover({
                         title: "Could not save annotation",
                         description: getStudentFacingErrorMessage(error, {
                           releasedReviewGraderBlocked:
-                            isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(reviewContext?.released)
+                            isGraderOrInstructor && !isInstructor && isTaOnly && releasedForWrite
                         })
                       });
                     }

--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -9,7 +9,7 @@ import {
   useRubricParts,
   useRubricWithParts
 } from "@/hooks/useAssignment";
-import { useClassProfiles, useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
+import { useClassProfiles, useIsGrader, useIsGraderOrInstructor, useIsInstructor } from "@/hooks/useClassProfiles";
 import { useAssignmentGroupWithMembers } from "@/hooks/useCourseController";
 import {
   computeRubricAnnotationTargetMeta,
@@ -25,6 +25,7 @@ import {
 } from "@/hooks/useSubmission";
 import { useActiveReviewAssignmentId, useActiveSubmissionReview } from "@/hooks/useSubmissionReview";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import {
   Json,
   RubricCheck,
@@ -751,6 +752,8 @@ function LineActionPopup({ lineNumber, top, left, visible, close, file }: LineAc
   const [selectOpen, setSelectOpen] = useState(true);
   const { private_profile_id, public_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const graderPseudonymousMode = useGraderPseudonymousMode();
   // Use public profile (pseudonym) when grader pseudonymous mode is enabled and user is staff
   const authorProfileId = isGraderOrInstructor && graderPseudonymousMode ? public_profile_id : private_profile_id;
@@ -1188,7 +1191,10 @@ function LineActionPopup({ lineNumber, top, left, visible, close, file }: LineAc
                 } catch (e) {
                   toaster.error({
                     title: "Error saving annotation",
-                    description: e instanceof Error ? e.message : "Unknown error"
+                    description: getStudentFacingErrorMessage(e, {
+                      releasedReviewGraderBlocked:
+                        isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(review?.released)
+                    })
                   });
                 }
               }}

--- a/components/ui/line-comments-form.tsx
+++ b/components/ui/line-comments-form.tsx
@@ -1,11 +1,12 @@
 import { useGraderPseudonymousMode } from "@/hooks/useAssignment";
-import { useClassProfiles, useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
+import { useClassProfiles, useIsGrader, useIsGraderOrInstructor, useIsInstructor } from "@/hooks/useClassProfiles";
 import { useSubmissionController, useSubmissionReviewOrGradingReview } from "@/hooks/useSubmission";
 import {
   SubmissionFile,
   SubmissionFileComment,
   SubmissionWithGraderResultsAndFiles
 } from "@/utils/supabase/DatabaseTypes";
+import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import { Box, Skeleton } from "@chakra-ui/react";
 import { useCallback, useState } from "react";
 import { Checkbox } from "./checkbox";
@@ -39,6 +40,8 @@ export default function LineCommentForm({
   const submissionController = useSubmissionController();
   const { private_profile_id, public_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const graderPseudonymousMode = useGraderPseudonymousMode();
   // Use public profile (pseudonym) when grader pseudonymous mode is enabled and user is staff
   const authorProfileId = isGraderOrInstructor && graderPseudonymousMode ? public_profile_id : private_profile_id;
@@ -71,6 +74,7 @@ export default function LineCommentForm({
         submission_review_id: submissionReviewId,
         rubric_check_id: rubricCheckId ?? null,
         points: defaultPoints ?? null,
+        released: fetchedSubmissionReview?.released ?? true,
         eventually_visible: isGraderOrInstructor ? eventuallyVisible : true
       };
       try {
@@ -86,7 +90,13 @@ export default function LineCommentForm({
         if (onCancel) onCancel();
         toaster.success({ title: "Comment posted" });
       } catch (err) {
-        toaster.error({ title: "Error posting comment", description: (err as Error).message });
+        toaster.error({
+          title: "Error posting comment",
+          description: getStudentFacingErrorMessage(err, {
+            releasedReviewGraderBlocked:
+              isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(fetchedSubmissionReview?.released)
+          })
+        });
       } finally {
         setIsLoading(false);
       }
@@ -104,6 +114,8 @@ export default function LineCommentForm({
       rubricCheckId,
       defaultPoints,
       isGraderOrInstructor,
+      isInstructor,
+      isTaOnly,
       onSubmitted,
       onCancel
     ]

--- a/components/ui/markdown-file-preview.tsx
+++ b/components/ui/markdown-file-preview.tsx
@@ -8,7 +8,7 @@ import {
   useRubricParts,
   useRubricWithParts
 } from "@/hooks/useAssignment";
-import { useClassProfiles, useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
+import { useClassProfiles, useIsGrader, useIsGraderOrInstructor, useIsInstructor } from "@/hooks/useClassProfiles";
 import { useAssignmentGroupWithMembers } from "@/hooks/useCourseController";
 import {
   computeRubricAnnotationTargetMeta,
@@ -22,6 +22,7 @@ import { RubricCheck, RubricCriteria, SubmissionFile, SubmissionFileComment } fr
 import type { SubmissionWithGraderResultsAndFiles } from "@/utils/supabase/DatabaseTypes";
 import { createClient } from "@/utils/supabase/client";
 import rehypeSourcePositions from "@/lib/rehype-source-positions";
+import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import {
   Box,
   Badge,
@@ -312,6 +313,8 @@ function MarkdownLineActionPopup({
   const [selectOpen, setSelectOpen] = useState(true);
   const { private_profile_id, public_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const graderPseudonymousMode = useGraderPseudonymousMode();
   const authorProfileId = isGraderOrInstructor && graderPseudonymousMode ? public_profile_id : private_profile_id;
 
@@ -631,7 +634,10 @@ function MarkdownLineActionPopup({
                 } catch (e) {
                   toaster.error({
                     title: "Error saving annotation",
-                    description: e instanceof Error ? e.message : "Unknown error"
+                    description: getStudentFacingErrorMessage(e, {
+                      releasedReviewGraderBlocked:
+                        isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(review?.released)
+                    })
                   });
                 }
               }}

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -1004,6 +1004,7 @@ export function RubricCheckGlobal({
     ? submission?.submission_files.find((file) => file.name === check.file)?.id
     : undefined;
   const activeAssignmentReview = useActiveReviewAssignment();
+  const taMarksLockedByRelease = isTaOnly && !isInstructor && Boolean(reviewForThisRubric?.released);
 
   // Check if this check should be visible to the current user
   const shouldShowCheck = useShouldShowRubricCheck({
@@ -1033,6 +1034,15 @@ export function RubricCheckGlobal({
     checkboxIsChecked
   ]);
 
+  useEffect(() => {
+    if (taMarksLockedByRelease) {
+      setIsEditing(false);
+      if (rubricCheckComments.length === 0) {
+        setCheckboxIsChecked(false);
+      }
+    }
+  }, [taMarksLockedByRelease, rubricCheckComments.length]);
+
   if (!shouldShowCheck) {
     return null;
   }
@@ -1040,7 +1050,6 @@ export function RubricCheckGlobal({
   const points = check.points === 0 ? "" : criteria.is_additive ? `+${check.points}` : `-${check.points}`;
   const format = criteria.max_checks_per_submission != 1 ? "checkbox" : "radio";
   const gradingIsRequired = reviewForThisRubric && check.is_required && rubricCheckComments.length == 0;
-  const taMarksLockedByRelease = isTaOnly && !isInstructor && Boolean(reviewForThisRubric?.released);
   const gradingIsPermitted =
     (isGrader ||
       (activeAssignmentReview &&
@@ -1153,7 +1162,9 @@ export function RubricCheckGlobal({
                     aria-label={`${check.name} (${points})`}
                     onCheckedChange={(newState) => {
                       if (newState.checked) {
-                        setIsEditing(true);
+                        if (gradingIsPermitted && !taMarksLockedByRelease) {
+                          setIsEditing(true);
+                        }
                       } else {
                         setIsEditing(false);
                       }
@@ -1206,7 +1217,10 @@ export function RubricCheckGlobal({
                 borderRadius="md"
               >
                 <HStack justify="space-between" w="100%">
-                  <Radio value={check.id.toString()} disabled={rubricCheckComments.length > 0 || !reviewForThisRubric}>
+                  <Radio
+                    value={check.id.toString()}
+                    disabled={rubricCheckComments.length > 0 || !reviewForThisRubric || !gradingIsPermitted}
+                  >
                     <Field.Label>
                       <Text>
                         {points} {check.name}
@@ -1257,7 +1271,7 @@ export function RubricCheckGlobal({
           </HStack>
         </Link>
       )}
-      {isEditing && (
+      {isEditing && gradingIsPermitted && !taMarksLockedByRelease && (
         <SubmissionCommentForm
           check={check}
           criteriaRubricId={criteria.rubric_id}

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -34,6 +34,7 @@ import {
 import { linkToSubPage } from "@/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/utils";
 import { TimeZoneAwareDate } from "@/components/TimeZoneAwareDate";
 import { createClient } from "@/utils/supabase/client";
+import { Alert } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import Link from "@/components/ui/link";
@@ -56,7 +57,13 @@ import {
   useRubricParts,
   useRubrics
 } from "@/hooks/useAssignment";
-import { useClassProfiles, useIsGraderOrInstructor, useIsInstructor, useIsStudent } from "@/hooks/useClassProfiles";
+import {
+  useClassProfiles,
+  useIsGrader,
+  useIsGraderOrInstructor,
+  useIsInstructor,
+  useIsStudent
+} from "@/hooks/useClassProfiles";
 import { useAssignmentGroupWithMembers, useCourseController } from "@/hooks/useCourseController";
 import { useShouldShowRubricCheck } from "@/hooks/useRubricVisibility";
 import {
@@ -71,7 +78,10 @@ import {
 } from "@/hooks/useSubmission";
 import { useActiveReviewAssignment, useActiveReviewAssignmentId, useActiveRubricId } from "@/hooks/useSubmissionReview";
 import { useUserProfile } from "@/hooks/useUserProfiles";
-import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
+import {
+  getStudentFacingErrorMessage,
+  GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE
+} from "@/lib/studentFacingErrorMessages";
 import { useIsTableControllerReady } from "@/lib/TableController";
 import { Icon } from "@chakra-ui/react";
 import { Select as ChakraReactSelect, OptionBase } from "chakra-react-select";
@@ -491,7 +501,9 @@ export function RubricCheckComment({
   const boxRef = useRef<HTMLDivElement>(null);
 
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
   const pathname = usePathname();
+  const submissionReviewForComment = useSubmissionReviewOrGradingReview(comment?.submission_review_id ?? undefined);
 
   // Auto-scroll to this regrade request if the URL hash matches
   useEffect(() => {
@@ -528,13 +540,24 @@ export function RubricCheckComment({
         throw new Error(
           getStudentFacingErrorMessage(error, {
             isStudent,
-            rubricReviewRound: rubricForCriteria?.review_round ?? null
+            rubricReviewRound: rubricForCriteria?.review_round ?? null,
+            releasedReviewGraderBlocked:
+              isGraderOrInstructor && !isInstructor && Boolean(submissionReviewForComment?.released)
           })
         );
       }
       setIsEditing(false);
     },
-    [comment_id, comment_type, submissionController, isStudent, rubricForCriteria?.review_round]
+    [
+      comment_id,
+      comment_type,
+      submissionController,
+      isStudent,
+      rubricForCriteria?.review_round,
+      isGraderOrInstructor,
+      isInstructor,
+      submissionReviewForComment?.released
+    ]
   );
 
   const linkedFileId =
@@ -970,6 +993,8 @@ export function RubricCheckGlobal({
 
   const submission = useSubmissionMaybe();
   const isGrader = useIsGraderOrInstructor();
+  const isTaOnly = useIsGrader();
+  const isInstructor = useIsInstructor();
   const pathname = usePathname();
   const isPreviewMode = !submission;
   const linkedAritfactId = check.artifact
@@ -1015,11 +1040,13 @@ export function RubricCheckGlobal({
   const points = check.points === 0 ? "" : criteria.is_additive ? `+${check.points}` : `-${check.points}`;
   const format = criteria.max_checks_per_submission != 1 ? "checkbox" : "radio";
   const gradingIsRequired = reviewForThisRubric && check.is_required && rubricCheckComments.length == 0;
+  const taMarksLockedByRelease = isTaOnly && !isInstructor && Boolean(reviewForThisRubric?.released);
   const gradingIsPermitted =
     (isGrader ||
       (activeAssignmentReview &&
         reviewForThisRubric &&
         activeAssignmentReview.submission_review_id === reviewForThisRubric.id)) &&
+    !taMarksLockedByRelease &&
     reviewForThisRubric &&
     (criteria.max_checks_per_submission === null ||
       criteriaCheckComments.length < (criteria.max_checks_per_submission || 1000));
@@ -1299,6 +1326,8 @@ function SubmissionCommentForm({
   const isStudent = useIsStudent();
   const { private_profile_id, public_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const isInstructor = useIsInstructor();
+  const isTaOnly = useIsGrader();
   const graderPseudonymousMode = useGraderPseudonymousMode();
   // Use public profile (pseudonym) when grader pseudonymous mode is enabled and user is staff
   const authorProfileId = isGraderOrInstructor && graderPseudonymousMode ? public_profile_id : private_profile_id;
@@ -1369,7 +1398,9 @@ function SubmissionCommentForm({
             throw new Error(
               getStudentFacingErrorMessage(error, {
                 isStudent,
-                rubricReviewRound: rubricForCriteria?.review_round ?? null
+                rubricReviewRound: rubricForCriteria?.review_round ?? null,
+                releasedReviewGraderBlocked:
+                  isGraderOrInstructor && !isInstructor && isTaOnly && Boolean(submissionReview?.released)
               })
             );
           }
@@ -1457,6 +1488,8 @@ export function RubricCriteria({
     }
   }
   const isGrader = useIsGraderOrInstructor();
+  const isTaOnly = useIsGrader();
+  const isInstructor = useIsInstructor();
   const gradingIsRequired =
     isGrader && reviewForThisRubric && comments.length < (criteria.min_checks_per_submission || 0);
   let instructions = "";
@@ -1505,6 +1538,11 @@ export function RubricCriteria({
             {criteria.description}
           </Markdown>
         </Fieldset.HelperText>
+        {isTaOnly && !isInstructor && reviewForThisRubric?.released && (
+          <Alert status="warning" variant="subtle" borderRadius="md" mb={2} title="Grading is locked">
+            {GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE}
+          </Alert>
+        )}
         <Fieldset.Content>
           <VStack align="flex-start" w="100%" gap={0}>
             <Heading size="sm">Checks</Heading>
@@ -1804,7 +1842,7 @@ function AssignToStudentPart({
         });
       }
     },
-    [review?.id, part.id]
+    [review, part.id]
   );
 
   if (!isGrader) {

--- a/lib/studentFacingErrorMessages.ts
+++ b/lib/studentFacingErrorMessages.ts
@@ -2,7 +2,15 @@ export type StudentFacingErrorContext = {
   isStudent?: boolean;
   /** When set with `isStudent`, refines Postgres permission errors during self-review */
   rubricReviewRound?: string | null;
+  /**
+   * When true with Postgres 42501, maps to copy for TAs blocked because hand-grading feedback
+   * was already released on the submission review (RLS issue #446).
+   */
+  releasedReviewGraderBlocked?: boolean;
 };
+
+export const GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE =
+  "This grading feedback has already been released to students, so you cannot add or change marks. Ask your instructor to click Unrelease on this submission review if a change is needed; after edits, they can release again.";
 
 const SELF_REVIEW_PAST_DUE_MESSAGE =
   "The self-review due date has passed, so you can no longer add or change checks. If you need more time, ask your instructor.";
@@ -20,6 +28,10 @@ export function getStudentFacingErrorMessage(error: unknown, context?: StudentFa
   }
 
   const code = getErrorCode(error);
+
+  if (code === "42501" && context?.releasedReviewGraderBlocked) {
+    return GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE;
+  }
 
   if (code === "42501" && context?.isStudent && context.rubricReviewRound === "self-review") {
     return SELF_REVIEW_PAST_DUE_MESSAGE;

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -48,6 +48,8 @@ let assignment: (Assignment & { rubricParts: RubricPart[]; rubricChecks: RubricC
 let grader: TestingUser | undefined;
 let student2: TestingUser | undefined;
 let submission_id2: number | undefined;
+/** Grading review row for submission_id2 — used to unreleased after "Release All" from an earlier serial test */
+let submission2_grading_review_id: number | undefined;
 test.beforeAll(async () => {
   course = await createClass();
   [student, instructor, grader, student2] = await createUsersInClass([
@@ -99,6 +101,7 @@ test.beforeAll(async () => {
     class_id: course.id
   });
   submission_id2 = submission_res2.submission_id;
+  submission2_grading_review_id = submission_res2.grading_review_id!;
   // Assign grader to the first rubric part
   const private_profile_id = grader!.private_profile_id;
   const review_assignment_res = await supabase
@@ -430,6 +433,16 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await expect(page.getByLabel("Grading checks on line 4").getByRole("heading")).toContainText("Regrade Closed");
   });
   test("Graders assigned to a rubric part see just that rubric part to grade", async ({ page }) => {
+    // Earlier test releases all submission reviews on this assignment; second submission gets released too,
+    // which blocks TA grading. Unrelease only this review so the grader can apply marks for E2E.
+    const { error } = await supabase
+      .from("submission_reviews")
+      .update({ released: false })
+      .eq("id", submission2_grading_review_id!);
+    if (error) {
+      throw new Error(`Failed to unrelease grading review for submission 2 (grader test): ${error.message}`);
+    }
+
     await loginAsUser(page, grader!, course);
     await expect(page.getByRole("heading", { name: /Upcoming Assignments|Assignment Grading Overview/ })).toBeVisible();
     await page.goto(`/course/${course.id}/assignments/${assignment!.id}/submissions/${submission_id2}/files`);

--- a/tests/unit/student-facing-error-messages.test.ts
+++ b/tests/unit/student-facing-error-messages.test.ts
@@ -1,4 +1,7 @@
-import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
+import {
+  getStudentFacingErrorMessage,
+  GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE
+} from "@/lib/studentFacingErrorMessages";
 
 describe("getStudentFacingErrorMessage", () => {
   it("maps common PostgREST codes to plain language", () => {
@@ -13,6 +16,15 @@ describe("getStudentFacingErrorMessage", () => {
         { isStudent: true, rubricReviewRound: "self-review" }
       )
     ).toContain("self-review due date has passed");
+  });
+
+  it("maps 42501 for graders when released-review context is set", () => {
+    expect(
+      getStudentFacingErrorMessage(
+        { code: "42501", message: "permission denied" },
+        { releasedReviewGraderBlocked: true }
+      )
+    ).toBe(GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE);
   });
 
   it("falls back to message when no code mapping applies", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a submission review is already released to students, TAs cannot add or change marks (RLS / issue #446). This change makes that situation obvious instead of surfacing a generic permission error.

## What changed

- **Shared message** in `getStudentFacingErrorMessage`: when Postgres `42501` is returned and the caller indicates a grader blocked by a released review, we show copy that explains the restriction and tells the TA to ask the instructor to use **Unrelease**, edit, then release again.
- **Rubric sidebar**: for graders who are not instructors, if the active review is released, we show a **warning** at the criteria level and treat marks as read-only (checkboxes/radios disabled, no new mark form) so TAs see the reason before attempting a save. **Follow-up:** radio-only and checkbox paths no longer bypass the release lock; editing state clears when a review becomes released.
- **Line comments, code/markdown annotations, artifact comments**: map permission errors with the same released-review context; **line comment create** now sets `released` from the loaded review (was missing and could behave incorrectly).
- **Artifact comments (PR feedback):** `submissionReviewId` and the loaded review row are aligned—`released` on create and `releasedReviewGraderBlocked` both derive from the same effective submission review id.

## Tests

- `npm test -- tests/unit/student-facing-error-messages.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d8cd87f-dbd0-4389-a72c-89e57621b744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d8cd87f-dbd0-4389-a72c-89e57621b744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warning alert for TAs when grading feedback has been released, locking edits and comments.

* **Bug Fixes**
  * Clearer student-facing error text for release-locked grading.
  * Improved error handling for comment/annotation saves (toasts shown on failure, prevents silent UI closure).
  * Ensures release state is respected when posting comments/annotations.

* **Tests**
  * Added unit test for the released-feedback error message; updated e2e grading setup to control review release state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->