### PR TITLE
Fix submission history not reflecting realtime review changes (#598)

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/submissions/[submissions_id]/layout.tsx
@@ -1130,6 +1130,40 @@ function SubmissionHistoryContents({ submission }: { submission: SubmissionWithG
       pageSize: 1000
     }
   });
+  const courseController = useCourseController();
+
+  // Refresh the history when a submission_review changes — e.g. when grading is
+  // completed on the active (or a reactivated older) submission. Issue #598: the
+  // "Total Score" column reflects submission_reviews data, but the only realtime
+  // listener here fires on `submissions` is_active changes, not on review
+  // completion, so the manually-graded total stayed stale until a manual reload.
+  // We listen on each listed submission's review channel and invalidate the list.
+  const submissionIds = useMemo(() => (data?.data ?? []).map((s) => s.id), [data?.data]);
+  const submissionIdsKey = submissionIds.join(",");
+  useEffect(() => {
+    const realtime = courseController?.classRealTimeController;
+    if (!realtime || submissionIds.length === 0) return;
+
+    const unsubscribers = submissionIds.map((id) =>
+      realtime.subscribeToTableForSubmission(
+        "submission_reviews",
+        id,
+        (message: import("@/lib/TableController").BroadcastMessage) => {
+          if (message.operation === "INSERT" || message.operation === "UPDATE" || message.operation === "BULK_UPDATE") {
+            invalidate({ resource: "submissions", invalidates: ["list"] });
+          }
+        }
+      )
+    );
+
+    return () => {
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+    };
+    // submissionIdsKey is a stable string derived from submissionIds; depending on
+    // the array directly would re-subscribe on every refetch even when ids are equal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [courseController, submissionIdsKey, invalidate]);
+
   const router = useRouter();
   const { time_zone } = useCourse();
   const [isActivating, setIsActivating] = useState(false);

--- a/tests/e2e/submission-history-review-realtime.spec.ts
+++ b/tests/e2e/submission-history-review-realtime.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Submission history realtime review updates (issue #598).
+ *
+ * Bug: the "Submission History" popover shows a "Total Score" column sourced from
+ * submission_reviews, but the only realtime listener on that list fired on
+ * `submissions` is_active changes — not on submission_review completion. So when
+ * an instructor completed manual grading (e.g. after reactivating an older
+ * submission), the manually-graded total stayed stale in the history until a
+ * full page reload, even though the gradebook and the big "Overall Score" on the
+ * page updated correctly.
+ *
+ * This test opens the student-facing submission history popover, then completes
+ * the grading review out-of-band (DB), and asserts the Total Score cell *inside
+ * the history table* updates without a reload. The assertion is deliberately
+ * scoped to the history table: the page-level "Overall Score" already updated via
+ * its own realtime subscription, so an unscoped assertion would pass even with
+ * the bug present.
+ *
+ * Chromium only (default project). Requires: local Supabase + `npm run dev` on
+ * port 3000 (or BASE_URL for deployed E2E).
+ */
+import { expect, test } from "@playwright/test";
+import { addDays } from "date-fns";
+import {
+  createClass,
+  createUserInClass,
+  dismissTimeZonePreferenceModal,
+  insertAssignment,
+  insertPreBakedSubmission,
+  loginAsUser,
+  supabase
+} from "./TestingUtils";
+import type { TestingUser } from "./TestingUtils";
+
+const GRADED_TOTAL = 42;
+const GRADED_TOTAL_TEXT = `${GRADED_TOTAL}/100`; // total_points defaults to 100 in insertAssignment.
+
+test.describe("Submission history review realtime (issue #598)", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  let classId: number;
+  let assignmentId: number;
+  let instructor: TestingUser;
+  let student: TestingUser;
+  let submissionId: number;
+  let gradingReviewId: number;
+
+  test.beforeAll(async () => {
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const course = await createClass({ name: `E2E Submission History RT ${suffix}` });
+    classId = course.id;
+
+    instructor = await createUserInClass({
+      role: "instructor",
+      class_id: classId,
+      name: `E2E Sub History Instructor ${suffix}`,
+      email: `e2e-subhist-inst-${suffix}@pawtograder.net`
+    });
+    student = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Sub History Student ${suffix}`,
+      email: `e2e-subhist-stu-${suffix}@pawtograder.net`
+    });
+
+    const assignment = await insertAssignment({
+      class_id: classId,
+      due_date: addDays(new Date(), -1).toISOString(),
+      name: `E2E Sub History Assignment ${suffix}`,
+      assignment_slug: `e2e-sub-history-${suffix}`
+    });
+    assignmentId = assignment.id;
+
+    const submission = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `sub-history-rt-${classId}`
+    });
+    submissionId = submission.submission_id;
+    gradingReviewId = submission.grading_review_id;
+  });
+
+  test("history Total Score updates in realtime when grading is completed", async ({ page, browserName }) => {
+    test.skip(browserName !== "chromium", "Chromium only (matches the rest of the realtime UI e2e suite)");
+
+    await loginAsUser(page, student);
+
+    await page.goto(`/course/${classId}/assignments/${assignmentId}/submissions/${submissionId}/results`, {
+      waitUntil: "domcontentloaded"
+    });
+    await page.waitForLoadState("networkidle");
+    await dismissTimeZonePreferenceModal(page, 10_000);
+
+    // Open the submission history popover.
+    const historyButton = page.getByRole("button", { name: "Submission History" });
+    await expect(historyButton).toBeVisible({ timeout: 30_000 });
+    await historyButton.click();
+
+    // Scope every assertion to the popover content so the page-level "Overall
+    // Score" / rubric totals can't mask the bug — the page-level review score
+    // updates via its own subscription, but the history popover is the surface
+    // that regressed in #598.
+    const historyPopover = page
+      .locator('[data-scope="popover"][data-part="content"]')
+      .filter({ hasText: "Submission History" });
+    await expect(historyPopover).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the history row to load (autograder score 5/10 from the prebaked
+    // submission) so the absence check below is meaningful rather than racing the
+    // initial query, and so the realtime channel is set up before grading.
+    await expect(historyPopover.getByText("5/10")).toBeVisible({ timeout: 30_000 });
+
+    // Grading has not been completed yet, so the history shows no graded total.
+    await expect(historyPopover.getByText(GRADED_TOTAL_TEXT)).toHaveCount(0);
+
+    // Complete the manual grading review out-of-band, the same way the gradebook
+    // recalc flow does. With the popover open, this must propagate to the history
+    // table via the submission_reviews realtime channel. We re-apply inside a
+    // toPass loop so a broadcast that arrives before the realtime channel has
+    // finished subscribing is retried rather than flaking — without the fix, no
+    // listener exists at all and the cell never updates regardless of retries.
+    await expect(async () => {
+      const { error } = await supabase
+        .from("submission_reviews")
+        .update({
+          completed_at: new Date().toISOString(),
+          completed_by: instructor.private_profile_id,
+          released: true,
+          total_score: GRADED_TOTAL
+        })
+        .eq("id", gradingReviewId);
+      expect(error).toBeNull();
+
+      await expect(historyPopover.getByText(GRADED_TOTAL_TEXT)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 60_000 });
+  });
+});


### PR DESCRIPTION
The "Submission History" popover's Total Score column reflects submission_reviews data, but the only realtime listener fired on `submissions` is_active changes. Completing a manual grading review updates submission_reviews (broadcast on a per-submission channel), which nothing here listened for, so the column stayed stale until a full page reload — even though the gradebook and page-level Overall Score updated correctly.

Subscribe to each listed submission's submission_reviews channel and invalidate the submissions list on insert/update, matching the existing realtime pattern in this component and StaffCommitHistory.

Adds an E2E test that opens the student-facing history popover, completes the review out-of-band, and asserts the popover-scoped Total Score updates without a reload. Verified red/green (fails when the subscription is removed).

Fixes #598.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submission history now synchronizes automatically in real-time when grading reviews are updated, eliminating the need for manual page refreshes to see the latest scores.

* **Tests**
  * Added end-to-end tests verifying real-time updates to submission history during grading review workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/769?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->