### PR TITLE
ci(e2e): tune ephemeral Postgres for speed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,7 +204,8 @@ jobs:
           # destroyed at job end, so fsync/full_page_writes give us nothing.
           # synchronous_commit is SIGHUP-reloadable; fsync and full_page_writes
           # require a restart.
-          docker exec -i "supabase_db_${SUPABASE_PROJECT}" psql -U postgres -d postgres -c "
+          docker exec -i "supabase_db_${SUPABASE_PROJECT}" \
+            psql -v ON_ERROR_STOP=1 -U postgres -d postgres -c "
             ALTER SYSTEM SET synchronous_commit = off;
             ALTER SYSTEM SET fsync = off;
             ALTER SYSTEM SET full_page_writes = off;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,6 +200,35 @@ jobs:
             -H "apikey: ${LOCAL_SUPABASE_ANON_KEY}" \
             "${LOCAL_SUPABASE_URL}/rest/v1/"
 
+          # Ephemeral CI Postgres — trade durability for speed. The volume is
+          # destroyed at job end, so fsync/full_page_writes give us nothing.
+          # synchronous_commit is SIGHUP-reloadable; fsync and full_page_writes
+          # require a restart.
+          docker exec -i "supabase_db_${SUPABASE_PROJECT}" psql -U postgres -d postgres -c "
+            ALTER SYSTEM SET synchronous_commit = off;
+            ALTER SYSTEM SET fsync = off;
+            ALTER SYSTEM SET full_page_writes = off;
+            ALTER SYSTEM SET shared_buffers = '512MB';
+            ALTER SYSTEM SET work_mem = '32MB';
+            ALTER SYSTEM SET maintenance_work_mem = '256MB';
+            ALTER SYSTEM SET autovacuum = off;
+          "
+          docker restart "supabase_db_${SUPABASE_PROJECT}"
+
+          # Re-wait for REST after the db bounce — PostgREST reconnects lazily
+          # but Kong returns 5xx until the upstream is healthy again.
+          for i in $(seq 1 120); do
+            if curl -sf -o /dev/null \
+                 -H "apikey: ${LOCAL_SUPABASE_ANON_KEY}" \
+                 "${LOCAL_SUPABASE_URL}/rest/v1/"; then
+              break
+            fi
+            sleep 1
+          done
+          curl -sf -o /dev/null \
+            -H "apikey: ${LOCAL_SUPABASE_ANON_KEY}" \
+            "${LOCAL_SUPABASE_URL}/rest/v1/"
+
           # Audit table is partitioned; seed today's partition (and the next 7 days).
           docker exec -i "supabase_db_${SUPABASE_PROJECT}" psql -U postgres -d postgres -c \
             "SELECT public.audit_maintain_partitions();"


### PR DESCRIPTION
## Summary
- Disable durability knobs (`synchronous_commit`, `fsync`, `full_page_writes`) on the E2E Postgres — its volume is destroyed at job end, so the fsync cost buys us nothing.
- Bump `shared_buffers` (512MB), `work_mem` (32MB), `maintenance_work_mem` (256MB), and turn off autovacuum since the DB only lives ~30 min.
- Restart the db container after `ALTER SYSTEM` so `fsync` / `full_page_writes` / `shared_buffers` (non-SIGHUP-reloadable) actually take effect, then re-poll the REST gateway before continuing.

## Test plan
- [ ] CI E2E run on this PR completes green
- [ ] Compare e2e-local job duration against a recent staging run to confirm a measurable speedup
- [ ] Confirm no `out of memory` / container-restart errors in `server-logs/supabase_db_*.log` artifact (validates the 512MB `shared_buffers` fits on the runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing infrastructure for improved performance and reliability during the automated testing process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->