### PR TITLE
Stabilize visual regression screenshots

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/page.tsx
@@ -221,7 +221,7 @@ export default function AssignmentPage() {
                         : `(Old #${submission.ordinal})`}
                     </Link>
                   </Table.Cell>
-                  <Table.Cell data-visual-test="transparent">
+                  <Table.Cell data-visual-test="transparent" data-visual-placeholder="date">
                     <Link href={`/course/${course_id}/assignments/${assignment_id}/submissions/${submission.id}`}>
                       {format(new TZDate(submission.created_at, timeZone), "MMM d h:mm aaa")}
                     </Link>

--- a/app/course/[course_id]/assignments/[assignment_id]/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/page.tsx
@@ -221,9 +221,11 @@ export default function AssignmentPage() {
                         : `(Old #${submission.ordinal})`}
                     </Link>
                   </Table.Cell>
-                  <Table.Cell data-visual-test="transparent" data-visual-placeholder="date">
+                  <Table.Cell>
                     <Link href={`/course/${course_id}/assignments/${assignment_id}/submissions/${submission.id}`}>
-                      {format(new TZDate(submission.created_at, timeZone), "MMM d h:mm aaa")}
+                      <span data-visual-test="transparent" data-visual-placeholder="date">
+                        {format(new TZDate(submission.created_at, timeZone), "MMM d h:mm aaa")}
+                      </span>
                     </Link>
                   </Table.Cell>
                   <Table.Cell>

--- a/app/course/[course_id]/assignments/[assignment_id]/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/page.tsx
@@ -221,7 +221,7 @@ export default function AssignmentPage() {
                         : `(Old #${submission.ordinal})`}
                     </Link>
                   </Table.Cell>
