### PR TITLE
Fix gradebook recalculation on active submission changes

### DIFF
--- a/supabase/migrations/20260518203000_recalculate_gradebook_on_submission_active_change.sql
+++ b/supabase/migrations/20260518203000_recalculate_gradebook_on_submission_active_change.sql
@@ -98,8 +98,7 @@ JOIN public.gradebook_columns gc
 JOIN public.gradebook_column_students gcs
   ON gcs.gradebook_column_id = gc.id
  AND gcs.student_id = s.profile_id
-WHERE s.is_active = true
-  AND s.assignment_group_id IS NULL
+WHERE s.assignment_group_id IS NULL
   AND s.profile_id IS NOT NULL
 
 UNION
@@ -115,8 +114,7 @@ JOIN public.gradebook_columns gc
 JOIN public.gradebook_column_students gcs
   ON gcs.gradebook_column_id = gc.id
  AND gcs.student_id = agm.profile_id
-WHERE s.is_active = true
-  AND s.assignment_group_id IS NOT NULL;
+WHERE s.assignment_group_id IS NOT NULL;
 
 DO $backfill$
 DECLARE

--- a/supabase/migrations/20260518203000_recalculate_gradebook_on_submission_active_change.sql
+++ b/supabase/migrations/20260518203000_recalculate_gradebook_on_submission_active_change.sql
@@ -1,0 +1,156 @@
+-- Assignment gradebook columns read from the currently active submission.
+-- Recalculate dependent gradebook rows whenever a submission activation changes.
+
+CREATE OR REPLACE FUNCTION public.submission_active_recalculate_dependent_columns_statement()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_batch jsonb[];
+BEGIN
+  WITH changed_submissions AS (
+    SELECT
+      n.id,
+      n.class_id,
+      n.assignment_id,
+      n.profile_id,
+      n.assignment_group_id
+    FROM new_table n
+    JOIN old_table o ON o.id = n.id
+    WHERE n.is_active IS DISTINCT FROM o.is_active
+  ),
+  affected_rows AS (
+    SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+    FROM changed_submissions s
+    JOIN public.gradebook_columns gc
+      ON gc.class_id = s.class_id
+     AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[s.assignment_id]::bigint[])
+    JOIN public.gradebook_column_students gcs
+      ON gcs.gradebook_column_id = gc.id
+     AND gcs.student_id = s.profile_id
+    WHERE s.assignment_group_id IS NULL
+      AND s.profile_id IS NOT NULL
+
+    UNION
+
+    SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+    FROM changed_submissions s
+    JOIN public.assignment_groups_members agm
+      ON agm.assignment_id = s.assignment_id
+     AND agm.assignment_group_id = s.assignment_group_id
+    JOIN public.gradebook_columns gc
+      ON gc.class_id = s.class_id
+     AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[s.assignment_id]::bigint[])
+    JOIN public.gradebook_column_students gcs
+      ON gcs.gradebook_column_id = gc.id
+     AND gcs.student_id = agm.profile_id
+    WHERE s.assignment_group_id IS NOT NULL
+  )
+  SELECT coalesce(
+    array_agg(
+      jsonb_build_object(
+        'class_id', class_id,
+        'gradebook_id', gradebook_id,
+        'student_id', student_id,
+        'is_private', is_private,
+        'source', 'deps_update'
+      )
+    ),
+    ARRAY[]::jsonb[]
+  )
+  INTO v_batch
+  FROM affected_rows;
+
+  IF coalesce(array_length(v_batch, 1), 0) > 0 THEN
+    PERFORM public.enqueue_gradebook_row_recalculation_batch(v_batch);
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.submission_active_recalculate_dependent_columns_statement() IS
+  'After submissions UPDATE: enqueue gradebook row recalculation when is_active changes for assignment-dependent columns.';
+
+DROP TRIGGER IF EXISTS trigger_recalculate_dependent_columns_on_submission_active_change ON public.submissions;
+CREATE TRIGGER trigger_recalculate_dependent_columns_on_submission_active_change
+  AFTER UPDATE ON public.submissions
+  REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.submission_active_recalculate_dependent_columns_statement();
+
+-- Backfill existing rows so deployments with stale active-submission gradebook cells repair themselves.
+CREATE TEMP TABLE _mig_active_submission_gb_backfill (
+  class_id bigint NOT NULL,
+  gradebook_id bigint NOT NULL,
+  student_id uuid NOT NULL,
+  is_private boolean NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO _mig_active_submission_gb_backfill (class_id, gradebook_id, student_id, is_private)
+SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+FROM public.submissions s
+JOIN public.gradebook_columns gc
+  ON gc.class_id = s.class_id
+ AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[s.assignment_id]::bigint[])
+JOIN public.gradebook_column_students gcs
+  ON gcs.gradebook_column_id = gc.id
+ AND gcs.student_id = s.profile_id
+WHERE s.is_active = true
+  AND s.assignment_group_id IS NULL
+  AND s.profile_id IS NOT NULL
+
+UNION
+
+SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+FROM public.submissions s
+JOIN public.assignment_groups_members agm
+  ON agm.assignment_id = s.assignment_id
+ AND agm.assignment_group_id = s.assignment_group_id
+JOIN public.gradebook_columns gc
+  ON gc.class_id = s.class_id
+ AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[s.assignment_id]::bigint[])
+JOIN public.gradebook_column_students gcs
+  ON gcs.gradebook_column_id = gc.id
+ AND gcs.student_id = agm.profile_id
+WHERE s.is_active = true
+  AND s.assignment_group_id IS NOT NULL;
+
+DO $backfill$
+DECLARE
+  v_batch jsonb[];
+  v_chunk int := 400;
+BEGIN
+  LOOP
+    WITH picked AS (
+      SELECT ctid FROM _mig_active_submission_gb_backfill LIMIT v_chunk
+    ),
+    del AS (
+      DELETE FROM _mig_active_submission_gb_backfill g
+      USING picked p
+      WHERE g.ctid = p.ctid
+      RETURNING g.class_id, g.gradebook_id, g.student_id, g.is_private
+    )
+    SELECT coalesce(
+      array_agg(
+        jsonb_build_object(
+          'class_id', del.class_id,
+          'gradebook_id', del.gradebook_id,
+          'student_id', del.student_id,
+          'is_private', del.is_private,
+          'source', 'deps_update'
+        )
+      ),
+      ARRAY[]::jsonb[]
+    )
+    INTO v_batch
+    FROM del;
+
+    EXIT WHEN coalesce(array_length(v_batch, 1), 0) = 0;
+
+    PERFORM public.enqueue_gradebook_row_recalculation_batch(v_batch);
+  END LOOP;
+END;
+$backfill$;

