### PR TITLE
Instructor assignment table: group mentor column and filter

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/assignmentsTable.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/assignmentsTable.tsx
@@ -298,11 +298,17 @@ export default function AssignmentsTable({
   // Get sections and assignment data for default visibility logic
   const classSections = useClassSections();
   const hasGroups = useMemo(() => assignmentGroups.length > 0, [assignmentGroups]);
+  const hasAnyGroupMentor = useMemo(
+    () => assignmentGroups.some((g) => g.mentor_profile_id != null),
+    [assignmentGroups]
+  );
+  const showGroupMentorColumn = hasGroups && hasAnyGroupMentor;
 
   // Column visibility state with dynamic defaults
   const [columnVisibility, setColumnVisibility] = useState(() => {
     return {
       groupname: false,
+      assignment_group_mentor_name: false,
       class_section_name: false,
       lab_section_name: false,
       late_due_date: false,
@@ -322,11 +328,12 @@ export default function AssignmentsTable({
       setColumnVisibility((prev) => ({
         ...prev,
         groupname: hasGroups,
+        assignment_group_mentor_name: showGroupMentorColumn,
         class_section_name: hasMultipleClassSections,
         lab_section_name: hasLabScheduling
       }));
     }
-  }, [classSections.length, assignment, hasGroups]);
+  }, [classSections.length, assignment, hasGroups, showGroupMentorColumn]);
 
   const columns = useMemo<ColumnDef<ActiveSubmissionsWithGradesForAssignment>[]>(
     () => [
@@ -381,6 +388,25 @@ export default function AssignmentsTable({
         accessorKey: "groupname",
         header: "Group"
       },
+      ...(showGroupMentorColumn
+        ? ([
+            {
+              id: "assignment_group_mentor_name",
+              accessorKey: "assignment_group_mentor_name",
+              header: "Group mentor",
+              enableColumnFilter: true,
+              filterFn: (row, id, filterValue) => {
+                if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) return true;
+                const values = Array.isArray(filterValue) ? filterValue : [filterValue];
+                if (!row.original.assignment_group_mentor_name) return values.includes("No mentor");
+                return values.some((val) =>
+                  row.original.assignment_group_mentor_name!.toLowerCase().includes(val.toLowerCase())
+                );
+              },
+              cell: (props) => <Text>{(props.getValue() as string | null | undefined) ?? "—"}</Text>
+            }
+          ] satisfies ColumnDef<ActiveSubmissionsWithGradesForAssignment>[])
+        : []),
       {
         id: "class_section_name",
         accessorKey: "class_section_name",
@@ -579,7 +605,7 @@ export default function AssignmentsTable({
         }
       }
     ],
-    [timeZone, course_id, assignment_id, assignment]
+    [timeZone, course_id, assignment_id, assignment, showGroupMentorColumn]
   );
 
   const [internalTableController, setInternalTableController] = useState<TableController<"submissions"> | null>(null);
@@ -750,6 +776,14 @@ export default function AssignmentsTable({
             <Checkbox checked={columnVisibility.groupname} onCheckedChange={() => toggleColumnVisibility("groupname")}>
               Group
             </Checkbox>
+            {showGroupMentorColumn && (
+              <Checkbox
+                checked={columnVisibility.assignment_group_mentor_name}
+                onCheckedChange={() => toggleColumnVisibility("assignment_group_mentor_name")}
+              >
+                Group mentor
+              </Checkbox>
+            )}
             <Checkbox
               checked={columnVisibility.class_section_name}
               onCheckedChange={() => toggleColumnVisibility("class_section_name")}
@@ -807,6 +841,9 @@ export default function AssignmentsTable({
                           h.id === "autograder_score" ||
                           h.id === "total_score" ||
                           h.id === "released" ||
+                          (h.id === "assignment_group_mentor_name" &&
+                            showGroupMentorColumn &&
+                            columnVisibility.assignment_group_mentor_name) ||
                           columnVisibility[h.id as keyof typeof columnVisibility])
                     )
                     .map((header, colIdx) => (
@@ -913,6 +950,31 @@ export default function AssignmentsTable({
                                   { label: "Not assigned", value: "Not assigned" }
                                 ]}
                                 placeholder="Filter by lab section..."
+                              />
+                            )}
+                            {header.id === "assignment_group_mentor_name" && (
+                              <Select
+                                isMulti={true}
+                                id={header.id}
+                                onChange={(e) => {
+                                  const values = Array.isArray(e) ? e.map((item) => item.value) : [];
+                                  header.column.setFilterValue(values.length > 0 ? values : undefined);
+                                }}
+                                options={[
+                                  ...Array.from(
+                                    getCoreRowModel()
+                                      .rows.reduce((map, row) => {
+                                        const mentorName = row.original.assignment_group_mentor_name;
+                                        if (mentorName && !map.has(mentorName)) {
+                                          map.set(mentorName, mentorName);
+                                        }
+                                        return map;
+                                      }, new Map())
+                                      .values()
+                                  ).map((name) => ({ label: name, value: name })),
+                                  { label: "No mentor", value: "No mentor" }
+                                ]}
+                                placeholder="Filter by group mentor..."
                               />
                             )}
                             {header.id === "gradername" && (
@@ -1140,6 +1202,9 @@ export default function AssignmentsTable({
                                 header.id === "autograder_score" ||
                                 header.id === "total_score" ||
                                 header.id === "released" ||
+                                (header.id === "assignment_group_mentor_name" &&
+                                  showGroupMentorColumn &&
+                                  columnVisibility.assignment_group_mentor_name) ||
                                 columnVisibility[header.id as keyof typeof columnVisibility])
                           ).length
                       )
@@ -1195,6 +1260,9 @@ export default function AssignmentsTable({
                               c.column.id === "autograder_score" ||
                               c.column.id === "total_score" ||
                               c.column.id === "released" ||
+                              (c.column.id === "assignment_group_mentor_name" &&
+                                showGroupMentorColumn &&
+                                columnVisibility.assignment_group_mentor_name) ||
                               columnVisibility[c.column.id as keyof typeof columnVisibility])
                         )
                         .map((cell, colIdx) => (

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -10764,6 +10764,7 @@ export type Database = {
           assignedgradername: string | null;
           assignedmetagradername: string | null;
           assignment_id: number | null;
+          assignment_group_mentor_name: string | null;
           assignment_slug: string | null;
           autograder_score: number | null;
           checked_at: string | null;

--- a/supabase/migrations/20260422140000_submissions_nice_assignment_group_mentor.sql
+++ b/supabase/migrations/20260422140000_submissions_nice_assignment_group_mentor.sql
@@ -1,0 +1,94 @@
+-- Add assignment group mentor display name to instructor submissions grade view.
+
+DROP VIEW IF EXISTS public.submissions_with_grades_for_assignment_nice;
+
+CREATE VIEW public.submissions_with_grades_for_assignment_nice WITH (security_invoker = 'true') AS
+ WITH assignment_students AS (
+         SELECT DISTINCT ur.id AS user_role_id,
+            ur.private_profile_id, a.class_id, a.id AS assignment_id,
+            a.due_date, a.slug AS assignment_slug,
+            ur.class_section_id, ur.lab_section_id
+           FROM public.assignments a
+             JOIN public.user_roles ur ON ((ur.class_id = a.class_id AND ur.role = 'student'::public.app_role AND ur.disabled = false))
+        ), individual_submissions AS (
+         SELECT ast.user_role_id, ast.private_profile_id, ast.class_id,
+            ast.assignment_id, s_1.id AS submission_id,
+            NULL::bigint AS assignment_group_id, ast.due_date,
+            ast.assignment_slug, ast.class_section_id, ast.lab_section_id
+           FROM assignment_students ast
+             JOIN public.submissions s_1 ON ((s_1.assignment_id = ast.assignment_id AND s_1.profile_id = ast.private_profile_id AND s_1.is_active = true AND s_1.assignment_group_id IS NULL))
+        ), group_submissions AS (
+         SELECT ast.user_role_id, ast.private_profile_id, ast.class_id,
+            ast.assignment_id, s_1.id AS submission_id,
+            agm.assignment_group_id, ast.due_date,
+            ast.assignment_slug, ast.class_section_id, ast.lab_section_id
+           FROM assignment_students ast
+             JOIN public.assignment_groups_members agm ON ((agm.assignment_id = ast.assignment_id AND agm.profile_id = ast.private_profile_id))
+             JOIN public.submissions s_1 ON ((s_1.assignment_id = ast.assignment_id AND s_1.assignment_group_id = agm.assignment_group_id AND s_1.is_active = true))
+        ), all_submissions AS (
+         SELECT * FROM individual_submissions
+        UNION ALL
+         SELECT * FROM group_submissions
+        ), due_date_extensions AS (
+         SELECT COALESCE(ade.student_id, ag_1.profile_id) AS effective_student_id,
+            COALESCE(ade.assignment_group_id, ag_1.assignment_group_id) AS effective_assignment_group_id,
+            ade.assignment_id,
+            sum(ade.tokens_consumed) AS tokens_consumed,
+            sum(ade.hours) AS hours
+           FROM public.assignment_due_date_exceptions ade
+             LEFT JOIN public.assignment_groups_members ag_1 ON ((ade.assignment_group_id = ag_1.assignment_group_id))
+          GROUP BY COALESCE(ade.student_id, ag_1.profile_id), COALESCE(ade.assignment_group_id, ag_1.assignment_group_id), ade.assignment_id
+        ), submissions_with_extensions AS (
+         SELECT asub.user_role_id, asub.private_profile_id, asub.class_id,
+            asub.assignment_id, asub.submission_id, asub.assignment_group_id,
+            asub.due_date, asub.assignment_slug,
+            COALESCE(dde.tokens_consumed, (0)::bigint) AS tokens_consumed,
+            COALESCE(dde.hours, (0)::bigint) AS hours,
+            asub.class_section_id, asub.lab_section_id
+           FROM all_submissions asub
+             LEFT JOIN due_date_extensions dde ON (
+               (dde.effective_student_id = asub.private_profile_id)
+               AND (dde.assignment_id = asub.assignment_id)
+               AND (
+                 (asub.assignment_group_id IS NULL AND dde.effective_assignment_group_id IS NULL)
+                 OR (asub.assignment_group_id = dde.effective_assignment_group_id)
+               )
+             )
+        )
+ SELECT swe.user_role_id AS id, swe.class_id, swe.assignment_id,
+    p.id AS student_private_profile_id, p.name, p.sortable_name,
+    s.id AS activesubmissionid, s.ordinal, s.created_at, s.released,
+    s.repository, s.sha,
+    rev.total_autograde_score AS autograder_score,
+    rev.grader, rev.meta_grader, rev.total_score, rev.tweak,
+    rev.completed_by, rev.completed_at, rev.checked_at, rev.checked_by,
+    rev.individual_scores,
+    rev.per_student_grading_totals,
+    rev.per_student_grading_shared_base,
+    graderprofile.name AS assignedgradername,
+    metagraderprofile.name AS assignedmetagradername,
+    completerprofile.name AS gradername,
+    checkgraderprofile.name AS checkername,
+    ag.name AS groupname,
+    mentorprofile.name AS assignment_group_mentor_name,
+    swe.tokens_consumed, swe.hours, swe.due_date,
+    (swe.due_date + ('01:00:00'::interval * (swe.hours)::double precision)) AS late_due_date,
+    ar.grader_sha, ar.grader_action_sha,
+    swe.assignment_slug, swe.class_section_id,
+    cs.name AS class_section_name,
+    swe.lab_section_id, ls.name AS lab_section_name
+   FROM submissions_with_extensions swe
+     JOIN public.profiles p ON ((p.id = swe.private_profile_id))
+     JOIN public.submissions s ON ((s.id = swe.submission_id))
+     LEFT JOIN public.submission_reviews rev ON ((rev.id = s.grading_review_id))
+     LEFT JOIN public.grader_results ar ON ((ar.submission_id = s.id))
+     LEFT JOIN public.assignment_groups ag ON ((ag.id = swe.assignment_group_id))
+     LEFT JOIN public.profiles mentorprofile ON ((mentorprofile.id = ag.mentor_profile_id))
+     LEFT JOIN public.profiles completerprofile ON ((completerprofile.id = rev.completed_by))
+     LEFT JOIN public.profiles graderprofile ON ((graderprofile.id = rev.grader))
+     LEFT JOIN public.profiles metagraderprofile ON ((metagraderprofile.id = rev.meta_grader))
+     LEFT JOIN public.profiles checkgraderprofile ON ((checkgraderprofile.id = rev.checked_by))
+     LEFT JOIN public.class_sections cs ON ((cs.id = swe.class_section_id))
+     LEFT JOIN public.lab_sections ls ON ((ls.id = swe.lab_section_id));
+
+ALTER VIEW public.submissions_with_grades_for_assignment_nice OWNER TO postgres;

--- a/utils/supabase/DatabaseTypes.d.ts
+++ b/utils/supabase/DatabaseTypes.d.ts
@@ -56,6 +56,8 @@ export type AggregatedSubmissions = Database["public"]["Views"]["submissions_agg
 export type ActiveSubmissionsWithGradesForAssignment =
   Database["public"]["Views"]["submissions_with_grades_for_assignment"]["Row"] & {
     id: number;
+    /** Present on `submissions_with_grades_for_assignment_nice` when group mentors exist. */
+    assignment_group_mentor_name?: string | null;
   };
 export type ActiveSubmissionsWithRegressionTestResults =
   Database["public"]["Views"]["submissions_with_grades_for_assignment_and_regression_test"]["Row"] & {

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -10764,6 +10764,7 @@ export type Database = {
           assignedgradername: string | null;
           assignedmetagradername: string | null;
           assignment_id: number | null;
+          assignment_group_mentor_name: string | null;
           assignment_slug: string | null;
           autograder_score: number | null;
           checked_at: string | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`assignment_group_mentor_name`** to the `submissions_with_grades_for_assignment_nice` view (join mentor profile from `assignment_groups.mentor_profile_id`).

In the instructor **Manage → Assignment** submissions table:

- When the assignment **has groups** and **at least one group has a mentor**, a **Group mentor** column appears (on by default), with a multi-select filter (includes **No mentor** for groups without a mentor).
- A **Group mentor** visibility toggle is shown only in that case.

## Files

- `supabase/migrations/20260422140000_submissions_nice_assignment_group_mentor.sql` — view definition
- `app/course/.../assignmentsTable.tsx` — column + filter + visibility
- `utils/supabase/SupabaseTypes.d.ts`, `supabase/functions/_shared/SupabaseTypes.d.ts`, `utils/supabase/DatabaseTypes.d.ts` — types

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad043ec5-9b18-488c-a138-229345dc5ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad043ec5-9b18-488c-a138-229345dc5ce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

