### PR TITLE
fix(useCustomTable): fetch all rows via paginated range()

### DIFF
--- a/hooks/useCustomTable.tsx
+++ b/hooks/useCustomTable.tsx
@@ -107,53 +107,72 @@ export function useCustomTable<TData>({
       setError(null);
 
       const supabase = createClient();
-      let query = supabase.from(resource).select(select);
+      const PAGE_SIZE = 1000;
 
-      // Apply server filters
-      serverFilters.forEach((filter) => {
-        switch (filter.operator) {
-          case "eq":
-            query = query.eq(filter.field, filter.value);
-            break;
-          case "neq":
-            query = query.neq(filter.field, filter.value);
-            break;
-          case "gt":
-            query = query.gt(filter.field, filter.value);
-            break;
-          case "gte":
-            query = query.gte(filter.field, filter.value);
-            break;
-          case "lt":
-            query = query.lt(filter.field, filter.value);
-            break;
-          case "lte":
-            query = query.lte(filter.field, filter.value);
-            break;
-          case "like":
-            query = query.like(filter.field, String(filter.value));
-            break;
-          case "ilike":
-            query = query.ilike(filter.field, String(filter.value));
-            break;
-          case "in":
-            query = query.in(filter.field, Array.isArray(filter.value) ? filter.value : [filter.value]);
-            break;
+      const buildQuery = () => {
+        let query = supabase.from(resource).select(select);
+
+        serverFilters.forEach((filter) => {
+          switch (filter.operator) {
+            case "eq":
+              query = query.eq(filter.field, filter.value);
+              break;
+            case "neq":
+              query = query.neq(filter.field, filter.value);
+              break;
+            case "gt":
+              query = query.gt(filter.field, filter.value);
+              break;
+            case "gte":
+              query = query.gte(filter.field, filter.value);
+              break;
+            case "lt":
+              query = query.lt(filter.field, filter.value);
+              break;
+            case "lte":
+              query = query.lte(filter.field, filter.value);
+              break;
+            case "like":
+              query = query.like(filter.field, String(filter.value));
+              break;
+            case "ilike":
+              query = query.ilike(filter.field, String(filter.value));
+              break;
+            case "in":
+              query = query.in(filter.field, Array.isArray(filter.value) ? filter.value : [filter.value]);
+              break;
+          }
+        });
+
+        if (serverOrderBys.length > 0) {
+          serverOrderBys.forEach((orderBy) => {
+            query = query.order(orderBy.field, { ascending: orderBy.direction === "asc" });
+          });
+        } else {
+          // Deterministic order is required for stable pagination across pages
+          query = query.order("id", { ascending: true });
         }
-      });
 
-      // Apply server order bys
-      serverOrderBys.forEach((orderBy) => {
-        query = query.order(orderBy.field, orderBy.direction === "asc" ? { ascending: true } : { ascending: false });
-      });
+        return query;
+      };
 
-      const { data: result, error: queryError } = await query.limit(1000);
+      const allRows: TData[] = [];
+      for (let page = 0; ; page++) {
+        const from = page * PAGE_SIZE;
+        const to = from + PAGE_SIZE - 1;
+        const { data: pageRows, error: queryError } = await buildQuery().range(from, to);
 
-      if (queryError) {
-        throw queryError;
+        if (queryError) {
+          throw queryError;
+        }
+
+        const rows = (pageRows || []) as TData[];
+        allRows.push(...rows);
+
+        if (rows.length < PAGE_SIZE) break;
       }
 
-      setData((result || []) as TData[]);
+      setData(allRows);
     } catch (err) {
       setError(err instanceof Error ? err : new Error("An unknown error occurred"));
     } finally {


### PR DESCRIPTION
## Summary
- `useCustomTable` previously called `.limit(1000)` on a single Supabase query, silently truncating any table with more than 1000 rows.
- Replaced with a paged `.range()` loop that keeps fetching until a short page is returned, matching the pattern in `lib/ssrUtils.ts`.
- When the caller does not pass `serverOrderBys`, default to `order("id", ascending: true)` so page boundaries are deterministic across rounds.

Follow-up to CodeRabbit feedback on #753 (all other comments on that PR are already addressed in the squash-merged commit on staging — verified each location).

## Test plan
- [ ] Audit page (`/course/[id]/manage/course/audit`) lists more than 1000 audit rows for a high-traffic course
- [ ] Workflow-run errors page paginates client-side over the full dataset
- [ ] Regrade requests table shows all requests, not the first 1000
- [ ] No regression in initial load time for small datasets (single page returned, loop exits immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)