### PR TITLE
Fix code renderer dark/light mode to follow app theme, not OS (#711)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,6 +15,78 @@ select {
   cursor: pointer;
 }
 
+/* starry-night (code-file syntax highlighting) ships its palette via
+   `@media (prefers-color-scheme: dark)`, which tracks the OS appearance and
+   ignores the in-app theme toggle. Re-bind the palette to the `light`/`dark`
+   class that next-themes sets on <html> so highlighting follows the user's
+   chosen color mode. The `.light`/`.dark` selectors outrank `:root` (incl. the
+   one inside the media query) on specificity, so they win regardless of OS. */
+html.light {
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+  --color-prettylights-syntax-carriage-return-bg: #cf222e;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
+  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
+  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+  --color-prettylights-syntax-variable: #953800;
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+}
+
+html.dark {
+  --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-comment: #9198a1;
+  --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+  --color-prettylights-syntax-entity: #d2a8ff;
+  --color-prettylights-syntax-entity-tag: #7ee787;
+  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+  --color-prettylights-syntax-keyword: #ff7b72;
+  --color-prettylights-syntax-markup-bold: #f0f6fc;
+  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
+  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-italic: #f0f6fc;
+  --color-prettylights-syntax-markup-list: #f2cc60;
+  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+  --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+  --color-prettylights-syntax-variable: #ffa657;
+}
+
 /* Fix for WebKit: Disable pointer events on dialog backdrop during exit animation.
    Without this, the backdrop intercepts clicks even when data-state="closed",
    causing flaky tests especially in WebKit where animation timing differs. */


### PR DESCRIPTION
## Summary
- The code-file syntax highlighter (`@wooorm/starry-night`) loaded `style/both.css`, whose palette is gated on `@media (prefers-color-scheme: dark)`. That tracks the **OS** appearance and ignores the in-app theme toggle, so highlighting used the wrong palette whenever the OS and app themes disagreed (#711).
- Fix is CSS-only (`app/globals.css`): re-bind the `--color-prettylights-syntax-*` variables to the `light`/`dark` class that next-themes sets on `<html>`. The class selectors outrank the media-query `:root` by specificity, so the user's chosen color mode always wins regardless of OS. Reactive via the existing class toggle, no JS change.

## Test plan
- [x] Local repro on seeded demo class (instructor view, submission code file), headless Chromium emulating all four OS x app theme combinations, asserting the resolved keyword color (light `#cf222e` / dark `#ff7b72`).
- [x] Confirmed the two mismatch cases (OS light/app dark, OS dark/app light) failed before the fix and pass after.
- [x] Manual sanity check in a real browser by a reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #711