### PR TITLE
Use async archive queue for large assignment deletes

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
@@ -98,9 +98,12 @@ export default function DeleteAssignmentButton({ assignmentId, courseId }: Delet
                     <strong>If checks pass, ALL related data will be permanently deleted:</strong>
                   </Text>
                   <Box as="ul" fontSize="sm" color="fg.muted" ml={4}>
-                    <Box as="li">• All student repositories from GitHub</Box>
-                    <Box as="li">• Handout repository (template) from GitHub</Box>
-                    <Box as="li">• Solution repository (grader) from GitHub</Box>
+                    <Box as="li">
+                      • GitHub repositories: small batches are deleted immediately; larger batches are queued for
+                      background archival and locking
+                    </Box>
+                    <Box as="li">• Handout repository (template) GitHub cleanup</Box>
+                    <Box as="li">• Solution repository (grader) GitHub cleanup</Box>
                     <Box as="li">• All submissions and grading results</Box>
                     <Box as="li">• All assignment groups, invitations, and join requests</Box>
                     <Box as="li">• All due date exceptions and late tokens</Box>
@@ -117,7 +120,8 @@ export default function DeleteAssignmentButton({ assignmentId, courseId }: Delet
                     fontSize="lg"
                     fontWeight="bold"
                   >
-                    This action is not undoable, and will delete content from GitHub!
+                    This action is not undoable. Assignment data is deleted permanently, and associated GitHub
+                    repositories are either deleted immediately or archived in the background.
                   </Box>
                 </VStack>
               </Dialog.Body>

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
@@ -33,7 +33,8 @@ export default function DeleteAssignmentButton({ assignmentId, courseId }: Delet
       toaster.create({
         title: "Assignment Deleted",
         description: result.message,
-        type: "success"
+        type: "success",
+        duration: 10000
       });
 
       // Redirect to assignments list
@@ -45,13 +46,15 @@ export default function DeleteAssignmentButton({ assignmentId, courseId }: Delet
         toaster.create({
           title: "Delete Failed",
           description: error.details,
-          type: "error"
+          type: "error",
+          duration: 10000
         });
       } else {
         toaster.create({
           title: "Delete Failed",
           description: "An unexpected error occurred while deleting the assignment.",
-          type: "error"
+          type: "error",
+          duration: 10000
         });
       }
     } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6775,6 +6775,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -377,6 +377,11 @@ export type AssignmentDeleteRequest = {
 
 export type AssignmentDeleteResponse = {
   message: string;
+  github_cleanup_strategy?: "delete_synchronously" | "archive_asynchronously";
+  github_repositories_total?: number;
+  github_repositories_deleted?: number;
+  github_repositories_queued_for_archive?: number;
+  github_repositories_skipped?: number;
 };
 
 // Course Import SIS Types

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1054,6 +1054,13 @@ export async function listFilesInRepo(org: string, repo: string, scope?: Sentry.
   return await listFilesInRepoDirectory(octokit, org, repo, "");
 }
 
+function isGitHubNotFoundError(error: unknown): boolean {
+  return (
+    (error instanceof RequestError && error.status === 404) ||
+    (error instanceof Error && error.message.includes("Not Found"))
+  );
+}
+
 export async function archiveRepoAndLock(org: string, repo: string, scope?: Sentry.Scope) {
   scope?.setTag("github_operation", "archive_repo");
   scope?.setTag("org", org);
@@ -1070,28 +1077,54 @@ export async function archiveRepoAndLock(org: string, repo: string, scope?: Sent
   }
   console.log(`archiving repo ${org}/${repo}`);
   //Remove all direct access to the repo
-  const collaborators = await octokit.request("GET /repos/{owner}/{repo}/collaborators", {
-    owner: org,
-    repo,
-    per_page: 100
-  });
-  for (const collaborator of collaborators.data) {
-    console.log("removing collaborator", collaborator.login);
-    await octokit.request("DELETE /repos/{owner}/{repo}/collaborators/{username}", {
+  let collaborators: Endpoints["GET /repos/{owner}/{repo}/collaborators"]["response"];
+  try {
+    collaborators = await octokit.request("GET /repos/{owner}/{repo}/collaborators", {
       owner: org,
       repo,
-      username: collaborator.login
+      per_page: 100
     });
+  } catch (error) {
+    if (isGitHubNotFoundError(error)) {
+      console.log(`repo ${org}/${repo} not found while archiving; treating as already archived`);
+      return;
+    }
+    throw error;
+  }
+  for (const collaborator of collaborators.data) {
+    console.log("removing collaborator", collaborator.login);
+    try {
+      await octokit.request("DELETE /repos/{owner}/{repo}/collaborators/{username}", {
+        owner: org,
+        repo,
+        username: collaborator.login
+      });
+    } catch (error) {
+      if (isGitHubNotFoundError(error)) {
+        console.log(`repo ${org}/${repo} or collaborator ${collaborator.login} not found while archiving; continuing`);
+        continue;
+      }
+      throw error;
+    }
   }
 
-  const newName = `archived-${new Date().toISOString()}-${repo}`;
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const newName = `archived-${timestamp}-${repo}`;
   console.log("renaming repo to", newName);
   //Rename the repo
-  await octokit.request("PATCH /repos/{owner}/{repo}", {
-    owner: org,
-    repo,
-    name: newName
-  });
+  try {
+    await octokit.request("PATCH /repos/{owner}/{repo}", {
+      owner: org,
+      repo,
+      name: newName
+    });
+  } catch (error) {
+    if (isGitHubNotFoundError(error)) {
+      console.log(`repo ${org}/${repo} not found while renaming; treating as already archived`);
+      return;
+    }
+    throw error;
+  }
 }
 /**
  * Syncs the staff team for a course.
@@ -2042,7 +2075,7 @@ export async function enqueueSyncRepoPermissions({
   }
   return data;
 }
-export async function enqueueGithubArchiveRepo(class_id: number, org: string, repo: string) {
+export async function enqueueGithubArchiveRepo(class_id: number, org: string, repo: string, debug_id?: string) {
   const adminSupabase = createClient<Database>(
     Deno.env.get("SUPABASE_URL") || "",
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
@@ -2050,7 +2083,8 @@ export async function enqueueGithubArchiveRepo(class_id: number, org: string, re
   const { data, error } = await adminSupabase.rpc("enqueue_github_archive_repo", {
     p_class_id: class_id,
     p_org: org,
-    p_repo: repo
+    p_repo: repo,
+    p_debug_id: debug_id
   });
   if (error) {
     Sentry.captureException(error);

--- a/supabase/functions/assignment-delete/index.ts
+++ b/supabase/functions/assignment-delete/index.ts
@@ -44,7 +44,7 @@ function isGitHubNotFoundError(error: unknown) {
 async function assertNoReleasedSubmissionReviews(adminSupabase: SupabaseClient<Database>, assignmentId: number) {
   const { data, error } = await adminSupabase
     .from("submission_reviews")
-    .select("id, submissions!inner(assignment_id)")
+    .select("id, submissions!submission_reviews_submission_id_fkey!inner(assignment_id)")
     .eq("released", true)
     .eq("submissions.assignment_id", assignmentId)
     .limit(1);

--- a/supabase/functions/assignment-delete/index.ts
+++ b/supabase/functions/assignment-delete/index.ts
@@ -1,16 +1,182 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { IllegalArgumentError, SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import { getOctoKit, listCommits } from "../_shared/GitHubWrapper.ts";
+import { enqueueGithubArchiveRepo, getOctoKit, listCommits } from "../_shared/GitHubWrapper.ts";
 import * as Sentry from "npm:@sentry/deno";
+import {
+  buildAssignmentDeleteArchiveDebugId,
+  collectGitHubRepoTargets,
+  selectGitHubCleanupStrategy
+} from "./repositoryCleanup.ts";
+import type { GitHubCleanupStrategy, GitHubRepoTarget } from "./repositoryCleanup.ts";
 
 interface AssignmentDeleteRequest {
   assignment_id: number;
   class_id: number;
 }
 
-async function deleteAssignment(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
+type RepositoryRow = {
+  id: number;
+  repository: string | null;
+  assignment_group_id: number | null;
+  profile_id: string | null;
+  synced_handout_sha: string | null;
+};
+
+type AssignmentDeleteResponse = {
+  message: string;
+  github_cleanup_strategy: GitHubCleanupStrategy;
+  github_repositories_total: number;
+  github_repositories_deleted: number;
+  github_repositories_queued_for_archive: number;
+  github_repositories_skipped: number;
+};
+
+const REPOSITORY_MODIFICATION_CHECK_CONCURRENCY = 5;
+
+function isGitHubNotFoundError(error: unknown) {
+  const maybeStatus = (error as { status?: number })?.status;
+  const message = error instanceof Error ? error.message : String(error);
+  return maybeStatus === 404 || message.includes("Not Found");
+}
+
+async function assertNoReleasedSubmissionReviews(adminSupabase: SupabaseClient<Database>, assignmentId: number) {
+  const { data, error } = await adminSupabase
+    .from("submission_reviews")
+    .select("id, submissions!inner(assignment_id)")
+    .eq("released", true)
+    .eq("submissions.assignment_id", assignmentId)
+    .limit(1);
+
+  if (error) {
+    console.error("Failed to check released submission reviews:", error);
+    throw new UserVisibleError(`Failed to check released submission reviews: ${error.message}`);
+  }
+
+  if (data && data.length > 0) {
+    throw new UserVisibleError(
+      "Cannot delete assignment: This assignment has released submission reviews. Delete cannot proceed.",
+      400
+    );
+  }
+}
+
+async function assertRepositoriesHaveOnlyTemplateCommits(repositories: RepositoryRow[], templateRepo: string | null) {
+  if (repositories.length === 0 || !templateRepo) {
+    return;
+  }
+
+  console.log(`Checking ${repositories.length} repositories for modifications...`);
+
+  let templateInitialCommitSha: string | undefined;
+  try {
+    const templateRepoCommits = await listCommits(templateRepo, 1);
+    templateInitialCommitSha = templateRepoCommits.commits[templateRepoCommits.commits.length - 1]?.sha;
+  } catch (error) {
+    console.warn("Error checking template repository:", error);
+    // If we can't access the template repo, preserve the previous behavior and proceed with deletion.
+    return;
+  }
+
+  async function checkRepository(repo: RepositoryRow) {
+    if (!repo.repository) {
+      console.log("Repository name is null, skipping");
+      return;
+    }
+
+    try {
+      const repoCommits = await listCommits(repo.repository, 1);
+
+      if (repoCommits.commits.length > 1) {
+        const oldestCommit = repoCommits.commits[repoCommits.commits.length - 1];
+
+        if (oldestCommit.sha !== templateInitialCommitSha && oldestCommit.sha !== repo.synced_handout_sha) {
+          throw new UserVisibleError(
+            `Cannot delete assignment: Repository ${repo.repository} has been modified beyond the template. ` +
+              `Please manually delete modified repositories if you want to proceed.`,
+            400
+          );
+        }
+      }
+    } catch (error) {
+      if (error instanceof UserVisibleError) {
+        throw error;
+      }
+      console.warn(`Error checking repository ${repo.repository}:`, error);
+      // If we can't check the repo (maybe it's already deleted), that's okay.
+      // Missing repos should not be an error according to requirements.
+    }
+  }
+
+  for (let i = 0; i < repositories.length; i += REPOSITORY_MODIFICATION_CHECK_CONCURRENCY) {
+    const batch = repositories.slice(i, i + REPOSITORY_MODIFICATION_CHECK_CONCURRENCY);
+    await Promise.all(batch.map(checkRepository));
+  }
+}
+
+async function deleteGitHubRepository(target: GitHubRepoTarget): Promise<"deleted" | "skipped"> {
+  try {
+    console.log(`Deleting ${target.kind} repository ${target.fullName} from GitHub...`);
+    const octokit = await getOctoKit(target.org);
+
+    if (!octokit) {
+      throw new Error(`No Octokit client found for organization ${target.org}`);
+    }
+
+    await octokit.request("DELETE /repos/{owner}/{repo}", {
+      owner: target.org,
+      repo: target.repo
+    });
+    console.log(`Successfully deleted repository ${target.fullName} from GitHub`);
+    return "deleted";
+  } catch (deleteError) {
+    if (isGitHubNotFoundError(deleteError)) {
+      console.log(`Repository ${target.fullName} not found, skipping`);
+      return "skipped";
+    }
+
+    if (target.kind === "student") {
+      console.warn(`Failed to delete repository ${target.fullName} from GitHub:`, deleteError);
+      return "skipped";
+    }
+
+    console.warn(`Failed to delete ${target.kind} repository ${target.fullName} from GitHub:`, deleteError);
+    throw new UserVisibleError(
+      `Failed to delete ${target.kind} repository ${target.fullName} from GitHub: ${
+        deleteError instanceof Error ? deleteError.message : "Unknown error"
+      }`
+    );
+  }
+}
+
+async function deleteGitHubRepositoriesSynchronously(targets: GitHubRepoTarget[]) {
+  let deleted = 0;
+  let skipped = 0;
+
+  for (const target of targets) {
+    const result = await deleteGitHubRepository(target);
+    if (result === "deleted") {
+      deleted++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return { deleted, skipped };
+}
+
+async function enqueueGitHubRepositoryArchives(classId: number, assignmentId: number, targets: GitHubRepoTarget[]) {
+  for (const [index, target] of targets.entries()) {
+    const debugId = buildAssignmentDeleteArchiveDebugId(assignmentId, target, index);
+    console.log(`Queueing ${target.fullName} for async archival with debug_id=${debugId}`);
+    await enqueueGithubArchiveRepo(classId, target.org, target.repo, debugId);
+  }
+
+  return targets.length;
+}
+
+async function deleteAssignment(req: Request, scope: Sentry.Scope): Promise<AssignmentDeleteResponse> {
   const supabase = createClient<Database>(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_ANON_KEY")!, {
     global: {
       headers: { Authorization: req.headers.get("Authorization")! }
@@ -71,148 +237,58 @@ async function deleteAssignment(req: Request, scope: Sentry.Scope): Promise<{ me
   // Get all repositories for this assignment
   const { data: repositories } = await adminSupabase
     .from("repositories")
-    .select("repository, assignment_group_id, profile_id, synced_handout_sha")
+    .select("id, repository, assignment_group_id, profile_id, synced_handout_sha")
     .eq("assignment_id", assignment_id);
+  const assignmentRepositories = (repositories ?? []) as RepositoryRow[];
 
-  // Check repository states - verify they haven't been modified beyond template
-  if (repositories && repositories.length > 0 && assignment.template_repo) {
-    console.log(`Checking ${repositories.length} repositories for modifications...`);
+  await assertNoReleasedSubmissionReviews(adminSupabase, assignment_id);
+  await assertRepositoriesHaveOnlyTemplateCommits(assignmentRepositories, assignment.template_repo);
 
-    try {
-      // Get template repo's initial commit to compare against
-      const templateRepoCommits = await listCommits(assignment.template_repo, 1);
-      const templateInitialCommit = templateRepoCommits.commits[templateRepoCommits.commits.length - 1];
+  const graderRepo =
+    assignment.autograder && !Array.isArray(assignment.autograder) ? assignment.autograder.grader_repo : null;
+  const { targets: githubTargets, invalidTargets } = collectGitHubRepoTargets({
+    repositories: assignmentRepositories,
+    templateRepo: assignment.template_repo,
+    graderRepo
+  });
 
-      for (const repo of repositories) {
-        if (!repo.repository) {
-          console.log("Repository name is null, skipping");
-          continue;
-        }
+  const criticalInvalidTargets = invalidTargets.filter((target) => target.critical);
+  if (criticalInvalidTargets.length > 0) {
+    throw new UserVisibleError(
+      `Cannot delete assignment: ${criticalInvalidTargets
+        .map((target) => `${target.kind} repository "${target.value}" is invalid (${target.reason})`)
+        .join("; ")}.`,
+      400
+    );
+  }
 
-        try {
-          // Get the repository's commit history
-          const repoCommits = await listCommits(repo.repository, 1);
-
-          // Check if repo has more commits than just the template
-          if (repoCommits.commits.length > 1) {
-            // Check if the oldest commit matches the template's initial commit
-            const oldestCommit = repoCommits.commits[repoCommits.commits.length - 1];
-
-            if (oldestCommit.sha !== templateInitialCommit?.sha && oldestCommit.sha !== repo.synced_handout_sha) {
-              throw new UserVisibleError(
-                `Cannot delete assignment: Repository ${repo.repository} has been modified beyond the template. ` +
-                  `Please manually delete modified repositories if you want to proceed.`,
-                400
-              );
-            }
-          }
-        } catch (error) {
-          console.warn(`Error checking repository ${repo.repository}:`, error);
-          // If we can't check the repo (maybe it's already deleted), that's okay
-          // Missing repos should not be an error according to requirements
-        }
-      }
-    } catch (error) {
-      console.warn("Error checking template repository:", error);
-      // If we can't access the template repo, we'll proceed with deletion
-    }
+  const skippedInvalidStudentRepos = invalidTargets.filter((target) => !target.critical).length;
+  if (skippedInvalidStudentRepos > 0) {
+    console.warn(`Skipping ${skippedInvalidStudentRepos} malformed student repository row(s) during GitHub cleanup`);
   }
 
   console.log("All safety checks passed. Proceeding with deletion...");
 
   // ========================
-  // PHASE 2: DELETE FROM GITHUB FIRST
+  // PHASE 2: CLEAN UP GITHUB FIRST
   // ========================
 
-  console.log("Phase 2: Deleting repositories from GitHub...");
+  const cleanupStrategy = selectGitHubCleanupStrategy(githubTargets.length);
+  scope?.setTag("github_cleanup_strategy", cleanupStrategy);
+  scope?.setTag("github_repositories_total", githubTargets.length.toString());
 
-  // Delete student repositories
-  if (repositories && repositories.length > 0) {
-    for (const repo of repositories) {
-      if (!repo.repository) {
-        continue;
-      }
+  console.log(`Phase 2: Cleaning up ${githubTargets.length} GitHub repositories via ${cleanupStrategy}...`);
 
-      try {
-        console.log(`Deleting student repository ${repo.repository} from GitHub...`);
-        const [org, repoName] = repo.repository.split("/");
-        const octokit = await getOctoKit(org);
+  let githubRepositoriesDeleted = 0;
+  let githubRepositoriesQueuedForArchive = 0;
+  let githubRepositoriesSkipped = skippedInvalidStudentRepos;
 
-        if (octokit) {
-          await octokit.request("DELETE /repos/{owner}/{repo}", {
-            owner: org,
-            repo: repoName
-          });
-          console.log(`Successfully deleted repository ${repo.repository} from GitHub`);
-        }
-      } catch (deleteError) {
-        if (deleteError instanceof Error && deleteError.message.includes("Not Found")) {
-          console.log(`Repository ${repo.repository} not found, skipping`);
-        } else {
-          console.warn(`Failed to delete repository ${repo.repository} from GitHub:`, deleteError);
-          // Continue with deletion - missing repos should not be an error
-        }
-      }
-    }
-  }
-
-  // Delete handout repo (template_repo)
-  if (assignment.template_repo) {
-    try {
-      console.log(`Deleting handout repository ${assignment.template_repo} from GitHub...`);
-      const [org, repoName] = assignment.template_repo.split("/");
-      const octokit = await getOctoKit(org);
-
-      if (octokit) {
-        await octokit.request("DELETE /repos/{owner}/{repo}", {
-          owner: org,
-          repo: repoName
-        });
-        console.log(`Successfully deleted handout repository ${assignment.template_repo} from GitHub`);
-      }
-    } catch (deleteError) {
-      if (deleteError instanceof Error && deleteError.message.includes("Not Found")) {
-        console.log(`Handout repository ${assignment.template_repo} not found, skipping`);
-      } else {
-        console.warn(`Failed to delete handout repository ${assignment.template_repo} from GitHub:`, deleteError);
-        throw new UserVisibleError(
-          `Failed to delete handout repository ${assignment.template_repo} from GitHub: ${
-            deleteError instanceof Error ? deleteError.message : "Unknown error"
-          }`
-        );
-      }
-    }
-  }
-
-  // Delete solution repo (grader_repo)
-  if (assignment.autograder?.grader_repo) {
-    try {
-      console.log(`Deleting solution repository ${assignment.autograder.grader_repo} from GitHub...`);
-      const [org, repoName] = assignment.autograder.grader_repo.split("/");
-      const octokit = await getOctoKit(org);
-
-      if (octokit) {
-        await octokit.request("DELETE /repos/{owner}/{repo}", {
-          owner: org,
-          repo: repoName
-        });
-        console.log(`Successfully deleted solution repository ${assignment.autograder.grader_repo} from GitHub`);
-      }
-    } catch (deleteError) {
-      if (deleteError instanceof Error && deleteError.message.includes("Not Found")) {
-        console.log(`Solution repository ${assignment.autograder.grader_repo} not found, skipping`);
-      } else {
-        console.warn(
-          `Failed to delete solution repository ${assignment.autograder.grader_repo} from GitHub:`,
-          deleteError
-        );
-        throw new UserVisibleError(
-          `Failed to delete solution repository ${assignment.autograder.grader_repo} from GitHub: ${
-            deleteError instanceof Error ? deleteError.message : "Unknown error"
-          }`
-        );
-      }
-    }
+  if (cleanupStrategy === "archive_asynchronously") {
+    githubRepositoriesQueuedForArchive = await enqueueGitHubRepositoryArchives(class_id, assignment_id, githubTargets);
+  } else {
+    const synchronousCleanup = await deleteGitHubRepositoriesSynchronously(githubTargets);
+    githubRepositoriesDeleted = synchronousCleanup.deleted;
+    githubRepositoriesSkipped += synchronousCleanup.skipped;
   }
 
   // ========================
@@ -245,10 +321,31 @@ async function deleteAssignment(req: Request, scope: Sentry.Scope): Promise<{ me
 
   console.log(`Successfully deleted assignment ${assignment_id}: "${assignment.title}"`);
 
+  const baseMessage =
+    deleteResult.message ||
+    `Assignment "${assignment.title}" has been successfully deleted along with all related data.`;
+  const githubMessage =
+    cleanupStrategy === "archive_asynchronously"
+      ? `${githubRepositoriesQueuedForArchive} GitHub ${
+          githubRepositoriesQueuedForArchive === 1 ? "repository was" : "repositories were"
+        } queued for background archival and locking.`
+      : `${githubRepositoriesDeleted} GitHub ${
+          githubRepositoriesDeleted === 1 ? "repository was" : "repositories were"
+        } deleted immediately.`;
+  const skippedMessage =
+    githubRepositoriesSkipped > 0
+      ? ` ${githubRepositoriesSkipped} GitHub ${
+          githubRepositoriesSkipped === 1 ? "repository was" : "repositories were"
+        } skipped because they were missing or invalid.`
+      : "";
+
   return {
-    message:
-      deleteResult.message ||
-      `Assignment "${assignment.title}" has been successfully deleted along with all related data.`
+    message: `${baseMessage} ${githubMessage}${skippedMessage}`,
+    github_cleanup_strategy: cleanupStrategy,
+    github_repositories_total: githubTargets.length,
+    github_repositories_deleted: githubRepositoriesDeleted,
+    github_repositories_queued_for_archive: githubRepositoriesQueuedForArchive,
+    github_repositories_skipped: githubRepositoriesSkipped
   };
 }
 

--- a/supabase/functions/assignment-delete/repositoryCleanup.ts
+++ b/supabase/functions/assignment-delete/repositoryCleanup.ts
@@ -1,0 +1,137 @@
+export const ASYNC_ARCHIVE_REPO_THRESHOLD = 5;
+
+export type GitHubCleanupStrategy = "delete_synchronously" | "archive_asynchronously";
+export type GitHubRepoTargetKind = "student" | "template" | "solution";
+
+export type GitHubRepoTarget = {
+  kind: GitHubRepoTargetKind;
+  fullName: string;
+  org: string;
+  repo: string;
+  sourceId?: number | string | null;
+};
+
+export type InvalidGitHubRepoTarget = {
+  kind: GitHubRepoTargetKind;
+  value: string | null | undefined;
+  sourceId?: number | string | null;
+  critical: boolean;
+  reason: string;
+};
+
+export type AssignmentRepositoryRow = {
+  id?: number | string | null;
+  repository?: string | null;
+};
+
+export type CollectGitHubRepoTargetsArgs = {
+  repositories?: AssignmentRepositoryRow[] | null;
+  templateRepo?: string | null;
+  graderRepo?: string | null;
+};
+
+export type CollectedGitHubRepoTargets = {
+  targets: GitHubRepoTarget[];
+  invalidTargets: InvalidGitHubRepoTarget[];
+};
+
+export function parseGitHubRepoFullName(value: string | null | undefined): {
+  fullName: string;
+  org: string;
+  repo: string;
+} | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parts = trimmed.split("/");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [org, repo] = parts.map((part) => part.trim());
+  if (!org || !repo) {
+    return null;
+  }
+
+  return {
+    fullName: `${org}/${repo}`,
+    org,
+    repo
+  };
+}
+
+export function selectGitHubCleanupStrategy(targetCount: number): GitHubCleanupStrategy {
+  return targetCount > ASYNC_ARCHIVE_REPO_THRESHOLD ? "archive_asynchronously" : "delete_synchronously";
+}
+
+function targetKey(org: string, repo: string) {
+  return `${org.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+function addTarget(
+  targets: GitHubRepoTarget[],
+  seen: Set<string>,
+  invalidTargets: InvalidGitHubRepoTarget[],
+  kind: GitHubRepoTargetKind,
+  value: string | null | undefined,
+  sourceId: number | string | null | undefined,
+  critical: boolean
+) {
+  if (!value?.trim()) {
+    return;
+  }
+
+  const parsed = parseGitHubRepoFullName(value);
+  if (!parsed) {
+    invalidTargets.push({
+      kind,
+      value,
+      sourceId,
+      critical,
+      reason: "Repository must be in owner/repo format"
+    });
+    return;
+  }
+
+  const key = targetKey(parsed.org, parsed.repo);
+  if (seen.has(key)) {
+    return;
+  }
+
+  seen.add(key);
+  targets.push({
+    kind,
+    sourceId,
+    ...parsed
+  });
+}
+
+export function collectGitHubRepoTargets({
+  repositories,
+  templateRepo,
+  graderRepo
+}: CollectGitHubRepoTargetsArgs): CollectedGitHubRepoTargets {
+  const targets: GitHubRepoTarget[] = [];
+  const invalidTargets: InvalidGitHubRepoTarget[] = [];
+  const seen = new Set<string>();
+
+  for (const repository of repositories ?? []) {
+    addTarget(targets, seen, invalidTargets, "student", repository.repository, repository.id, false);
+  }
+
+  addTarget(targets, seen, invalidTargets, "template", templateRepo, null, true);
+  addTarget(targets, seen, invalidTargets, "solution", graderRepo, null, true);
+
+  return { targets, invalidTargets };
+}
+
+export function buildAssignmentDeleteArchiveDebugId(
+  assignmentId: number,
+  target: Pick<GitHubRepoTarget, "kind" | "repo">,
+  index: number
+) {
+  const safeRepoName = target.repo.replace(/[^a-zA-Z0-9_.-]+/g, "-").slice(0, 80);
+  return `assignment-delete-${assignmentId}-${target.kind}-${index + 1}-${safeRepoName}`;
+}

--- a/supabase/functions/cli/commands/assignments.ts
+++ b/supabase/functions/cli/commands/assignments.ts
@@ -184,9 +184,9 @@ async function handleAssignmentsDelete(ctx: MCPAuthContext, params: Record<strin
   return {
     success: true,
     data: {
-      message: `Assignment "${assignment.title}" has been deleted`,
+      message: (data as { message?: string })?.message ?? `Assignment "${assignment.title}" has been deleted`,
       assignment_id: assignment.id,
-      details: (data as { message?: string })?.message
+      details: data
     }
   };
 }

--- a/tests/unit/assignment-delete-repository-cleanup.test.ts
+++ b/tests/unit/assignment-delete-repository-cleanup.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  ASYNC_ARCHIVE_REPO_THRESHOLD,
+  buildAssignmentDeleteArchiveDebugId,
+  collectGitHubRepoTargets,
+  parseGitHubRepoFullName,
+  selectGitHubCleanupStrategy
+} from "../../supabase/functions/assignment-delete/repositoryCleanup";
+
+describe("assignment-delete repository cleanup helpers", () => {
+  describe("selectGitHubCleanupStrategy", () => {
+    it("uses synchronous deletion for at most the async archival threshold", () => {
+      expect(selectGitHubCleanupStrategy(0)).toBe("delete_synchronously");
+      expect(selectGitHubCleanupStrategy(1)).toBe("delete_synchronously");
+      expect(selectGitHubCleanupStrategy(ASYNC_ARCHIVE_REPO_THRESHOLD)).toBe("delete_synchronously");
+    });
+
+    it("uses asynchronous archival above the threshold", () => {
+      expect(selectGitHubCleanupStrategy(ASYNC_ARCHIVE_REPO_THRESHOLD + 1)).toBe("archive_asynchronously");
+    });
+  });
+
+  describe("parseGitHubRepoFullName", () => {
+    it("parses valid owner/repo names", () => {
+      expect(parseGitHubRepoFullName(" pawtograder-playground/example-repo ")).toEqual({
+        fullName: "pawtograder-playground/example-repo",
+        org: "pawtograder-playground",
+        repo: "example-repo"
+      });
+    });
+
+    it("rejects empty and malformed names", () => {
+      expect(parseGitHubRepoFullName(null)).toBeNull();
+      expect(parseGitHubRepoFullName("")).toBeNull();
+      expect(parseGitHubRepoFullName("owner")).toBeNull();
+      expect(parseGitHubRepoFullName("owner/")).toBeNull();
+      expect(parseGitHubRepoFullName("/repo")).toBeNull();
+      expect(parseGitHubRepoFullName("owner/repo/extra")).toBeNull();
+    });
+  });
+
+  describe("collectGitHubRepoTargets", () => {
+    it("collects student, template, and solution repositories", () => {
+      const result = collectGitHubRepoTargets({
+        repositories: [
+          { id: 1, repository: "org/student-1" },
+          { id: 2, repository: "org/student-2" }
+        ],
+        templateRepo: "org/template",
+        graderRepo: "org/solution"
+      });
+
+      expect(result.invalidTargets).toEqual([]);
+      expect(result.targets.map((target) => `${target.kind}:${target.fullName}`)).toEqual([
+        "student:org/student-1",
+        "student:org/student-2",
+        "template:org/template",
+        "solution:org/solution"
+      ]);
+    });
+
+    it("deduplicates repository targets case-insensitively", () => {
+      const result = collectGitHubRepoTargets({
+        repositories: [
+          { id: 1, repository: "Org/shared" },
+          { id: 2, repository: "org/SHARED" }
+        ],
+        templateRepo: "org/shared",
+        graderRepo: "org/solution"
+      });
+
+      expect(result.targets.map((target) => target.fullName)).toEqual(["Org/shared", "org/solution"]);
+    });
+
+    it("reports invalid student rows as non-critical and invalid template/solution rows as critical", () => {
+      const result = collectGitHubRepoTargets({
+        repositories: [
+          { id: 1, repository: "org/valid-student" },
+          { id: 2, repository: "not-a-full-name" }
+        ],
+        templateRepo: "bad-template",
+        graderRepo: "bad/solution/extra"
+      });
+
+      expect(result.targets.map((target) => target.fullName)).toEqual(["org/valid-student"]);
+      expect(result.invalidTargets).toEqual([
+        expect.objectContaining({ kind: "student", sourceId: 2, critical: false }),
+        expect.objectContaining({ kind: "template", critical: true }),
+        expect.objectContaining({ kind: "solution", critical: true })
+      ]);
+    });
+
+    it("ignores empty optional repository values", () => {
+      const result = collectGitHubRepoTargets({
+        repositories: [{ id: 1, repository: null }],
+        templateRepo: "",
+        graderRepo: undefined
+      });
+
+      expect(result.targets).toEqual([]);
+      expect(result.invalidTargets).toEqual([]);
+    });
+  });
+
+  describe("buildAssignmentDeleteArchiveDebugId", () => {
+    it("includes assignment id, target kind, index, and sanitized repo name", () => {
+      expect(
+        buildAssignmentDeleteArchiveDebugId(
+          449,
+          {
+            kind: "student",
+            repo: "repo with spaces"
+          },
+          2
+        )
+      ).toBe("assignment-delete-449-student-3-repo-with-spaces");
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Switch assignment deletion to the existing async GitHub archive workflow when more than 5 unique repo targets are involved
- Keep the synchronous hard-delete path for small assignment deletes
- Add repo target parsing/deduping helpers, preflight safety checks, improved modified-repo handling, and clearer UI/CLI messaging
- Make async repo archival idempotent for already-missing GitHub repositories

Closes #449

## Testing
- `npx jest tests/unit/assignment-delete-repository-cleanup.test.ts`
- `npm run format`
- `npm run lint`
- `npx tsc --noEmit --pretty false`
- Local Supabase integration:
  - 6-repo assignment delete returned `archive_asynchronously`, removed assignment/repository rows, and queued 6 `archive_repo_and_lock` messages
  - 5-repo assignment delete returned `delete_synchronously`, removed assignment/repository rows, and queued 0 archive messages

## Notes
- `npm run typecheck:functions` did not provide a clean signal in this VM due pre-existing Deno/function typecheck issues unrelated to this change (including Octokit `Endpoints` and generated `SupabaseTypes.d.ts` ambient const errors).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-460be342-8848-4db5-b9c4-df6e360b7d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-460be342-8848-4db5-b9c4-df6e360b7d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub repository cleanup now uses two strategies: immediate deletion for small batches and background archival for larger batches.
  * Deletion responses now report the cleanup strategy and repository operation counts (total, deleted, queued, skipped).

* **Improvements**
  * Clarified delete-assignment confirmation dialog and non-undoable warning about GitHub repo handling.
  * Success/error toasts during deletion show longer visibility.

* **Tests**
  * Added unit tests for repository-target collection, parsing, strategy selection, and debug ID formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->