### PR TITLE
fix(webhook): detect grade.yml/pawtograder.yml changes across all push commits

### DIFF
--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -126,6 +126,25 @@ if (Deno.env.get("SENTRY_DSN")) {
 }
 const GRADER_WORKFLOW_PATH = ".github/workflows/grade.yml";
 
+/**
+ * Returns true if the given file path appears in the modified/added/removed lists
+ * of ANY commit in the push (not just `head_commit`). GitHub `push` events deliver
+ * up to 20 commits in `payload.commits`; checking only `head_commit` misses changes
+ * made in earlier commits of a multi-commit push.
+ */
+function pushTouchedFile(payload: PushEvent, path: string): boolean {
+  const head = payload.head_commit;
+  if (
+    head &&
+    (head.modified.includes(path) || head.added.includes(path) || head.removed.includes(path))
+  ) {
+    return true;
+  }
+  return payload.commits.some(
+    (c) => c.modified.includes(path) || c.added.includes(path) || c.removed.includes(path)
+  );
+}
+
 function sha256Hex(buf: Uint8Array): string {
   const hash = createHash("sha256");
   hash.update(buf);
@@ -500,14 +519,15 @@ async function handlePushToGraderSolution(
       Sentry.captureException(new Error("No head commit found in payload"), scope);
       return;
     }
-    const isModified = payload.head_commit.modified.includes(PAWTOGRADER_YML_PATH);
-    const isRemoved = payload.head_commit.removed.includes(PAWTOGRADER_YML_PATH);
-    const isAdded = payload.head_commit.added.includes(PAWTOGRADER_YML_PATH);
-    scope?.setTag("is_modified", isModified.toString());
-    scope?.setTag("is_removed", isRemoved.toString());
-    scope?.setTag("is_added", isAdded.toString());
-    if (isModified || isRemoved || isAdded) {
-      console.log("Pawtograder yml changed");
+    const ymlTouched = pushTouchedFile(payload, PAWTOGRADER_YML_PATH);
+    scope?.setTag("yml_touched_in_push", ymlTouched.toString());
+    // Always reconcile pawtograder.yml on a push to main, even if no commit in this
+    // push touched the file. This makes the autograder config self-healing: if a
+    // previous webhook missed an update (e.g. the file was changed in a non-head
+    // commit of a multi-commit push, or the >20-commit truncation hid it), an
+    // instructor can force a re-sync by pushing any commit (e.g. touching README).
+    try {
+      console.log("Reconciling pawtograder.yml on push to main", { ymlTouched });
       const file = await getFileFromRepo(repoName, PAWTOGRADER_YML_PATH);
       const parsedYml = parse(file.content) as PawtograderConfig;
       if (!parsedYml.gradedParts) {
@@ -557,12 +577,24 @@ async function handlePushToGraderSolution(
         })
       );
       scope?.setTag("updated_autograders_count", autograders.length.toString());
+    } catch (err) {
+      // Don't fail the whole webhook if pawtograder.yml is missing/malformed —
+      // log it and continue so we still update the latest_autograder_sha below.
+      scope?.setTag("error_source", "pawtograder_yml_reconcile_failed");
+      scope?.setTag("yml_touched_in_push", ymlTouched.toString());
+      console.error("Failed to reconcile pawtograder.yml", err);
+      Sentry.captureException(err, scope);
     }
+    // `payload.commits` is ordered oldest -> newest, so commits[0] is the FIRST
+    // (oldest) commit in the push, not the head. Use payload.after / head_commit
+    // so multi-commit pushes don't leave latest_autograder_sha stuck on an old SHA.
+    const newAutograderSha =
+      payload.after || payload.head_commit?.id || payload.commits.at(-1)?.id || payload.commits[0]?.id;
     for (const autograder of autograders) {
       const { error } = await adminSupabase
         .from("autograder")
         .update({
-          latest_autograder_sha: payload.commits[0].id
+          latest_autograder_sha: newAutograderSha
         })
         .eq("id", autograder.id)
         .single();
@@ -626,42 +658,51 @@ async function handlePushToTemplateRepo(
     Sentry.captureException(new Error("No head commit found in payload"), scope);
     return;
   }
-  //Check for modifications
-  const isModified = payload.head_commit.modified.includes(GRADER_WORKFLOW_PATH);
-  const isRemoved = payload.head_commit.removed.includes(GRADER_WORKFLOW_PATH);
-  const isAdded = payload.head_commit.added.includes(GRADER_WORKFLOW_PATH);
-  scope?.setTag("is_modified", isModified.toString());
-  scope?.setTag("is_removed", isRemoved.toString());
-  scope?.setTag("is_added", isAdded.toString());
-  if (isModified || isRemoved || isAdded) {
-    if (!assignments[0].template_repo) {
-      Sentry.captureMessage("No matching assignment found", scope);
-      return;
-    }
-    const file = (await getFileFromRepo(assignments[0].template_repo!, GRADER_WORKFLOW_PATH)) as { content: string };
-    const hash = createHash("sha256");
-    if (!file.content) {
-      Sentry.captureMessage(`File ${GRADER_WORKFLOW_PATH} not found for ${assignments[0].template_repo}`, scope);
-      return;
-    }
-    // Remove all whitespace (spaces, tabs, newlines, etc.) before hashing
-    const contentWithoutWhitespace = file.content.replace(/\s+/g, "");
-    hash.update(contentWithoutWhitespace);
-    const hashStr = hash.digest("hex");
-    scope?.setTag("new_autograder_workflow_hash", hashStr);
-    for (const assignment of assignments) {
-      const { error } = await adminSupabase
-        .from("autograder")
-        .update({
-          workflow_sha: hashStr
-        })
-        .eq("id", assignment.id);
-      if (error) {
-        scope.setTag("error_source", "autograder_workflow_hash_update_failed");
-        scope.setTag("error_context", "Failed to update autograder workflow hash");
-        Sentry.captureException(error, scope);
-        throw error;
+  // Always reconcile the grade.yml workflow hash on a push to main, even if no
+  // commit in this push touched the file. This makes workflow_sha self-healing:
+  // an instructor can fix a stale hash (e.g. caused by a multi-commit push where
+  // grade.yml was changed in a non-head commit, or by GitHub's 20-commit truncation)
+  // by pushing any commit (e.g. touching README) to the template repo.
+  const workflowTouched = pushTouchedFile(payload, GRADER_WORKFLOW_PATH);
+  scope?.setTag("workflow_touched_in_push", workflowTouched.toString());
+  if (!assignments[0].template_repo) {
+    Sentry.captureMessage("No matching assignment found", scope);
+  } else {
+    try {
+      const file = (await getFileFromRepo(assignments[0].template_repo!, GRADER_WORKFLOW_PATH)) as {
+        content: string;
+      };
+      if (!file.content) {
+        Sentry.captureMessage(`File ${GRADER_WORKFLOW_PATH} not found for ${assignments[0].template_repo}`, scope);
+      } else {
+        // Remove all whitespace (spaces, tabs, newlines, etc.) before hashing
+        const contentWithoutWhitespace = file.content.replace(/\s+/g, "");
+        const hash = createHash("sha256");
+        hash.update(contentWithoutWhitespace);
+        const hashStr = hash.digest("hex");
+        scope?.setTag("new_autograder_workflow_hash", hashStr);
+        for (const assignment of assignments) {
+          const { error } = await adminSupabase
+            .from("autograder")
+            .update({
+              workflow_sha: hashStr
+            })
+            .eq("id", assignment.id);
+          if (error) {
+            scope.setTag("error_source", "autograder_workflow_hash_update_failed");
+            scope.setTag("error_context", "Failed to update autograder workflow hash");
+            Sentry.captureException(error, scope);
+            throw error;
+          }
+        }
       }
+    } catch (err) {
+      // Don't fail the whole webhook if grade.yml is missing — log and continue
+      // so latest_template_sha still gets updated below.
+      scope?.setTag("error_source", "grade_yml_reconcile_failed");
+      scope?.setTag("workflow_touched_in_push", workflowTouched.toString());
+      console.error("Failed to reconcile grade.yml workflow hash", err);
+      Sentry.captureException(err, scope);
     }
   }
   for (const assignment of assignments) {

--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -134,15 +134,10 @@ const GRADER_WORKFLOW_PATH = ".github/workflows/grade.yml";
  */
 function pushTouchedFile(payload: PushEvent, path: string): boolean {
   const head = payload.head_commit;
-  if (
-    head &&
-    (head.modified.includes(path) || head.added.includes(path) || head.removed.includes(path))
-  ) {
+  if (head && (head.modified.includes(path) || head.added.includes(path) || head.removed.includes(path))) {
     return true;
   }
-  return payload.commits.some(
-    (c) => c.modified.includes(path) || c.added.includes(path) || c.removed.includes(path)
-  );
+  return payload.commits.some((c) => c.modified.includes(path) || c.added.includes(path) || c.removed.includes(path));
 }
 
 function sha256Hex(buf: Uint8Array): string {


### PR DESCRIPTION
## Summary

Fixes a bug where pushing multiple commits at once to the handout/template repo could leave `autograder.workflow_sha` (and `autograder.config` / `latest_autograder_sha`) stale, causing submissions to run against new YAML content but the old recorded SHA.

Three related fixes in `supabase/functions/github-repo-webhook/index.ts`:

1. **Multi-commit detection.** Previously we only checked `payload.head_commit.modified/added/removed` for `grade.yml` and `pawtograder.yml`. GitHub `push` events deliver up to 20 commits in `payload.commits`, so a YAML change made in any non-head commit was silently missed. Added a `pushTouchedFile()` helper that inspects every commit in the push (used for Sentry tagging now that reconciliation is unconditional — see #3).
2. **`latest_autograder_sha` bug.** It was being set to `payload.commits[0].id`, which is the *oldest* commit in the push, not the newest. Now uses `payload.after || payload.head_commit?.id || payload.commits.at(-1)?.id`, mirroring the existing `latest_template_sha` logic.
3. **Self-healing reconciliation.** Every push to `main` of the handout/template repo now re-fetches and re-applies the YAML state regardless of whether a commit appeared to touch it. An instructor can fix a stuck `workflow_sha` or stale autograder config by pushing any commit (e.g. touching `README.md`) — no SQL/redeploy needed. Wrapped in try/catch so a missing/malformed YAML doesn't block the SHA update that follows.

Cost: one extra `GET /repos/{owner}/{repo}/contents/{path}` per push to `main` of the handout/template repos (low volume) in exchange for self-healing.

## Test plan

- [x] Sanity: push a single commit modifying `grade.yml` to a handout repo on staging → `autograder.workflow_sha` updates as before.
- [x] Bug repro: push two commits at once where commit A modifies `grade.yml` and commit B (head) modifies an unrelated file → `workflow_sha` now updates (previously did not).
- [x] Self-heal: with a known-stale `workflow_sha`, push a commit that touches only `README.md` → `workflow_sha` is recomputed from current `grade.yml`.
- [x] `latest_autograder_sha` after a multi-commit push to a grader-solution repo equals the head SHA, not the first.
- [x] Sentry: confirm new tags `workflow_touched_in_push` / `yml_touched_in_push` show up on push events; look for instances where the tag is `false` but reconciliation still corrected drift (these are previously-silent bug instances).
- [x] Negative: push to main of a handout repo where `pawtograder.yml` is missing → webhook does not 500; `latest_autograder_sha` still updates; Sentry captures the fetch failure.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook reliability to detect file changes across all commits in a push, not just the head commit.
  * Enhanced configuration synchronization on main branch with better error handling to prevent webhook failures.
  * Fixed autograder SHA computation for more accurate revision tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/748)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->