--- a/tests/e2e/active-submission-gradebook-db.spec.ts
+++ b/tests/e2e/active-submission-gradebook-db.spec.ts
@@ -133,8 +133,9 @@ test.describe("active submission gradebook recalculation", () => {
   async function kickGradebookWorker() {
     try {
       await supabase.rpc("invoke_gradebook_recalculation_background_task");
-    } catch {
+    } catch (error) {
       // The direct edge-function kick below is the reliable local fallback.
+      console.warn("Failed to invoke gradebook recalculation background RPC:", error);
     }
 
     const edgeSecret = process.env.EDGE_FUNCTION_SECRET || process.env.EDGE_FUNCTION_SECRET_OVERRIDE;
@@ -143,7 +144,9 @@ test.describe("active submission gradebook recalculation", () => {
         .invoke("gradebook-column-recalculate", {
           headers: { "x-edge-function-secret": edgeSecret }
         })
-        .catch(() => {});
+        .catch((error) => {
+          console.warn("Failed to invoke gradebook recalculation edge function:", error);
+        });
     }
   }
 
@@ -189,6 +192,7 @@ test.describe("active submission gradebook recalculation", () => {
 
   async function waitForRecalcVersionGreaterThan(version: number) {
     await expect(async () => {
+      await kickGradebookWorker();
       const nextVersion = await getRecalcVersion();
       expect(nextVersion).toBeGreaterThan(version);
     }).toPass({ timeout: 30_000 });

--- a/tests/e2e/active-submission-gradebook-db.spec.ts
+++ b/tests/e2e/active-submission-gradebook-db.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "@playwright/test";
+import { addDays } from "date-fns";
+import {
+  createAuthenticatedClient,
+  createClass,
+  createUserInClass,
+  insertAssignment,
+  insertPreBakedSubmission,
+  supabase
+} from "@/tests/e2e/TestingUtils";
+import type { TestingUser } from "@/tests/e2e/TestingUtils";
+
+test.describe("active submission gradebook recalculation", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  let classId: number;
+  let assignmentId: number;
+  let assignmentSlug: string;
+  let gradebookId: number;
+  let gradebookColumnId: number;
+  let instructor: TestingUser;
+  let student: TestingUser;
+
+  test.beforeAll(async () => {
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const course = await createClass({ name: `E2E Active Submission Gradebook ${suffix}` });
+    classId = course.id;
+
+    instructor = await createUserInClass({
+      role: "instructor",
+      class_id: classId,
+      name: `E2E Active Submission Instructor ${suffix}`,
+      email: `e2e-active-submission-instructor-${suffix}@pawtograder.net`
+    });
+    student = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Active Submission Student ${suffix}`,
+      email: `e2e-active-submission-student-${suffix}@pawtograder.net`
+    });
+
+    const assignment = await insertAssignment({
+      class_id: classId,
+      due_date: addDays(new Date(), -1).toISOString(),
+      name: `E2E Active Submission Assignment ${suffix}`,
+      assignment_slug: `e2e-active-submission-${suffix}`
+    });
+    assignmentId = assignment.id;
+    assignmentSlug = assignment.slug;
+
+    const gradebookColumn = await getAssignmentGradebookColumn(classId, assignmentSlug);
+    gradebookId = gradebookColumn.gradebook_id;
+    gradebookColumnId = gradebookColumn.id;
+  });
+
+  test("reactivating a completed latest submission refreshes the assignment gradebook cell", async () => {
+    const oldSubmission = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `active-submission-old-${classId}`
+    });
+    await completeGrading(oldSubmission.grading_review_id, 21, instructor.private_profile_id);
+    await waitForAssignmentScore(21);
+
+    const latestSubmission = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `active-submission-latest-${classId}`
+    });
+    await completeGrading(latestSubmission.grading_review_id, 86, instructor.private_profile_id);
+    await waitForAssignmentScore(86);
+
+    const instructorClient = await createAuthenticatedClient(instructor);
+
+    const versionBeforeOldActivation = await getRecalcVersion();
+    await setActiveSubmission(instructorClient, oldSubmission.submission_id);
+    await waitForRecalcVersionGreaterThan(versionBeforeOldActivation);
+    await waitForAssignmentScore(21);
+
+    const versionBeforeLatestActivation = await getRecalcVersion();
+    await setActiveSubmission(instructorClient, latestSubmission.submission_id);
+    await waitForRecalcVersionGreaterThan(versionBeforeLatestActivation);
+    await waitForAssignmentScore(86);
+  });
+
+  async function completeGrading(gradingReviewId: number, score: number, completedBy: string) {
+    const { error } = await supabase
+      .from("submission_reviews")
+      .update({
+        completed_at: new Date().toISOString(),
+        completed_by: completedBy,
+        released: true,
+        total_score: score
+      })
+      .eq("id", gradingReviewId);
+
+    if (error) {
+      throw new Error(`Failed to complete grading review ${gradingReviewId}: ${error.message}`);
+    }
+  }
+
+  async function getAssignmentGradebookColumn(class_id: number, slug: string) {
+    const { data, error } = await supabase
+      .from("gradebook_columns")
+      .select("id, gradebook_id")
+      .eq("class_id", class_id)
+      .eq("slug", `assignment-${slug}`)
+      .single();
+
+    if (error || !data) {
+      throw new Error(`Failed to load assignment gradebook column: ${error?.message ?? "missing row"}`);
+    }
+
+    return data;
+  }
+
+  async function setActiveSubmission(
+    instructorClient: Awaited<ReturnType<typeof createAuthenticatedClient>>,
+    submissionId: number
+  ) {
+    const { data, error } = await instructorClient.rpc("submission_set_active", {
+      _submission_id: submissionId
+    });
+
+    if (error) {
+      throw new Error(`Failed to activate submission ${submissionId}: ${error.message}`);
+    }
+    expect(data).toBe(true);
+  }
+
+  async function kickGradebookWorker() {
+    await supabase.rpc("invoke_gradebook_recalculation_background_task").catch(() => {});
+
+    const edgeSecret = process.env.EDGE_FUNCTION_SECRET || process.env.EDGE_FUNCTION_SECRET_OVERRIDE;
+    if (edgeSecret) {
+      await supabase.functions
+        .invoke("gradebook-column-recalculate", {
+          headers: { "x-edge-function-secret": edgeSecret }
+        })
+        .catch(() => {});
+    }
+  }
+
+  async function getAssignmentScore() {
+    const { data, error } = await supabase
+      .from("gradebook_column_students")
+      .select("score, score_override")
+      .eq("gradebook_column_id", gradebookColumnId)
+      .eq("student_id", student.private_profile_id)
+      .eq("is_private", true)
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to load gradebook score: ${error.message}`);
+    }
+
+    return data.score_override ?? data.score;
+  }
+
+  async function waitForAssignmentScore(expected: number) {
+    await expect(async () => {
+      await kickGradebookWorker();
+      expect(await getAssignmentScore()).toBe(expected);
+    }).toPass({ timeout: 90_000 });
+  }
+
+  async function getRecalcVersion() {
+    const { data, error } = await supabase
+      .from("gradebook_row_recalc_state")
+      .select("version")
+      .eq("class_id", classId)
+      .eq("gradebook_id", gradebookId)
+      .eq("student_id", student.private_profile_id)
+      .eq("is_private", true)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to load recalculation state: ${error.message}`);
+    }
+
+    return data?.version ?? 0;
+  }
+
+  async function waitForRecalcVersionGreaterThan(version: number) {
+    await expect(async () => {
+      const nextVersion = await getRecalcVersion();
+      expect(nextVersion).toBeGreaterThan(version);
+    }).toPass({ timeout: 30_000 });
+  }
+});

--- a/tests/e2e/active-submission-gradebook-db.spec.ts
+++ b/tests/e2e/active-submission-gradebook-db.spec.ts
@@ -131,7 +131,11 @@ test.describe("active submission gradebook recalculation", () => {
   }
 
   async function kickGradebookWorker() {
-    await supabase.rpc("invoke_gradebook_recalculation_background_task").catch(() => {});
+    try {
+      await supabase.rpc("invoke_gradebook_recalculation_background_task");
+    } catch {
+      // The direct edge-function kick below is the reliable local fallback.
+    }
 
     const edgeSecret = process.env.EDGE_FUNCTION_SECRET || process.env.EDGE_FUNCTION_SECRET_OVERRIDE;
     if (edgeSecret) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a statement-level `submissions` trigger that enqueues assignment-dependent gradebook rows whenever `is_active` changes.
- Add a backfill enqueue for all submission-linked assignment gradebook rows so stale or missing-active cells are repaired.
- Add a DB-only E2E regression test that grades old/latest submissions, activates old, then reactivates latest and waits for gradebook recalculation.
- Address CodeRabbit feedback by broadening backfill coverage, kicking the worker while polling recalc state, and logging worker-kick failures.
- Merge latest `staging` into this branch before pushing.

### Testing
- `npm run format`
- `sg docker -c 'docker exec -i supabase_db_pawtograder-platform psql -U postgres -d postgres -v ON_ERROR_STOP=1 -1 < supabase/migrations/20260518203000_recalculate_gradebook_on_submission_active_change.sql'`
- `npm run lint`
- `BASE_URL=http://localhost:3000 npx playwright test tests/e2e/active-submission-gradebook-db.spec.ts --project=chromium`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9163e040-d38f-476b-89a8-295201561f61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9163e040-d38f-476b-89a8-295201561f61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gradebook now automatically recalculates when a submission's active status changes.

* **Bug Fixes**
  * Repaired stale gradebook data by backfilling and enqueuing recalculations to ensure accurate scores.

* **Tests**
  * Added end-to-end tests verifying activation-driven grade updates, recalculation triggers, and versioned recalculation completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->