### PR TITLE
Add instructor GitHub diagnostics

### DIFF
--- a/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
@@ -42,7 +42,7 @@ import { Select } from "chakra-react-select";
 import { CheckIcon } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FaEdit, FaLink, FaTrash, FaUserCog, FaClock, FaTimes, FaFileExport } from "react-icons/fa";
+import { FaEdit, FaLink, FaTrash, FaUserCog, FaClock, FaTimes, FaFileExport, FaGithub } from "react-icons/fa";
 import { PiArrowBendLeftUpBold } from "react-icons/pi";
 import EditUserProfileModal from "./editUserProfileModal";
 import EditUserRoleModal from "./editUserRoleModal";
@@ -50,6 +50,7 @@ import RemoveStudentModal from "./removeStudentModal";
 import ImportStudentsCSVModal from "./importStudentsCSVModal";
 import AddSingleCourseMember from "./addSingleCourseMember";
 import StudentSummaryTrigger from "@/components/ui/student-summary";
+import GitHubDiagnosticsModal from "./githubDiagnosticsModal";
 
 type EditProfileModalData = string; // userId
 type EditUserRoleModalData = {
@@ -61,6 +62,10 @@ type RemoveStudentModalData = {
   userRoleId: string;
   userName: string | null | undefined;
   role: UserRoleWithPrivateProfileAndUser["role"];
+};
+type GitHubDiagnosticsModalData = {
+  userRoleId: number;
+  userName: string | null | undefined;
 };
 
 // Invitation type for display
@@ -125,6 +130,13 @@ export default function EnrollmentsTable() {
     openModal: openRemoveStudentModal,
     closeModal: closeRemoveStudentModal
   } = useModalManager<RemoveStudentModalData>();
+
+  const {
+    isOpen: isGitHubDiagnosticsModalOpen,
+    modalData: githubDiagnosticsData,
+    openModal: openGitHubDiagnosticsModal,
+    closeModal: closeGitHubDiagnosticsModal
+  } = useModalManager<GitHubDiagnosticsModalData>();
 
   const [pageCount, setPageCount] = useState(0);
 
@@ -768,6 +780,7 @@ export default function EnrollmentsTable() {
           const userRoleEntry = row.original;
           const isCurrentUserRow = currentUser?.id === userRoleEntry.user_id;
           const isTargetInstructor = userRoleEntry.role === "instructor";
+          const canDiagnoseGitHub = userRoleEntry.role === "student";
 
           const canEditThisUserRole = !isCurrentUserRow && !isTargetInstructor;
           let editRoleTooltipContent = "Edit user role";
@@ -789,6 +802,23 @@ export default function EnrollmentsTable() {
             <HStack gap={2} justifyContent="center">
               {profile && studentProfileId && (
                 <StudentSummaryTrigger student_id={studentProfileId} course_id={Number(course_id)} />
+              )}
+              {canDiagnoseGitHub && (
+                <Tooltip content="Diagnose GitHub errors">
+                  <Icon
+                    as={FaGithub}
+                    aria-label="Diagnose GitHub errors"
+                    cursor="pointer"
+                    color="purple.500"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      openGitHubDiagnosticsModal({
+                        userRoleId: userRoleEntry.id,
+                        userName: profile?.name
+                      });
+                    }}
+                  />
+                </Tooltip>
               )}
               {profile && studentProfileId && (
                 <Tooltip content="Edit student profile">
@@ -849,6 +879,7 @@ export default function EnrollmentsTable() {
       course_id,
       openEditProfileModal,
       openEditUserRoleModal,
+      openGitHubDiagnosticsModal,
       openRemoveStudentModal,
       tagData,
       handleSingleCheckboxChange,
@@ -1642,6 +1673,15 @@ export default function EnrollmentsTable() {
           userRoleId={removingStudentData.userRoleId}
           onConfirmRemove={handleConfirmRemoveStudent}
           isLoading={isDeletingUserRole}
+        />
+      )}
+      {githubDiagnosticsData && (
+        <GitHubDiagnosticsModal
+          isOpen={isGitHubDiagnosticsModalOpen}
+          onClose={closeGitHubDiagnosticsModal}
+          courseId={Number(course_id)}
+          userRoleId={githubDiagnosticsData.userRoleId}
+          studentName={githubDiagnosticsData.userName}
         />
       )}
     </VStack>

--- a/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
@@ -50,7 +50,7 @@ import RemoveStudentModal from "./removeStudentModal";
 import ImportStudentsCSVModal from "./importStudentsCSVModal";
 import AddSingleCourseMember from "./addSingleCourseMember";
 import StudentSummaryTrigger from "@/components/ui/student-summary";
-import GitHubDiagnosticsModal from "./githubDiagnosticsModal";
+import GitHubDiagnosticsModal from "@/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal";
 
 type EditProfileModalData = string; // userId
 type EditUserRoleModalData = {

--- a/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
@@ -80,6 +80,7 @@ export default function GitHubDiagnosticsModal({
 
   const fetchStatus = useCallback(async () => {
     setIsLoading(true);
+    setStatus(null);
     try {
       const response = await diagnoseInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -102,6 +103,7 @@ export default function GitHubDiagnosticsModal({
 
   const handleSync = useCallback(async () => {
     setIsSyncing(true);
+    setStatus(null);
     try {
       const response = await syncInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -122,6 +124,7 @@ export default function GitHubDiagnosticsModal({
 
   const handleUnlink = useCallback(async () => {
     setIsUnlinking(true);
+    setStatus(null);
     try {
       const response = await unlinkInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -141,6 +144,7 @@ export default function GitHubDiagnosticsModal({
   }, [courseId, supabase, userRoleId]);
 
   const linkedUsername = status?.currentGithubUsername ?? status?.githubUsername ?? null;
+  const isActionDisabled = isLoading || isSyncing || isUnlinking || !status;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(details) => !details.open && onClose()}>
@@ -233,7 +237,7 @@ export default function GitHubDiagnosticsModal({
                 <PopConfirm
                   triggerLabel="Unlink GitHub identity"
                   trigger={
-                    <Button colorPalette="red" variant="surface" loading={isUnlinking} disabled={!status}>
+                    <Button colorPalette="red" variant="surface" loading={isUnlinking} disabled={isActionDisabled}>
                       Unlink GitHub identity
                     </Button>
                   }
@@ -246,7 +250,7 @@ export default function GitHubDiagnosticsModal({
                   <Button variant="ghost" onClick={onClose}>
                     Close
                   </Button>
-                  <Button colorPalette="green" onClick={handleSync} loading={isSyncing} disabled={!status}>
+                  <Button colorPalette="green" onClick={handleSync} loading={isSyncing} disabled={isActionDisabled}>
                     Sync permissions
                   </Button>
                 </HStack>

--- a/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { PopConfirm } from "@/components/ui/popconfirm";
+import { toaster } from "@/components/ui/toaster";
+import {
+  diagnoseInstructorGitHubAccount,
+  syncInstructorGitHubAccount,
+  unlinkInstructorGitHubAccount
+} from "@/lib/edgeFunctions";
+import type { GitHubLinkStatus, GitHubMembershipStatus } from "@/supabase/functions/_shared/FunctionTypes";
+import { createClient } from "@/utils/supabase/client";
+import { Badge, Box, Button, Dialog, HStack, Portal, Spinner, Text, VStack } from "@chakra-ui/react";
+import * as Sentry from "@sentry/nextjs";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { BsGithub } from "react-icons/bs";
+
+type GitHubDiagnosticsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  courseId: number;
+  userRoleId: number;
+  studentName: string | null | undefined;
+};
+
+function membershipLabel(status: GitHubMembershipStatus) {
+  if (status.state === "active") {
+    return "Joined";
+  }
+  if (status.state === "pending") {
+    return "Pending invitation";
+  }
+  if (status.state === "not_found") {
+    return "Not joined";
+  }
+  return "Unknown";
+}
+
+function membershipColor(status: GitHubMembershipStatus) {
+  if (status.state === "active") {
+    return "green";
+  }
+  if (status.state === "pending") {
+    return "yellow";
+  }
+  if (status.state === "not_found") {
+    return "red";
+  }
+  return "gray";
+}
+
+function StatusRow({ label, value, detail }: { label: string; value: ReactNode; detail?: string | null }) {
+  return (
+    <HStack align="start" justify="space-between" w="100%" gap={4}>
+      <Text fontWeight="medium">{label}</Text>
+      <VStack align="end" gap={1}>
+        {value}
+        {detail && (
+          <Text color="fg.muted" fontSize="sm" textAlign="right">
+            {detail}
+          </Text>
+        )}
+      </VStack>
+    </HStack>
+  );
+}
+
+export default function GitHubDiagnosticsModal({
+  isOpen,
+  onClose,
+  courseId,
+  userRoleId,
+  studentName
+}: GitHubDiagnosticsModalProps) {
+  const supabase = useMemo(() => createClient(), []);
+  const [status, setStatus] = useState<GitHubLinkStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await diagnoseInstructorGitHubAccount({ courseId, userRoleId }, supabase);
+      setStatus(response.status);
+    } catch (error) {
+      Sentry.captureException(error);
+      toaster.error({
+        title: "Error diagnosing GitHub account",
+        description: error instanceof Error ? error.message : "Unknown error"
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [courseId, supabase, userRoleId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      void fetchStatus();
+    }
+  }, [fetchStatus, isOpen]);
+
+  const handleSync = useCallback(async () => {
+    setIsSyncing(true);
+    try {
+      const response = await syncInstructorGitHubAccount({ courseId, userRoleId }, supabase);
+      setStatus(response.status);
+      toaster.success({
+        title: "GitHub permissions synced",
+        description: response.message || "Student GitHub permissions were synced."
+      });
+    } catch (error) {
+      Sentry.captureException(error);
+      toaster.error({
+        title: "Error syncing GitHub permissions",
+        description: error instanceof Error ? error.message : "Unknown error"
+      });
+    } finally {
+      setIsSyncing(false);
+    }
+  }, [courseId, supabase, userRoleId]);
+
+  const handleUnlink = useCallback(async () => {
+    setIsUnlinking(true);
+    try {
+      const response = await unlinkInstructorGitHubAccount({ courseId, userRoleId }, supabase);
+      setStatus(response.status);
+      toaster.success({
+        title: "GitHub identity unlinked",
+        description: response.message
+      });
+    } catch (error) {
+      Sentry.captureException(error);
+      toaster.error({
+        title: "Error unlinking GitHub identity",
+        description: error instanceof Error ? error.message : "Unknown error"
+      });
+    } finally {
+      setIsUnlinking(false);
+    }
+  }, [courseId, supabase, userRoleId]);
+
+  const linkedUsername = status?.currentGithubUsername ?? status?.githubUsername ?? null;
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(details) => !details.open && onClose()}>
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Diagnose GitHub errors</Dialog.Title>
+              <Dialog.CloseTrigger onClick={onClose} />
+            </Dialog.Header>
+            <Dialog.Body>
+              <VStack align="stretch" gap={4}>
+                <Text color="fg.muted">
+                  Checking GitHub link status for {studentName || "this student"} in this course.
+                </Text>
+                {isLoading && (
+                  <HStack>
+                    <Spinner size="sm" />
+                    <Text>Fetching GitHub status...</Text>
+                  </HStack>
+                )}
+                {!isLoading && status && (
+                  <VStack align="stretch" gap={3}>
+                    <StatusRow
+                      label="Linked account"
+                      value={
+                        linkedUsername ? (
+                          <Badge colorPalette="blue">
+                            <BsGithub /> {linkedUsername}
+                          </Badge>
+                        ) : (
+                          <Badge colorPalette="red">No GitHub account linked</Badge>
+                        )
+                      }
+                      detail={status.githubUserId ? `GitHub ID: ${status.githubUserId}` : null}
+                    />
+                    <StatusRow
+                      label="Username changed"
+                      value={
+                        status.usernameChanged ? (
+                          <Badge colorPalette="yellow">Yes</Badge>
+                        ) : (
+                          <Badge colorPalette="green">No</Badge>
+                        )
+                      }
+                      detail={
+                        status.usernameChanged
+                          ? `Stored as ${status.githubUsername}, now ${status.currentGithubUsername}`
+                          : null
+                      }
+                    />
+                    <StatusRow
+                      label="Organization"
+                      value={
+                        <Badge colorPalette={membershipColor(status.orgMembership)}>
+                          {membershipLabel(status.orgMembership)}
+                        </Badge>
+                      }
+                      detail={status.orgMembership.error ?? status.classOrg}
+                    />
+                    <StatusRow
+                      label="Student team"
+                      value={
+                        <Badge colorPalette={membershipColor(status.teamMembership)}>
+                          {membershipLabel(status.teamMembership)}
+                        </Badge>
+                      }
+                      detail={status.teamMembership.error ?? status.studentTeamSlug}
+                    />
+                    <StatusRow
+                      label="Database org status"
+                      value={
+                        status.githubOrgConfirmed ? (
+                          <Badge colorPalette="green">Confirmed</Badge>
+                        ) : (
+                          <Badge colorPalette="red">Not confirmed</Badge>
+                        )
+                      }
+                    />
+                  </VStack>
+                )}
+                {!isLoading && !status && (
+                  <Box color="fg.muted">No GitHub status has been fetched for this student yet.</Box>
+                )}
+              </VStack>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <HStack justify="space-between" w="100%" gap={3}>
+                <PopConfirm
+                  triggerLabel="Unlink GitHub identity"
+                  trigger={
+                    <Button colorPalette="red" variant="surface" loading={isUnlinking} disabled={!status}>
+                      Unlink GitHub identity
+                    </Button>
+                  }
+                  confirmHeader="Unlink GitHub identity"
+                  confirmText="This removes the student's GitHub identity from Pawtograder and removes them from the class GitHub organization."
+                  onConfirm={handleUnlink}
+                  placement="top-start"
+                />
+                <HStack>
+                  <Button variant="ghost" onClick={onClose}>
+                    Close
+                  </Button>
+                  <Button colorPalette="green" onClick={handleSync} loading={isSyncing} disabled={!status}>
+                    Sync permissions
+                  </Button>
+                </HStack>
+              </HStack>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/githubDiagnosticsModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PopConfirm } from "@/components/ui/popconfirm";
+import { Skeleton } from "@/components/ui/skeleton";
 import { toaster } from "@/components/ui/toaster";
 import {
   diagnoseInstructorGitHubAccount,
@@ -9,7 +10,7 @@ import {
 } from "@/lib/edgeFunctions";
 import type { GitHubLinkStatus, GitHubMembershipStatus } from "@/supabase/functions/_shared/FunctionTypes";
 import { createClient } from "@/utils/supabase/client";
-import { Badge, Box, Button, Dialog, HStack, Portal, Spinner, Text, VStack } from "@chakra-ui/react";
+import { Badge, Button, Dialog, HStack, Portal, Spinner, Text, VStack } from "@chakra-ui/react";
 import * as Sentry from "@sentry/nextjs";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -80,7 +81,6 @@ export default function GitHubDiagnosticsModal({
 
   const fetchStatus = useCallback(async () => {
     setIsLoading(true);
-    setStatus(null);
     try {
       const response = await diagnoseInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -98,12 +98,13 @@ export default function GitHubDiagnosticsModal({
   useEffect(() => {
     if (isOpen) {
       void fetchStatus();
+    } else {
+      setStatus(null);
     }
   }, [fetchStatus, isOpen]);
 
   const handleSync = useCallback(async () => {
     setIsSyncing(true);
-    setStatus(null);
     try {
       const response = await syncInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -124,7 +125,6 @@ export default function GitHubDiagnosticsModal({
 
   const handleUnlink = useCallback(async () => {
     setIsUnlinking(true);
-    setStatus(null);
     try {
       const response = await unlinkInstructorGitHubAccount({ courseId, userRoleId }, supabase);
       setStatus(response.status);
@@ -144,7 +144,14 @@ export default function GitHubDiagnosticsModal({
   }, [courseId, supabase, userRoleId]);
 
   const linkedUsername = status?.currentGithubUsername ?? status?.githubUsername ?? null;
-  const isActionDisabled = isLoading || isSyncing || isUnlinking || !status;
+  const isBusy = isLoading || isSyncing || isUnlinking;
+  const isActionDisabled = isBusy || !status;
+  const busyMessage = isSyncing
+    ? "Resyncing GitHub status..."
+    : isUnlinking
+      ? "Unlinking GitHub identity..."
+      : "Fetching GitHub status...";
+  const skeletonBadge = <Skeleton height="6" width="24" />;
 
   return (
     <Dialog.Root open={isOpen} onOpenChange={(details) => !details.open && onClose()}>
@@ -161,75 +168,88 @@ export default function GitHubDiagnosticsModal({
                 <Text color="fg.muted">
                   Checking GitHub link status for {studentName || "this student"} in this course.
                 </Text>
-                {isLoading && (
+                {isBusy && (
                   <HStack>
                     <Spinner size="sm" />
-                    <Text>Fetching GitHub status...</Text>
+                    <Text>{busyMessage}</Text>
                   </HStack>
                 )}
-                {!isLoading && status && (
-                  <VStack align="stretch" gap={3}>
-                    <StatusRow
-                      label="Linked account"
-                      value={
-                        linkedUsername ? (
-                          <Badge colorPalette="blue">
-                            <BsGithub /> {linkedUsername}
-                          </Badge>
-                        ) : (
-                          <Badge colorPalette="red">No GitHub account linked</Badge>
-                        )
-                      }
-                      detail={status.githubUserId ? `GitHub ID: ${status.githubUserId}` : null}
-                    />
-                    <StatusRow
-                      label="Username changed"
-                      value={
-                        status.usernameChanged ? (
-                          <Badge colorPalette="yellow">Yes</Badge>
-                        ) : (
-                          <Badge colorPalette="green">No</Badge>
-                        )
-                      }
-                      detail={
-                        status.usernameChanged
-                          ? `Stored as ${status.githubUsername}, now ${status.currentGithubUsername}`
-                          : null
-                      }
-                    />
-                    <StatusRow
-                      label="Organization"
-                      value={
+                <VStack align="stretch" gap={3}>
+                  <StatusRow
+                    label="Linked account"
+                    value={
+                      isBusy ? (
+                        skeletonBadge
+                      ) : linkedUsername ? (
+                        <Badge colorPalette="blue">
+                          <BsGithub /> {linkedUsername}
+                        </Badge>
+                      ) : (
+                        <Badge colorPalette="red">No GitHub account linked</Badge>
+                      )
+                    }
+                    detail={!isBusy && status?.githubUserId ? `GitHub ID: ${status.githubUserId}` : null}
+                  />
+                  <StatusRow
+                    label="Username changed"
+                    value={
+                      isBusy ? (
+                        skeletonBadge
+                      ) : status?.usernameChanged ? (
+                        <Badge colorPalette="yellow">Yes</Badge>
+                      ) : (
+                        <Badge colorPalette="green">No</Badge>
+                      )
+                    }
+                    detail={
+                      !isBusy && status?.usernameChanged
+                        ? `Stored as ${status.githubUsername}, now ${status.currentGithubUsername}`
+                        : null
+                    }
+                  />
+                  <StatusRow
+                    label="Organization"
+                    value={
+                      isBusy ? (
+                        skeletonBadge
+                      ) : status ? (
                         <Badge colorPalette={membershipColor(status.orgMembership)}>
                           {membershipLabel(status.orgMembership)}
                         </Badge>
-                      }
-                      detail={status.orgMembership.error ?? status.classOrg}
-                    />
-                    <StatusRow
-                      label="Student team"
-                      value={
+                      ) : (
+                        skeletonBadge
+                      )
+                    }
+                    detail={!isBusy && status ? (status.orgMembership.error ?? status.classOrg) : null}
+                  />
+                  <StatusRow
+                    label="Student team"
+                    value={
+                      isBusy ? (
+                        skeletonBadge
+                      ) : status ? (
                         <Badge colorPalette={membershipColor(status.teamMembership)}>
                           {membershipLabel(status.teamMembership)}
                         </Badge>
-                      }
-                      detail={status.teamMembership.error ?? status.studentTeamSlug}
-                    />
-                    <StatusRow
-                      label="Database org status"
-                      value={
-                        status.githubOrgConfirmed ? (
-                          <Badge colorPalette="green">Confirmed</Badge>
-                        ) : (
-                          <Badge colorPalette="red">Not confirmed</Badge>
-                        )
-                      }
-                    />
-                  </VStack>
-                )}
-                {!isLoading && !status && (
-                  <Box color="fg.muted">No GitHub status has been fetched for this student yet.</Box>
-                )}
+                      ) : (
+                        skeletonBadge
+                      )
+                    }
+                    detail={!isBusy && status ? (status.teamMembership.error ?? status.studentTeamSlug) : null}
+                  />
+                  <StatusRow
+                    label="Database org status"
+                    value={
+                      isBusy ? (
+                        skeletonBadge
+                      ) : status?.githubOrgConfirmed ? (
+                        <Badge colorPalette="green">Confirmed</Badge>
+                      ) : (
+                        <Badge colorPalette="red">Not confirmed</Badge>
+                      )
+                    }
+                  />
+                </VStack>
               </VStack>
             </Dialog.Body>
             <Dialog.Footer>

--- a/lib/edgeFunctions.ts
+++ b/lib/edgeFunctions.ts
@@ -257,6 +257,33 @@ export async function userFetchAzureProfile(params: { accessToken: string }, sup
 export async function syncGitHubAccount(supabase: SupabaseClient<Database>) {
   return await invokeEdgeFunction<{ message: string }>(supabase, "github-user-sync", { body: {} });
 }
+
+export async function diagnoseInstructorGitHubAccount(
+  params: Omit<FunctionTypes.InstructorGitHubDiagnoseRequest, "action">,
+  supabase: SupabaseClient<Database>
+) {
+  return await invokeEdgeFunction<FunctionTypes.InstructorGitHubDiagnoseResponse>(supabase, "github-user-sync", {
+    body: { ...params, action: "diagnose" }
+  });
+}
+
+export async function syncInstructorGitHubAccount(
+  params: Omit<FunctionTypes.InstructorGitHubSyncRequest, "action">,
+  supabase: SupabaseClient<Database>
+) {
+  return await invokeEdgeFunction<FunctionTypes.InstructorGitHubSyncResponse>(supabase, "github-user-sync", {
+    body: { ...params, action: "sync" }
+  });
+}
+
+export async function unlinkInstructorGitHubAccount(
+  params: Omit<FunctionTypes.InstructorGitHubUnlinkRequest, "action">,
+  supabase: SupabaseClient<Database>
+) {
+  return await invokeEdgeFunction<FunctionTypes.InstructorGitHubUnlinkResponse>(supabase, "github-user-sync", {
+    body: { ...params, action: "unlink" }
+  });
+}
 export class EdgeFunctionError extends Error {
   details: string;
   recoverable: boolean;

--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -197,6 +197,63 @@ export type GenericResponse = {
   };
 };
 
+export type GitHubMembershipStatus = {
+  state: "active" | "pending" | "not_found" | "unknown";
+  isMember: boolean;
+  error?: string;
+};
+
+export type InstructorGitHubDiagnoseRequest = {
+  action: "diagnose";
+  courseId: number;
+  userRoleId: number;
+};
+
+export type InstructorGitHubSyncRequest = {
+  action: "sync";
+  courseId: number;
+  userRoleId: number;
+};
+
+export type InstructorGitHubUnlinkRequest = {
+  action: "unlink";
+  courseId: number;
+  userRoleId: number;
+};
+
+export type GitHubLinkStatus = {
+  courseId: number;
+  userRoleId: number;
+  userId: string;
+  email: string | null;
+  githubUsername: string | null;
+  githubUserId: string | null;
+  currentGithubUsername: string | null;
+  usernameChanged: boolean;
+  classOrg: string | null;
+  studentTeamSlug: string | null;
+  githubOrgConfirmed: boolean;
+  lastGithubUserSync: string | null;
+  orgMembership: GitHubMembershipStatus;
+  teamMembership: GitHubMembershipStatus;
+};
+
+export type InstructorGitHubDiagnoseResponse = {
+  status: GitHubLinkStatus;
+};
+
+export type InstructorGitHubSyncResponse = {
+  message: string;
+  status: GitHubLinkStatus;
+};
+
+export type InstructorGitHubUnlinkResponse = {
+  message: string;
+  removedFromOrg: boolean;
+  unlinkedIdentity: boolean;
+  status: GitHubLinkStatus;
+};
+
 export type AssignmentGroupJoinRequest = {
   assignment_group_id: number;
 };

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -807,7 +807,9 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   }
   const { data: classData, error: classError } = await supabase
     .from("classes")
-    .select("github_org")
+    .select("github_org, user_roles!inner(user_id, disabled)")
+    .eq("user_roles.user_id", user.id)
+    .eq("user_roles.disabled", false)
     .not("github_org", "is", "null")
     .limit(1)
     .single();

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -3,8 +3,49 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { TZDate } from "npm:@date-fns/tz";
 import * as Sentry from "npm:@sentry/deno";
 import { createRepo, getOctoKit, reinviteToOrgTeam, syncRepoPermissions } from "../_shared/GitHubWrapper.ts";
-import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import {
+  assertUserIsInstructor,
+  SecurityError,
+  UserVisibleError,
+  wrapRequestHandler
+} from "../_shared/HandlerUtils.ts";
+import type {
+  GitHubLinkStatus,
+  GitHubMembershipStatus,
+  InstructorGitHubDiagnoseRequest,
+  InstructorGitHubSyncRequest,
+  InstructorGitHubUnlinkRequest
+} from "../_shared/FunctionTypes.d.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
+
+type InstructorGitHubRequest =
+  | InstructorGitHubDiagnoseRequest
+  | InstructorGitHubSyncRequest
+  | InstructorGitHubUnlinkRequest;
+
+type AdminSupabase = ReturnType<typeof createClient<Database>>;
+
+type TargetStudentEnrollment = {
+  id: number;
+  user_id: string;
+  role: Database["public"]["Enums"]["app_role"];
+  github_org_confirmed: boolean;
+  users: {
+    email: string | null;
+    github_username: string | null;
+    github_user_id: string | null;
+    last_github_user_sync: string | null;
+  } | null;
+  classes: {
+    id: number;
+    slug: string | null;
+    github_org: string | null;
+  } | null;
+};
+
+function getAdminSupabase() {
+  return createClient<Database>(Deno.env.get("SUPABASE_URL") || "", Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "");
+}
 
 async function ensureStaffOrgMembership(userID: string, githubUsername: string, scope: Sentry.Scope) {
   const adminSupabase = createClient<Database>(
@@ -56,10 +97,7 @@ async function ensureStaffOrgMembership(userID: string, githubUsername: string, 
 }
 
 async function ensureAllReposExist(userID: string, githubUsername: string, scope: Sentry.Scope) {
-  const adminSupabase = createClient<Database>(
-    Deno.env.get("SUPABASE_URL") || "",
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
-  );
+  const adminSupabase = getAdminSupabase();
   const { data: classes, error: classesError } = await adminSupabase
     .from("user_roles")
     .select(
@@ -369,7 +407,388 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   }
   return { madeChanges, errorMessages };
 }
-async function handleRequest(req: Request, scope: Sentry.Scope) {
+async function fetchGitHubUserLogin(
+  githubUserId: string | null | undefined,
+  githubOrg: string,
+  scope: Sentry.Scope
+): Promise<{ login: string | null; error?: string }> {
+  if (!githubUserId) {
+    return { login: null, error: "User has no GitHub user ID" };
+  }
+  const accountId = Number(githubUserId);
+  if (!Number.isFinite(accountId)) {
+    return { login: null, error: "User has an invalid GitHub user ID" };
+  }
+  const octokit = await getOctoKit(githubOrg, scope);
+  if (!octokit) {
+    throw new UserVisibleError("Error fetching octokit");
+  }
+  try {
+    const gitHubUser = await octokit.request("GET /user/{account_id}", {
+      account_id: accountId,
+      headers: {
+        "X-GitHub-Api-Version": "2022-11-28"
+      }
+    });
+    if (gitHubUser.status !== 200) {
+      Sentry.captureException(gitHubUser, scope);
+      return { login: null, error: "Error fetching GitHub user" };
+    }
+    return { login: gitHubUser.data.login };
+  } catch (error) {
+    Sentry.captureException(error, scope);
+    return { login: null, error: "Error fetching GitHub user" };
+  }
+}
+
+async function getOrgMembershipStatus(
+  org: string,
+  username: string | null,
+  scope: Sentry.Scope
+): Promise<GitHubMembershipStatus> {
+  if (!username) {
+    return { state: "unknown", isMember: false, error: "No GitHub username is linked" };
+  }
+  const octokit = await getOctoKit(org, scope);
+  if (!octokit) {
+    throw new UserVisibleError("Error fetching octokit");
+  }
+  try {
+    const membership = await octokit.request("GET /orgs/{org}/memberships/{username}", {
+      org,
+      username
+    });
+    const state =
+      membership.data.state === "active" || membership.data.state === "pending" ? membership.data.state : "unknown";
+    return { state, isMember: state === "active" };
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) {
+      return { state: "not_found", isMember: false };
+    }
+    Sentry.captureException(error, scope);
+    return { state: "unknown", isMember: false, error: "Error checking organization membership" };
+  }
+}
+
+async function getTeamMembershipStatus(
+  org: string,
+  teamSlug: string | null,
+  username: string | null,
+  scope: Sentry.Scope
+): Promise<GitHubMembershipStatus> {
+  if (!teamSlug) {
+    return { state: "unknown", isMember: false, error: "Course has no student team slug" };
+  }
+  if (!username) {
+    return { state: "unknown", isMember: false, error: "No GitHub username is linked" };
+  }
+  const octokit = await getOctoKit(org, scope);
+  if (!octokit) {
+    throw new UserVisibleError("Error fetching octokit");
+  }
+  try {
+    const membership = await octokit.request("GET /orgs/{org}/teams/{team_slug}/memberships/{username}", {
+      org,
+      team_slug: teamSlug,
+      username
+    });
+    const state =
+      membership.data.state === "active" || membership.data.state === "pending" ? membership.data.state : "unknown";
+    return { state, isMember: state === "active" };
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) {
+      return { state: "not_found", isMember: false };
+    }
+    Sentry.captureException(error, scope);
+    return { state: "unknown", isMember: false, error: "Error checking team membership" };
+  }
+}
+
+async function getTargetStudentEnrollment(
+  adminSupabase: AdminSupabase,
+  courseId: number,
+  userRoleId: number,
+  scope: Sentry.Scope
+): Promise<TargetStudentEnrollment> {
+  const { data, error } = await adminSupabase
+    .from("user_roles")
+    .select(
+      "id, user_id, role, github_org_confirmed, users(email, github_username, github_user_id, last_github_user_sync), classes(id, slug, github_org)"
+    )
+    .eq("id", userRoleId)
+    .eq("class_id", courseId)
+    .maybeSingle();
+  if (error) {
+    Sentry.captureException(error, scope);
+    throw new UserVisibleError("Error fetching enrollment");
+  }
+  if (!data) {
+    throw new UserVisibleError("Student enrollment not found");
+  }
+  if (data.role !== "student") {
+    throw new UserVisibleError("GitHub diagnostics are only available for students");
+  }
+  return data as TargetStudentEnrollment;
+}
+
+async function diagnoseGitHubLinkStatus(
+  target: TargetStudentEnrollment,
+  scope: Sentry.Scope
+): Promise<GitHubLinkStatus> {
+  const githubOrg = target.classes?.github_org ?? null;
+  const studentTeamSlug = target.classes?.slug ? `${target.classes.slug}-students` : null;
+  let currentGithubUsername: string | null = null;
+  if (githubOrg) {
+    const currentUser = await fetchGitHubUserLogin(target.users?.github_user_id, githubOrg, scope);
+    currentGithubUsername = currentUser.login;
+  }
+  const usernameForMembership = currentGithubUsername ?? target.users?.github_username ?? null;
+  const orgMembership: GitHubMembershipStatus = githubOrg
+    ? await getOrgMembershipStatus(githubOrg, usernameForMembership, scope)
+    : { state: "unknown", isMember: false, error: "Course has no GitHub organization" };
+  const teamMembership: GitHubMembershipStatus = githubOrg
+    ? await getTeamMembershipStatus(githubOrg, studentTeamSlug, usernameForMembership, scope)
+    : { state: "unknown", isMember: false, error: "Course has no GitHub organization" };
+
+  return {
+    courseId: target.classes?.id ?? 0,
+    userRoleId: target.id,
+    userId: target.user_id,
+    email: target.users?.email ?? null,
+    githubUsername: target.users?.github_username ?? null,
+    githubUserId: target.users?.github_user_id ?? null,
+    currentGithubUsername,
+    usernameChanged: Boolean(
+      currentGithubUsername &&
+        target.users?.github_username &&
+        currentGithubUsername.toLowerCase() !== target.users.github_username.toLowerCase()
+    ),
+    classOrg: githubOrg,
+    studentTeamSlug,
+    githubOrgConfirmed: target.github_org_confirmed,
+    lastGithubUserSync: target.users?.last_github_user_sync ?? null,
+    orgMembership,
+    teamMembership
+  };
+}
+
+async function syncGitHubUser(
+  userId: string,
+  githubOrg: string,
+  force: boolean,
+  scope: Sentry.Scope
+): Promise<{ success: boolean; message: string }> {
+  const adminSupabase = getAdminSupabase();
+  const { data: userData, error: userError } = await adminSupabase
+    .from("users")
+    .select("github_username, github_user_id, last_github_user_sync")
+    .eq("user_id", userId)
+    .single();
+  if (userError) {
+    Sentry.captureException(userError, scope);
+    throw new SecurityError("Error fetching user");
+  }
+  if (
+    !force &&
+    userData?.last_github_user_sync &&
+    new Date(userData.last_github_user_sync) > new Date(new Date().getTime() - 1000 * 60 * 60 * 24)
+  ) {
+    return {
+      success: false,
+      message: `User has already been synced recently. If you still are struggling with GitHub permissions, please email ${Deno.env.get("SUPPORT_EMAIL") || "(No support email set)"}.`
+    };
+  }
+  if (!userData?.github_user_id) {
+    throw new UserVisibleError("User has no github user id");
+  }
+  const gitHubUser = await fetchGitHubUserLogin(userData.github_user_id, githubOrg, scope);
+  if (!gitHubUser.login) {
+    throw new UserVisibleError("Error fetching github user");
+  }
+  const { error: updateError } = await adminSupabase
+    .from("users")
+    .update({ github_username: gitHubUser.login, last_github_user_sync: new Date().toISOString() })
+    .eq("user_id", userId);
+  if (updateError) {
+    Sentry.captureException(updateError, scope);
+    throw new UserVisibleError("Error updating user");
+  }
+
+  // Ensure staff org/team membership for any instructor/grader roles this user has.
+  // (ensureAllReposExist only operates on student roles.)
+  const staffResult = await ensureStaffOrgMembership(userId, gitHubUser.login, scope);
+
+  //For good measure, make sure that all repos for the student exist and have the correct permissions
+  const { madeChanges: studentMadeChanges, errorMessages: studentErrorMessages } = await ensureAllReposExist(
+    userId,
+    gitHubUser.login,
+    scope
+  );
+  const madeChanges = staffResult.madeChanges || studentMadeChanges;
+  const errorMessages = [...staffResult.errorMessages, ...studentErrorMessages];
+  const changedUsername = userData.github_username !== gitHubUser.login;
+  const messages = [];
+  if (changedUsername) {
+    Sentry.addBreadcrumb({
+      category: "github",
+      message: `GitHub username updated from ${userData.github_username} to ${gitHubUser.login}. Please refresh the page.`,
+      level: "info"
+    });
+    messages.push(
+      `GitHub username updated from ${userData.github_username} to ${gitHubUser.login}. Please refresh the page.`
+    );
+  }
+  if (madeChanges) {
+    messages.push(`Repositories were updated. Please refresh the page.`);
+  }
+  messages.push(...errorMessages);
+  return {
+    success: true,
+    message: messages.join("\n")
+  };
+}
+
+async function removeUserFromOrg(githubOrg: string, githubUsername: string, scope: Sentry.Scope) {
+  const octokit = await getOctoKit(githubOrg, scope);
+  if (!octokit) {
+    throw new UserVisibleError("Error fetching octokit");
+  }
+  try {
+    await octokit.request("DELETE /orgs/{org}/memberships/{username}", {
+      org: githubOrg,
+      username: githubUsername
+    });
+    return true;
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) {
+      return false;
+    }
+    Sentry.captureException(error, scope);
+    throw new UserVisibleError("Error removing student from GitHub organization");
+  }
+}
+
+async function unlinkGitHubIdentityForUser(userEmail: string, scope: Sentry.Scope) {
+  const adminSupabase = getAdminSupabase();
+  const { data: magicLinkData, error: magicLinkError } = await adminSupabase.auth.admin.generateLink({
+    email: userEmail,
+    type: "magiclink"
+  });
+  if (magicLinkError || !magicLinkData.properties?.hashed_token) {
+    Sentry.captureException(magicLinkError, scope);
+    throw new UserVisibleError("Error generating sign-in link for student");
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? Deno.env.get("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new UserVisibleError("Missing Supabase URL or anon key");
+  }
+
+  const userSupabase = createClient<Database>(supabaseUrl, supabaseAnonKey);
+  const { data: sessionData, error: sessionError } = await userSupabase.auth.verifyOtp({
+    token_hash: magicLinkData.properties.hashed_token,
+    type: "magiclink"
+  });
+  if (sessionError || !sessionData.session) {
+    Sentry.captureException(sessionError, scope);
+    throw new UserVisibleError("Error signing in as student");
+  }
+
+  const { data: identitiesData, error: identitiesError } = await userSupabase.auth.getUserIdentities();
+  if (identitiesError) {
+    Sentry.captureException(identitiesError, scope);
+    throw new UserVisibleError("Error fetching student identities");
+  }
+
+  const githubIdentity = identitiesData?.identities.find((identity) => identity.provider === "github");
+  if (!githubIdentity) {
+    return false;
+  }
+
+  const { error: unlinkError } = await userSupabase.auth.unlinkIdentity(githubIdentity);
+  if (unlinkError) {
+    Sentry.captureException(unlinkError, scope);
+    throw new UserVisibleError("Error unlinking GitHub identity");
+  }
+  await userSupabase.auth.signOut();
+  return true;
+}
+
+async function handleInstructorGitHubRequest(req: Request, body: InstructorGitHubRequest, scope: Sentry.Scope) {
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    throw new SecurityError("Missing Authorization header");
+  }
+  await assertUserIsInstructor(body.courseId, authHeader);
+  const adminSupabase = getAdminSupabase();
+  const target = await getTargetStudentEnrollment(adminSupabase, body.courseId, body.userRoleId, scope);
+
+  if (body.action === "diagnose") {
+    return { status: await diagnoseGitHubLinkStatus(target, scope) };
+  }
+
+  if (body.action === "sync") {
+    if (!target.classes?.github_org) {
+      throw new UserVisibleError("Course has no GitHub organization configured");
+    }
+    const syncResult = await syncGitHubUser(target.user_id, target.classes.github_org, true, scope);
+    const refreshedTarget = await getTargetStudentEnrollment(adminSupabase, body.courseId, body.userRoleId, scope);
+    return {
+      message: syncResult.message || "GitHub permissions synced.",
+      status: await diagnoseGitHubLinkStatus(refreshedTarget, scope)
+    };
+  }
+
+  if (!target.users?.email) {
+    throw new UserVisibleError("Student has no email address");
+  }
+  let removedFromOrg = false;
+  if (target.classes?.github_org) {
+    const currentUser = await fetchGitHubUserLogin(target.users.github_user_id, target.classes.github_org, scope);
+    const usernameForRemoval = currentUser.login ?? target.users.github_username;
+    if (usernameForRemoval) {
+      removedFromOrg = await removeUserFromOrg(target.classes.github_org, usernameForRemoval, scope);
+    }
+  }
+  const unlinkedIdentity = await unlinkGitHubIdentityForUser(target.users.email, scope);
+  const { error: updateUserError } = await adminSupabase
+    .from("users")
+    .update({ github_username: null, github_user_id: null, last_github_user_sync: null })
+    .eq("user_id", target.user_id);
+  if (updateUserError) {
+    Sentry.captureException(updateUserError, scope);
+    throw new UserVisibleError("Error clearing GitHub link from student");
+  }
+  const { error: updateRoleError } = await adminSupabase
+    .from("user_roles")
+    .update({ github_org_confirmed: false })
+    .eq("id", target.id);
+  if (updateRoleError) {
+    Sentry.captureException(updateRoleError, scope);
+    throw new UserVisibleError("Error clearing GitHub organization status");
+  }
+
+  const refreshedTarget = await getTargetStudentEnrollment(adminSupabase, body.courseId, body.userRoleId, scope);
+  return {
+    message: unlinkedIdentity
+      ? "GitHub identity unlinked and organization membership removed."
+      : "No GitHub identity was linked; organization membership was checked.",
+    removedFromOrg,
+    unlinkedIdentity,
+    status: await diagnoseGitHubLinkStatus(refreshedTarget, scope)
+  };
+}
+
+async function parseRequestBody(req: Request): Promise<Record<string, unknown>> {
+  try {
+    return await req.json();
+  } catch {
+    return {};
+  }
+}
+
+async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   const authHeader = req.headers.get("Authorization");
   if (!authHeader) {
     throw new SecurityError("Missing Authorization header");
@@ -399,86 +818,15 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
   if (!classData) {
     throw new UserVisibleError("User not in any classes");
   }
-  const { data: userData, error: userError } = await supabase
-    .from("users")
-    .select("github_username, github_user_id, last_github_user_sync")
-    .eq("user_id", user.id)
-    .single();
-  if (userError) {
-    Sentry.captureException(userError, scope);
-    throw new SecurityError("Error fetching user");
-  }
-  if (
-    userData?.last_github_user_sync &&
-    new Date(userData.last_github_user_sync) > new Date(new Date().getTime() - 1000 * 60 * 60 * 24)
-  ) {
-    return {
-      success: false,
-      message: `User has already been synced recently. If you still are struggling with GitHub permissions, please email ${Deno.env.get("SUPPORT_EMAIL") || "(No support email set)"}.`
-    };
-  }
-  const octokit = await getOctoKit(classData.github_org!, scope);
-  if (!octokit) {
-    throw new UserVisibleError("Error fetching octokit");
-  }
-  if (!userData?.github_user_id) {
-    throw new UserVisibleError("User has no github user id");
-  }
-  const gitHubUser = await octokit.request("GET /user/{account_id}", {
-    account_id: Number(userData.github_user_id),
-    headers: {
-      "X-GitHub-Api-Version": "2022-11-28"
-    }
-  });
-  if (gitHubUser.status !== 200) {
-    Sentry.captureException(gitHubUser, scope);
-    throw new UserVisibleError("Error fetching github user");
-  }
-  const adminSupabase = createClient<Database>(
-    Deno.env.get("SUPABASE_URL") || "",
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
-  );
-  const { error: updateError } = await adminSupabase
-    .from("users")
-    .update({ github_username: gitHubUser.data.login, last_github_user_sync: new Date().toISOString() })
-    .eq("user_id", user.id);
-  if (updateError) {
-    Sentry.captureException(updateError, scope);
-    throw new UserVisibleError("Error updating user");
-  }
+  return await syncGitHubUser(user.id, classData.github_org!, false, scope);
+}
 
-  // Ensure staff org/team membership for any instructor/grader roles this user has.
-  // (ensureAllReposExist only operates on student roles.)
-  const staffResult = await ensureStaffOrgMembership(user.id, gitHubUser.data.login, scope);
-
-  //For good measure, make sure that all repos for the student exist and have the correct permissions
-  const { madeChanges: studentMadeChanges, errorMessages: studentErrorMessages } = await ensureAllReposExist(
-    user.id,
-    gitHubUser.data.login,
-    scope
-  );
-  const madeChanges = staffResult.madeChanges || studentMadeChanges;
-  const errorMessages = [...staffResult.errorMessages, ...studentErrorMessages];
-  const changedUsername = userData.github_username !== gitHubUser.data.login;
-  const messages = [];
-  if (changedUsername) {
-    Sentry.addBreadcrumb({
-      category: "github",
-      message: `GitHub username updated from ${userData.github_username} to ${gitHubUser.data.login}. Please refresh the page.`,
-      level: "info"
-    });
-    messages.push(
-      `GitHub username updated from ${userData.github_username} to ${gitHubUser.data.login}. Please refresh the page.`
-    );
+async function handleRequest(req: Request, scope: Sentry.Scope) {
+  const body = await parseRequestBody(req);
+  if (body.action === "diagnose" || body.action === "sync" || body.action === "unlink") {
+    return await handleInstructorGitHubRequest(req, body as InstructorGitHubRequest, scope);
   }
-  if (madeChanges) {
-    messages.push(`Repositories were updated. Please refresh the page.`);
-  }
-  messages.push(...errorMessages);
-  return {
-    success: true,
-    message: messages.join("\n")
-  };
+  return await handleStudentGitHubSync(req, scope);
 }
 Deno.serve(async (req) => {
   return await wrapRequestHandler(req, handleRequest);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add instructor-only GitHub diagnose, forced sync, and unlink actions to the existing `github-user-sync` edge function.
- Add an enrollments-page diagnostics modal showing linked account, username-change, org membership, team membership, and DB org status.
- Add an instructor unlink path that removes the student from the course GitHub org, unlinks the Supabase GitHub identity, and clears stored GitHub metadata.
- Address review feedback: reset modal status during refresh/actions, disable actions while busy, use the root import alias, and constrain student sync org lookup to classes the user is enrolled in.

### Walkthrough
[instructor_github_diagnostics_modal.mp4](https://cursor.com/agents/bc-7e67815a-f879-48f6-8484-f86db80b9e5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstructor_github_diagnostics_modal.mp4)
[Instructor GitHub diagnostics modal](https://cursor.com/agents/bc-7e67815a-f879-48f6-8484-f86db80b9e5a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finstructor_github_diagnostics_modal.webp)

### Testing
- `npm run format`
- `npm run lint`
- `set -a && source .env.local.staging && set +a && npm run build`
- `npm run typecheck:functions` attempted, but this VM is missing `deno`.
- Local Supabase fresh start + seed, Next dev server, and Edge Functions serve.
- Browser walkthrough opened the enrollments page as a seeded instructor and verified the GitHub diagnostics modal.
- Direct `github-user-sync` instructor diagnose invoke returned expected no-GitHub status for a seeded student.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e67815a-f879-48f6-8484-f86db80b9e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e67815a-f879-48f6-8484-f86db80b9e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub account diagnostics modal accessible from the enrollments table for managing student GitHub accounts and permissions.
  * Added ability to sync GitHub permissions for linked student accounts.
  * Added ability to unlink GitHub identities from student accounts.
  * Added GitHub account status display showing linkage status, organization membership, team membership, and username changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->