### PR TITLE
Add axe-core accessibility scans to student E2E workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
       },
       "devDependencies": {
         "@argos-ci/playwright": "^6.0.4",
+        "@axe-core/playwright": "^4.11.2",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.26.0",
         "@faker-js/faker": "^9.9.0",
@@ -1141,6 +1142,19 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15631,9 +15645,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
-      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -29299,6 +29313,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
   },
   "devDependencies": {
     "@argos-ci/playwright": "^6.0.4",
+    "@axe-core/playwright": "^4.11.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.26.0",
     "@faker-js/faker": "^9.9.0",

--- a/tests/e2e/axeStudentA11y.ts
+++ b/tests/e2e/axeStudentA11y.ts
@@ -1,0 +1,31 @@
+import { AxeBuilder } from "@axe-core/playwright";
+import { expect, Page } from "@playwright/test";
+import type { Page as PlaywrightCorePage } from "playwright-core";
+
+const DEFAULT_EXCLUDES = [
+  // Third-party / rich editors often fail strict axe rules without affecting core app UX in E2E.
+  ".monaco-editor",
+  ".monaco-mouse-cursor-text",
+  "[data-surveyjs]",
+  ".sv-root",
+  ".sv_main"
+];
+
+/**
+ * Runs axe-core against the current page and fails the test if any violations are found.
+ * Use after navigations and key UI settles (e.g. after expect().toBeVisible() on main content).
+ */
+export async function assertStudentPageAccessible(page: Page, contextLabel?: string): Promise<void> {
+  // @axe-core/playwright types against playwright-core's Page; cast for compatibility with test fixtures.
+  let builder = new AxeBuilder({ page: page as unknown as PlaywrightCorePage });
+  for (const sel of DEFAULT_EXCLUDES) {
+    builder = builder.exclude(sel);
+  }
+  const results = await builder.analyze();
+  const violations = results.violations ?? [];
+  if (violations.length === 0) return;
+
+  const summary = violations.map((v) => `${v.id} (${v.impact}): ${v.help} — ${v.nodes.length} node(s)`).join("\n");
+  const prefix = contextLabel ? `[${contextLabel}] ` : "";
+  expect(violations, `${prefix}Accessibility violations:\n${summary}`).toEqual([]);
+}

--- a/tests/e2e/create-submission.test.tsx
+++ b/tests/e2e/create-submission.test.tsx
@@ -13,6 +13,7 @@ import {
   submitFeedbackViaAPI,
   createSampleGradingResult
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 import { argosScreenshot } from "@argos-ci/playwright";
 
 let course: Course;
@@ -137,6 +138,7 @@ test.describe("Create submission", () => {
     await page.goto(submissionPage);
     await page.getByRole("button", { name: "Files" }).click();
     await expect(page.getByText("package com.pawtograder.example.java")).toBeVisible();
+    await assertStudentPageAccessible(page, "create submission - future deadline files");
   });
   test("If the deadline has passed, the student cannot create a submission", async () => {
     const submission = insertSubmissionViaAPI({
@@ -159,6 +161,7 @@ test.describe("Create submission", () => {
     await page.goto(submissionPage);
     await page.getByRole("button", { name: "Files" }).click();
     await expect(page.getByText("package com.pawtograder.example.java")).toBeVisible();
+    await assertStudentPageAccessible(page, "create submission - extended due date files");
   });
 
   test("Student can create NOT-GRADED submission after deadline when assignment allows it", async ({ page }) => {
@@ -176,6 +179,7 @@ test.describe("Create submission", () => {
     await page.goto(submissionPage);
     await page.getByRole("button", { name: "Files" }).click();
     await expect(page.getByText("package com.pawtograder.example.java")).toBeVisible();
+    await assertStudentPageAccessible(page, "create submission - not graded files");
   });
 
   test("NOT-GRADED submission does not become active", async ({ page }) => {
@@ -210,6 +214,7 @@ test.describe("Create submission", () => {
     await argosScreenshot(page, "Showing active and not-graded submissions");
     await page.getByRole("link", { name: "Not for grading" }).click();
     await expect(page.getByText("Viewing a not-for-grading submission")).toBeVisible();
+    await assertStudentPageAccessible(page, "create submission - not graded detail");
   });
 
   test("Empty submission is accepted when permitted, and flagged", async () => {

--- a/tests/e2e/discussion-threads.test.tsx
+++ b/tests/e2e/discussion-threads.test.tsx
@@ -3,6 +3,7 @@ import { test, expect } from "../global-setup";
 import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, loginAsUser, TestingUser } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 dotenv.config({ path: ".env.local" });
 
 let course: Course;
@@ -54,6 +55,7 @@ test.describe("Discussion Thread Page", () => {
       page.getByText("Your feed is empty. Follow a topic (Browse Topics) or follow a post to see it here.")
     ).toBeVisible();
     await argosScreenshot(page, "Discussion Thread Page");
+    await assertStudentPageAccessible(page, "discussion feed empty");
   });
   test("A student can view the create new thread form and create a new private thread", async ({ page }) => {
     await loginAsUser(page, student1!, course);
@@ -115,6 +117,7 @@ test.describe("Discussion Thread Page", () => {
     await expect(page.getByText("Viewable by poster and staff only")).toBeVisible();
     await expect(page.getByRole("button").filter({ hasText: "Unfollow" })).toBeVisible();
     await expect(page.getByRole("heading", { name: student1?.private_profile_name })).toBeVisible();
+    await assertStudentPageAccessible(page, "discussion private thread created");
   });
 
   test("Another student cannot view a private thread", async ({ page }) => {
@@ -126,6 +129,7 @@ test.describe("Discussion Thread Page", () => {
     await expect(page.getByText("Viewable by poster and staff only")).not.toBeVisible();
     await expect(page.getByRole("button").filter({ hasText: "Unfollow" })).not.toBeVisible();
     await expect(page.getByRole("heading", { name: student1?.private_profile_name })).not.toBeVisible();
+    await assertStudentPageAccessible(page, "discussion private thread hidden");
   });
 
   test("Another student creates a public thread", async ({ page }) => {
@@ -152,6 +156,7 @@ test.describe("Discussion Thread Page", () => {
     await expect(page.getByRole("heading", { name: "JAVA SUCKS" })).toBeVisible();
     await expect(page.getByRole("button").filter({ hasText: "Unfollow" })).toBeVisible();
     await expect(page.getByRole("heading", { name: student2?.public_profile_name })).toBeVisible();
+    await assertStudentPageAccessible(page, "discussion public thread");
   });
 
   test("An instructor can view all threads and reply to them", async ({ page }) => {

--- a/tests/e2e/due-dates.test.tsx
+++ b/tests/e2e/due-dates.test.tsx
@@ -12,6 +12,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 let course: Course;
 let student: TestingUser | undefined;
@@ -214,6 +215,7 @@ test.describe("Assignment due dates", () => {
     await expect(
       groupRow.getByText(formatDateForTest(new TZDate(testGroupAssignment!.due_date, "America/New_York")))
     ).toBeVisible();
+    await assertStudentPageAccessible(page, "due dates assignments table");
   });
   test("When students extend their due date, the due date is updated on the assignments page", async ({ page }) => {
     //Test with the lab section assignment
@@ -265,6 +267,7 @@ test.describe("Assignment due dates", () => {
     await expect(
       page.getByText(formatDateForTest(addHours(new TZDate(groupAssignmentDueDate, "America/New_York"), 24)))
     ).toBeVisible();
+    await assertStudentPageAccessible(page, "due dates after token extensions");
   });
 });
 

--- a/tests/e2e/gifted-tokens.test.tsx
+++ b/tests/e2e/gifted-tokens.test.tsx
@@ -11,6 +11,7 @@ import {
   TestingUser,
   supabase
 } from "@/tests/e2e/TestingUtils";
+import { assertStudentPageAccessible } from "@/tests/e2e/axeStudentA11y";
 
 let course: Course;
 let student: TestingUser | undefined;
@@ -127,5 +128,6 @@ test.describe("Gifted tokens bug (#648)", () => {
 
     const expectedDueDate = addHours(new TZDate(lastAssignment.due_date, "America/New_York"), 24);
     await expect(page.getByText(getDueDateString(expectedDueDate))).toBeVisible();
+    await assertStudentPageAccessible(page, "gifted tokens after extend due date");
   });
 });

--- a/tests/e2e/gradebook-calculations.test.tsx
+++ b/tests/e2e/gradebook-calculations.test.tsx
@@ -22,6 +22,7 @@ import { test, expect } from "../global-setup";
 import { createClient } from "@supabase/supabase-js";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, loginAsUser, TestingUser, supabase } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -728,6 +729,7 @@ test.describe("Fixture 1: Weighted Average Course", () => {
     const finalCard = page.getByRole("article", { name: "Grade for Final Grade" });
     await expect(finalCard).toBeVisible({ timeout: 10_000 });
     await expect(finalCard).toContainText(/84(\.0+)?/);
+    await assertStudentPageAccessible(page, "gradebook calculations student released grades");
   });
 });
 
@@ -2002,5 +2004,6 @@ test.describe("Fixture 5: Score Override Precedence", () => {
     const bonusCard = page.getByRole("article", { name: "Grade for Final with Bonus" });
     await expect(bonusCard).toBeVisible({ timeout: 30_000 });
     await expect(bonusCard).toContainText(/82(\.0+)?/);
+    await assertStudentPageAccessible(page, "gradebook calculations student overrides UI");
   });
 });

--- a/tests/e2e/gradebook-whatif.test.tsx
+++ b/tests/e2e/gradebook-whatif.test.tsx
@@ -11,6 +11,7 @@ import {
   setCourseFeature,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -42,6 +43,7 @@ async function gotoStudentGradebook(page: Page) {
     throw lastError;
   }
   await expect(page.getByRole("region", { name: "Student Gradebook" })).toBeVisible();
+  await assertStudentPageAccessible(page, "student gradebook what-if");
 }
 
 test.setTimeout(180_000);

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -16,6 +16,7 @@ import {
   supabase,
   createAuthenticatedClient
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 // removed unused import
 
 dotenv.config({ path: ".env.local" });
@@ -1203,6 +1204,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
     await expect(page.getByRole("article", { name: "Grade for Participation" })).toBeVisible();
     // Validate that the final grade shown is correctly calcualted
     await expect(page.getByText(`Final Grade90.8`)).toBeVisible({ timeout: 70_000 });
+    await assertStudentPageAccessible(page, "student gradebook released participation");
 
     // Now unrelease the column and verify it's hidden from student
     await loginAsUser(page, instructor!, course);
@@ -1254,6 +1256,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
     const unreleasedCard = page.getByRole("article", { name: "Grade for Participation" });
     await expect(unreleasedCard).toBeVisible();
     await expect(unreleasedCard).toContainText(/In Progress/i);
+    await assertStudentPageAccessible(page, "student gradebook unreleased participation");
   });
 });
 

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -13,6 +13,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -209,6 +210,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("button", { name: "Mark Review Assignment as Complete" }).click();
     await expect(page.getByText("Self-Review Rubric completed")).toBeVisible();
     await argosScreenshot(page, "Self-Review Rubric completed");
+    await assertStudentPageAccessible(page, "grading self-review completed");
   });
 
   test("Instructors can view the student's self-review and create their own grading review", async ({ page }) => {
@@ -311,6 +313,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     });
     await page.waitForTimeout(100); // Ensure scroll completes before screenshot
     await argosScreenshot(page, "Student can view their grading results");
+    await assertStudentPageAccessible(page, "grading results submission files");
 
     await expect(rubricSidebar).toContainText(`${instructor!.private_profile_name} applied today`);
     // Find the region with aria-label 'Grading checks on line 4'
@@ -398,6 +401,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Escalate to Instructor" }).click();
     await argosScreenshot(page, "Students can appeal their regrade request");
     await page.getByRole("button", { name: "Escalate Request" }).click();
+    await assertStudentPageAccessible(page, "grading regrade appeal escalated");
   });
   test("Instructors can view the student's regrade appeal and resolve it", async ({ page }) => {
     const region = await page.getByRole("region", { name: "Grading checks on line 4" });

--- a/tests/e2e/leaderboard.test.tsx
+++ b/tests/e2e/leaderboard.test.tsx
@@ -11,6 +11,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -126,6 +127,7 @@ test.describe("Assignment Leaderboard", () => {
     // Verify the leaderboard contains the heading and student entries
     await expect(page.getByText("Top")).toBeVisible();
     await expect(page.getByText("by autograder score")).toBeVisible();
+    await assertStudentPageAccessible(page, "leaderboard assignment page");
   });
 
   test("Student sees their own pseudonym name with 'You' badge on leaderboard", async ({ page }) => {
@@ -144,6 +146,7 @@ test.describe("Assignment Leaderboard", () => {
 
     // The first place should show gold medal emoji
     await expect(page.getByText("🥇")).toBeVisible();
+    await assertStudentPageAccessible(page, "leaderboard you badge");
   });
 
   test("Instructor sees real names in parentheses on leaderboard", async ({ page }) => {
@@ -185,6 +188,7 @@ test.describe("Assignment Leaderboard", () => {
     // Student2 is logged in, so they should not see Student1 or Student3's real names
     await expect(leaderboardArea).not.toContainText("(Leaderboard Student 1)");
     await expect(leaderboardArea).not.toContainText("(Leaderboard Student 3)");
+    await assertStudentPageAccessible(page, "leaderboard pseudonyms only");
   });
 
   test("Leaderboard shows correct score ordering", async ({ page }) => {
@@ -217,6 +221,7 @@ test.describe("Assignment Leaderboard", () => {
     const thirdRow = tableRows.nth(2);
     await expect(thirdRow.getByText("🥉")).toBeVisible();
     await expect(thirdRow.getByText("70/100")).toBeVisible();
+    await assertStudentPageAccessible(page, "leaderboard score ordering");
   });
 
   test("Leaderboard updates when new submission is created", async ({ page }) => {
@@ -252,5 +257,6 @@ test.describe("Assignment Leaderboard", () => {
     await expect(firstRow.getByText("🥇")).toBeVisible();
     await expect(firstRow.getByText("You")).toBeVisible();
     await expect(firstRow.getByText("99/100")).toBeVisible();
+    await assertStudentPageAccessible(page, "leaderboard after score update");
   });
 });

--- a/tests/e2e/manual-grading-scores.test.tsx
+++ b/tests/e2e/manual-grading-scores.test.tsx
@@ -13,6 +13,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -270,6 +271,7 @@ test.describe("Manual grading score calculation", () => {
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
       await argosScreenshot(page, "Individual grading - student view with score");
+      await assertStudentPageAccessible(page, "manual grading individual student score");
     });
   });
 
@@ -350,6 +352,7 @@ test.describe("Manual grading score calculation", () => {
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
       await argosScreenshot(page, "Group grading shared - student view with score");
+      await assertStudentPageAccessible(page, "manual grading group shared student score");
     });
   });
 
@@ -550,6 +553,7 @@ test.describe("Manual grading score calculation", () => {
       await expect(page.getByRole("heading", { name: /Overall Score/ })).not.toBeVisible();
       await expect(page.getByText("(You)")).toBeVisible();
       await argosScreenshot(page, "Group individual grading - student view with individual score");
+      await assertStudentPageAccessible(page, "manual grading group individual student score");
     });
 
     test("instructor sees all individual scores", async ({ page }) => {

--- a/tests/e2e/office-hours.test.tsx
+++ b/tests/e2e/office-hours.test.tsx
@@ -12,6 +12,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 dotenv.config({ path: ".env.local" });
 
 let course: Course;
@@ -136,6 +137,7 @@ test.describe("Office Hours", () => {
     await page.getByRole("textbox", { name: "Type your message" }).click();
     await page.getByRole("textbox", { name: "Type your message" }).fill(HELP_REQUEST_FOLLOW_UP_MESSAGE_1);
     await page.getByRole("button", { name: "Send" }).click();
+    await assertStudentPageAccessible(page, "office hours student queue");
   });
   test("Another student can view the public request and comment on it, but cant see the private", async ({ page }) => {
     await loginAsUser(page, student2!, course);
@@ -151,6 +153,7 @@ test.describe("Office Hours", () => {
     await page.getByRole("textbox", { name: "Type your message" }).click();
     await page.getByRole("textbox", { name: "Type your message" }).fill(HELP_REQUEST_OTHER_STUDENT_MESSAGE_1);
     await page.getByRole("button", { name: "Send" }).click();
+    await assertStudentPageAccessible(page, "office hours second student chat");
   });
   test("Instructor can view all, comment, and start a video call", async ({ page }) => {
     await loginAsUser(page, instructor!, course);

--- a/tests/e2e/polls.test.tsx
+++ b/tests/e2e/polls.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "../global-setup";
 import { createClass, createUsersInClass, loginAsUser, supabase } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 type Course = Awaited<ReturnType<typeof createClass>>;
 type User = Awaited<ReturnType<typeof createUsersInClass>>[number];
@@ -95,6 +96,7 @@ test.describe("Polls", () => {
 
     await expect(page.getByRole("heading", { name: "No Live Polls Available" })).toBeVisible();
     await expect(page.getByText("There are currently no live polls available for this course.")).toBeVisible();
+    await assertStudentPageAccessible(page, "polls empty state");
   });
 
   // TODO: Possible vulnerability to flakiness, check issue and reduce the time limit for the check
@@ -140,6 +142,7 @@ test.describe("Polls", () => {
       .toBe(true);
 
     await expect(emptyHeading).toBeHidden();
+    await assertStudentPageAccessible(page, "polls realtime live row");
   });
 
   test("student sees active poll with answer action", async ({ page }) => {
@@ -155,6 +158,7 @@ test.describe("Polls", () => {
     const pollRow = page.getByRole("row", { name: /active poll/i });
     await expect(pollRow).toBeVisible();
     await expect(pollRow.getByRole("button", { name: /answer poll/i })).toBeVisible();
+    await assertStudentPageAccessible(page, "polls active poll row");
   });
 
   test("instructor sees empty manage polls state", async ({ page }) => {
@@ -234,6 +238,7 @@ test.describe("Polls", () => {
 
     await expect(page.getByRole("heading", { name: "No Live Polls Available" })).toBeVisible();
     await expect(page.getByText("Hidden Closed Poll")).not.toBeVisible();
+    await assertStudentPageAccessible(page, "polls closed hidden");
   });
 
   test("student only sees the most recent live poll", async ({ page }) => {
@@ -261,6 +266,7 @@ test.describe("Polls", () => {
     await expect(page.getByText("Newer Live Poll")).toBeVisible();
     await expect(page.getByText("Older Live Poll")).not.toBeVisible();
     await expect(page.getByRole("row", { name: /Newer Live Poll/i })).toHaveCount(1);
+    await assertStudentPageAccessible(page, "polls most recent live");
   });
 
   test("instructor sees poll actions menu items", async ({ page }) => {
@@ -374,6 +380,7 @@ test.describe("Polls", () => {
     const [pollPage] = await Promise.all([page.waitForEvent("popup"), answerButton.click()]);
     await pollPage.waitForLoadState("domcontentloaded");
     await expect(pollPage).toHaveURL(new RegExp(`/poll/${course.id}`));
+    await assertStudentPageAccessible(pollPage, "poll answer popup");
   });
 
   test("student submits a require-login poll and response is stored", async ({ page }) => {
@@ -396,6 +403,7 @@ test.describe("Polls", () => {
     await page.getByRole("button", { name: /Complete|Submit/i }).click();
 
     await expect(page.getByRole("heading", { name: /Thank You!/i })).toBeVisible();
+    await assertStudentPageAccessible(page, "poll submit thank you");
 
     await expect
       .poll(

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -12,6 +12,7 @@ import {
   loginAsUser,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -145,6 +146,7 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await page.getByRole("button", { name: "Complete Review" }).click();
     await page.getByRole("button", { name: "Mark Review Assignment as Complete" }).click();
     await expect(page.getByText("Self-Review Rubric completed")).toBeVisible();
+    await assertStudentPageAccessible(page, "pseudonymous self-review completed");
   });
 
   test("Instructors can grade the submission with pseudonymous mode enabled", async ({ page }) => {
@@ -257,6 +259,7 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     });
     await page.waitForTimeout(100);
     await argosScreenshot(page, "Pseudonymous grading - Student sees only pseudonym");
+    await assertStudentPageAccessible(page, "pseudonymous student grading view");
   });
 
   test("Student can request a regrade and sees grader's pseudonym in responses", async ({ page }) => {
@@ -279,6 +282,7 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(region.getByText(REGRADE_REQUEST_COMMENT).first()).toBeVisible();
     await expect(region.getByText("Submitting your comment...")).not.toBeVisible();
     await argosScreenshot(page, "Pseudonymous grading - Student opens regrade request");
+    await assertStudentPageAccessible(page, "pseudonymous regrade request opened");
   });
 
   test("Instructor resolves regrade with pseudonymous profile and adds comment", async ({ page }) => {
@@ -394,5 +398,6 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(region.getByText(INSTRUCTOR_FINAL_DECISION)).toBeVisible();
 
     await argosScreenshot(page, "Pseudonymous grading - Student sees instructor real name for final decision");
+    await assertStudentPageAccessible(page, "pseudonymous regrade closed student view");
   });
 });

--- a/tests/e2e/pyret-repl.test.tsx
+++ b/tests/e2e/pyret-repl.test.tsx
@@ -10,6 +10,7 @@ import {
   TestingUser,
   getTestRunPrefix
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 let course: Course;
 let student: TestingUser;
@@ -268,6 +269,7 @@ test.describe("Pyret REPL Integration", () => {
     ).not.toBeVisible();
 
     await page.waitForLoadState("networkidle");
+    await assertStudentPageAccessible(page, "pyret test results before REPL");
 
     const replToggle = page.getByRole("button", { name: /Interactive Pyret REPL/i }).first();
     await expect(replToggle).toBeVisible();
@@ -353,6 +355,7 @@ test.describe("Pyret REPL Integration", () => {
     const hasErrorMessage = await page.getByText(/Failed to load REPL|Error loading/i).isVisible();
 
     expect(hasLoadedSuccessfully || hasErrorMessage).toBeTruthy();
+    await assertStudentPageAccessible(page, "pyret REPL load or error state");
 
     if (hasErrorMessage) {
       await replToggle.click();
@@ -394,5 +397,6 @@ test.describe("Pyret REPL Integration", () => {
       }
       return loadedCount >= expectedCount;
     }, expectedOpenReplCount);
+    await assertStudentPageAccessible(page, "pyret multiple REPLs open");
   });
 });

--- a/tests/e2e/rubric-editor.test.tsx
+++ b/tests/e2e/rubric-editor.test.tsx
@@ -12,6 +12,7 @@ import {
   loginAsUser,
   TestingUser
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -149,5 +150,6 @@ test.describe("Rubric editor", () => {
     await expect(
       page.getByText(/The final score \(manual \+ autograder\) will be capped to \d+ points maximum\./)
     ).toBeVisible();
+    await assertStudentPageAccessible(page, "student submission score capping copy");
   });
 });

--- a/tests/e2e/student-dashboard-total-score.test.tsx
+++ b/tests/e2e/student-dashboard-total-score.test.tsx
@@ -10,6 +10,7 @@ import {
   loginAsUser,
   supabase
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -60,5 +61,6 @@ test.describe("Student assignments dashboard score display", () => {
 
     await expect(page.getByRole("link", { name: new RegExp(`#\\d+ \\(${finalTotal}/100\\)`) })).toBeVisible();
     await expect(page.getByRole("link", { name: "#1 (5/10)" })).not.toBeVisible();
+    await assertStudentPageAccessible(page, "student assignments dashboard after grading");
   });
 });

--- a/tests/e2e/survey-assignment-grading.test.tsx
+++ b/tests/e2e/survey-assignment-grading.test.tsx
@@ -9,6 +9,7 @@ import {
   loginAsUser,
   supabase
 } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 import type { TablesInsert } from "../../utils/supabase/SupabaseTypes";
 import { addDays } from "date-fns";
 import { TEAM_COLLABORATION_SURVEY } from "../fixtures/teamCollaborationSurvey";
@@ -108,6 +109,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     // Navigate to the survey list
     await page.goto(`/course/${course.id}/surveys`);
     await expect(page.getByText("Week 5 Team Collaboration Survey")).toBeVisible();
+    await assertStudentPageAccessible(page, "survey assignment grading - survey list");
     await argosScreenshot(page, "Student Survey List - Team Collaboration Survey Available");
 
     // Click to start the survey
@@ -161,6 +163,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
       page.getByText("How do you feel about your team's collaboration process in this project?").first()
     ).toBeVisible();
     await argosScreenshot(page, "Student Survey - Page 4 Impediments and Reflection");
+    await assertStudentPageAccessible(page, "team collaboration survey page 4 (shell)");
   });
 
   test("student sees survey status banner on submission page", async ({ page }) => {
@@ -196,6 +199,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await expect(page.getByText("Survey: Week 5 Team Collaboration Survey")).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Pending")).toBeVisible();
     await expect(page.getByText("Take Survey")).toBeVisible();
+    await assertStudentPageAccessible(page, "submission page survey pending banner");
 
     await argosScreenshot(page, "Student Submission Page - Survey Pending Banner");
 
@@ -228,6 +232,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await expect(page.getByText("Survey: Week 5 Team Collaboration Survey")).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Completed")).toBeVisible();
     await expect(page.getByText("View Response")).toBeVisible();
+    await assertStudentPageAccessible(page, "submission page survey completed banner");
 
     await argosScreenshot(page, "Student Submission Page - Survey Completed Banner");
   });
@@ -478,6 +483,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
 
     // Should show read-only indicator
     await expect(page.getByText("This survey has been submitted and cannot be edited.")).toBeVisible();
+    await assertStudentPageAccessible(page, "submitted survey read-only (shell)");
     await argosScreenshot(page, "Student Survey - Submitted Read Only View");
   });
 });

--- a/tests/e2e/surveys.test.tsx
+++ b/tests/e2e/surveys.test.tsx
@@ -3,6 +3,7 @@ import { test, expect } from "../global-setup";
 import { createClient } from "@supabase/supabase-js";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, getAuthTokenForUser, loginAsUser, supabase } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -108,6 +109,7 @@ test.describe("Surveys Page", () => {
     await page.goto(`/course/${course.id}/surveys`);
 
     await expect(page.getByRole("heading", { name: "No Surveys Available" })).toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list empty");
   });
 
   test("student sees published survey and updated status", async ({ page }) => {
@@ -125,6 +127,7 @@ test.describe("Surveys Page", () => {
     await expect(page.getByText("Quick check-in")).toBeVisible();
     await expect(page.locator("span.chakra-badge", { hasText: "Not Started" })).toBeVisible();
     await expect(page.getByText("No Surveys Available")).not.toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list with published");
   });
 
   test("draft survey is not visible to students", async ({ page }) => {
@@ -139,6 +142,7 @@ test.describe("Surveys Page", () => {
 
     await expect(page.getByRole("heading", { name: "No Surveys Available" })).toBeVisible();
     await expect(page.getByText("Draft Survey")).not.toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list draft hidden");
   });
 
   test("closed survey is not visible to students", async ({ page }) => {
@@ -153,6 +157,7 @@ test.describe("Surveys Page", () => {
 
     await expect(page.getByRole("heading", { name: "No Surveys Available" })).toBeVisible();
     await expect(page.getByText("Closed Survey")).not.toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list closed hidden");
   });
 
   test("student without assignment sees only surveys assigned to all", async ({ page }) => {
@@ -184,6 +189,7 @@ test.describe("Surveys Page", () => {
 
     await expect(page.getByText("All Students Survey")).toBeVisible();
     await expect(page.getByText("Specific Student Survey")).not.toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list assignment filter A");
   });
 
   test("student with assignment sees both all-student and targeted survey", async ({ page }) => {
@@ -215,6 +221,7 @@ test.describe("Surveys Page", () => {
 
     await expect(page.getByText("All Students Survey")).toBeVisible();
     await expect(page.getByText("Specific Student Survey")).toBeVisible();
+    await assertStudentPageAccessible(page, "surveys list assignment filter B");
   });
 
   test("instructor RPC can assign specific students", async () => {
@@ -323,6 +330,7 @@ test.describe("Surveys Page", () => {
 
     await expect(page.getByRole("heading", { name: "Active Surveys" })).toBeVisible();
     await expect(page.getByText("No active surveys")).toBeVisible();
+    await assertStudentPageAccessible(page, "student dashboard surveys empty");
   });
 
   test("student dashboard active surveys show correct actions", async ({ page }) => {
@@ -391,6 +399,7 @@ test.describe("Surveys Page", () => {
     const editableCard = surveysSection.locator("div").filter({ hasText: "Dashboard Submitted Editable" }).first();
     await expect(editableCard.getByRole("link", { name: "Edit survey: Dashboard Submitted Editable" })).toBeVisible();
     await expect(editableCard.getByText("Submitted (editable)")).toBeVisible();
+    await assertStudentPageAccessible(page, "student dashboard active surveys");
   });
 
   test.skip("survey builder saves default JSON on create", async ({ page }) => {
@@ -599,6 +608,7 @@ test.describe("Surveys Page", () => {
     await expect(startLink).toBeVisible();
     await startLink.click();
     await expect(page).toHaveURL(new RegExp(`/course/${course.id}/surveys/${survey.id}`));
+    await assertStudentPageAccessible(page, "survey in-progress (shell)");
 
     const input = page.getByRole("textbox", { name: "Question 1" });
     await expect(input).toBeVisible();

--- a/tests/e2e/timezone-preferences.test.tsx
+++ b/tests/e2e/timezone-preferences.test.tsx
@@ -2,6 +2,7 @@ import { type Course } from "@/utils/supabase/DatabaseTypes";
 import dotenv from "dotenv";
 import { expect, test } from "../global-setup";
 import { createClass, createUsersInClass, loginAsUser, type TestingUser } from "./TestingUtils";
+import { assertStudentPageAccessible } from "./axeStudentA11y";
 
 dotenv.config({ path: ".env.local" });
 
@@ -53,6 +54,7 @@ test.describe("Time zone dialog and indicator", () => {
     expect(pref).toBe("browser");
 
     await expect(page.getByRole("button", { name: /Local Time Zone \(.+\)/ })).toBeVisible();
+    await assertStudentPageAccessible(page, "timezone preference local selected");
   });
 
   test("Preference persists across page reloads", async ({ page }) => {
@@ -68,6 +70,7 @@ test.describe("Time zone dialog and indicator", () => {
 
     const pref = await page.evaluate(() => localStorage.getItem("pawtograder-timezone-pref"));
     expect(pref).toBe("browser");
+    await assertStudentPageAccessible(page, "timezone preference persisted reload");
   });
 
   test("Indicator opens dialog and toggles back to course time zone", async ({ page }) => {
@@ -96,6 +99,7 @@ test.describe("Time zone dialog and indicator", () => {
 
     pref = await page.evaluate(() => localStorage.getItem("pawtograder-timezone-pref"));
     expect(pref).toBe("course");
+    await assertStudentPageAccessible(page, "timezone preference course selected");
   });
   test("Manually setting localStorage prevents dialog from showing", async ({ context }) => {
     // Create a new context to simulate a fresh browser session
@@ -114,6 +118,7 @@ test.describe("Time zone dialog and indicator", () => {
 
     // Indicator should show Course Time Zone
     await expect(newPage.getByRole("button", { name: /Course Time Zone \(.+\)/ })).toBeVisible();
+    await assertStudentPageAccessible(newPage, "timezone pref from localStorage no dialog");
 
     await newPage.close();
   });
@@ -138,6 +143,7 @@ test.describe("Time zone dialog and indicator", () => {
     // Should default to course timezone
     const pref = await newPage.evaluate(() => localStorage.getItem("pawtograder-timezone-pref"));
     expect(pref).toBeNull(); // No preference needed when they match
+    await assertStudentPageAccessible(newPage, "timezone browser matches course");
 
     await contextWithNYTime.close();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated accessibility checks to existing Playwright end-to-end tests that exercise **student** flows (assignments, submissions, gradebook, surveys, polls, discussion, office hours, grading, etc.).

## Implementation

- New dev dependency: `@axe-core/playwright` (wraps axe-core for Playwright).
- Shared helper `tests/e2e/axeStudentA11y.ts` with `assertStudentPageAccessible(page, contextLabel?)` that runs `AxeBuilder` and fails the test on violations.
- Default excludes for third-party surfaces that are noisy in strict a11y scans: Monaco editor and SurveyJS root selectors (SurveyJS-heavy pages still scan the surrounding app shell where assertions run).
- Calls are placed **after** existing UI assertions so the page is in a stable state.

## Notes

- Full Playwright suite was not run in this environment (no local app/Supabase). CI should surface any real violations; adjust excludes or fix UI as needed.
- TypeScript: small cast bridges `@playwright/test` Page vs `playwright-core` Page types expected by `@axe-core/playwright`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a438b715-ef97-45d7-aacd-9070326fd109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a438b715-ef97-45d7-aacd-9070326fd109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

