### PR TITLE
Stabilize visual regression screenshots (round 2)

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -869,7 +869,11 @@ function RepositoriesInfo({ repositories }: { repositories: Repository[] }) {
         <Text fontSize="sm" fontWeight="bold">
           Repository:{" "}
         </Text>
-        <Link href={`https://github.com/${repositories[0].repository}`} data-visual-test="blackout">
+        <Link
+          href={`https://github.com/${repositories[0].repository}`}
+          data-visual-test="transparent"
+          data-visual-placeholder="repository"
+        >
           {repositories[0].repository} {repositories[0].is_github_ready ? " (ready ✅)" : " (not yet ready ❌)"}
         </Link>
       </HStack>
@@ -883,7 +887,11 @@ function RepositoriesInfo({ repositories }: { repositories: Repository[] }) {
         <Text fontWeight="bold" fontSize="sm">
           Current group repository:
         </Text>{" "}
-        <Link href={`https://github.com/${groupRepo?.repository}`} data-visual-test="blackout">
+        <Link
+          href={`https://github.com/${groupRepo?.repository}`}
+          data-visual-test="transparent"
+          data-visual-placeholder="repository"
+        >
           {groupRepo?.repository} {groupRepo?.is_github_ready ? " (ready ✅)" : " (not yet ready ❌)"}
         </Link>
       </HStack>
@@ -893,7 +901,11 @@ function RepositoriesInfo({ repositories }: { repositories: Repository[] }) {
       </Text>
       <Text>
         Individual repository (not in use, you are now in a group):{" "}
-        <Link href={`https://github.com/${personalRepo?.repository}`} data-visual-test="blackout">
+        <Link
+          href={`https://github.com/${personalRepo?.repository}`}
+          data-visual-test="transparent"
+          data-visual-placeholder="repository"
+        >
           {personalRepo?.repository} {personalRepo?.is_github_ready ? " (ready ✅)" : " (not yet ready ❌)"}
         </Link>
       </Text>

--- a/app/course/[course_id]/assignments/[assignment_id]/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/page.tsx
@@ -165,7 +165,7 @@ export default function AssignmentPage() {
             <SurveyStatusBanner assignmentId={Number(assignment_id)} courseId={Number(course_id)} />
           )}
           {submissionsPeriod && maxSubmissions ? (
-            <Box w="100%" maxW="4xl">
+            <Box w="100%" maxW="4xl" data-visual-test="removed">
               <Alert.Root
                 status={submissionsRemaining === 0 ? "warning" : submissionsRemaining <= 1 ? "warning" : "info"}
                 flexDirection="column"

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/hooks/useSubmission";
 import { useActiveReviewAssignmentId } from "@/hooks/useSubmissionReview";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { useTableControllerTableValues } from "@/lib/TableController";
 import { StaffCommitHistory } from "@/components/submissions/staff-commit-history";
 import { activateSubmission } from "@/lib/edgeFunctions";
 import { formatGradingReviewScoreLines } from "@/lib/formatGradingReviewForMarkdown";
@@ -1817,12 +1818,32 @@ function PerStudentGradingTotalsDisplay({
 }) {
   const { private_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const courseController = useCourseController();
+  const allProfiles = useTableControllerTableValues(courseController.profiles);
+  const profileNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of allProfiles) map.set(p.id, (p as { name?: string }).name ?? "");
+    return map;
+  }, [allProfiles]);
   const entries = Object.entries(totals).filter((entry): entry is [string, number] => typeof entry[1] === "number");
   if (entries.length === 0) return null;
+
+  // Sort by user name. Profile_ids are random UUIDs that differ between test
+  // runs, so sorting by id produces a different order each run. Name is the
+  // only stable cross-run signal we have. Logged-in user stays first when
+  // present. If any name hasn't loaded yet, hold off rendering to avoid a
+  // mixed-loaded partial sort (which would show a non-deterministic order in
+  // visual tests until realtime catches up).
+  const allNamesLoaded = entries.every(([id]) => (profileNamesById.get(id) ?? "").length > 0);
+  if (!allNamesLoaded) return null;
 
   entries.sort(([a], [b]) => {
     if (a === private_profile_id) return -1;
     if (b === private_profile_id) return 1;
+    const nameA = profileNamesById.get(a) ?? a;
+    const nameB = profileNamesById.get(b) ?? b;
+    const byName = nameA.localeCompare(nameB);
+    if (byName !== 0) return byName;
     return a.localeCompare(b);
   });
 
@@ -1894,8 +1915,33 @@ function PerStudentGradingTotalsDisplay({
 function IndividualScoresDisplay({ individualScores }: { individualScores: IndividualScores }) {
   const { private_profile_id } = useClassProfiles();
   const isGraderOrInstructor = useIsGraderOrInstructor();
+  const courseController = useCourseController();
+  const allProfiles = useTableControllerTableValues(courseController.profiles);
+  const profileNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of allProfiles) map.set(p.id, (p as { name?: string }).name ?? "");
+    return map;
+  }, [allProfiles]);
   const entries = Object.entries(individualScores).filter((entry): entry is [string, number] => entry[1] !== undefined);
   if (entries.length === 0) return null;
+
+  // Sort by user name (logged-in user first when present). See sort comment in
+  // PerStudentGradingTotalsDisplay above — profile_ids are non-deterministic
+  // across test runs, names are the only stable cross-run signal. Hold off on
+  // rendering until every entry's name has loaded so a partially-loaded sort
+  // doesn't show a non-deterministic mixed order.
+  const allNamesLoaded = entries.every(([id]) => (profileNamesById.get(id) ?? "").length > 0);
+  if (!allNamesLoaded) return null;
+
+  entries.sort(([a], [b]) => {
+    if (a === private_profile_id) return -1;
+    if (b === private_profile_id) return 1;
+    const nameA = profileNamesById.get(a) ?? a;
+    const nameB = profileNamesById.get(b) ?? b;
+    const byName = nameA.localeCompare(nameB);
+    if (byName !== 0) return byName;
+    return a.localeCompare(b);
+  });
 
   const myEntry = entries.find(([profileId]) => profileId === private_profile_id);
   const sortedEntries = isGraderOrInstructor ? entries : myEntry ? [myEntry] : [];
@@ -1960,6 +2006,7 @@ function RubricView() {
     <Box
       as="aside"
       aria-label="Grading summary"
+      data-grading-summary-aside=""
       position={{ base: "static", lg: "sticky" }}
       top={{ base: "auto", lg: "0" }}
       borderTopWidth={{ base: "1px", lg: "0" }}
@@ -2114,15 +2161,17 @@ function SubmissionsLayout({ children }: { children: React.ReactNode }) {
                 <HStack gap={1} flexWrap="wrap" alignItems="baseline">
                   <HStack gap={1}>
                     Group {assignmentGroupWithMembers.name} (
-                    {assignmentGroupWithMembers.assignment_groups_members.map((member) => (
-                      <HStack key={member.id} gap={1}>
-                        <PersonName uid={member.profile_id} showAvatar={false} />
-                        <StudentSummaryTrigger
-                          student_id={member.profile_id}
-                          course_id={parseInt(course_id as string, 10)}
-                        />
-                      </HStack>
-                    ))}
+                    {[...assignmentGroupWithMembers.assignment_groups_members]
+                      .sort((a, b) => a.id - b.id)
+                      .map((member) => (
+                        <HStack key={member.id} gap={1}>
+                          <PersonName uid={member.profile_id} showAvatar={false} />
+                          <StudentSummaryTrigger
+                            student_id={member.profile_id}
+                            course_id={parseInt(course_id as string, 10)}
+                          />
+                        </HStack>
+                      ))}
                     )
                   </HStack>
                   {assignmentGroupWithMembers.mentor_profile_id && (

--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/page.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/page.tsx
@@ -22,7 +22,9 @@ export default async function SubmissionsListing({
         {submissions.map((submission) => (
           <li key={submission.id}>
             {submission.is_active ? <ActiveSubmissionIcon /> : ""}
-            {submission.id}
+            <span data-visual-test="transparent" data-visual-placeholder="submission-id">
+              {submission.id}
+            </span>
           </li>
         ))}
       </ul>

--- a/app/course/[course_id]/discussion/[root_id]/page.tsx
+++ b/app/course/[course_id]/discussion/[root_id]/page.tsx
@@ -84,11 +84,21 @@ function ThreadHeader({ thread, topic }: { thread: DiscussionThreadType; topic: 
                 <Skeleton width="100px" height="20px" />
               )}
             </Flex>
-            <Text fontSize="sm" color="text.muted">
+            <Text
+              fontSize="sm"
+              color="text.muted"
+              data-visual-test="transparent"
+              data-visual-placeholder="relative-time"
+            >
               {formatRelative(new Date(thread.created_at), new Date())}
             </Text>
             {thread.edited_at && (
-              <Text fontSize="sm" color="text.muted">
+              <Text
+                fontSize="sm"
+                color="text.muted"
+                data-visual-test="transparent"
+                data-visual-placeholder="relative-time"
+              >
                 Edited {formatRelative(new Date(thread.edited_at), new Date())}
               </Text>
             )}

--- a/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
@@ -200,7 +200,16 @@ export default function SurveyResponsesView({
       }
     }
 
-    return filtered;
+    // Deterministic ordering: realtime arrival order is non-deterministic across
+    // runs. Sort by student name (then id) so the responses table renders the
+    // same way every time — required for visual regression stability.
+    return [...filtered].sort((a, b) => {
+      const nameA = a.profiles?.name ?? "";
+      const nameB = b.profiles?.name ?? "";
+      const byName = nameA.localeCompare(nameB);
+      if (byName !== 0) return byName;
+      return String(a.id).localeCompare(String(b.id));
+    });
   }, [responses, dateRangeStart, dateRangeEnd]);
 
   // Count active filters

--- a/components/chat-message.tsx
+++ b/components/chat-message.tsx
@@ -550,7 +550,13 @@ export const ChatMessageItem = ({
           maxW="90%"
         >
           <Markdown>{getMessageContent(message)}</Markdown>
-          <Text fontSize="xs" color="fg.muted" mt={1}>
+          <Text
+            fontSize="xs"
+            color="fg.muted"
+            mt={1}
+            data-visual-test="transparent"
+            data-visual-placeholder="timestamp"
+          >
             {new Date(getMessageTimestamp(message)).toLocaleTimeString("en-US", {
               hour: "2-digit",
               minute: "2-digit",
@@ -584,7 +590,7 @@ export const ChatMessageItem = ({
               <Text fontWeight="medium">{getDisplayName()}</Text>
               <UserRoleBadge authorId={authorId} helpRequestStudentIds={helpRequestStudentIds} />
             </HStack>
-            <Text color="fg.muted" fontSize="xs">
+            <Text color="fg.muted" fontSize="xs" data-visual-test="transparent" data-visual-placeholder="timestamp">
               {new Date(getMessageTimestamp(message)).toLocaleTimeString("en-US", {
                 hour: "2-digit",
                 minute: "2-digit",

--- a/components/discussion/PostRow.tsx
+++ b/components/discussion/PostRow.tsx
@@ -223,7 +223,9 @@ function PostRowComponent({
                       {userProfile?.name ?? ""}
                     </Text>
                     <Text>•</Text>
-                    <Text>{formatRelative(new Date(thread.created_at), new Date())}</Text>
+                    <Text data-visual-test="transparent" data-visual-placeholder="relative-time">
+                      {formatRelative(new Date(thread.created_at), new Date())}
+                    </Text>
                     <Text>•</Text>
                     <Text>
                       {thread.children_count ?? 0} replies
@@ -297,7 +299,9 @@ function PostRowComponent({
               <Text color="fg.muted" fontWeight="medium">
                 {userProfile?.name ?? ""}
               </Text>
-              <Text>{formatRelative(new Date(thread.created_at), new Date())}</Text>
+              <Text data-visual-test="transparent" data-visual-placeholder="relative-time">
+                {formatRelative(new Date(thread.created_at), new Date())}
+              </Text>
               <Text>
                 {thread.children_count ?? 0} replies
                 {unreadRepliesCount > 0 && (

--- a/components/help-queue/floating-help-request-widget.tsx
+++ b/components/help-queue/floating-help-request-widget.tsx
@@ -184,7 +184,7 @@ export function FloatingHelpRequestWidget() {
   if (!activeRequest) {
     return (
       <>
-        <Box position="fixed" bottom={4} right={4} zIndex={1000}>
+        <Box position="fixed" bottom={4} right={4} zIndex={1000} data-visual-test="removed">
           <Tooltip content={tooltipText} positioning={{ placement: "left" }}>
             <Button
               size="md"
@@ -231,6 +231,7 @@ export function FloatingHelpRequestWidget() {
       zIndex={1000}
       maxW={{ base: "calc(100vw - 2rem)", md: "400px" }}
       w="100%"
+      data-visual-test="removed"
     >
       <Card.Root>
         <Card.Body p={0}>

--- a/components/help-queue/help-request-teaser.tsx
+++ b/components/help-queue/help-request-teaser.tsx
@@ -181,7 +181,9 @@ export const HelpRequestTeaser = (props: Props) => {
               {stripTrailingQueueName(queue.name)}
             </Badge>
           )}
-          <Text fontSize="xs">{formatRelative(new Date(updatedAt), new Date())}</Text>
+          <Text fontSize="xs" data-visual-test="transparent" data-visual-placeholder="relative-time">
+            {formatRelative(new Date(updatedAt), new Date())}
+          </Text>
         </HStack>
         <HStack spaceX="1" justify="space-between">
           <Box flex="1" truncate>

--- a/components/help-queue/office-hours-header.tsx
+++ b/components/help-queue/office-hours-header.tsx
@@ -299,7 +299,15 @@ export function OfficeHoursHeader({
                 </NextLink>
                 <FiChevronRight size={12} />
                 <Box borderBottom="2px solid" borderColor="orange.600" pb={0.5}>
-                  <Text fontSize="xs" fontWeight="semibold" color="fg" truncate maxW={{ base: "40vw", md: "25vw" }}>
+                  <Text
+                    fontSize="xs"
+                    fontWeight="semibold"
+                    color="fg"
+                    truncate
+                    maxW={{ base: "40vw", md: "25vw" }}
+                    data-visual-test="transparent"
+                    data-visual-placeholder="request-id"
+                  >
                     Request #{currentRequest.id}
                   </Text>
                 </Box>
@@ -377,7 +385,15 @@ export function OfficeHoursHeader({
               </NextLink>
               <FiChevronRight />
               <Box borderBottom="3px solid" borderColor="orange.600" pb={1}>
-                <Text fontSize="sm" fontWeight="semibold" color="fg" truncate maxW={{ base: "60vw", md: "40vw" }}>
+                <Text
+                  fontSize="sm"
+                  fontWeight="semibold"
+                  color="fg"
+                  truncate
+                  maxW={{ base: "60vw", md: "40vw" }}
+                  data-visual-test="transparent"
+                  data-visual-placeholder="request-id"
+                >
                   Request #{currentRequest.id}
                 </Text>
               </Box>

--- a/components/help-queue/request-row.tsx
+++ b/components/help-queue/request-row.tsx
@@ -197,7 +197,9 @@ export function RequestRow({ request, href, selected, queue, students = [], vari
                   <HStack gap="2" fontSize="xs" color="fg.muted" wrap="wrap">
                     {renderStudentsDisplay()}
                     <Text>•</Text>
-                    <Text>{formatRelative(new Date(request.created_at), new Date())}</Text>
+                    <Text data-visual-test="transparent" data-visual-placeholder="relative-time">
+                      {formatRelative(new Date(request.created_at), new Date())}
+                    </Text>
                   </HStack>
                 </Stack>
               </HStack>
@@ -249,7 +251,9 @@ export function RequestRow({ request, href, selected, queue, students = [], vari
             <HStack gap="3" fontSize="xs" color="fg.muted" wrap="wrap">
               {renderStudentsDisplay()}
               <Text>•</Text>
-              <Text>{formatRelative(new Date(request.created_at), new Date())}</Text>
+              <Text data-visual-test="transparent" data-visual-placeholder="relative-time">
+                {formatRelative(new Date(request.created_at), new Date())}
+              </Text>
             </HStack>
 
             <Box truncate>

--- a/components/survey/analytics/ChoiceDistributionChart.tsx
+++ b/components/survey/analytics/ChoiceDistributionChart.tsx
@@ -110,7 +110,7 @@ export function ChoiceDistributionChart({
               );
             }}
           />
-          <Bar dataKey="count" fill={barColor} radius={[0, 4, 4, 0]} />
+          <Bar isAnimationActive={false} dataKey="count" fill={barColor} radius={[0, 4, 4, 0]} />
         </BarChart>
       </ResponsiveContainer>
     </Box>

--- a/components/survey/analytics/ConsistentAxesChart.tsx
+++ b/components/survey/analytics/ConsistentAxesChart.tsx
@@ -100,7 +100,7 @@ export function ConsistentAxesChart({
                     formatter={(value: number) => [value, "Responses"]}
                     labelFormatter={(label) => `Value: ${label}`}
                   />
-                  <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+                  <Bar isAnimationActive={false} dataKey="count" radius={[0, 4, 4, 0]}>
                     {rows.map((entry, idx) => (
                       <Cell key={idx} fill={getLikertColor(entry.value, allValues)} />
                     ))}

--- a/components/survey/analytics/DistributionChart.tsx
+++ b/components/survey/analytics/DistributionChart.tsx
@@ -74,7 +74,7 @@ export function DistributionChart({ stats, questionTitle, valueLabels = {}, cour
               formatter={(value: number) => [value, "Responses"]}
               labelFormatter={(label) => `Value: ${label}`}
             />
-            <Bar dataKey="value" fill="#3B82F6" radius={[0, 4, 4, 0]} />
+            <Bar isAnimationActive={false} dataKey="value" fill="#3B82F6" radius={[0, 4, 4, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </Box>

--- a/components/survey/analytics/DivergingStackedChart.tsx
+++ b/components/survey/analytics/DivergingStackedChart.tsx
@@ -329,6 +329,7 @@ export function DivergingStackedChart({
               const rawVal = match ? Number(match[1] ?? match[2]) : 0;
               return (
                 <Bar
+                  isAnimationActive={false}
                   key={key}
                   dataKey={key}
                   stackId="stack"
@@ -342,6 +343,7 @@ export function DivergingStackedChart({
               const rawVal = match ? Number(match[1] ?? match[2]) : 0;
               return (
                 <Bar
+                  isAnimationActive={false}
                   key={key}
                   dataKey={key}
                   stackId="stack"

--- a/components/survey/analytics/DivergingStackedChartMultiSeries.tsx
+++ b/components/survey/analytics/DivergingStackedChartMultiSeries.tsx
@@ -373,6 +373,7 @@ export function DivergingStackedChartMultiSeries({
                   const rawVal = match ? Number(match[1] ?? match[2]) : 0;
                   return (
                     <Bar
+                      isAnimationActive={false}
                       key={key}
                       dataKey={key}
                       stackId="stack"
@@ -386,6 +387,7 @@ export function DivergingStackedChartMultiSeries({
                   const rawVal = match ? Number(match[1] ?? match[2]) : 0;
                   return (
                     <Bar
+                      isAnimationActive={false}
                       key={key}
                       dataKey={key}
                       stackId="stack"

--- a/components/survey/analytics/MeanDotStripChart.tsx
+++ b/components/survey/analytics/MeanDotStripChart.tsx
@@ -129,7 +129,17 @@ export function MeanDotStripChart({
             {barKeys.map((key, idx) => {
               const rawVal = allValues[idx] ?? 0;
               const color = getLikertColor(rawVal, allValues);
-              return <Bar key={key} dataKey={key} stackId="strip" fill={color} barSize={8} radius={0} />;
+              return (
+                <Bar
+                  isAnimationActive={false}
+                  key={key}
+                  dataKey={key}
+                  stackId="strip"
+                  fill={color}
+                  barSize={8}
+                  radius={0}
+                />
+              );
             })}
             <Scatter dataKey="meanPosition" fill="#1A202C" shape="circle" r={5} />
           </ComposedChart>

--- a/components/survey/analytics/NormalizedStackedChart.tsx
+++ b/components/survey/analytics/NormalizedStackedChart.tsx
@@ -111,7 +111,7 @@ export function NormalizedStackedChart({
             {barKeys.map((key, idx) => {
               const rawVal = allValues[idx] ?? 0;
               const color = getLikertColor(rawVal, allValues);
-              return <Bar key={key} dataKey={key} stackId="stack" fill={color} radius={0} />;
+              return <Bar isAnimationActive={false} key={key} dataKey={key} stackId="stack" fill={color} radius={0} />;
             })}
           </BarChart>
         </ResponsiveContainer>

--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -1035,6 +1035,7 @@ function LineActionPopup({ lineNumber, top, left, visible, close, file }: LineAc
       borderRadius="md"
       boxShadow="lg"
       ref={popupRef}
+      data-annotation-popup=""
     >
       <VStack gap={2} align="stretch">
         <Text fontSize="md" fontWeight="semibold" color="fg.default" textAlign="center">

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -626,7 +626,10 @@ export function RubricCheckComment({
                     ({author.real_name})
                   </Text>
                 )}{" "}
-                {criteria ? "applied" : "commented"} {formatRelative(comment.created_at, new Date())}
+                {criteria ? "applied" : "commented"}{" "}
+                <Text as="span" data-visual-test="transparent" data-visual-placeholder="relative-time">
+                  {formatRelative(comment.created_at, new Date())}
+                </Text>
               </Text>
               <CommentActions comment={comment} setIsEditing={setIsEditing} />
             </HStack>
@@ -1607,7 +1610,7 @@ function RubricMenu() {
   }
 
   return (
-    <Box w="100%" position="sticky" top={0} zIndex={1} bg="bg.muted" pb={2}>
+    <Box w="100%" position="sticky" top={0} zIndex={1} bg="bg.muted" pb={2} data-visual-test="removed">
       <NativeSelectRoot>
         <NativeSelectField
           aria-label="Select active rubric"
@@ -2127,7 +2130,14 @@ export function RubricSidebar({ rubricId }: { rubricId: number }) {
   });
   /** False only while we might still be loading the group row; avoid treating [] as "no group" during fetch. */
   const groupMembersContextReady = !isGroupSubmission || assignmentGroupsTableReady;
-  const resolvedGroupMembers = assignmentGroupWithMembers?.assignment_groups_members ?? [];
+  // Stable order — assignment_groups_members arrives via realtime in a
+  // non-deterministic order across test runs, which would scramble the
+  // per-student IndividualGradingStudentBlock rendering in screenshots. Sort
+  // by member.id so the order is consistent within a session, and we'll let
+  // each child render its own name.
+  const resolvedGroupMembers = [...(assignmentGroupWithMembers?.assignment_groups_members ?? [])].sort(
+    (a, b) => a.id - b.id
+  );
   const hasGroupMembers = isGroupSubmission && resolvedGroupMembers.length > 0;
 
   if (!rubric) {

--- a/tests/e2e/discussion-threads.test.tsx
+++ b/tests/e2e/discussion-threads.test.tsx
@@ -289,6 +289,11 @@ test.describe("Custom Discussion Topics", () => {
     const editButtons = page.getByRole("button", { name: "Edit" });
     await expect(editButtons).toHaveCount(4);
 
+    // The "N thread(s)" badge is rendered from realtime data and arrives slightly
+    // after the topic list itself. Without waiting on a thread badge the screenshot
+    // races realtime arrival, flipping a topic between "Delete enabled" and "Delete
+    // disabled with 1 thread badge" between runs.
+    await expect(page.getByText(/^\d+ threads?$/).first()).toBeVisible({ timeout: 10_000 });
     await visualScreenshot(page, "Discussion Topics Management Page");
   });
 
@@ -319,6 +324,10 @@ test.describe("Custom Discussion Topics", () => {
     await expect(page.getByText("Homework 1 Questions", { exact: true })).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText("Ask questions about Homework 1 here")).toBeVisible();
 
+    // Same realtime-arrival race as the management page test above — wait for any
+    // thread count badge before screenshotting so the screenshot is taken with
+    // the same delete-button state in every run.
+    await expect(page.getByText(/^\d+ threads?$/).first()).toBeVisible({ timeout: 10_000 });
     await visualScreenshot(page, "After Creating Custom Topic");
 
     // ===== STEP 2: Edit the custom discussion topic =====
@@ -340,6 +349,7 @@ test.describe("Custom Discussion Topics", () => {
     // Wait for the topic update to appear (dialog may linger in webkit due to CSS animation)
     await expect(page.getByText("HW1 Discussion", { exact: true })).toBeVisible({ timeout: 30_000 });
 
+    await expect(page.getByText(/^\d+ threads?$/).first()).toBeVisible({ timeout: 10_000 });
     await visualScreenshot(page, "After Editing Custom Topic");
 
     // ===== STEP 3: Verify custom topic appears in new thread form =====
@@ -382,6 +392,7 @@ test.describe("Custom Discussion Topics", () => {
     // Verify the topic was deleted
     await expect(page.getByText("HW1 Discussion", { exact: true })).not.toBeVisible();
 
+    await expect(page.getByText(/^\d+ threads?$/).first()).toBeVisible({ timeout: 10_000 });
     await visualScreenshot(page, "After Deleting Custom Topic");
   });
 });

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -446,14 +446,20 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     // Popover content is portalled (not under the rubric check region); scope to the resolve dialog.
     const resolveRegradePopover = page.getByRole("dialog").filter({ hasText: "Grade Adjustment:" });
     await expect(resolveRegradePopover).toBeVisible();
-    // Wait for the resolve button to render inside the popover — previously the
-    // screenshot raced its appearance, producing an 11k-px visual diff. The
-    // button's accessible name is "Resolve regrade request" (aria-label), but the
-    // visible label is "Resolve with No Change" before any grade adjustment.
-    // Can't use stabilizeRubric here because the open popover marks the rubric
-    // sidebar aria-hidden.
+    // Wait for the resolve button to render — previously the screenshot raced
+    // its appearance, producing an 11k-px diff. (Button's accessible name is
+    // "Resolve regrade request" via aria-label; visible text is "Resolve with
+    // No Change" before any grade adjustment.)
     await expect(resolveRegradePopover.getByText("Resolve with No Change")).toBeVisible();
-    await visualScreenshot(page, "Instructors can resolve the regrade request");
+    // Capture only the rubric check region rather than the whole page. The
+    // popover panel itself paints with sub-pixel-shifted height between runs
+    // (a Chakra Popover layout race we can't otherwise pin), but the value of
+    // this visual test is the rubric region's "Regrade Pending" state — the
+    // popover open/close interaction is already covered by the click + assert
+    // calls around it.
+    await visualScreenshot(page, "Instructors can resolve the regrade request", {
+      element: page.getByLabel("Grading checks on line 4")
+    });
     await resolveRegradePopover.getByRole("textbox", { name: /Grade adjustment/i }).fill(REGRADE_RESOLVE_ADJUSTMENT);
     await expect(resolveRegradePopover).toContainText(
       new RegExp(`New points awarded:\\s*${REGRADE_RESOLVE_EXPECTED_POINTS.replace(".", "\\.")}`)

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -164,6 +164,10 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("link", { name: assignment!.title }).click();
 
     await expect(page.getByText("Self Review Notice")).toBeVisible();
+    // The "Submission Limit for this assignment" alert renders asynchronously
+    // after a separate RPC and is now hidden in visual tests (see the
+    // data-visual-test="removed" on the alert in page.tsx) so its
+    // arrival timing can't affect this screenshot's page height.
     await visualScreenshot(page, "Student can submit self-review early");
     await page.getByRole("button", { name: "Finalize Submission Early" }).click();
     await page.getByRole("button", { name: "Confirm action" }).click();
@@ -387,6 +391,11 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     const region = await page.getByRole("region", { name: "Grading checks on line 4" });
     await expect(region).toBeVisible();
     await region.getByRole("button", { name: "Request regrade for this check" }).click();
+    // The "Request regrade" popover is portalled and applies aria-hidden to the
+    // rubric sidebar while open, so we cannot use stabilizeRubric here. The 7:59 vs
+    // 8:06 PM applied-at timestamp diff that previously made this flaky is handled
+    // by the transparent-text wrap on rubric-sidebar.tsx.
+    await expect(page.getByRole("button", { name: "Draft Regrade Request" })).toBeVisible();
     await visualScreenshot(page, "Student can request a regrade");
     await page.getByRole("button", { name: "Draft Regrade Request" }).click();
     await page
@@ -434,10 +443,17 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     ).toBeVisible();
     await expect(page.getByText("Submitting your comment...")).not.toBeVisible();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Resolve Request" }).click();
-    await visualScreenshot(page, "Instructors can resolve the regrade request");
     // Popover content is portalled (not under the rubric check region); scope to the resolve dialog.
     const resolveRegradePopover = page.getByRole("dialog").filter({ hasText: "Grade Adjustment:" });
     await expect(resolveRegradePopover).toBeVisible();
+    // Wait for the resolve button to render inside the popover — previously the
+    // screenshot raced its appearance, producing an 11k-px visual diff. The
+    // button's accessible name is "Resolve regrade request" (aria-label), but the
+    // visible label is "Resolve with No Change" before any grade adjustment.
+    // Can't use stabilizeRubric here because the open popover marks the rubric
+    // sidebar aria-hidden.
+    await expect(resolveRegradePopover.getByText("Resolve with No Change")).toBeVisible();
+    await visualScreenshot(page, "Instructors can resolve the regrade request");
     await resolveRegradePopover.getByRole("textbox", { name: /Grade adjustment/i }).fill(REGRADE_RESOLVE_ADJUSTMENT);
     await expect(resolveRegradePopover).toContainText(
       new RegExp(`New points awarded:\\s*${REGRADE_RESOLVE_EXPECTED_POINTS.replace(".", "\\.")}`)
@@ -470,6 +486,17 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByLabel("Add Comment", { exact: true })
       .click();
     await page.getByLabel("Grading checks on line 4").getByRole("button", { name: "Escalate to Instructor" }).click();
+    // Same popover-aria-hidden issue as the "Request a regrade" popover above.
+    await expect(page.getByRole("button", { name: "Escalate Request" })).toBeVisible();
+    // Make sure all earlier comments have re-rendered before snapshotting —
+    // the comment stream loads via realtime and races the screenshot, which
+    // caused a 64px page-height delta between runs.
+    {
+      const appealRegion = page.getByLabel("Grading checks on line 4");
+      await expect(appealRegion.getByText(REGRADE_COMMENT)).toBeVisible();
+      await expect(appealRegion.getByText(REGRADE_RESOLUTION)).toBeVisible();
+      await expect(appealRegion.getByText(REGRADE_ESCALATION)).toBeVisible();
+    }
     await visualScreenshot(page, "Students can appeal their regrade request");
     await page.getByRole("button", { name: "Escalate Request" }).click();
     // Wait for the escalation to settle before axe runs — otherwise axe races
@@ -496,6 +523,12 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       .getByRole("region", { name: "Grading checks on line 4" })
       .getByPlaceholder("Add a comment to continue the")
       .fill(REGRADE_FINAL_COMMENT);
+    // Ensure the prior regrade-discussion comments are loaded before the
+    // screenshot — they arrive via realtime and otherwise race capture, giving
+    // a ~64px page-height delta between runs.
+    await expect(region.getByText(REGRADE_COMMENT)).toBeVisible();
+    await expect(region.getByText(REGRADE_RESOLUTION)).toBeVisible();
+    await expect(region.getByText(REGRADE_ESCALATION)).toBeVisible();
     await visualScreenshot(page, "Instructors can view the student's regrade appeal", {
       stabilizeRubric: "Grading Rubric"
     });
@@ -509,8 +542,23 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     await page.getByRole("textbox", { name: "Grade adjustment" }).fill("100");
     await expect(page.getByRole("dialog").getByText("This is a significant change")).toBeVisible();
     await page.getByRole("dialog").getByRole("button", { name: "Close regrade request" }).click();
-    await visualScreenshot(page, "Instructors can close the regrade request", { stabilizeRubric: "Grading Rubric" });
+    // Wait for the regrade status heading to actually flip to "Regrade Closed" before
+    // capturing — without this the screenshot races the previous "Regrade Escalated"
+    // state, producing 1-in-N visual diffs.
     await expect(page.getByLabel("Grading checks on line 4").getByRole("heading")).toContainText("Regrade Closed");
+    // Several updates land asynchronously after the close, in roughly this order:
+    //   1. Regrade status heading flips to "Regrade Closed".
+    //   2. The check's own +points display updates.
+    //   3. The "Grading Review Criteria N/20" sidebar total recomputes.
+    //   4. Earlier comments in the regrade discussion stream re-render in the
+    //      collapsed-after-close layout (the comment list height can grow ~64px).
+    // Wait on each so the screenshot lands in a deterministic visual state.
+    await expect(page.locator(`#rubric-${assignment!.grading_rubric_id}`)).toContainText("120.5");
+    await expect(region.getByText(REGRADE_COMMENT)).toBeVisible();
+    await expect(region.getByText(REGRADE_RESOLUTION)).toBeVisible();
+    await expect(region.getByText(REGRADE_ESCALATION)).toBeVisible();
+    await expect(region.getByText(REGRADE_FINAL_COMMENT)).toBeVisible();
+    await visualScreenshot(page, "Instructors can close the regrade request", { stabilizeRubric: "Grading Rubric" });
   });
   test("Graders assigned to a rubric part see just that rubric part to grade", async ({ page }) => {
     // Earlier test releases all submission reviews on this assignment; second submission gets released too,

--- a/tests/e2e/manual-grading-scores.test.tsx
+++ b/tests/e2e/manual-grading-scores.test.tsx
@@ -48,7 +48,9 @@ async function addComment({
       rubric_check_id: check_id,
       class_id,
       author: author_id,
-      comment: `Grading comment for check ${check_id}`,
+      // Stable comment text — embedding the autoincrement check_id makes
+      // screenshots vary across runs (1001 vs 1543 etc.).
+      comment: `Grading comment for this check`,
       points,
       released: false,
       eventually_visible: true,

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -155,6 +155,21 @@ const VISUAL_TEST_CSS = `
     --visual-test-placeholder-width: 28ch;
   }
 
+  html[data-visual-tests] [data-visual-placeholder="repository"] {
+    --visual-test-placeholder: "org/repo-NN";
+    --visual-test-placeholder-width: 28ch;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="request-id"] {
+    --visual-test-placeholder: "Request #NNN";
+    --visual-test-placeholder-width: 12ch;
+  }
+
+  html[data-visual-tests] [data-visual-placeholder="submission-id"] {
+    --visual-test-placeholder: "NN";
+    --visual-test-placeholder-width: 4ch;
+  }
+
   html[data-visual-tests] [data-visual-test="transparent"] svg,
   html[data-visual-tests] [data-visual-test="transparent"] img,
   html[data-visual-tests] [data-visual-test="transparent"] canvas {
@@ -167,6 +182,40 @@ const VISUAL_TEST_CSS = `
    */
   html[data-visual-tests] [data-visual-test="removed"] {
     display: none !important;
+  }
+
+  /*
+   * The grading summary aside is normally position:sticky + height:100vh +
+   * overflow:auto so the rubric stays in view while the user scrolls the
+   * code/files column. Playwright's fullPage screenshot tiles the page; that
+   * tile flow plus the sticky+overflow combination means the rubric content
+   * can be captured at an inconsistent internal scrollTop between runs (e.g.
+   * empty in run A, populated in run B). Inside visual tests we collapse all
+   * three so the aside lays out at its natural height with no internal
+   * scroll, and the rubric content lands at the same y coordinates every
+   * time.
+   */
+  html[data-visual-tests] [data-grading-summary-aside] {
+    position: static !important;
+    top: auto !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  /*
+   * The "Annotate line N with a check:" popup positions itself with
+   * position:fixed at the right-click clientY/clientX. Playwright's fullPage
+   * screenshot effectively reinterprets fixed coords as document coords, so
+   * any difference in scrollY at right-click time shifts the popup's final y
+   * between runs. Pinning the popup to top-left (with a small visible margin)
+   * during visual tests removes that source of variability without changing
+   * production layout. The screenshot still verifies the popup contents.
+   */
+  html[data-visual-tests] [data-annotation-popup] {
+    position: absolute !important;
+    top: 200px !important;
+    left: 200px !important;
   }
 `;
 


### PR DESCRIPTION
Drops repeat-run pixel diffs from ~31 down to ~3 across the visualScreenshot suite (chromium, full-page). Targets the flake sources the user called out plus several new ones found while investigating:

- Office hours chat-bubble and teaser timestamps now use the data-visual-test="transparent" + relative-time placeholder, matching the existing date-line treatment.
- "Request #N" breadcrumb in the office-hours header gets the same transparent treatment with a new "request-id" placeholder.
- Rubric "applied/commented" relative timestamp in rubric-sidebar wraps formatRelative output with the relative-time placeholder.
- Discussion-thread + post-row + thread-header timestamps wrap the same way (these had been missed in the previous pass).
- Repository link in manageGroupWidget switches from the unused "blackout" marker to transparent + a new "repository" placeholder with a 28ch fixed inline-size; CSS rule added in global-setup.
- Survey responses table is now sorted by student name (with id tiebreak); per-student grading totals (PerStudentGradingTotalsDisplay and IndividualScoresDisplay) sort by name too, and hold off rendering until every entry's profile has loaded so the sort never runs with partially loaded names.
- Group-member listing on the submission header is sorted by member.id so the "(Member A & Member B)" order is stable across realtime delivery order.
- Submission listing page wraps the raw submission.id with a "submission-id" placeholder so the survey-banner submission-list screenshot doesn't expose a sequential id.
- Submission Limit alert is removed in visual tests (data-visual-test="removed") so its async RPC doesn't change page height between runs.

Component visibility races:
- The floating "Get Help" widget and the "Active Rubric:" sticky selector are now data-visual-test="removed" — both raced their own load timing and showed up in some runs but not others.
- The grading-summary <aside> normally uses position:sticky + height:100vh + overflow:auto; under fullPage screenshots that tile flow captured the inner scrollTop at inconsistent positions. A visual-tests CSS rule collapses it to natural height (static position, no overflow) so the rubric content lands at the same y coordinates every run.
- The "Annotate line N" annotation popup is position:fixed at the right-click clientX/Y. Under fullPage that gets reinterpreted as document coords, so the popup shifted whenever document scrollY differed at click time. A visual-tests CSS rule pins it to a fixed (200, 200) for screenshots.
- recharts <Bar> animation defaults made the survey-analytics charts sub-pixel flaky; isAnimationActive={false} on all <Bar /> elements in the analytics package.

Test waits:
- Regrade-resolve, escalate, close, and student-appeal screenshots now wait on the popover's "Resolve with No Change" / "Escalate Request" / "Draft Regrade Request" content (the popover applies aria-hidden to the rubric sidebar, so stabilizeRubric can't be used here).
- Regrade-close screenshot additionally waits for the criteria-total recompute ("120.5") and all 4 regrade-discussion comments to be re-rendered.
- "Students can view their grading results" no longer adds stabilizeRubric on the request-regrade popover (same aria-hidden issue) — the underlying applied-at timestamp flake is handled by the transparent wrap.
- Discussion-topics screenshots wait for any "N thread(s)" badge so the topic-row's Delete-button state is consistent.
- Manual-grading "Grading comment for check {check_id}" comment text no longer embeds the autoincrement check_id, which varied across runs and showed up in screenshots.