-                  <Table.Cell data-visual-test="blackout">
+                  <Table.Cell data-visual-test="transparent">
                     <Link href={`/course/${course_id}/assignments/${assignment_id}/submissions/${submission.id}`}>
                       {format(new TZDate(submission.created_at, timeZone), "MMM d h:mm aaa")}
                     </Link>

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
@@ -367,7 +367,7 @@ function ArtifactComment({
           >
             <HStack gap={1} fontSize="sm" color="fg.muted" ml={1}>
               <Text fontWeight="bold">{authorProfile?.name}</Text>
-              <Text data-visual-test="blackout">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
             </HStack>
             <HStack>
               {isAuthor || authorProfile?.flair ? (

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/files/page.tsx
@@ -367,7 +367,9 @@ function ArtifactComment({
           >
             <HStack gap={1} fontSize="sm" color="fg.muted" ml={1}>
               <Text fontWeight="bold">{authorProfile?.name}</Text>
-              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent" data-visual-placeholder="timestamp">
+                commented on {format(comment.created_at, "MMM d, yyyy")}
+              </Text>
             </HStack>
             <HStack>
               {isAuthor || authorProfile?.flair ? (

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -1503,9 +1503,27 @@ function ReviewStats() {
       )}
       {!isInstructor && <DataListItem label="Released to student" value={review.released ? "Yes" : "No"} />}
       {completed_by && <DataListItem label="Completed by" value={<PersonName size="2xs" uid={completed_by} />} />}
-      {completed_at && <DataListItem label="Completed at" value={formatRelative(completed_at, new Date())} />}
+      {completed_at && (
+        <DataListItem
+          label="Completed at"
+          value={
+            <Text as="span" data-visual-test="transparent" data-visual-placeholder="relative-time">
+              {formatRelative(completed_at, new Date())}
+            </Text>
+          }
+        />
+      )}
       {checked_by && <DataListItem label="Checked by" value={<PersonName size="2xs" uid={checked_by} />} />}
-      {checked_at && <DataListItem label="Checked at" value={formatRelative(checked_at, new Date())} />}
+      {checked_at && (
+        <DataListItem
+          label="Checked at"
+          value={
+            <Text as="span" data-visual-test="transparent" data-visual-placeholder="relative-time">
+              {formatRelative(checked_at, new Date())}
+            </Text>
+          }
+        />
+      )}
       {mostRecentGrader && (
         <DataListItem label="Last updated by" value={<PersonName size="2xs" uid={mostRecentGrader} />} />
       )}
@@ -1884,7 +1902,9 @@ function RubricView() {
               Review Task: {rubric?.name} ({rubric?.review_round})
             </Heading>
             {rubricPartsAdvice && <Text fontSize="sm">Only grading rubric part(s): {rubricPartsAdvice}</Text>}
-            <Text fontSize="sm">Assigned to: {reviewAssignment.assignee_profile_id || "N/A"}</Text>
+            <Text fontSize="sm" data-visual-test="transparent" data-visual-placeholder="review-status">
+              Assigned to: {reviewAssignment.assignee_profile_id || "N/A"}
+            </Text>
             <Text fontSize="sm" data-visual-test="transparent" data-visual-placeholder="review-status">
               Due:{" "}
               {reviewAssignment.due_date ? (

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -1885,7 +1885,7 @@ function RubricView() {
             </Heading>
             {rubricPartsAdvice && <Text fontSize="sm">Only grading rubric part(s): {rubricPartsAdvice}</Text>}
             <Text fontSize="sm">Assigned to: {reviewAssignment.assignee_profile_id || "N/A"}</Text>
-            <Text fontSize="sm" data-visual-test="transparent">
+            <Text fontSize="sm" data-visual-test="transparent" data-visual-placeholder="review-status">
               Due:{" "}
               {reviewAssignment.due_date ? (
                 <TimeZoneAwareDate date={reviewAssignment.due_date} format="MMM d, h:mm a" />

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -1885,7 +1885,7 @@ function RubricView() {
             </Heading>
             {rubricPartsAdvice && <Text fontSize="sm">Only grading rubric part(s): {rubricPartsAdvice}</Text>}
             <Text fontSize="sm">Assigned to: {reviewAssignment.assignee_profile_id || "N/A"}</Text>
-            <Text fontSize="sm" data-visual-test="blackout">
+            <Text fontSize="sm" data-visual-test="transparent">
               Due:{" "}
               {reviewAssignment.due_date ? (
                 <TimeZoneAwareDate date={reviewAssignment.due_date} format="MMM d, h:mm a" />

--- a/app/course/[course_id]/discussion/DiscussionThreadList.tsx
+++ b/app/course/[course_id]/discussion/DiscussionThreadList.tsx
@@ -152,7 +152,12 @@ export const DiscussionThreadTeaser = memo((props: Props) => {
                   </Badge>
                 )}
                 <Spacer />
-                <Text fontSize="xs" color="text.muted" data-visual-test="transparent">
+                <Text
+                  fontSize="xs"
+                  color="text.muted"
+                  data-visual-test="transparent"
+                  data-visual-placeholder="relative-time"
+                >
                   {thread?.created_at ? formatRelative(new Date(thread?.created_at), new Date()) : ""}
                 </Text>
               </HStack>

--- a/app/course/[course_id]/discussion/DiscussionThreadList.tsx
+++ b/app/course/[course_id]/discussion/DiscussionThreadList.tsx
@@ -152,7 +152,7 @@ export const DiscussionThreadTeaser = memo((props: Props) => {
                   </Badge>
                 )}
                 <Spacer />
-                <Text fontSize="xs" color="text.muted" data-visual-test="blackout">
+                <Text fontSize="xs" color="text.muted" data-visual-test="transparent">
                   {thread?.created_at ? formatRelative(new Date(thread?.created_at), new Date()) : ""}
                 </Text>
               </HStack>

--- a/app/course/[course_id]/discussion/discussion_thread.tsx
+++ b/app/course/[course_id]/discussion/discussion_thread.tsx
@@ -363,7 +363,13 @@ const DiscussionThreadContent = memo(
                   )}
                 </Box>
                 <HStack fontWeight="semibold" textStyle="xs" ps="2">
-                  <Text textStyle="sm" color="fg.muted" ms="3" data-visual-test="transparent">
+                  <Text
+                    textStyle="sm"
+                    color="fg.muted"
+                    ms="3"
+                    data-visual-test="transparent"
+                    data-visual-placeholder="relative-time"
+                  >
                     {formatRelative(thread.created_at, new Date())}
                   </Text>
                   <Link onClick={showReply} color="fg.muted">

--- a/app/course/[course_id]/discussion/discussion_thread.tsx
+++ b/app/course/[course_id]/discussion/discussion_thread.tsx
@@ -363,7 +363,7 @@ const DiscussionThreadContent = memo(
                   )}
                 </Box>
                 <HStack fontWeight="semibold" textStyle="xs" ps="2">
-                  <Text textStyle="sm" color="fg.muted" ms="3" data-visual-test="blackout">
+                  <Text textStyle="sm" color="fg.muted" ms="3" data-visual-test="transparent">
                     {formatRelative(thread.created_at, new Date())}
                   </Text>
                   <Link onClick={showReply} color="fg.muted">

--- a/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
@@ -512,6 +512,7 @@ export default function SurveyResponsesView({
             fontWeight="bold"
             color={isOverdue ? "red.fg" : isLessThan24Hours ? "orange.fg" : "fg"}
             data-visual-test="transparent"
+            data-visual-placeholder="relative-time"
           >
             {timeRemaining}
           </Text>

--- a/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
@@ -507,7 +507,12 @@ export default function SurveyResponsesView({
           <Text fontSize="sm" color="fg.muted" mb={1}>
             TIME REMAINING
           </Text>
-          <Text fontSize="2xl" fontWeight="bold" color={isOverdue ? "red.fg" : isLessThan24Hours ? "orange.fg" : "fg"}>
+          <Text
+            fontSize="2xl"
+            fontWeight="bold"
+            color={isOverdue ? "red.fg" : isLessThan24Hours ? "orange.fg" : "fg"}
+            data-visual-test="transparent"
+          >
             {timeRemaining}
           </Text>
         </Box>

--- a/components/TimeZoneAwareDate.tsx
+++ b/components/TimeZoneAwareDate.tsx
@@ -6,10 +6,12 @@ import { useMemo } from "react";
 
 export function TimeZoneAwareDate({
   date,
-  format = "full"
+  format = "full",
+  visualPlaceholder = "date"
 }: {
   date: string | Date | TZDate;
   format?: "full" | "compact" | "dateOnly" | "timeOnly" | "Pp" | "MMM d, h:mm a" | "MMM d";
+  visualPlaceholder?: "date" | "relative-time" | "timestamp" | "review-status";
 }) {
   const { timeZone } = useTimeZone();
 
@@ -63,5 +65,9 @@ export function TimeZoneAwareDate({
     }
   }, [date, format, timeZone]);
 
-  return <span data-visual-test="transparent">{formattedDate}</span>;
+  return (
+    <span data-visual-test="transparent" data-visual-placeholder={visualPlaceholder}>
+      {formattedDate}
+    </span>
+  );
 }

--- a/components/TimeZoneAwareDate.tsx
+++ b/components/TimeZoneAwareDate.tsx
@@ -63,5 +63,5 @@ export function TimeZoneAwareDate({
     }
   }, [date, format, timeZone]);
 
-  return <>{formattedDate}</>;
+  return <span data-visual-test="transparent">{formattedDate}</span>;
 }

--- a/components/ui/assignment-due-date.tsx
+++ b/components/ui/assignment-due-date.tsx
@@ -195,7 +195,7 @@ export function AssignmentDueDate({
     <Flex gap={1} wrap="wrap" maxWidth="100%">
       <Flex alignItems={"center"} gap={1} wrap="wrap" minWidth={0}>
         {showDue && <Text flexShrink={0}>Due: </Text>}
-        <Text minWidth={0} data-visual-test="transparent">
+        <Text minWidth={0} data-visual-test="transparent" data-visual-placeholder="date">
           <TimeZoneAwareDate date={dueDate} format="MMM d, h:mm a" />
         </Text>
         {hoursExtended > 0 && (

--- a/components/ui/assignment-due-date.tsx
+++ b/components/ui/assignment-due-date.tsx
@@ -195,7 +195,7 @@ export function AssignmentDueDate({
     <Flex gap={1} wrap="wrap" maxWidth="100%">
       <Flex alignItems={"center"} gap={1} wrap="wrap" minWidth={0}>
         {showDue && <Text flexShrink={0}>Due: </Text>}
-        <Text minWidth={0} data-visual-test="blackout">
+        <Text minWidth={0} data-visual-test="transparent">
           <TimeZoneAwareDate date={dueDate} format="MMM d, h:mm a" />
         </Text>
         {hoursExtended > 0 && (

--- a/components/ui/assignment-due-date.tsx
+++ b/components/ui/assignment-due-date.tsx
@@ -196,7 +196,7 @@ export function AssignmentDueDate({
       <Flex alignItems={"center"} gap={1} wrap="wrap" minWidth={0}>
         {showDue && <Text flexShrink={0}>Due: </Text>}
         <Text minWidth={0} data-visual-test="transparent" data-visual-placeholder="date">
-          <TimeZoneAwareDate date={dueDate} format="MMM d, h:mm a" />
+          <TimeZoneAwareDate date={dueDate} format="MMM d, h:mm a" visualPlaceholder="date" />
         </Text>
         {hoursExtended > 0 && (
           <Text>

--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -668,7 +668,7 @@ export function CodeLineComment({ comment_id }: { comment_id: number }) {
                   </Text>
                 )}
               </Text>
-              <Text data-visual-test="blackout">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
             </HStack>
             <HStack>
               {authorProfile?.flair ? (

--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -668,7 +668,9 @@ export function CodeLineComment({ comment_id }: { comment_id: number }) {
                   </Text>
                 )}
               </Text>
-              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent" data-visual-placeholder="timestamp">
+                commented on {format(comment.created_at, "MMM d, yyyy")}
+              </Text>
             </HStack>
             <HStack>
               {authorProfile?.flair ? (

--- a/components/ui/regrade-request-wrapper.tsx
+++ b/components/ui/regrade-request-wrapper.tsx
@@ -151,7 +151,7 @@ function RegradeRequestComment({ comment }: { comment: RegradeRequestCommentType
                   </Text>
                 )}
               </Text>
-              <Text data-visual-test="blackout">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
             </HStack>
             <HStack>
               {authorRole === "grader" || authorRole === "instructor" || authorProfile?.flair ? (
@@ -1095,7 +1095,7 @@ export default function RegradeRequestWrapper({
               <VStack align="flex-start" gap={0} flexGrow={10}>
                 <Heading size="sm">Regrade {config.label}</Heading>
                 {regradeRequest.opened_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="blackout">
+                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
                     Opened {formatRelative(regradeRequest.opened_at, new Date())}, initial score:{" "}
                     <Text as="span" fontWeight="semibold">
                       {regradeRequest.initial_points || 0}
@@ -1119,7 +1119,7 @@ export default function RegradeRequestWrapper({
                   </Text>
                 )}
                 {regradeRequest.resolved_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="blackout">
+                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
                     Resolved {formatRelative(regradeRequest.resolved_at, new Date())} by {resolver?.name}, new score:{" "}
                     {isInstructor ? (
                       <EditablePoints
@@ -1149,12 +1149,12 @@ export default function RegradeRequestWrapper({
                   </Text>
                 )}
                 {regradeRequest.escalated_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="blackout">
+                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
                     Escalated {formatRelative(regradeRequest.escalated_at, new Date())} by {escalator?.name}
                   </Text>
                 )}
                 {regradeRequest.closed_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="blackout">
+                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
                     Closed {formatRelative(regradeRequest.closed_at, new Date())} by {closer?.name}, final score:{" "}
                     {/* Note: Instructors always sign final decisions with their real identity */}
                     {isInstructor ? (

--- a/components/ui/regrade-request-wrapper.tsx
+++ b/components/ui/regrade-request-wrapper.tsx
@@ -151,7 +151,9 @@ function RegradeRequestComment({ comment }: { comment: RegradeRequestCommentType
                   </Text>
                 )}
               </Text>
-              <Text data-visual-test="transparent">commented on {format(comment.created_at, "MMM d, yyyy")}</Text>
+              <Text data-visual-test="transparent" data-visual-placeholder="timestamp">
+                commented on {format(comment.created_at, "MMM d, yyyy")}
+              </Text>
             </HStack>
             <HStack>
               {authorRole === "grader" || authorRole === "instructor" || authorProfile?.flair ? (
@@ -1095,7 +1097,12 @@ export default function RegradeRequestWrapper({
               <VStack align="flex-start" gap={0} flexGrow={10}>
                 <Heading size="sm">Regrade {config.label}</Heading>
                 {regradeRequest.opened_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    data-visual-test="transparent"
+                    data-visual-placeholder="review-status"
+                  >
                     Opened {formatRelative(regradeRequest.opened_at, new Date())}, initial score:{" "}
                     <Text as="span" fontWeight="semibold">
                       {regradeRequest.initial_points || 0}
@@ -1119,7 +1126,12 @@ export default function RegradeRequestWrapper({
                   </Text>
                 )}
                 {regradeRequest.resolved_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    data-visual-test="transparent"
+                    data-visual-placeholder="review-status"
+                  >
                     Resolved {formatRelative(regradeRequest.resolved_at, new Date())} by {resolver?.name}, new score:{" "}
                     {isInstructor ? (
                       <EditablePoints
@@ -1149,12 +1161,22 @@ export default function RegradeRequestWrapper({
                   </Text>
                 )}
                 {regradeRequest.escalated_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    data-visual-test="transparent"
+                    data-visual-placeholder="review-status"
+                  >
                     Escalated {formatRelative(regradeRequest.escalated_at, new Date())} by {escalator?.name}
                   </Text>
                 )}
                 {regradeRequest.closed_at && (
-                  <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
+                  <Text
+                    fontSize="xs"
+                    color="fg.muted"
+                    data-visual-test="transparent"
+                    data-visual-placeholder="review-status"
+                  >
                     Closed {formatRelative(regradeRequest.closed_at, new Date())} by {closer?.name}, final score:{" "}
                     {/* Note: Instructors always sign final decisions with their real identity */}
                     {isInstructor ? (

--- a/components/ui/submission-review-toolbar.tsx
+++ b/components/ui/submission-review-toolbar.tsx
@@ -526,7 +526,7 @@ function ReviewAssignmentActions() {
         {activeReviewAssignment.completed_by && rubric && (
           <Text>
             {rubric.name} completed on{" "}
-            <span data-visual-test="blackout">
+            <span data-visual-test="transparent">
               <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
             </span>{" "}
             by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
@@ -543,7 +543,7 @@ function ReviewAssignmentActions() {
           <Text textAlign="left">
             Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} is required on this
             submission by{" "}
-            <span data-visual-test="blackout">
+            <span data-visual-test="transparent">
               <TimeZoneAwareDate date={activeReviewAssignment.due_date} format="MMM d, h:mm a" />.
             </span>
           </Text>
@@ -563,7 +563,7 @@ function ReviewAssignmentActions() {
       {activeReviewAssignment && activeReviewAssignment.completed_at && activeReviewAssignment.completed_by && (
         <Text textAlign="left" fontSize="sm" color="fg.muted">
           Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} was completed on{" "}
-          <span data-visual-test="blackout">
+          <span data-visual-test="transparent">
             <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
           </span>{" "}
           by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
@@ -605,7 +605,7 @@ function AssignedReviewHistory({ review_assignment_id }: { review_assignment_id:
   return (
     <Text>
       {rubric.name} completed on{" "}
-      <span data-visual-test="blackout">
+      <span data-visual-test="transparent">
         <TimeZoneAwareDate date={submissionReview?.completed_at} format="Pp" />
       </span>{" "}
       by <PersonName uid={submissionReview.completed_by} showAvatar={false} />

--- a/components/ui/submission-review-toolbar.tsx
+++ b/components/ui/submission-review-toolbar.tsx
@@ -527,7 +527,7 @@ function ReviewAssignmentActions() {
           <Text>
             {rubric.name} completed on{" "}
             <span data-visual-test="transparent" data-visual-placeholder="review-status">
-              <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" visualPlaceholder="date" />
+              <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
             </span>{" "}
             by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
           </Text>
@@ -544,12 +544,7 @@ function ReviewAssignmentActions() {
             Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} is required on this
             submission by{" "}
             <span data-visual-test="transparent" data-visual-placeholder="review-status">
-              <TimeZoneAwareDate
-                date={activeReviewAssignment.due_date}
-                format="MMM d, h:mm a"
-                visualPlaceholder="date"
-              />
-              .
+              <TimeZoneAwareDate date={activeReviewAssignment.due_date} format="MMM d, h:mm a" />.
             </span>
           </Text>
           {!ignoreAssignedReview && (
@@ -569,7 +564,7 @@ function ReviewAssignmentActions() {
         <Text textAlign="left" fontSize="sm" color="fg.muted">
           Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} was completed on{" "}
           <span data-visual-test="transparent" data-visual-placeholder="review-status">
-            <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" visualPlaceholder="date" />
+            <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
           </span>{" "}
           by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
         </Text>
@@ -611,7 +606,7 @@ function AssignedReviewHistory({ review_assignment_id }: { review_assignment_id:
     <Text>
       {rubric.name} completed on{" "}
       <span data-visual-test="transparent" data-visual-placeholder="review-status">
-        <TimeZoneAwareDate date={submissionReview?.completed_at} format="Pp" visualPlaceholder="date" />
+        <TimeZoneAwareDate date={submissionReview?.completed_at} format="Pp" />
       </span>{" "}
       by <PersonName uid={submissionReview.completed_by} showAvatar={false} />
     </Text>

--- a/components/ui/submission-review-toolbar.tsx
+++ b/components/ui/submission-review-toolbar.tsx
@@ -526,8 +526,8 @@ function ReviewAssignmentActions() {
         {activeReviewAssignment.completed_by && rubric && (
           <Text>
             {rubric.name} completed on{" "}
-            <span data-visual-test="transparent">
-              <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
+            <span data-visual-test="transparent" data-visual-placeholder="review-status">
+              <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" visualPlaceholder="date" />
             </span>{" "}
             by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
           </Text>
@@ -543,8 +543,13 @@ function ReviewAssignmentActions() {
           <Text textAlign="left">
             Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} is required on this
             submission by{" "}
-            <span data-visual-test="transparent">
-              <TimeZoneAwareDate date={activeReviewAssignment.due_date} format="MMM d, h:mm a" />.
+            <span data-visual-test="transparent" data-visual-placeholder="review-status">
+              <TimeZoneAwareDate
+                date={activeReviewAssignment.due_date}
+                format="MMM d, h:mm a"
+                visualPlaceholder="date"
+              />
+              .
             </span>
           </Text>
           {!ignoreAssignedReview && (
@@ -563,8 +568,8 @@ function ReviewAssignmentActions() {
       {activeReviewAssignment && activeReviewAssignment.completed_at && activeReviewAssignment.completed_by && (
         <Text textAlign="left" fontSize="sm" color="fg.muted">
           Your {rubric?.name} review {rubricPartsAdvice ? `(on ${rubricPartsAdvice})` : ""} was completed on{" "}
-          <span data-visual-test="transparent">
-            <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" />
+          <span data-visual-test="transparent" data-visual-placeholder="review-status">
+            <TimeZoneAwareDate date={activeReviewAssignment.completed_at} format="Pp" visualPlaceholder="date" />
           </span>{" "}
           by <PersonName uid={activeReviewAssignment.completed_by} showAvatar={false} />
         </Text>
@@ -605,8 +610,8 @@ function AssignedReviewHistory({ review_assignment_id }: { review_assignment_id:
   return (
     <Text>
       {rubric.name} completed on{" "}
-      <span data-visual-test="transparent">
-        <TimeZoneAwareDate date={submissionReview?.completed_at} format="Pp" />
+      <span data-visual-test="transparent" data-visual-placeholder="review-status">
+        <TimeZoneAwareDate date={submissionReview?.completed_at} format="Pp" visualPlaceholder="date" />
       </span>{" "}
       by <PersonName uid={submissionReview.completed_by} showAvatar={false} />
     </Text>

--- a/components/ui/survey-status-banner.tsx
+++ b/components/ui/survey-status-banner.tsx
@@ -80,7 +80,7 @@ export function SurveyStatusBanner({ assignmentId, courseId }: { assignmentId: n
                     </Badge>
                   </HStack>
                   {survey.due_date && (
-                    <Text fontSize="xs" color="fg.muted">
+                    <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
                       {survey.is_submitted
                         ? `Submitted ${survey.submitted_at ? formatDistanceToNow(new Date(survey.submitted_at), { addSuffix: true }) : ""}`
                         : isOverdue

--- a/components/ui/survey-status-banner.tsx
+++ b/components/ui/survey-status-banner.tsx
@@ -80,7 +80,12 @@ export function SurveyStatusBanner({ assignmentId, courseId }: { assignmentId: n
                     </Badge>
                   </HStack>
                   {survey.due_date && (
-                    <Text fontSize="xs" color="fg.muted" data-visual-test="transparent">
+                    <Text
+                      fontSize="xs"
+                      color="fg.muted"
+                      data-visual-test="transparent"
+                      data-visual-placeholder="relative-time"
+                    >
                       {survey.is_submitted
                         ? `Submitted ${survey.submitted_at ? formatDistanceToNow(new Date(survey.submitted_at), { addSuffix: true }) : ""}`
                         : isOverdue

--- a/scripts/next-start-https.cjs
+++ b/scripts/next-start-https.cjs
@@ -1,0 +1,187 @@
+"use strict";
+
+/**
+ * Production Next.js over HTTPS (TLS terminates in Node; same runtime as `next start`).
+ *
+ * Requires `npm run build` first. Paths default to `.certs/` (files are gitignored via *.pem).
+ *
+ * Env:
+ *   PORT          — HTTPS listen port (default 3443)
+ *   HOSTNAME      — bind host (default localhost)
+ *   SSL_KEY_PATH  — PEM private key (default .certs/localhost-key.pem under repo root)
+ *   SSL_CERT_PATH — PEM certificate (default .certs/localhost.pem); set both if you override
+ *   SSL_CERT_DIR  — optional extra directory (first in search list) for localhost-key.pem / discovery
+ *
+ * Defaults search (first match wins), all under repo root — not shell cwd:
+ *   .certs/              — expected location
+ *   certificates/       — alternate folder (already gitignored in this repo)
+ *   .certs/.certs/      — if you ran `mkdir .certs` while already inside `.certs/`, certs end up here (last resort)
+ * If only mkcert-style names exist (e.g. localhost+2-key.pem + localhost+2.pem), those are picked per-directory when unambiguous.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const { parse } = require("url");
+const next = require("next");
+
+/** Repo root (directory that contains `package.json`), not `process.cwd()` — that may differ if you invoke Node from elsewhere. */
+const projectRoot = path.resolve(__dirname, "..");
+const defaultCertDir = path.join(projectRoot, ".certs");
+
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = "production";
+}
+
+/**
+ * @param {string} p
+ * @returns {string}
+ */
+function resolveUserPath(p) {
+  return path.isAbsolute(p) ? p : path.resolve(process.cwd(), p);
+}
+
+/** Directories to look for localhost*.pem or a single mkcert *-key.pem pair (in order). */
+function getTlsSearchDirs() {
+  const extra = process.env.SSL_CERT_DIR ? [resolveUserPath(process.env.SSL_CERT_DIR)] : [];
+  return [...extra, defaultCertDir, path.join(projectRoot, "certificates"), path.join(defaultCertDir, ".certs")];
+}
+
+/**
+ * mkcert writes e.g. `localhost+2-key.pem` + `localhost+2.pem`. If defaults are missing, use the only *-key.pem / *.pem pair in `.certs/`.
+ * @returns {{ keyPath: string, certPath: string } | null}
+ */
+function discoverMkcertPair(certDir) {
+  if (!fs.existsSync(certDir)) {
+    return null;
+  }
+  const names = fs.readdirSync(certDir);
+  const pairs = [];
+  for (const name of names) {
+    if (!name.endsWith("-key.pem")) {
+      continue;
+    }
+    const certName = name.replace(/-key\.pem$/, ".pem");
+    const keyPath = path.join(certDir, name);
+    const certPath = path.join(certDir, certName);
+    if (names.includes(certName) && fs.statSync(keyPath).isFile() && fs.statSync(certPath).isFile()) {
+      pairs.push({ keyPath, certPath });
+    }
+  }
+  if (pairs.length === 1) {
+    return pairs[0];
+  }
+  return null;
+}
+
+/**
+ * @returns {{ keyPath: string, certPath: string, dir: string } | null}
+ */
+function findFirstTlsPair() {
+  for (const dir of getTlsSearchDirs()) {
+    if (!fs.existsSync(dir)) {
+      continue;
+    }
+    const k = path.join(dir, "localhost-key.pem");
+    const c = path.join(dir, "localhost.pem");
+    if (fs.existsSync(k) && fs.existsSync(c)) {
+      return { keyPath: k, certPath: c, dir };
+    }
+    const discovered = discoverMkcertPair(dir);
+    if (discovered) {
+      return { keyPath: discovered.keyPath, certPath: discovered.certPath, dir };
+    }
+  }
+  return null;
+}
+
+const hostname = process.env.HOSTNAME || "localhost";
+const port = Number.parseInt(process.env.PORT || "3443", 10);
+
+let keyPath;
+let certPath;
+if (process.env.SSL_KEY_PATH || process.env.SSL_CERT_PATH) {
+  if (!process.env.SSL_KEY_PATH || !process.env.SSL_CERT_PATH) {
+    console.error("Set both SSL_KEY_PATH and SSL_CERT_PATH (or neither to use defaults / auto-discovery).");
+    process.exit(1);
+  }
+  keyPath = resolveUserPath(process.env.SSL_KEY_PATH);
+  certPath = resolveUserPath(process.env.SSL_CERT_PATH);
+} else {
+  const found = findFirstTlsPair();
+  if (found) {
+    keyPath = found.keyPath;
+    certPath = found.certPath;
+    if (found.dir !== defaultCertDir) {
+      console.info(`Using TLS directory: ${path.relative(projectRoot, found.dir) || "."}`);
+    }
+  } else {
+    keyPath = path.join(defaultCertDir, "localhost-key.pem");
+    certPath = path.join(defaultCertDir, "localhost.pem");
+  }
+}
+
+if (!fs.existsSync(keyPath) || !fs.existsSync(certPath)) {
+  const scanned = getTlsSearchDirs()
+    .map((dir) => {
+      if (!fs.existsSync(dir)) {
+        return `  (missing) ${dir}`;
+      }
+      try {
+        const names = fs.readdirSync(dir);
+        const pem = names.filter((f) => f.endsWith(".pem"));
+        const label = pem.length > 0 ? pem.join(", ") : names.join(", ") || "(empty)";
+        return `  ${dir}\n    → ${label}`;
+      } catch {
+        return `  (unreadable) ${dir}`;
+      }
+    })
+    .join("\n");
+  console.error(
+    [
+      "Missing TLS certificate files.",
+      `  Looked for: localhost-key.pem + localhost.pem (or one mkcert *-key.pem pair) in:`,
+      scanned,
+      "",
+      "Tip: if your shell is already in project/.certs, use `keyout localhost-key.pem` (no extra .certs/),",
+      "  or put files in project/certificates/ — this script searches .certs/, certificates/, then .certs/.certs/.",
+      "",
+      "From repo root, self-signed (browser will warn):",
+      "  mkdir -p .certs && openssl req -x509 -newkey rsa:2048 -nodes -keyout .certs/localhost-key.pem \\",
+      '    -out .certs/localhost.pem -days 365 -subj "/CN=localhost"',
+      ""
+    ].join("\n")
+  );
+  process.exit(1);
+}
+
+const app = next({ dev: false, hostname, port, dir: projectRoot });
+
+app
+  .prepare()
+  .then(() => {
+    const handle = app.getRequestHandler();
+    https
+      .createServer(
+        {
+          key: fs.readFileSync(keyPath),
+          cert: fs.readFileSync(certPath)
+        },
+        async (req, res) => {
+          try {
+            await handle(req, res, parse(req.url, true));
+          } catch (err) {
+            console.error("Request handler error", req.url, err);
+            res.statusCode = 500;
+            res.end("internal server error");
+          }
+        }
+      )
+      .listen(port, hostname, () => {
+        console.log(`Ready — production build over HTTPS: https://${hostname}:${port}`);
+      });
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/next-start-https.cjs
+++ b/scripts/next-start-https.cjs
@@ -97,6 +97,10 @@ function findFirstTlsPair() {
 
 const hostname = process.env.HOSTNAME || "localhost";
 const port = Number.parseInt(process.env.PORT || "3443", 10);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  console.error(`Invalid PORT "${process.env.PORT}". Expected an integer between 1 and 65535.`);
+  process.exit(1);
+}
 
 let keyPath;
 let certPath;

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -634,6 +634,7 @@ export async function createUserInClass({
   lab_section_id,
   randomSuffix,
   name,
+  public_profile_name: requested_public_profile_name,
   email,
   rateLimitManager,
   useMagicLink = false
@@ -644,6 +645,7 @@ export async function createUserInClass({
   lab_section_id?: number;
   randomSuffix?: string;
   name?: string;
+  public_profile_name?: string;
   email?: string;
   rateLimitManager?: RateLimitManager;
   useMagicLink?: boolean;
@@ -652,9 +654,11 @@ export async function createUserInClass({
   const workerIndex = process.env.TEST_WORKER_INDEX || "undefined-worker-index";
   const resolvedEmail = email ?? `${role}-${workerIndex}-${extra_randomness}-${userIdx[role]}@pawtograder.net`;
   const resolvedName = name ? name : `${role.charAt(0).toUpperCase()}${role.slice(1)} #${userIdx[role]}Test`;
-  const public_profile_name = name
-    ? `Pseudonym #${userIdx[role]}`
-    : `Pseudonym #${userIdx[role]} ${role.charAt(0).toUpperCase()}${role.slice(1)}`;
+  const public_profile_name =
+    requested_public_profile_name ??
+    (name
+      ? `Pseudonym #${userIdx[role]}`
+      : `Pseudonym #${userIdx[role]} ${role.charAt(0).toUpperCase()}${role.slice(1)}`);
   const private_profile_name = `${resolvedName}`;
   userIdx[role]++;
   // Try to create user, if it fails due to existing email, try to get the existing user
@@ -841,6 +845,7 @@ export async function createUsersInClass(
     lab_section_id?: number;
     randomSuffix?: string;
     name?: string;
+    public_profile_name?: string;
     email?: string;
     rateLimitManager?: RateLimitManager;
     useMagicLink?: boolean;
@@ -887,9 +892,11 @@ export async function createUsersInClass(
   for (const request of resolvedRequests) {
     const { role, class_id, section_id, lab_section_id, resolvedEmail, resolvedName, useMagicLink = false } = request;
 
-    const public_profile_name = request.name
-      ? `Pseudonym #${userIdx[role] - 1}`
-      : `Pseudonym #${userIdx[role] - 1} ${role.charAt(0).toUpperCase()}${role.slice(1)}`;
+    const public_profile_name =
+      request.public_profile_name ??
+      (request.name
+        ? `Pseudonym #${userIdx[role] - 1}`
+        : `Pseudonym #${userIdx[role] - 1} ${role.charAt(0).toUpperCase()}${role.slice(1)}`);
     const private_profile_name = resolvedName;
 
     let userId: string;

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -854,19 +854,20 @@ export async function createUsersInClass(
 ): Promise<TestingUser[]> {
   // Resolve all emails first
   const resolvedRequests = userRequests.map((req) => {
+    const roleOrdinal = userIdx[req.role];
     const extra_randomness = req.randomSuffix ?? Math.random().toString(36).substring(2, 20);
     const workerIndex = process.env.TEST_WORKER_INDEX || "undefined-worker-index";
-    const resolvedEmail =
-      req.email ?? `${req.role}-${workerIndex}-${extra_randomness}-${userIdx[req.role]}@pawtograder.net`;
+    const resolvedEmail = req.email ?? `${req.role}-${workerIndex}-${extra_randomness}-${roleOrdinal}@pawtograder.net`;
     const resolvedName = req.name
       ? req.name
-      : `${req.role.charAt(0).toUpperCase()}${req.role.slice(1)} #${userIdx[req.role]}Test`;
+      : `${req.role.charAt(0).toUpperCase()}${req.role.slice(1)} #${roleOrdinal}Test`;
     userIdx[req.role]++;
 
     return {
       ...req,
       resolvedEmail,
-      resolvedName
+      resolvedName,
+      roleOrdinal
     };
   });
 
@@ -895,8 +896,8 @@ export async function createUsersInClass(
     const public_profile_name =
       request.public_profile_name ??
       (request.name
-        ? `Pseudonym #${userIdx[role] - 1}`
-        : `Pseudonym #${userIdx[role] - 1} ${role.charAt(0).toUpperCase()}${role.slice(1)}`);
+        ? `Pseudonym #${request.roleOrdinal}`
+        : `Pseudonym #${request.roleOrdinal} ${role.charAt(0).toUpperCase()}${role.slice(1)}`);
     const private_profile_name = resolvedName;
 
     let userId: string;

--- a/tests/e2e/VisualTestUtils.ts
+++ b/tests/e2e/VisualTestUtils.ts
@@ -1,0 +1,134 @@
+import { expect } from "../global-setup";
+import { argosScreenshot, type ArgosScreenshotOptions } from "@argos-ci/playwright";
+import type { Locator, Page } from "@playwright/test";
+
+type VisualScreenshotOptions = ArgosScreenshotOptions & {
+  /**
+   * Scroll this rubric sidebar region to the top of its scroll container before
+   * capture. Pass "Grading Rubric", "Self-Review Rubric", or the full
+   * accessible region label.
+   */
+  stabilizeRubric?: string | RegExp;
+};
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function waitForFonts(page: Page) {
+  await page
+    .evaluate(async () => {
+      await document.fonts?.ready;
+    })
+    .catch(() => {
+      // Some engines/pages do not expose document.fonts during early failure
+      // states. Argos still performs its own stabilization afterwards.
+    });
+}
+
+async function waitForStableLocator(locator: Locator) {
+  let previous: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null = null;
+
+  for (let i = 0; i < 10; i++) {
+    const box = await locator.boundingBox();
+    if (!box) {
+      await locator.page().waitForTimeout(50);
+      continue;
+    }
+    if (
+      previous &&
+      Math.abs(previous.x - box.x) < 1 &&
+      Math.abs(previous.y - box.y) < 1 &&
+      Math.abs(previous.width - box.width) < 1 &&
+      Math.abs(previous.height - box.height) < 1
+    ) {
+      return;
+    }
+    previous = box;
+    await locator.page().waitForTimeout(75);
+  }
+}
+
+export async function waitForVisualIdle(page: Page) {
+  await page.waitForLoadState("domcontentloaded");
+  await page.waitForLoadState("networkidle", { timeout: 3_000 }).catch(() => {
+    // Realtime/websocket-backed pages do not always reach networkidle. The
+    // explicit UI readiness assertions below are the stronger signal.
+  });
+  await waitForFonts(page);
+
+  const transientText = [
+    "Loading analytics...",
+    "Loading surveys...",
+    "Loading lab sections...",
+    "Loading lab roster...",
+    "Submitting your comment..."
+  ];
+
+  for (const text of transientText) {
+    await expect(page.getByText(text))
+      .toBeHidden({ timeout: 1_000 })
+      .catch(() => {
+        // These strings are page-specific; absence/visibility is handled by each
+        // test's domain assertions when it matters.
+      });
+  }
+}
+
+export async function stabilizeRubricSidebar(page: Page, rubricName: string | RegExp) {
+  const accessibleName =
+    typeof rubricName === "string" ? new RegExp(`^(Rubric:\\s*)?${escapeRegExp(rubricName)}$`) : rubricName;
+  const rubricRegion = page.getByRole("region", { name: accessibleName }).first();
+  await expect(rubricRegion).toBeVisible();
+
+  await rubricRegion.evaluate((element) => {
+    const isScrollable = (candidate: HTMLElement) => {
+      const style = window.getComputedStyle(candidate);
+      const overflowY = style.overflowY;
+      return (
+        (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+        candidate.scrollHeight > candidate.clientHeight
+      );
+    };
+
+    let scrollParent: HTMLElement | null = element.parentElement;
+    while (scrollParent && !isScrollable(scrollParent)) {
+      scrollParent = scrollParent.parentElement;
+    }
+
+    const container = scrollParent ?? document.scrollingElement;
+    if (!container) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const offset = 8;
+    container.scrollTop += elementRect.top - containerRect.top - offset;
+  });
+
+  await waitForStableLocator(rubricRegion);
+}
+
+export async function visualScreenshot(page: Page, name: string, options: VisualScreenshotOptions = {}) {
+  const { stabilizeRubric, beforeScreenshot, ...argosOptions } = options;
+
+  await waitForVisualIdle(page);
+  if (stabilizeRubric) {
+    await stabilizeRubricSidebar(page, stabilizeRubric);
+  }
+
+  return argosScreenshot(page, name, {
+    ...argosOptions,
+    beforeScreenshot: async (api) => {
+      await waitForVisualIdle(page);
+      if (stabilizeRubric) {
+        await stabilizeRubricSidebar(page, stabilizeRubric);
+      }
+      await beforeScreenshot?.(api);
+    }
+  });
+}

--- a/tests/e2e/create-submission.test.tsx
+++ b/tests/e2e/create-submission.test.tsx
@@ -14,7 +14,7 @@ import {
   createSampleGradingResult
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
-import { argosScreenshot } from "@argos-ci/playwright";
+import { visualScreenshot } from "./VisualTestUtils";
 
 let course: Course;
 let student: TestingUser | undefined;
@@ -57,6 +57,7 @@ test.beforeAll(async () => {
   [student] = await createUsersInClass([
     {
       name: "Create Submission Student",
+      public_profile_name: "Create Submission Pseudonym Student",
       role: "student",
       class_id: course.id,
       useMagicLink: true
@@ -211,7 +212,9 @@ test.describe("Create submission", () => {
     await expect(notGradedRow).toBeVisible();
     await expect(activeRow.getByText("Pending")).toBeVisible();
     await expect(notGradedRow.getByText("Not for grading")).toBeVisible();
-    await argosScreenshot(page, "Showing active and not-graded submissions");
+    await expect(page.getByRole("row").filter({ hasText: activeSHA })).toHaveCount(1);
+    await expect(page.getByRole("row").filter({ hasText: notGradedSHA })).toHaveCount(1);
+    await visualScreenshot(page, "Showing active and not-graded submissions");
     await page.getByRole("link", { name: "Not for grading" }).click();
     await expect(page.getByText("Viewing a not-for-grading submission")).toBeVisible();
     await assertStudentPageAccessible(page, "create submission - not graded detail");

--- a/tests/e2e/discussion-threads.test.tsx
+++ b/tests/e2e/discussion-threads.test.tsx
@@ -1,9 +1,9 @@
 import { Course } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
-import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, loginAsUser, TestingUser } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
 let course: Course;
@@ -16,6 +16,7 @@ test.beforeAll(async () => {
   [student1, student2, instructor] = await createUsersInClass([
     {
       name: "Discussion Thread Student 1",
+      public_profile_name: "Discussion Pseudonym Student 1",
       email: "discussion-thread-student1@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -23,6 +24,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Discussion Thread Student 2",
+      public_profile_name: "Discussion Pseudonym Student 2",
       email: "discussion-thread-student2@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -30,6 +32,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Discussion Thread Instructor",
+      public_profile_name: "Discussion Pseudonym Instructor",
       email: "discussion-thread-instructor@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -54,7 +57,7 @@ test.describe("Discussion Thread Page", () => {
     await expect(
       page.getByText("Your feed is empty. Follow a topic (Browse Topics) or follow a post to see it here.")
     ).toBeVisible();
-    await argosScreenshot(page, "Discussion Thread Page");
+    await visualScreenshot(page, "Discussion Thread Page");
     await assertStudentPageAccessible(page, "discussion feed empty");
   });
   test("A student can view the create new thread form and create a new private thread", async ({ page }) => {
@@ -67,7 +70,7 @@ test.describe("Discussion Thread Page", () => {
     await page.getByText("New Post").click();
     // Wait for the form to appear
     await expect(page.getByRole("heading", { name: "New Discussion Thread" })).toBeVisible();
-    await argosScreenshot(page, "Create New Thread Form");
+    await visualScreenshot(page, "Create New Thread Form");
     await expect(page.getByText("Topic", { exact: true })).toBeVisible();
     // await expect(page.getByText("Assignments", { exact: true })).toBeVisible(); // Too annoying to test
     await expect(page.getByText("Questions and notes about assignments.")).toBeVisible();
@@ -231,7 +234,7 @@ test.describe("Discussion Thread Page", () => {
     await expect(page.getByText("Reply")).toBeVisible();
     await expect(page.getByText("Edit")).toBeVisible();
     await expect(page.getByRole("button").filter({ hasText: "Unfollow" })).toBeVisible();
-    await argosScreenshot(page, "After Instructor Replied to Public Thread");
+    await visualScreenshot(page, "After Instructor Replied to Public Thread");
   });
 });
 
@@ -281,7 +284,7 @@ test.describe("Custom Discussion Topics", () => {
     const editButtons = page.getByRole("button", { name: "Edit" });
     await expect(editButtons).toHaveCount(4);
 
-    await argosScreenshot(page, "Discussion Topics Management Page");
+    await visualScreenshot(page, "Discussion Topics Management Page");
   });
 
   test("Custom discussion topic lifecycle: create, edit, verify visibility, and delete", async ({ page }) => {
@@ -311,7 +314,7 @@ test.describe("Custom Discussion Topics", () => {
     await expect(page.getByText("Homework 1 Questions", { exact: true })).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText("Ask questions about Homework 1 here")).toBeVisible();
 
-    await argosScreenshot(page, "After Creating Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Creating Custom Topic").catch(() => {});
 
     // ===== STEP 2: Edit the custom discussion topic =====
     // Find and click the Edit button for the custom topic, within the container for that topic
@@ -332,7 +335,7 @@ test.describe("Custom Discussion Topics", () => {
     // Wait for the topic update to appear (dialog may linger in webkit due to CSS animation)
     await expect(page.getByText("HW1 Discussion", { exact: true })).toBeVisible({ timeout: 30_000 });
 
-    await argosScreenshot(page, "After Editing Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Editing Custom Topic").catch(() => {});
 
     // ===== STEP 3: Verify custom topic appears in new thread form =====
     const navRegion = await page.locator("#course-nav");
@@ -350,7 +353,7 @@ test.describe("Custom Discussion Topics", () => {
       await expect(page.getByText("Ask questions about Homework 1 here")).toBeVisible();
     }).toPass({ timeout: 20000 });
 
-    await argosScreenshot(page, "New Thread Form With Custom Topic").catch(() => {});
+    await visualScreenshot(page, "New Thread Form With Custom Topic").catch(() => {});
 
     // ===== STEP 4: Verify custom topic appears in Browse Topics =====
     await navRegion.getByRole("link").filter({ hasText: "Discussion" }).click();
@@ -374,6 +377,6 @@ test.describe("Custom Discussion Topics", () => {
     // Verify the topic was deleted
     await expect(page.getByText("HW1 Discussion", { exact: true })).not.toBeVisible();
 
-    await argosScreenshot(page, "After Deleting Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Deleting Custom Topic").catch(() => {});
   });
 });

--- a/tests/e2e/discussion-threads.test.tsx
+++ b/tests/e2e/discussion-threads.test.tsx
@@ -314,7 +314,7 @@ test.describe("Custom Discussion Topics", () => {
     await expect(page.getByText("Homework 1 Questions", { exact: true })).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText("Ask questions about Homework 1 here")).toBeVisible();
 
-    await visualScreenshot(page, "After Creating Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Creating Custom Topic");
 
     // ===== STEP 2: Edit the custom discussion topic =====
     // Find and click the Edit button for the custom topic, within the container for that topic
@@ -335,7 +335,7 @@ test.describe("Custom Discussion Topics", () => {
     // Wait for the topic update to appear (dialog may linger in webkit due to CSS animation)
     await expect(page.getByText("HW1 Discussion", { exact: true })).toBeVisible({ timeout: 30_000 });
 
-    await visualScreenshot(page, "After Editing Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Editing Custom Topic");
 
     // ===== STEP 3: Verify custom topic appears in new thread form =====
     const navRegion = await page.locator("#course-nav");
@@ -353,7 +353,7 @@ test.describe("Custom Discussion Topics", () => {
       await expect(page.getByText("Ask questions about Homework 1 here")).toBeVisible();
     }).toPass({ timeout: 20000 });
 
-    await visualScreenshot(page, "New Thread Form With Custom Topic").catch(() => {});
+    await visualScreenshot(page, "New Thread Form With Custom Topic");
 
     // ===== STEP 4: Verify custom topic appears in Browse Topics =====
     await navRegion.getByRole("link").filter({ hasText: "Discussion" }).click();
@@ -377,6 +377,6 @@ test.describe("Custom Discussion Topics", () => {
     // Verify the topic was deleted
     await expect(page.getByText("HW1 Discussion", { exact: true })).not.toBeVisible();
 
-    await visualScreenshot(page, "After Deleting Custom Topic").catch(() => {});
+    await visualScreenshot(page, "After Deleting Custom Topic");
   });
 });

--- a/tests/e2e/enrollments.test.tsx
+++ b/tests/e2e/enrollments.test.tsx
@@ -5,6 +5,8 @@ import { createClass, createUsersInClass, loginAsUser, TestingUser } from "./Tes
 import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
+test.setTimeout(120_000);
+
 let course: Course;
 let student1: TestingUser | undefined;
 let instructor1: TestingUser | undefined;

--- a/tests/e2e/enrollments.test.tsx
+++ b/tests/e2e/enrollments.test.tsx
@@ -34,7 +34,8 @@ async function stabilizeImportPreviewDialog(page: import("@playwright/test").Pag
   return dialog;
 }
 
-test.beforeAll(async () => {
+test.beforeAll(async ({}, testInfo) => {
+  testInfo.setTimeout(120_000);
   course = await createClass();
   [student1, instructor1] = await createUsersInClass([
     {

--- a/tests/e2e/enrollments.test.tsx
+++ b/tests/e2e/enrollments.test.tsx
@@ -1,9 +1,9 @@
 import { Course } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
-import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, loginAsUser, TestingUser } from "./TestingUtils";
 import { random } from "mathjs";
+import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
 let course: Course;
@@ -22,6 +22,7 @@ test.beforeAll(async () => {
   [student1, instructor1] = await createUsersInClass([
     {
       name: "Enrollments Student 1",
+      public_profile_name: "Enrollments Pseudonym Student 1",
       email: "enrollments-student1@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -29,6 +30,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Enrollments Instructor 1",
+      public_profile_name: "Enrollments Pseudonym Instructor 1",
       email: "enrollments-instructor1@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -64,7 +66,7 @@ test.describe("Enrollments Page", () => {
     await expect(page.getByText(student1?.private_profile_name ?? "")).toBeVisible();
     await expect(page.getByText(instructor1?.email ?? "")).toBeVisible();
     await expect(page.getByText(instructor1?.private_profile_name ?? "")).toBeVisible();
-    await argosScreenshot(page, "Enrollments Page");
+    await visualScreenshot(page, "Enrollments Page");
   });
 
   // Note: Creating users is expensive and can overwhelm supabase auth connections.
@@ -114,7 +116,7 @@ test.describe("Enrollments Page", () => {
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles("tests/e2e/test.csv");
     await page.getByLabel("Import Roster from CSV").getByRole("button", { name: "Import" }).click();
-    await argosScreenshot(page, "Importing CSV of 2 users");
+    await visualScreenshot(page, "Importing CSV of 2 users");
     await page.getByRole("button", { name: "Confirm Import (2)" }).click();
     await expect(page.getByText("test-student-import-csv@pawtograder.net")).toBeVisible();
     await expect(page.getByText("test-grader-import-csv@pawtograder.net")).toBeVisible();

--- a/tests/e2e/enrollments.test.tsx
+++ b/tests/e2e/enrollments.test.tsx
@@ -2,7 +2,6 @@ import { Course } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
 import dotenv from "dotenv";
 import { createClass, createUsersInClass, loginAsUser, TestingUser } from "./TestingUtils";
-import { random } from "mathjs";
 import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -10,12 +9,28 @@ let course: Course;
 let student1: TestingUser | undefined;
 let instructor1: TestingUser | undefined;
 
-const student2Name = `${"Student".charAt(0).toUpperCase()}${"student".slice(1)} #${random()}studentTest`;
-const student2Email = `$student-${random()}-${random()}student@pawtograder.net`;
-const graderName = `${"Grader".charAt(0).toUpperCase()}${"grader".slice(1)} #${random()}graderTest`;
-const graderEmail = `$grader-${random()}-${random()}grader@pawtograder.net`;
-const instructor2Name = `${"Instructor".charAt(0).toUpperCase()}${"instructor".slice(1)} #${random()}instructorTest`;
-const instructor2Email = `$instructor-${random()}-${random()}instructor@pawtograder.net`;
+const student2Name = "Enrollments Added Student";
+const student2Email = "enrollments-added-student@pawtograder.net";
+const graderName = "Enrollments Added Grader";
+const graderEmail = "enrollments-added-grader@pawtograder.net";
+const instructor2Name = "Enrollments Added Instructor";
+const instructor2Email = "enrollments-added-instructor@pawtograder.net";
+
+async function stabilizeImportPreviewDialog(page: import("@playwright/test").Page) {
+  await page.evaluate(() => window.scrollTo(0, 0));
+  const dialog = page.getByLabel("Import Roster from CSV");
+  await expect(dialog).toBeVisible();
+  await dialog.evaluate((element) => {
+    element.scrollTop = 0;
+    for (const child of Array.from(element.querySelectorAll("*"))) {
+      if (child instanceof HTMLElement) {
+        child.scrollTop = 0;
+        child.scrollLeft = 0;
+      }
+    }
+  });
+  return dialog;
+}
 
 test.beforeAll(async () => {
   course = await createClass();
@@ -115,8 +130,15 @@ test.describe("Enrollments Page", () => {
     // Upload the test CSV file
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles("tests/e2e/test.csv");
-    await page.getByLabel("Import Roster from CSV").getByRole("button", { name: "Import" }).click();
-    await visualScreenshot(page, "Importing CSV of 2 users");
+    await page.getByLabel("Import Roster from CSV").getByRole("button", { name: "Show Import Preview" }).click();
+    const importDialog = await stabilizeImportPreviewDialog(page);
+    await expect(importDialog.getByText("Will be enrolled directly (2)")).toBeVisible();
+    await expect(
+      importDialog.getByText("Test Student (test-student-import-csv@pawtograder.net) - student")
+    ).toBeVisible();
+    await expect(importDialog.getByText("Test Grader (test-grader-import-csv@pawtograder.net) - grader")).toBeVisible();
+    await expect(importDialog.getByRole("button", { name: "Confirm Import (2)" })).toBeVisible();
+    await visualScreenshot(page, "Importing CSV of 2 users", { element: importDialog });
     await page.getByRole("button", { name: "Confirm Import (2)" }).click();
     await expect(page.getByText("test-student-import-csv@pawtograder.net")).toBeVisible();
     await expect(page.getByText("test-grader-import-csv@pawtograder.net")).toBeVisible();

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -1633,10 +1633,8 @@ test.describe("Gradebook column reorder (issue #531)", () => {
     // chakra menu it controls. Retry the entire open+click sequence as a
     // single unit so a transient detach doesn't fail the test. Each attempt
     // re-resolves the locator (so the new mount is targeted), waits for
-    // virtualizer idle, opens the menu, and clicks Move Right. Any
-    // intermediate detach throws and we try again. The ultimate signal that
-    // the click succeeded is the "Column moved right" toast (matching how
-    // Move Left works above), and the DB sort_order assertion that follows.
+    // virtualizer idle, opens the menu, clicks Move Right, then verifies the
+    // DB sort_order. Any intermediate detach throws and we try again.
     await expect(async () => {
       // If a previous attempt's Move Right click already landed in the DB
       // (sort_order back to original) but the toast assertion timed out
@@ -1659,7 +1657,14 @@ test.describe("Gradebook column reorder (issue #531)", () => {
       await buttonNow.scrollIntoViewIfNeeded();
       await buttonNow.click();
       await page.getByRole("menuitem", { name: "Move Right", exact: true }).click({ force: true });
-      await expect(page.getByText("Column moved right").first()).toBeAttached({ timeout: 5000 });
+      await expect(async () => {
+        const { data: colAfterClick } = await supabase
+          .from("gradebook_columns")
+          .select("sort_order")
+          .eq("id", colBefore!.id)
+          .single();
+        expect(colAfterClick?.sort_order).toBe(sortOrderBefore);
+      }).toPass({ timeout: 5_000, intervals: [250, 500] });
     }).toPass({ timeout: 30_000, intervals: [250, 500, 1000] });
 
     // Verify sort_order restored to original

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -2,7 +2,6 @@ import { resolveTargetStudentProfileIdForRubricComment } from "@/lib/rubricComme
 import { Course } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
 import type { Page, Locator } from "@playwright/test";
-import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import { promises as fs } from "node:fs";
 import Papa from "papaparse";
@@ -17,6 +16,7 @@ import {
   createAuthenticatedClient
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { visualScreenshot } from "./VisualTestUtils";
 // removed unused import
 
 dotenv.config({ path: ".env.local", quiet: true });
@@ -213,6 +213,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
     const users = await createUsersInClass([
       {
         name: "Alice Anderson",
+        public_profile_name: "Gradebook Pseudonym Alice",
         email: "alice-gradebook@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -220,6 +221,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
       },
       {
         name: "Bob Brown",
+        public_profile_name: "Gradebook Pseudonym Bob",
         email: "bob-gradebook@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -227,6 +229,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
       },
       {
         name: "Charlie Chen",
+        public_profile_name: "Gradebook Pseudonym Charlie",
         email: "charlie-gradebook@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -234,6 +237,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
       },
       {
         name: "Professor Smith",
+        public_profile_name: "Gradebook Pseudonym Instructor",
         email: "prof-smith-gradebook@pawtograder.net",
         role: "instructor",
         class_id: course.id,
@@ -873,7 +877,7 @@ test.describe("Gradebook Page - Comprehensive", () => {
     }).toPass({ timeout: 60_000 });
 
     // Take screenshot for visual regression testing
-    await argosScreenshot(page, "Gradebook Page - Full Data");
+    await visualScreenshot(page, "Gradebook Page - Full Data");
   });
 
   test("Editing a manual column updates the Participation cell value", async ({ page }) => {

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -1653,10 +1653,19 @@ test.describe("Gradebook column reorder (issue #531)", () => {
         return;
       }
       await waitForVirtualizerIdle(page);
-      const buttonNow = headerCellAfterMove.getByRole("button", { name: "Column options" });
+      const freshHeaderCellAfterMove = region
+        .locator("thead tr")
+        .filter({ has: page.locator("th").filter({ hasText: "Student Name" }) })
+        .locator("[data-col-id]")
+        .filter({ hasText: colName });
+      await freshHeaderCellAfterMove.scrollIntoViewIfNeeded();
+      await waitForVirtualizerIdle(page);
+      const buttonNow = freshHeaderCellAfterMove.getByRole("button", { name: "Column options" });
       await buttonNow.scrollIntoViewIfNeeded();
       await buttonNow.click();
-      await page.getByRole("menuitem", { name: "Move Right", exact: true }).click({ force: true });
+      const moveRightItem = page.getByRole("menuitem", { name: "Move Right", exact: true });
+      await expect(moveRightItem).toBeVisible({ timeout: 5_000 });
+      await moveRightItem.click({ force: true });
       await expect(async () => {
         const { data: colAfterClick } = await supabase
           .from("gradebook_columns")

--- a/tests/e2e/gradebook.test.tsx
+++ b/tests/e2e/gradebook.test.tsx
@@ -1602,7 +1602,7 @@ test.describe("Gradebook column reorder (issue #531)", () => {
       .filter({ hasText: colName });
     await headerCell.getByRole("button", { name: "Column options" }).click();
     await page.getByRole("menuitem", { name: "Move Left", exact: true }).click();
-    await expect(page.getByText("Column moved left").first()).toBeVisible();
+    await expect(page.getByText("Column moved left").first()).toBeAttached();
 
     // Verify sort_order decreased by 1 in the database
     await expect(async () => {
@@ -1659,7 +1659,7 @@ test.describe("Gradebook column reorder (issue #531)", () => {
       await buttonNow.scrollIntoViewIfNeeded();
       await buttonNow.click();
       await page.getByRole("menuitem", { name: "Move Right", exact: true }).click({ force: true });
-      await expect(page.getByText("Column moved right").first()).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("Column moved right").first()).toBeAttached({ timeout: 5000 });
     }).toPass({ timeout: 30_000, intervals: [250, 500, 1000] });
 
     // Verify sort_order restored to original

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -381,7 +381,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     const region = await page.getByRole("region", { name: "Grading checks on line 4" });
     await expect(region).toBeVisible();
     await region.getByRole("button", { name: "Request regrade for this check" }).click();
-    await visualScreenshot(page, "Student can request a regrade", { stabilizeRubric: "Grading Rubric" });
+    await visualScreenshot(page, "Student can request a regrade");
     await page.getByRole("button", { name: "Draft Regrade Request" }).click();
     await page
       .getByRole("region", { name: "Grading checks on line 4" })
@@ -428,7 +428,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     ).toBeVisible();
     await expect(page.getByText("Submitting your comment...")).not.toBeVisible();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Resolve Request" }).click();
-    await visualScreenshot(page, "Instructors can resolve the regrade request", { stabilizeRubric: "Grading Rubric" });
+    await visualScreenshot(page, "Instructors can resolve the regrade request");
     // Popover content is portalled (not under the rubric check region); scope to the resolve dialog.
     const resolveRegradePopover = page.getByRole("dialog").filter({ hasText: "Grade Adjustment:" });
     await expect(resolveRegradePopover).toBeVisible();
@@ -464,7 +464,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByLabel("Add Comment", { exact: true })
       .click();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Escalate to Instructor" }).click();
-    await visualScreenshot(page, "Students can appeal their regrade request", { stabilizeRubric: "Grading Rubric" });
+    await visualScreenshot(page, "Students can appeal their regrade request");
     await page.getByRole("button", { name: "Escalate Request" }).click();
     // Wait for the escalation to settle before axe runs — otherwise axe races
     // the closing popover / toast and reports transient focus-trap / labeling violations.

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -171,9 +171,9 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     // finalize_submission_early completed and reviewAssignments has been
     // refetched (see finalizeSubmissionEarly.tsx). Without this, the test
     // races the "Complete Self Review" button into existence.
-    // Chakra renders the toast title twice (visible toast + portal duplicate
-    // both with the same id), so .first() is required to satisfy strict mode.
-    await expect(page.getByText("Submission finalized").first()).toBeVisible();
+    // Visual-test mode removes toasts from layout before screenshots, so the
+    // explicit app signal is attachment rather than visibility.
+    await expect(page.getByText("Submission finalized").first()).toBeAttached();
     // Even after the toast appears, the "Complete Self Review" button only
     // renders once useMyReviewAssignments() observes the new row AND
     // useRubric("self-review") returns the matching rubric (see

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -1,7 +1,6 @@
 import { Assignment, Course, RubricCheck, RubricPart } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
 import { type Page } from "@playwright/test";
-import { argosScreenshot } from "@argos-ci/playwright";
 import { addDays } from "date-fns";
 import dotenv from "dotenv";
 import {
@@ -14,6 +13,7 @@ import {
   TestingUser
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { stabilizeRubricSidebar, visualScreenshot } from "./VisualTestUtils";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -56,6 +56,7 @@ test.beforeAll(async () => {
   [student, instructor, grader, student2] = await createUsersInClass([
     {
       name: "Grading Student",
+      public_profile_name: "Grading Pseudonym Student",
       email: "grading-student@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -63,6 +64,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Grading Instructor",
+      public_profile_name: "Grading Pseudonym Instructor",
       email: "grading-instructor@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -70,6 +72,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Grading Grader",
+      public_profile_name: "Grading Pseudonym Grader",
       email: "grading-grader@pawtograder.net",
       role: "grader",
       class_id: course.id,
@@ -77,6 +80,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Grading Student 2",
+      public_profile_name: "Grading Pseudonym Student 2",
       email: "grading-student2@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -160,7 +164,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("link", { name: assignment!.title }).click();
 
     await expect(page.getByText("Self Review Notice")).toBeVisible();
-    await argosScreenshot(page, "Student can submit self-review early");
+    await visualScreenshot(page, "Student can submit self-review early");
     await page.getByRole("button", { name: "Finalize Submission Early" }).click();
     await page.getByRole("button", { name: "Confirm action" }).click();
     // The "Submission finalized" success toast is the explicit signal that
@@ -212,7 +216,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
 
     await page.getByRole("textbox", { name: "Add a comment about this line" }).click();
     await page.getByRole("textbox", { name: "Add a comment about this line" }).fill(SELF_REVIEW_COMMENT_1);
-    await argosScreenshot(page, "Adding a comment on the self-review");
+    await visualScreenshot(page, "Adding a comment on the self-review", { stabilizeRubric: "Self-Review Rubric" });
     await page.getByRole("button", { name: "Add Comment" }).click();
     await page.getByText("Annotate line 15 with a check:").waitFor({ state: "hidden" });
 
@@ -221,7 +225,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     });
     await page.getByRole("option", { name: "Self Review Check 1 (+5)" }).click();
     await page.getByRole("textbox", { name: "Optionally add a comment, or" }).fill("comment");
-    await argosScreenshot(page, "Adding a second self-review check");
+    await visualScreenshot(page, "Adding a second self-review check", { stabilizeRubric: "Self-Review Rubric" });
     await page.getByRole("button", { name: "Add Check" }).click();
     // await clickAddCheckWithRetry(page);
     await page.getByText("Annotate line 5 with a check:").waitFor({ state: "hidden" });
@@ -236,7 +240,9 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page
       .getByRole("textbox", { name: "Optional: comment on check Self Review Check 2" })
       .fill(SELF_REVIEW_COMMENT_2);
-    await argosScreenshot(page, "Adding a global self-review check with a comment");
+    await visualScreenshot(page, "Adding a global self-review check with a comment", {
+      stabilizeRubric: "Self-Review Rubric"
+    });
 
     await page.getByRole("button", { name: "Add Check" }).click();
     //Wait for the textbox to disappear
@@ -245,7 +251,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("button", { name: "Complete Review" }).click();
     await page.getByRole("button", { name: "Mark Review Assignment as Complete" }).click();
     await expect(page.getByText("Self-Review Rubric completed")).toBeVisible();
-    await argosScreenshot(page, "Self-Review Rubric completed");
+    await visualScreenshot(page, "Self-Review Rubric completed", { stabilizeRubric: "Self-Review Rubric" });
     await assertStudentPageAccessible(page, "grading self-review completed");
   });
 
@@ -273,11 +279,10 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await expect(page.getByRole("region", { name: "Grading check Self Review Check 2" }).first()).toBeVisible();
     await expect(page.getByText(SELF_REVIEW_COMMENT_2)).toBeVisible();
     //Scroll self-review rubric to top of its container
-    await page.getByRole("region", { name: "Self-Review Rubric" }).evaluate((el) => {
-      el.scrollIntoView({ block: "start", behavior: "instant" });
+    await stabilizeRubricSidebar(page, "Self-Review Rubric");
+    await visualScreenshot(page, "Instructor can view the student's self-review", {
+      stabilizeRubric: "Self-Review Rubric"
     });
-    await page.waitForTimeout(100); // Ensure scroll completes before screenshot
-    await argosScreenshot(page, "Instructor can view the student's self-review");
 
     //Scroll grading rubric to top of its container
     await page.getByRole("region", { name: "Grading Rubric" }).evaluate((el) => {
@@ -290,7 +295,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("option", { name: "Grading Review Check 1 (+10)" }).click();
     await page.getByRole("button", { name: "Add Check" }).waitFor({ state: "visible", timeout: 1000 });
     await page.getByRole("textbox", { name: "Optionally add a comment, or" }).fill(GRADING_REVIEW_COMMENT_1);
-    await argosScreenshot(page, "Instructor adds a grading review check");
+    await visualScreenshot(page, "Instructor adds a grading review check", { stabilizeRubric: "Grading Rubric" });
     await page.getByRole("button", { name: "Add Check" }).click();
     // await clickAddCheckWithRetry(page);
     await page.getByText("Annotate line 4 with a check:").waitFor({ state: "hidden" });
@@ -323,7 +328,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("textbox", { name: "Optional: comment on check" }).waitFor({ state: "hidden" });
 
     await page.getByRole("button", { name: "Complete Review" }).click();
-    await argosScreenshot(page, "Instructor completes the grading review");
+    await visualScreenshot(page, "Instructor completes the grading review", { stabilizeRubric: "Grading Rubric" });
     await page.getByRole("button", { name: "Mark as Complete" }).click();
     await expect(page.getByText("Completed by")).toBeVisible();
 
@@ -367,11 +372,8 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await expect(rubricSidebar).toContainText(GRADING_REVIEW_COMMENT_1);
     await expect(rubricSidebar).toContainText(GRADING_REVIEW_COMMENT_2);
     //Scroll grading rubric to top of its container
-    await page.getByRole("region", { name: "Grading Rubric" }).evaluate((el) => {
-      el.scrollIntoView({ block: "start", behavior: "instant" });
-    });
-    await page.waitForTimeout(100); // Ensure scroll completes before screenshot
-    await argosScreenshot(page, "Student can view their grading results");
+    await stabilizeRubricSidebar(page, "Grading Rubric");
+    await visualScreenshot(page, "Student can view their grading results", { stabilizeRubric: "Grading Rubric" });
     await assertStudentPageAccessible(page, "grading results submission files");
 
     await expect(rubricSidebar).toContainText(`${instructor!.private_profile_name} applied today`);
@@ -379,7 +381,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     const region = await page.getByRole("region", { name: "Grading checks on line 4" });
     await expect(region).toBeVisible();
     await region.getByRole("button", { name: "Request regrade for this check" }).click();
-    await argosScreenshot(page, "Student can request a regrade");
+    await visualScreenshot(page, "Student can request a regrade", { stabilizeRubric: "Grading Rubric" });
     await page.getByRole("button", { name: "Draft Regrade Request" }).click();
     await page
       .getByRole("region", { name: "Grading checks on line 4" })
@@ -395,7 +397,9 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .click();
     await expect(region.getByText(REGRADE_COMMENT)).toBeVisible();
     await expect(region.getByText("Submitting your comment...")).not.toBeVisible();
-    await argosScreenshot(page, "Student can add a comment to open the regrade request");
+    await visualScreenshot(page, "Student can add a comment to open the regrade request", {
+      stabilizeRubric: "Grading Rubric"
+    });
   });
   test("Instructors can view the student's regrade request and resolve it", async ({ page }) => {
     await loginAsUser(page, instructor!, course);
@@ -408,7 +412,9 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByRole("region", { name: "Grading checks on line 4" })
       .getByPlaceholder("Add a comment to continue the")
       .click();
-    await argosScreenshot(page, "Instructors can view the student's regrade request");
+    await visualScreenshot(page, "Instructors can view the student's regrade request", {
+      stabilizeRubric: "Grading Rubric"
+    });
     await page
       .getByRole("region", { name: "Grading checks on line 4" })
       .getByPlaceholder("Add a comment to continue the")
@@ -422,7 +428,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     ).toBeVisible();
     await expect(page.getByText("Submitting your comment...")).not.toBeVisible();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Resolve Request" }).click();
-    await argosScreenshot(page, "Instructors can resolve the regrade request");
+    await visualScreenshot(page, "Instructors can resolve the regrade request", { stabilizeRubric: "Grading Rubric" });
     // Popover content is portalled (not under the rubric check region); scope to the resolve dialog.
     const resolveRegradePopover = page.getByRole("dialog").filter({ hasText: "Grade Adjustment:" });
     await expect(resolveRegradePopover).toBeVisible();
@@ -458,7 +464,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByLabel("Add Comment", { exact: true })
       .click();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Escalate to Instructor" }).click();
-    await argosScreenshot(page, "Students can appeal their regrade request");
+    await visualScreenshot(page, "Students can appeal their regrade request", { stabilizeRubric: "Grading Rubric" });
     await page.getByRole("button", { name: "Escalate Request" }).click();
     // Wait for the escalation to settle before axe runs — otherwise axe races
     // the closing popover / toast and reports transient focus-trap / labeling violations.
@@ -484,7 +490,9 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByRole("region", { name: "Grading checks on line 4" })
       .getByPlaceholder("Add a comment to continue the")
       .fill(REGRADE_FINAL_COMMENT);
-    await argosScreenshot(page, "Instructors can view the student's regrade appeal");
+    await visualScreenshot(page, "Instructors can view the student's regrade appeal", {
+      stabilizeRubric: "Grading Rubric"
+    });
     await page
       .getByRole("region", { name: "Grading checks on line 4" })
       .getByLabel("Add Comment", { exact: true })
@@ -495,7 +503,7 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("textbox", { name: "Grade adjustment" }).fill("100");
     await expect(page.getByRole("dialog").getByText("This is a significant change")).toBeVisible();
     await page.getByRole("dialog").getByRole("button", { name: "Close regrade request" }).click();
-    await argosScreenshot(page, "Instructors can close the regrade request");
+    await visualScreenshot(page, "Instructors can close the regrade request", { stabilizeRubric: "Grading Rubric" });
     await expect(page.getByLabel("Grading checks on line 4").getByRole("heading")).toContainText("Regrade Closed");
   });
   test("Graders assigned to a rubric part see just that rubric part to grade", async ({ page }) => {
@@ -520,11 +528,10 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await expect(page.getByText("public static void main(")).toBeVisible();
 
     //Scroll grading rubric to top of its container
-    await page.getByRole("region", { name: "Grading Rubric" }).evaluate((el) => {
-      el.scrollIntoView({ block: "start", behavior: "instant" });
+    await stabilizeRubricSidebar(page, "Grading Rubric");
+    await visualScreenshot(page, "Graders assigned to a rubric part see just that rubric part to grade", {
+      stabilizeRubric: "Grading Rubric"
     });
-    await page.waitForTimeout(1000); // Ensure scroll completes before screenshot
-    await argosScreenshot(page, "Graders assigned to a rubric part see just that rubric part to grade");
     await page.getByText("Third check for grading review").click();
 
     await clickWithTextboxRetry(

--- a/tests/e2e/lab-sections.test.tsx
+++ b/tests/e2e/lab-sections.test.tsx
@@ -1,8 +1,8 @@
 import { Course, DayOfWeek } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
-import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import { supabase, createClass, createUsersInClass, loginAsUser, TestingUser } from "./TestingUtils";
+import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
 let course: Course;
@@ -26,6 +26,7 @@ test.beforeAll(async () => {
   [instructor1, instructor2] = await createUsersInClass([
     {
       name: "Lab Sections Instructor 1",
+      public_profile_name: "Lab Sections Pseudonym Instructor 1",
       email: "lab-sections-instructor1@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -33,6 +34,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Lab Sections Instructor 2",
+      public_profile_name: "Lab Sections Pseudonym Instructor 2",
       email: "lab-sections-instructor2@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -169,7 +171,7 @@ test.describe("Lab Sections Page", () => {
     }
     await expect(page.getByText("<Lab Section 1>", { exact: true })).toBeVisible();
     await page.getByText("No upcoming meetings").first().waitFor({ state: "hidden" });
-    await argosScreenshot(page, "Lab Sections Page Contents");
+    await visualScreenshot(page, "Lab Sections Page Contents");
   });
   test("Instructors can create a lab section", async ({ page }) => {
     // Create a lab section

--- a/tests/e2e/manual-grading-scores.test.tsx
+++ b/tests/e2e/manual-grading-scores.test.tsx
@@ -2,7 +2,6 @@ import { Assignment, Course, RubricCheck, RubricPart } from "@/utils/supabase/Da
 import { test, expect } from "../global-setup";
 import { addDays } from "date-fns";
 import dotenv from "dotenv";
-import { argosScreenshot } from "@argos-ci/playwright";
 import { resolveTargetStudentProfileIdForRubricComment } from "@/lib/rubricCommentTargetStudentProfileId";
 import {
   createClass,
@@ -14,6 +13,7 @@ import {
   TestingUser
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { visualScreenshot } from "./VisualTestUtils";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -108,7 +108,7 @@ async function createGroupSubmission({
   const { data: groupData, error: groupError } = await supabase
     .from("assignment_groups")
     .insert({
-      name: `Test Group ${Date.now()}`,
+      name: `Manual Score Group - ${assignment.title}`,
       class_id: course.id,
       assignment_id: assignment.id
     })
@@ -152,6 +152,7 @@ test.describe("Manual grading score calculation", () => {
     [instructor, studentA, studentB, studentC] = await createUsersInClass([
       {
         name: "Score Instructor",
+        public_profile_name: "Score Pseudonym Instructor",
         email: "score-instructor@pawtograder.net",
         role: "instructor",
         class_id: course.id,
@@ -159,6 +160,7 @@ test.describe("Manual grading score calculation", () => {
       },
       {
         name: "Score Student A",
+        public_profile_name: "Score Pseudonym Student A",
         email: "score-student-a@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -166,6 +168,7 @@ test.describe("Manual grading score calculation", () => {
       },
       {
         name: "Score Student B",
+        public_profile_name: "Score Pseudonym Student B",
         email: "score-student-b@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -173,6 +176,7 @@ test.describe("Manual grading score calculation", () => {
       },
       {
         name: "Score Student C",
+        public_profile_name: "Score Pseudonym Student C",
         email: "score-student-c@pawtograder.net",
         role: "student",
         class_id: course.id,
@@ -270,7 +274,9 @@ test.describe("Manual grading score calculation", () => {
 
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
-      await argosScreenshot(page, "Individual grading - student view with score");
+      await visualScreenshot(page, "Individual grading - student view with score", {
+        stabilizeRubric: "Grading Rubric"
+      });
       await assertStudentPageAccessible(page, "manual grading individual student score");
     });
   });
@@ -351,7 +357,9 @@ test.describe("Manual grading score calculation", () => {
 
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
-      await argosScreenshot(page, "Group grading shared - student view with score");
+      await visualScreenshot(page, "Group grading shared - student view with score", {
+        stabilizeRubric: "Grading Rubric"
+      });
       await assertStudentPageAccessible(page, "manual grading group shared student score");
     });
   });
@@ -552,7 +560,9 @@ test.describe("Manual grading score calculation", () => {
       await expect(page.getByText("Scores by student")).toBeVisible({ timeout: 15000 });
       await expect(page.getByRole("heading", { name: /Overall Score/ })).not.toBeVisible();
       await expect(page.getByText("(You)")).toBeVisible();
-      await argosScreenshot(page, "Group individual grading - student view with individual score");
+      await visualScreenshot(page, "Group individual grading - student view with individual score", {
+        stabilizeRubric: "Grading Rubric"
+      });
       await assertStudentPageAccessible(page, "manual grading group individual student score");
     });
 
@@ -570,7 +580,9 @@ test.describe("Manual grading score calculation", () => {
       await expect(scoresSection.getByText("Score Student A").first()).toBeVisible();
       await expect(scoresSection.getByText("Score Student B").first()).toBeVisible();
       await expect(scoresSection.getByText("Score Student C").first()).toBeVisible();
-      await argosScreenshot(page, "Group individual grading - instructor view with all scores");
+      await visualScreenshot(page, "Group individual grading - instructor view with all scores", {
+        stabilizeRubric: "Grading Rubric"
+      });
     });
 
     test("removing individual grading comments clears individual_scores", async () => {

--- a/tests/e2e/office-hours.test.tsx
+++ b/tests/e2e/office-hours.test.tsx
@@ -1,6 +1,5 @@
 import { Assignment, Course } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
-import { argosScreenshot } from "@argos-ci/playwright";
 import { addDays } from "date-fns";
 import dotenv from "dotenv";
 import {
@@ -13,6 +12,7 @@ import {
   TestingUser
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { visualScreenshot } from "./VisualTestUtils";
 dotenv.config({ path: ".env.local", quiet: true });
 
 let course: Course;
@@ -28,6 +28,7 @@ test.beforeAll(async () => {
   [student, student2, instructor] = await createUsersInClass([
     {
       name: "Office Hours Student",
+      public_profile_name: "Office Hours Pseudonym Student",
       email: "office-hours-student@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -35,6 +36,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Office Hours Student 2",
+      public_profile_name: "Office Hours Pseudonym Student 2",
       email: "office-hours-student2@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -42,6 +44,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Office Hours Instructor",
+      public_profile_name: "Office Hours Pseudonym Instructor",
       email: "office-hours-instructor@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -112,7 +115,7 @@ test.describe("Office Hours", () => {
     await page.getByRole("textbox", { name: "Help Request Description" }).click();
     await page.getByRole("textbox", { name: "Help Request Description" }).fill(PRIVATE_HELP_REQUEST_MESSAGE_1);
     await page.locator("label").filter({ hasText: "Private" }).locator("svg").click();
-    await argosScreenshot(page, "Office Hours - Submit a Private Request");
+    await visualScreenshot(page, "Office Hours - Submit a Private Request");
     await page.getByRole("button", { name: "Submit Request" }).click();
 
     // newRequestForm.tsx awaits helpRequests.create() then router.push() to
@@ -126,7 +129,7 @@ test.describe("Office Hours", () => {
       .getByRole("textbox", { name: "Type your message" })
       .fill("Thanks in advance! I might try to open a more geeral request too.");
     await page.getByRole("button", { name: "Send" }).click();
-    await argosScreenshot(page, "Office Hours - Private Request with Comment");
+    await visualScreenshot(page, "Office Hours - Private Request with Comment");
 
     //Make a public request
     await page.getByRole("link", { name: "New Request" }).click();
@@ -156,7 +159,7 @@ test.describe("Office Hours", () => {
     await page.waitForURL("**/office-hours/**");
 
     await page.getByRole("button", { name: "View Chat" }).click();
-    await argosScreenshot(page, "Office Hours - View Queue with a public request");
+    await visualScreenshot(page, "Office Hours - View Queue with a public request");
     await expect(page.getByText(HELP_REQUEST_FOLLOW_UP_MESSAGE_1)).toBeVisible();
     await expect(page.getByText(PRIVATE_HELP_REQUEST_MESSAGE_1)).not.toBeVisible();
 
@@ -175,11 +178,11 @@ test.describe("Office Hours", () => {
     await page.getByRole("link", { name: HELP_REQUEST_MESSAGE_1 }).click();
     await expect(page.locator("body")).toContainText(HELP_REQUEST_FOLLOW_UP_MESSAGE_1);
     await expect(page.locator("body")).toContainText(HELP_REQUEST_OTHER_STUDENT_MESSAGE_1);
-    await argosScreenshot(page, "Office Hours - Instructor View Queue");
+    await visualScreenshot(page, "Office Hours - Instructor View Queue");
 
     await page.getByRole("textbox", { name: "Type your message" }).click();
     await page.getByRole("textbox", { name: "Type your message" }).fill(HELP_REQUEST_RESPONSE_1);
-    await argosScreenshot(page, "Office Hours - Instructor View Request with Comments");
+    await visualScreenshot(page, "Office Hours - Instructor View Request with Comments");
     await page.getByRole("button", { name: "Send" }).click();
     await page.getByRole("button", { name: "Show queue requests" }).click();
     await page.getByRole("link", { name: PRIVATE_HELP_REQUEST_MESSAGE_1 }).click();

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -295,7 +295,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await page.getByRole("link", { name: "1", exact: true }).click();
 
     await page.getByRole("button", { name: "Files" }).click();
-    await page.getByText("public int doMath(int a, int").click();
+    const doMathLine = page.getByText("public int doMath(int a, int");
+    await expect(doMathLine).toBeVisible();
+    await doMathLine.click({ force: true });
 
     const rubricSidebar = page.locator(`#rubric-${assignment!.grading_rubric_id}`);
     await expect(rubricSidebar).toContainText("Grading Review Criteria 20/20");

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -1,7 +1,6 @@
 import { Assignment, Course, RubricCheck, RubricPart } from "@/utils/supabase/DatabaseTypes";
 import { test, expect } from "../global-setup";
 import { type Page } from "@playwright/test";
-import { argosScreenshot } from "@argos-ci/playwright";
 import { addDays } from "date-fns";
 import dotenv from "dotenv";
 import {
@@ -14,6 +13,7 @@ import {
   TestingUser
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
+import { stabilizeRubricSidebar, visualScreenshot } from "./VisualTestUtils";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -52,6 +52,7 @@ test.beforeAll(async () => {
   [student, instructor] = await createUsersInClass([
     {
       name: "Pseudonymous Student",
+      public_profile_name: "Pseudonymous Student Alias",
       email: "pseudonymous-student@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -59,6 +60,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Pseudonymous Instructor",
+      public_profile_name: "Pseudonymous Instructor Alias",
       email: "pseudonymous-instructor@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -206,7 +208,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await page.getByRole("option", { name: "Grading Review Check 1 (+10)" }).click();
     await page.getByRole("button", { name: "Add Check" }).waitFor({ state: "visible", timeout: 1000 });
     await page.getByRole("textbox", { name: "Optionally add a comment, or" }).fill(GRADING_REVIEW_COMMENT_1);
-    await argosScreenshot(page, "Pseudonymous grading - Instructor adds a grading review check");
+    await visualScreenshot(page, "Pseudonymous grading - Instructor adds a grading review check", {
+      stabilizeRubric: "Grading Rubric"
+    });
     await page.getByRole("button", { name: "Add Check" }).click();
     await page.getByText("Annotate line 4 with a check:").waitFor({ state: "hidden" });
 
@@ -275,11 +279,10 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(rubricSidebar).toContainText(`(${instructor!.private_profile_name})`);
 
     // Scroll grading rubric to top of its container
-    await page.getByRole("region", { name: "Grading Rubric" }).evaluate((el) => {
-      el.scrollIntoView({ block: "start", behavior: "instant" });
+    await stabilizeRubricSidebar(page, "Grading Rubric");
+    await visualScreenshot(page, "Pseudonymous grading - Instructor sees real name in parentheses", {
+      stabilizeRubric: "Grading Rubric"
     });
-    await page.waitForTimeout(100);
-    await argosScreenshot(page, "Pseudonymous grading - Instructor sees real name in parentheses");
   });
 
   test("Students see only the grader's pseudonym, not their real name", async ({ page }) => {
@@ -307,11 +310,10 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(rubricSidebar).not.toContainText(`(${instructor!.private_profile_name})`);
 
     // Scroll grading rubric to top of its container
-    await page.getByRole("region", { name: "Grading Rubric" }).evaluate((el) => {
-      el.scrollIntoView({ block: "start", behavior: "instant" });
+    await stabilizeRubricSidebar(page, "Grading Rubric");
+    await visualScreenshot(page, "Pseudonymous grading - Student sees only pseudonym", {
+      stabilizeRubric: "Grading Rubric"
     });
-    await page.waitForTimeout(100);
-    await argosScreenshot(page, "Pseudonymous grading - Student sees only pseudonym");
     await assertStudentPageAccessible(page, "pseudonymous student grading view");
   });
 
@@ -334,7 +336,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
 
     await expect(region.getByText(REGRADE_REQUEST_COMMENT).first()).toBeVisible();
     await expect(region.getByText("Submitting your comment...")).not.toBeVisible();
-    await argosScreenshot(page, "Pseudonymous grading - Student opens regrade request");
+    await visualScreenshot(page, "Pseudonymous grading - Student opens regrade request", {
+      stabilizeRubric: "Grading Rubric"
+    });
     await assertStudentPageAccessible(page, "pseudonymous regrade request opened");
   });
 
@@ -359,7 +363,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(region).toContainText(instructor!.public_profile_name);
     await expect(region).toContainText(`(${instructor!.private_profile_name})`);
 
-    await argosScreenshot(page, "Pseudonymous grading - Instructor sees real name in regrade comment");
+    await visualScreenshot(page, "Pseudonymous grading - Instructor sees real name in regrade comment", {
+      stabilizeRubric: "Grading Rubric"
+    });
 
     // Resolve the regrade request
     await region.getByRole("button", { name: "Resolve Request" }).click();
@@ -383,7 +389,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     // Student should NOT see the grader's real name
     await expect(region).not.toContainText(`(${instructor!.private_profile_name})`);
 
-    await argosScreenshot(page, "Pseudonymous grading - Student sees only pseudonym in regrade");
+    await visualScreenshot(page, "Pseudonymous grading - Student sees only pseudonym in regrade", {
+      stabilizeRubric: "Grading Rubric"
+    });
   });
 
   test("Student escalates the regrade request", async ({ page }) => {
@@ -403,7 +411,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await region.getByRole("button", { name: "Escalate to Instructor" }).click();
     await page.getByRole("button", { name: "Escalate Request" }).click();
 
-    await argosScreenshot(page, "Pseudonymous grading - Student escalates regrade");
+    await visualScreenshot(page, "Pseudonymous grading - Student escalates regrade", {
+      stabilizeRubric: "Grading Rubric"
+    });
   });
 
   test("Instructor closes escalated regrade with their REAL identity (not pseudonym)", async ({ page }) => {
@@ -426,7 +436,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     // Verify the regrade is closed
     await expect(region.getByText("Regrade Closed")).toBeVisible();
 
-    await argosScreenshot(page, "Pseudonymous grading - Instructor closes escalation with real name");
+    await visualScreenshot(page, "Pseudonymous grading - Instructor closes escalation with real name", {
+      stabilizeRubric: "Grading Rubric"
+    });
   });
 
   test("Student sees instructor's REAL name (not pseudonym) for final escalation decision", async ({ page }) => {
@@ -450,7 +462,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await expect(region.getByText(GRADER_REGRADE_RESPONSE)).toBeVisible();
     await expect(region.getByText(INSTRUCTOR_FINAL_DECISION)).toBeVisible();
 
-    await argosScreenshot(page, "Pseudonymous grading - Student sees instructor real name for final decision");
+    await visualScreenshot(page, "Pseudonymous grading - Student sees instructor real name for final decision", {
+      stabilizeRubric: "Grading Rubric"
+    });
     await assertStudentPageAccessible(page, "pseudonymous regrade closed student view");
   });
 });

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -428,6 +428,8 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await region.getByPlaceholder("Add a comment to continue the").click();
     await region.getByPlaceholder("Add a comment to continue the").fill(INSTRUCTOR_FINAL_DECISION);
     await region.getByLabel("Add Comment", { exact: true }).click();
+    await expect(region.getByText("Submitting your comment...")).not.toBeVisible();
+    await expect(region.getByText(INSTRUCTOR_FINAL_DECISION)).toBeVisible();
 
     // Close the escalated regrade request
     await region.getByRole("button", { name: "Decide Escalation" }).click();

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -113,9 +113,9 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     // that finalize_submission_early completed and reviewAssignments has
     // refetched (see finalizeSubmissionEarly.tsx). Without it the next
     // assertion races the "Complete Self Review" button into existence.
-    // Chakra renders the toast title twice (visible toast + portal duplicate
-    // both with the same id), so .first() is required to satisfy strict mode.
-    await expect(page.getByText("Submission finalized").first()).toBeVisible();
+    // Visual-test mode removes toasts from layout before screenshots, so the
+    // explicit app signal is attachment rather than visibility.
+    await expect(page.getByText("Submission finalized").first()).toBeAttached();
     // Even after the toast appears, the "Complete Self Review" button only
     // renders once useMyReviewAssignments() observes the new row AND
     // useRubric("self-review") returns the matching rubric (see

--- a/tests/e2e/security-audit.test.tsx
+++ b/tests/e2e/security-audit.test.tsx
@@ -11,7 +11,7 @@ import {
   supabase,
   TestingUser
 } from "./TestingUtils";
-import { argosScreenshot } from "@argos-ci/playwright";
+import { visualScreenshot } from "./VisualTestUtils";
 
 /**
  * Security Audit Dashboard E2E Tests
@@ -188,6 +188,7 @@ test.beforeAll(async () => {
   [instructor, student1, student2, student3, grader] = await createUsersInClass([
     {
       name: "Professor Paranoid",
+      public_profile_name: "Security Pseudonym Instructor",
       email: "security-instructor@pawtograder.net",
       role: "instructor",
       class_id: course.id,
@@ -195,6 +196,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Claude McCheaterson",
+      public_profile_name: "Security Pseudonym Student 1",
       email: "claude-user@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -203,6 +205,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Backdoor Bobby",
+      public_profile_name: "Security Pseudonym Student 2",
       email: "backdoor-bobby@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -211,6 +214,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Honest Hannah",
+      public_profile_name: "Security Pseudonym Student 3",
       email: "honest-hannah@pawtograder.net",
       role: "student",
       class_id: course.id,
@@ -219,6 +223,7 @@ test.beforeAll(async () => {
     },
     {
       name: "Grading Gary",
+      public_profile_name: "Security Pseudonym Grader",
       email: "security-grader@pawtograder.net",
       role: "grader",
       class_id: course.id,
@@ -445,7 +450,7 @@ test.describe("Security Audit Dashboard", () => {
     const matchedContent = claudeRow.getByText(/java\.io\.File/);
     await expect(matchedContent).toBeVisible();
 
-    await argosScreenshot(page, "Security audit found matches");
+    await visualScreenshot(page, "Security audit found matches");
   });
 
   test("Search with no matches shows appropriate message", async ({ page }) => {
@@ -459,7 +464,7 @@ test.describe("Security Audit Dashboard", () => {
     // Should show no matches message
     await expect(page.getByText(/No matches found/)).toBeVisible({ timeout: 10000 });
 
-    await argosScreenshot(page, "Security audit no matches found");
+    await visualScreenshot(page, "Security audit no matches found");
   });
 
   test("Export to CSV button works when results exist", async ({ page }) => {
@@ -486,6 +491,6 @@ test.describe("Security Audit Dashboard", () => {
     expect(download.suggestedFilename()).toContain("security_audit");
     expect(download.suggestedFilename()).toContain(".csv");
 
-    await argosScreenshot(page, "Security audit export CSV");
+    await visualScreenshot(page, "Security audit export CSV");
   });
 });

--- a/tests/e2e/survey-assignment-grading.test.tsx
+++ b/tests/e2e/survey-assignment-grading.test.tsx
@@ -1,9 +1,9 @@
 import { test, expect } from "../global-setup";
-import { argosScreenshot } from "@argos-ci/playwright";
 import dotenv from "dotenv";
 import {
   createClass,
   createUsersInClass,
+  formatDateForTest,
   insertAssignment,
   insertPreBakedSubmission,
   loginAsUser,
@@ -11,8 +11,8 @@ import {
 } from "./TestingUtils";
 import { assertStudentPageAccessible } from "./axeStudentA11y";
 import type { TablesInsert } from "../../utils/supabase/SupabaseTypes";
-import { addDays } from "date-fns";
 import { TEAM_COLLABORATION_SURVEY } from "../fixtures/teamCollaborationSurvey";
+import { visualScreenshot } from "./VisualTestUtils";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -22,6 +22,15 @@ type SurveyInsert = TablesInsert<"surveys">;
 
 /** Use shared team collaboration survey (same as DB seeding) */
 const teamCollaborationSurveyJson = TEAM_COLLABORATION_SURVEY;
+const TEAM_SURVEY_TITLE = "Week 5 Team Collaboration Survey";
+const COURSE_FEEDBACK_SURVEY_TITLE = "General Course Feedback";
+const SURVEY_DUE_DATE = new Date("2035-03-15T16:00:00.000Z");
+const ASSIGNMENT_DUE_DATE = new Date("2035-03-17T16:00:00.000Z");
+const SUBMITTED_AT = new Date("2035-03-10T16:00:00.000Z");
+
+const expectTransparentText = async (page: import("@playwright/test").Page, text: string | RegExp) => {
+  await expect(page.locator('[data-visual-test="transparent"]').filter({ hasText: text }).first()).toBeVisible();
+};
 
 const buildSurveyPayload = (course: Course, instructor: User, overrides: Partial<SurveyInsert> = {}): SurveyInsert => {
   const { json, ...rest } = overrides;
@@ -81,11 +90,46 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
   test.beforeEach(async () => {
     course = await createClass();
     const users = await createUsersInClass([
-      { role: "student", class_id: course.id, name: "Alice Student", useMagicLink: true },
-      { role: "student", class_id: course.id, name: "Bob Student", useMagicLink: true },
-      { role: "student", class_id: course.id, name: "Carol Student", useMagicLink: true },
-      { role: "instructor", class_id: course.id, name: "Survey Instructor", useMagicLink: true },
-      { role: "grader", class_id: course.id, name: "Survey Grader", useMagicLink: true }
+      {
+        role: "student",
+        class_id: course.id,
+        name: "Alice Student",
+        public_profile_name: "Survey Pseudonym Alice",
+        email: `survey-alice-${course.id}@pawtograder.net`,
+        useMagicLink: true
+      },
+      {
+        role: "student",
+        class_id: course.id,
+        name: "Bob Student",
+        public_profile_name: "Survey Pseudonym Bob",
+        email: `survey-bob-${course.id}@pawtograder.net`,
+        useMagicLink: true
+      },
+      {
+        role: "student",
+        class_id: course.id,
+        name: "Carol Student",
+        public_profile_name: "Survey Pseudonym Carol",
+        email: `survey-carol-${course.id}@pawtograder.net`,
+        useMagicLink: true
+      },
+      {
+        role: "instructor",
+        class_id: course.id,
+        name: "Survey Instructor",
+        public_profile_name: "Survey Pseudonym Instructor",
+        email: `survey-instructor-${course.id}@pawtograder.net`,
+        useMagicLink: true
+      },
+      {
+        role: "grader",
+        class_id: course.id,
+        name: "Survey Grader",
+        public_profile_name: "Survey Pseudonym Grader",
+        email: `survey-grader-${course.id}@pawtograder.net`,
+        useMagicLink: true
+      }
     ]);
     [studentA, studentB, studentC, instructor, grader] = users;
     await clearCourseSurveys();
@@ -97,20 +141,21 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
   test("student views team collaboration survey and takes it", async ({ page }) => {
     // Create a published survey with the team collaboration JSON
     const survey = await seedSurvey<{ id: string; survey_id: string }>(course, instructor, {
-      title: "Week 5 Team Collaboration Survey",
+      title: TEAM_SURVEY_TITLE,
       description: "Please complete this weekly survey about your team collaboration experience.",
       status: "published",
       json: teamCollaborationSurveyJson,
-      due_date: addDays(new Date(), 3).toISOString()
+      due_date: SURVEY_DUE_DATE.toISOString()
     });
 
     await loginAsUser(page, studentA, course);
 
     // Navigate to the survey list
     await page.goto(`/course/${course.id}/surveys`);
-    await expect(page.getByText("Week 5 Team Collaboration Survey")).toBeVisible();
+    await expect(page.getByText(TEAM_SURVEY_TITLE)).toBeVisible();
+    await expectTransparentText(page, formatDateForTest(SURVEY_DUE_DATE, "America/New_York", "full"));
     await assertStudentPageAccessible(page, "survey assignment grading - survey list");
-    await argosScreenshot(page, "Student Survey List - Team Collaboration Survey Available");
+    await visualScreenshot(page, "Student Survey List - Team Collaboration Survey Available");
 
     // Click to start the survey
     const startLink = page.getByRole("link", { name: /Start Survey/i });
@@ -121,7 +166,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     // Page 1: Checkboxes
     // SurveyJS renders question titles in multiple places (span + hidden legend), so use .first()
     await expect(page.getByText("This week I have...").first()).toBeVisible();
-    await argosScreenshot(page, "Student Survey - Page 1 Checkboxes");
+    await visualScreenshot(page, "Student Survey - Page 1 Checkboxes");
 
     // Fill page 1 - click on the label text for SurveyJS checkboxes
     await page.locator("label").filter({ hasText: "Completed all my assigned tasks" }).click();
@@ -136,12 +181,12 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
       .filter({ hasText: "Opened a Pull Request and asked my team for feedback on my code" })
       .click();
 
-    await argosScreenshot(page, "Student Survey - Page 1 Filled");
+    await visualScreenshot(page, "Student Survey - Page 1 Filled");
 
     // Navigate to page 2
     await page.getByRole("button", { name: /Next/i }).click();
     await expect(page.getByText("This week, I knew what I needed to get done").first()).toBeVisible();
-    await argosScreenshot(page, "Student Survey - Page 2 Likert Questions");
+    await visualScreenshot(page, "Student Survey - Page 2 Likert Questions");
 
     // Fill page 2 - click on the label text for SurveyJS radio buttons
     await page
@@ -149,12 +194,12 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
       .filter({ hasText: /^Strongly agree$/ })
       .first()
       .click();
-    await argosScreenshot(page, "Student Survey - Page 2 Partially Filled");
+    await visualScreenshot(page, "Student Survey - Page 2 Partially Filled");
 
     // Navigate to page 3
     await page.getByRole("button", { name: /Next/i }).click();
     await expect(page.getByText("In our team we relied on each other to get the job done.").first()).toBeVisible();
-    await argosScreenshot(page, "Student Survey - Page 3 Team Dynamics");
+    await visualScreenshot(page, "Student Survey - Page 3 Team Dynamics");
 
     // Navigate to page 4
     await page.getByRole("button", { name: /Next/i }).click();
@@ -162,15 +207,17 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await expect(
       page.getByText("How do you feel about your team's collaboration process in this project?").first()
     ).toBeVisible();
-    await argosScreenshot(page, "Student Survey - Page 4 Impediments and Reflection");
+    await visualScreenshot(page, "Student Survey - Page 4 Impediments and Reflection");
     await assertStudentPageAccessible(page, "team collaboration survey page 4 (shell)");
   });
 
   test("student sees survey status banner on submission page", async ({ page }) => {
     // Create an assignment
     const assignment = await insertAssignment({
-      due_date: addDays(new Date(), 7).toISOString(),
-      class_id: course.id
+      due_date: ASSIGNMENT_DUE_DATE.toISOString(),
+      class_id: course.id,
+      name: "Survey Banner Assignment",
+      assignment_slug: `survey-banner-assignment-${course.id}`
     });
 
     // Create a submission for studentA
@@ -182,12 +229,12 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
 
     // Create a survey linked to this assignment
     const survey = await seedSurvey<{ id: string; survey_id: string }>(course, instructor, {
-      title: "Week 5 Team Collaboration Survey",
+      title: TEAM_SURVEY_TITLE,
       description: "Complete this survey about your team.",
       status: "published",
       json: teamCollaborationSurveyJson,
       assignment_id: assignment.id,
-      due_date: addDays(new Date(), 5).toISOString()
+      due_date: SURVEY_DUE_DATE.toISOString()
     });
 
     await loginAsUser(page, studentA, course);
@@ -196,12 +243,13 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await page.goto(`/course/${course.id}/assignments/${assignment.id}/submissions`);
 
     // Wait for the survey status banner to appear
-    await expect(page.getByText("Survey: Week 5 Team Collaboration Survey")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(`Survey: ${TEAM_SURVEY_TITLE}`)).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Pending")).toBeVisible();
     await expect(page.getByText("Take Survey")).toBeVisible();
+    await expectTransparentText(page, /Due /);
     await assertStudentPageAccessible(page, "submission page survey pending banner");
 
-    await argosScreenshot(page, "Student Submission Page - Survey Pending Banner");
+    await visualScreenshot(page, "Student Submission Page - Survey Pending Banner");
 
     // Now submit a response for this student to see the completed state
     const { error: respError } = await supabase.from("survey_responses").insert({
@@ -223,25 +271,28 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
         q15: "Our team collaborates well through regular meetings and code reviews."
       },
       is_submitted: true,
-      submitted_at: new Date().toISOString()
+      submitted_at: SUBMITTED_AT.toISOString()
     });
     if (respError) throw new Error(`Failed to insert response: ${respError.message}`);
 
     // Reload to see the completed status
     await page.reload();
-    await expect(page.getByText("Survey: Week 5 Team Collaboration Survey")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(`Survey: ${TEAM_SURVEY_TITLE}`)).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Completed")).toBeVisible();
     await expect(page.getByText("View Response")).toBeVisible();
+    await expectTransparentText(page, /Submitted /);
     await assertStudentPageAccessible(page, "submission page survey completed banner");
 
-    await argosScreenshot(page, "Student Submission Page - Survey Completed Banner");
+    await visualScreenshot(page, "Student Submission Page - Survey Completed Banner");
   });
 
   test("instructor views survey responses and analytics", async ({ page }) => {
     // Create an assignment
     const assignment = await insertAssignment({
-      due_date: addDays(new Date(), 7).toISOString(),
-      class_id: course.id
+      due_date: ASSIGNMENT_DUE_DATE.toISOString(),
+      class_id: course.id,
+      name: "Survey Responses Assignment",
+      assignment_slug: `survey-responses-assignment-${course.id}`
     });
 
     // Create groups for the assignment with a mentor
@@ -295,12 +346,12 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
 
     // Create a survey linked to this assignment
     const survey = await seedSurvey<{ id: string; survey_id: string }>(course, instructor, {
-      title: "Week 5 Team Collaboration Survey",
+      title: TEAM_SURVEY_TITLE,
       description: "Complete this survey about your team.",
       status: "published",
       json: teamCollaborationSurveyJson,
       assignment_id: assignment.id,
-      due_date: addDays(new Date(), 5).toISOString()
+      due_date: SURVEY_DUE_DATE.toISOString()
     });
 
     // Insert survey responses for all three students with varied numeric answers
@@ -324,7 +375,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
           q15: "Our team collaboration has been excellent. We meet regularly and everyone contributes."
         },
         is_submitted: true,
-        submitted_at: new Date().toISOString()
+        submitted_at: SUBMITTED_AT.toISOString()
       },
       {
         survey_id: survey.id,
@@ -345,7 +396,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
           q15: "Good progress but some scheduling issues. We need to plan our sprints better."
         },
         is_submitted: true,
-        submitted_at: new Date().toISOString()
+        submitted_at: SUBMITTED_AT.toISOString()
       },
       {
         survey_id: survey.id,
@@ -366,7 +417,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
           q15: "I feel our team could communicate more. I was stuck waiting for others to finish their parts."
         },
         is_submitted: true,
-        submitted_at: new Date().toISOString()
+        submitted_at: SUBMITTED_AT.toISOString()
       }
     ];
 
@@ -379,49 +430,54 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
 
     // Wait for the page to load
     await expect(page.getByRole("heading", { name: /Survey Responses/i })).toBeVisible();
-    await argosScreenshot(page, "Instructor Survey Responses - Overview");
 
     // Verify legacy summary stats are visible (exact match to avoid collision with analytics "Total Responses")
     await expect(page.getByText("TOTAL RESPONSES", { exact: true })).toBeVisible();
     await expect(page.getByText("RESPONSE RATE", { exact: true })).toBeVisible();
     await expect(page.getByText("TIME REMAINING", { exact: true })).toBeVisible();
+    await expectTransparentText(page, /day|Closed|Less than|h|m/);
 
     // Verify new analytics UI: SurveyAnalytics block and numeric stat
     await expect(page.getByRole("heading", { name: "Survey Analytics" })).toBeVisible();
+    await expect(page.getByText("Loading analytics...")).toBeHidden();
     await expect(page.getByText("Total Responses", { exact: true })).toBeVisible();
 
     // Verify group-specific section from group/mentor aggregation (GroupSummaryCards)
     await expect(page.getByText("Team Alpha").first()).toBeVisible();
     await expect(page.getByText("Team Beta").first()).toBeVisible();
 
+    await visualScreenshot(page, "Instructor Survey Responses - Overview");
+
     // Check responses table shows at least some survey response content (text may be truncated)
     await expect(page.locator("body")).toContainText("Our team collaboration");
     await expect(page.locator("body")).toContainText("Good progress");
 
-    await argosScreenshot(page, "Instructor Survey Responses - Individual Responses Table");
+    await expectTransparentText(page, formatDateForTest(SUBMITTED_AT, "America/New_York", "full"));
+    await visualScreenshot(page, "Instructor Survey Responses - Individual Responses Table");
   });
 
   test("instructor views survey manage page with linked assignment column", async ({ page }) => {
     // Create an assignment to link
     const assignment = await insertAssignment({
-      due_date: addDays(new Date(), 7).toISOString(),
+      due_date: ASSIGNMENT_DUE_DATE.toISOString(),
       class_id: course.id,
-      name: "Project Sprint 5"
+      name: "Project Sprint 5",
+      assignment_slug: `project-sprint-5-${course.id}`
     });
 
     // Create a survey linked to the assignment
     await seedSurvey(course, instructor, {
-      title: "Week 5 Team Collaboration Survey",
+      title: TEAM_SURVEY_TITLE,
       description: "Weekly team survey",
       status: "published",
       json: teamCollaborationSurveyJson,
       assignment_id: assignment.id,
-      due_date: addDays(new Date(), 5).toISOString()
+      due_date: SURVEY_DUE_DATE.toISOString()
     });
 
     // Create an unlinked survey
     await seedSurvey(course, instructor, {
-      title: "General Course Feedback",
+      title: COURSE_FEEDBACK_SURVEY_TITLE,
       description: "End of semester feedback",
       status: "published",
       json: { pages: [{ name: "p1", elements: [{ type: "comment", name: "feedback", title: "General feedback" }] }] }
@@ -431,28 +487,28 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await page.goto(`/course/${course.id}/manage/surveys`);
 
     // The manage page should show the linked assignment column
-    await expect(page.getByText("Week 5 Team Collaboration Survey")).toBeVisible();
-    await expect(page.getByText("General Course Feedback")).toBeVisible();
+    await expect(page.getByText(TEAM_SURVEY_TITLE)).toBeVisible();
+    await expect(page.getByText(COURSE_FEEDBACK_SURVEY_TITLE)).toBeVisible();
 
     // Verify linked-assignment column cells: linked survey shows assignment label, unlinked shows fallback
-    const linkedRow = page.getByRole("row").filter({ hasText: "Week 5 Team Collaboration Survey" });
+    const linkedRow = page.getByRole("row").filter({ hasText: TEAM_SURVEY_TITLE });
     await expect(linkedRow).toContainText("Project Sprint 5");
 
-    const unlinkedRow = page.getByRole("row").filter({ hasText: "General Course Feedback" });
+    const unlinkedRow = page.getByRole("row").filter({ hasText: COURSE_FEEDBACK_SURVEY_TITLE });
     await expect(unlinkedRow).toContainText("—");
 
-    await argosScreenshot(page, "Instructor Manage Surveys - Linked Assignment Column");
+    await visualScreenshot(page, "Instructor Manage Surveys - Linked Assignment Column");
   });
 
   test("student submitted survey shows read-only view", async ({ page }) => {
     // Create a published survey (editing NOT allowed)
     const survey = await seedSurvey<{ id: string; survey_id: string }>(course, instructor, {
-      title: "Week 5 Team Collaboration Survey",
+      title: TEAM_SURVEY_TITLE,
       description: "Please complete this weekly survey.",
       status: "published",
       json: teamCollaborationSurveyJson,
       allow_response_editing: false,
-      due_date: addDays(new Date(), 3).toISOString()
+      due_date: SURVEY_DUE_DATE.toISOString()
     });
 
     // Insert a submitted response for studentA
@@ -475,7 +531,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
         q15: "Great team collaboration this week!"
       },
       is_submitted: true,
-      submitted_at: new Date().toISOString()
+      submitted_at: SUBMITTED_AT.toISOString()
     });
 
     await loginAsUser(page, studentA, course);
@@ -484,6 +540,6 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     // Should show read-only indicator
     await expect(page.getByText("This survey has been submitted and cannot be edited.")).toBeVisible();
     await assertStudentPageAccessible(page, "submitted survey read-only (shell)");
-    await argosScreenshot(page, "Student Survey - Submitted Read Only View");
+    await visualScreenshot(page, "Student Survey - Submitted Read Only View");
   });
 });

--- a/tests/e2e/survey-assignment-grading.test.tsx
+++ b/tests/e2e/survey-assignment-grading.test.tsx
@@ -452,7 +452,7 @@ test.describe("Survey Assignment Grading - E2E Screenshots", () => {
     await expect(page.locator("body")).toContainText("Our team collaboration");
     await expect(page.locator("body")).toContainText("Good progress");
 
-    await expectTransparentText(page, formatDateForTest(SUBMITTED_AT, "America/New_York", "full"));
+    await expectTransparentText(page, /[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2} [AP]M E[DS]T/);
     await visualScreenshot(page, "Instructor Survey Responses - Individual Responses Table");
   });
 

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -14,15 +14,64 @@ const VISUAL_TEST_CSS = `
   }
 
   /*
-   * Preserve layout and accessible/text queryability while making volatile
-   * values invisible in screenshots. This is intended for dates, relative
-   * times, and other values that tests assert separately before capture.
+   * Preserve accessible/text queryability while replacing volatile values with
+   * stable placeholders in screenshots. Transparent text alone can still
+   * change layout when a date or relative time is longer in one run than
+   * another, so visual mode fixes inline sizing and paints deterministic
+   * pseudo-content instead.
    */
-  html[data-visual-tests] [data-visual-test="transparent"],
+  html[data-visual-tests] [data-visual-test="transparent"] {
+    --visual-test-placeholder: "████████████";
+    --visual-test-placeholder-width: 18ch;
+    display: inline-block !important;
+    inline-size: var(--visual-test-placeholder-width) !important;
+    max-inline-size: var(--visual-test-placeholder-width) !important;
+    min-inline-size: var(--visual-test-placeholder-width) !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+    vertical-align: baseline !important;
+    position: relative !important;
+    color: transparent !important;
+    text-shadow: none !important;
+    caret-color: transparent !important;
+  }
+
+  html[data-visual-tests] [data-visual-test="transparent"]::after {
+    content: var(--visual-test-placeholder) !important;
+    position: absolute !important;
+    inset-inline-start: 0 !important;
+    inset-block-start: 0 !important;
+    color: CanvasText !important;
+    opacity: 0.22 !important;
+    font: inherit !important;
+    letter-spacing: 0 !important;
+    pointer-events: none !important;
+  }
+
   html[data-visual-tests] [data-visual-test="transparent"] * {
     color: transparent !important;
     text-shadow: none !important;
     caret-color: transparent !important;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="date"] {
+    --visual-test-placeholder: "MMM 00, 0000 00:00 TZ";
+    --visual-test-placeholder-width: 22ch;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="relative-time"] {
+    --visual-test-placeholder: "relative time";
+    --visual-test-placeholder-width: 16ch;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="timestamp"] {
+    --visual-test-placeholder: "timestamp";
+    --visual-test-placeholder-width: 12ch;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="review-status"] {
+    --visual-test-placeholder: "review date/status";
+    --visual-test-placeholder-width: 28ch;
   }
 
   html[data-visual-tests] [data-visual-test="transparent"] svg,

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,9 +1,48 @@
 import { test as base, Page } from "@playwright/test";
 import { logMagicLink, TestingUser } from "@/tests/e2e/TestingUtils";
 
+const VISUAL_TEST_CSS = `
+  /* Visual test override - remove all border radius */
+  html[data-visual-tests] *,
+  html[data-visual-tests] *::before,
+  html[data-visual-tests] *::after {
+    border-radius: 0 !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+
+  /*
+   * Preserve layout and accessible/text queryability while making volatile
+   * values invisible in screenshots. This is intended for dates, relative
+   * times, and other values that tests assert separately before capture.
+   */
+  html[data-visual-tests] [data-visual-test="transparent"],
+  html[data-visual-tests] [data-visual-test="transparent"] * {
+    color: transparent !important;
+    text-shadow: none !important;
+    caret-color: transparent !important;
+  }
+
+  html[data-visual-tests] [data-visual-test="transparent"] svg,
+  html[data-visual-tests] [data-visual-test="transparent"] img,
+  html[data-visual-tests] [data-visual-test="transparent"] canvas {
+    opacity: 0 !important;
+  }
+
+  /*
+   * Remove transient UI entirely. The element remains in the DOM, but does
+   * not affect visual layout or screenshots while visual tests are active.
+   */
+  html[data-visual-tests] [data-visual-test="removed"] {
+    display: none !important;
+  }
+`;
+
 // Function to inject visual test setup
 const injectVisualTestSetup = async (page: Page) => {
-  await page.evaluate(() => {
+  await page.evaluate((visualTestCss) => {
     // Set the data-visual-tests attribute on the html element
     if (document.documentElement) {
       document.documentElement.setAttribute("data-visual-tests", "");
@@ -14,23 +53,12 @@ const injectVisualTestSetup = async (page: Page) => {
       // Create and inject CSS that removes all border-radius
       const style = document.createElement("style");
       style.id = "visual-test-style";
-      style.textContent = `
-        /* Visual test override - remove all border radius */
-        html[data-visual-tests] *,
-        html[data-visual-tests] *::before,
-        html[data-visual-tests] *::after {
-          border-radius: 0 !important;
-          border-top-left-radius: 0 !important;
-          border-top-right-radius: 0 !important;
-          border-bottom-left-radius: 0 !important;
-          border-bottom-right-radius: 0 !important;
-        }
-      `;
+      style.textContent = visualTestCss;
       if (document.head) {
         document.head.appendChild(style);
       }
     }
-  });
+  }, VISUAL_TEST_CSS);
 };
 
 type E2EFixtures = {
@@ -47,7 +75,7 @@ export const test = base.extend<E2EFixtures>({
   },
   page: async ({ page }, use) => {
     // Set up initial script for new page loads
-    await page.addInitScript(() => {
+    await page.addInitScript((visualTestCss) => {
       // Set the data-visual-tests attribute on the html element
       if (document.documentElement) {
         document.documentElement.setAttribute("data-visual-tests", "");
@@ -58,23 +86,12 @@ export const test = base.extend<E2EFixtures>({
         // Create and inject CSS that removes all border-radius
         const style = document.createElement("style");
         style.id = "visual-test-style";
-        style.textContent = `
-          /* Visual test override - remove all border radius */
-          html[data-visual-tests] *,
-          html[data-visual-tests] *::before,
-          html[data-visual-tests] *::after {
-            border-radius: 0 !important;
-            border-top-left-radius: 0 !important;
-            border-top-right-radius: 0 !important;
-            border-bottom-left-radius: 0 !important;
-            border-bottom-right-radius: 0 !important;
-          }
-        `;
+        style.textContent = visualTestCss;
         if (document.head) {
           document.head.appendChild(style);
         }
       }
-    });
+    }, VISUAL_TEST_CSS);
 
     // Listen for all navigations and re-inject the setup
     page.on("domcontentloaded", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add visual-test CSS support for removed elements and stable placeholders for transparent visual masks so date/time values no longer affect screenshot layout.
- Add a shared visual screenshot helper that waits for UI readiness and stabilizes rubric sidebar scroll positions.
- Make targeted visual E2E fixtures deterministic with explicit public names, stable survey/assignment data, and stronger readiness assertions.
- Expand visual screenshot stabilization to remaining Argos screenshot tests (gradebook, manual grading scores, office hours, discussions, enrollments, lab sections, and security audit).
- Stabilize the enrollments import visual by using deterministic add-member data, scoping the screenshot to the import dialog, resetting scroll positions, and asserting the preview rows before capture.
- Address CodeRabbit feedback: table-cell placeholder placement, HTTPS port validation, unsuppressed discussion screenshots, batch pseudonym ordinal fix, and placeholder prop consistency.

## 10x Local Stability Report
- Scope: all local screenshot-producing E2E files that do not require real GitHub credentials: surveys, grading, pseudonymous grading, manual grading scores, office hours, discussion threads, gradebook, enrollments, lab sections, and security audit.
- Excluded: `tests/e2e/create-submission.test.tsx`, because it is locally blocked by the documented missing-real-GitHub-credentials / GitHub circuit-breaker behavior.
- Command: `BASE_URL=http://localhost:3001 npx playwright test <all screenshot files except create-submission> --config=visual-local.config.ts --project=chromium --workers=1 --repeat-each=10`
- Result: 728/730 passed on the first 10x all-screenshot run. The 2 failures were both in pseudonymous grading and exposed real stability issues, not screenshot capture-only issues:
  - final instructor regrade comment was not always persisted before closing escalation;
  - code-line click could occasionally stall while scrolling into view.
- Fixes applied:
  - wait for final instructor comment persistence before closing the regrade escalation;
  - force the stable code-line click after asserting visibility;
  - additionally mask volatile review-sidebar metadata discovered while reviewing 10x screenshot diffs.
- Follow-up validation after fixes:
  - `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/pseudonymous-grading.test.tsx --config=visual-local.config.ts --project=chromium --workers=1 --repeat-each=10` — 100 passed after the fixes (the first attempt found the code-line click issue; after fixing it, the rerun passed 100/100).
  - `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/pseudonymous-grading.test.tsx --project=chromium --workers=1` — 10 passed after the final review-sidebar metadata masking commit and a Next server restart.
- Note: during the long 10x validation, the local `next start` process eventually OOMed after many repeated runs; restarting the prod server restored the environment. This appears to be a local long-run resource limitation, not a test assertion failure.

## Other Validation
- `npm run format`
- `npm run build` with `NEXT_PUBLIC_PAWTOGRADER_WEB_URL=http://localhost:3001`
- `npm run lint`
- `PORT=not-a-port node scripts/next-start-https.cjs` exits non-zero with a clear invalid-port error
- Fresh local Supabase + Edge Functions + prod Next server on port 3001
- `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/survey-assignment-grading.test.tsx tests/e2e/grading.test.tsx tests/e2e/pseudonymous-grading.test.tsx --project=chromium --workers=1 --repeat-each=2` — 44 passed
- `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/survey-assignment-grading.test.tsx tests/e2e/grading.test.tsx tests/e2e/pseudonymous-grading.test.tsx --project=webkit --workers=1 --repeat-each=2` — 44 passed
- `BASE_URL=http://localhost:3001 npx playwright test tests/e2e/enrollments.test.tsx --project=chromium --workers=1 --repeat-each=2` — 6 passed

## Notes
- `tests/e2e/create-submission.test.tsx` remains locally blocked by the documented missing-real-GitHub-credentials/circuit-breaker behavior; its visual call was migrated to the shared helper, but the full file is not a reliable local validation target without CI secrets.
- A follow-up discussion test run after CodeRabbit fixes was blocked by a local Supabase REST/Kong timeout (`/rest/v1/` returned curl 000/timeout), after the long local validation run; lint and the HTTPS script validation passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d742cd8-00fc-4a15-b662-efd451dc3c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d742cd8-00fc-4a15-b662-efd451dc3c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end visual testing utilities and stabilization helpers.
  * Switched many test suites to a unified visual screenshot flow and added deterministic pseudonymous test data.

* **Chores**
  * Added an HTTPS startup script for production runs.
  * Improved visual-test scaffolding to make date/time/status displays more stable during screenshots (no visible content changes).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->