### PR TITLE
fix: fail loudly when no repo files match submissionFiles patterns

### DIFF
--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -1239,6 +1239,14 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               expectedFiles.some((pattern) => micromatch.isMatch(stripTopDir(file.path), pattern))
           );
           if (submittedFiles.length === 0) {
+            if (submission_id !== undefined) {
+              try {
+                await safeCleanupRejectedSubmission({ adminSupabase, submissionId: submission_id });
+                submission_id = undefined;
+              } catch (cleanupErr) {
+                Sentry.captureException(cleanupErr, scope);
+              }
+            }
             throw new UserVisibleError(
               `No files in the repository matched the assignment's submissionFiles patterns (${expectedFiles.join(", ")}). ` +
                 `Instructor: check pawtograder.yml in grader repo ${config.grader_repo} at SHA ${config.grader_commit_sha} — the patterns appear not to match any file in the student repository.`,

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -1238,6 +1238,13 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               file.type === "File" && // Do not submit directories
               expectedFiles.some((pattern) => micromatch.isMatch(stripTopDir(file.path), pattern))
           );
+          if (submittedFiles.length === 0) {
+            throw new UserVisibleError(
+              `No files in the repository matched the assignment's submissionFiles patterns (${expectedFiles.join(", ")}). ` +
+                `Instructor: check pawtograder.yml in grader repo ${config.grader_repo} at SHA ${config.grader_commit_sha} — the patterns appear not to match any file in the student repository.`,
+              400
+            );
+          }
           // Make sure that all files that are NOT glob patterns are present
           const nonGlobFiles = expectedFiles.filter((pattern) => !pattern.includes("*"));
           const allNonGlobFilesPresent = nonGlobFiles.every((file) =>


### PR DESCRIPTION
## Summary
- Closes #738.
- Adds a guard in `autograder-create-submission` that throws `UserVisibleError(400)` when zero zipball entries match the assignment's `submissionFiles` glob patterns, instead of silently returning 200 with no `submission_files` rows.

## Why this happened
The flow at `supabase/functions/autograder-create-submission/index.ts` inserts the `submissions` row at line 1095, then later builds `submittedFiles` by filtering the cloned zipball against `expectedFiles` patterns (line 1236). The file-insert for-loop iterates `submittedFiles` — when that array is empty, **zero inserts are attempted, so no DB error is thrown**. The existing `nonGlobFiles` presence check (line 1242) only catches missing literal paths; if every pattern in `submissionFiles.files` / `testFiles` is a glob (e.g. `src/**/*.java`, `**/*.py`), it passes vacuously when nothing matches. Execution then falls through to `return {grader_url, grader_sha}` with status 200.

The reported incident appears to have been an instructor `pawtograder.yml` misconfiguration where the patterns matched no file in the student repo.

## What changes
After `submittedFiles` is computed, throw a `UserVisibleError(400)` if it's empty. The message names the patterns and the grader repo/SHA so the instructor can diagnose the misconfiguration directly from the submission page (the existing outer catch records a public `workflow_run_error`).

## Test plan
- [ ] Confirm normal submissions still succeed end-to-end (E2E student workflow).
- [ ] Manually configure an assignment with a `submissionFiles` pattern that matches nothing in the student repo, push, verify the action surfaces the error and the submission page shows the new message instead of an empty submission.
- [ ] `npm run typecheck:functions` (Deno) — no new errors introduced (4 pre-existing unrelated errors in `GitHubWrapper.ts` / `SupabaseTypes.d.ts` remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission file validation with clearer error messages. When repository files don't match configured submission file patterns, the request now fails immediately with a descriptive 400 error that lists the unmatched patterns and guides users to verify their configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->