### PR TITLE
Re-enqueue failed repo creations, reduce create-content rate limit budget (#710)

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -206,7 +206,7 @@ export function getCreateContentLimiter(org: string): Bottleneck {
   const existing = createContentLimiters.get(key);
   if (existing) return existing;
   const id = `create_content:${key}:${Deno.env.get("GITHUB_APP_ID") || ""}`;
-  const opts = { reservoir: 50, maxConcurrent: 50, reservoirRefreshAmount: 50, reservoirRefreshInterval: 60_000 };
+  const opts = { reservoir: 40, maxConcurrent: 40, reservoirRefreshAmount: 40, reservoirRefreshInterval: 60_000 };
   let limiter: Bottleneck;
   if (Deno.env.get("UPSTASH_REDIS_REST_URL") && Deno.env.get("UPSTASH_REDIS_REST_TOKEN")) {
     limiter = buildRedisBottleneck(id, opts, false);

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -965,12 +965,17 @@ export async function processEnvelope(
             if (updateError) throw updateError;
           }
         } catch (e) {
+          // The GitHub repo exists at this point, but we failed to mark it ready in the DB.
+          // Re-throw so the outer handler requeues: nothing else re-enqueues a repo whose row
+          // already exists (create_repos_for_student dedups on row existence, not is_github_ready),
+          // so swallowing here would strand the repo at is_github_ready=false forever. The retry is
+          // idempotent — createRepo handles the pre-existing repo and returns the head SHA.
           scope.setContext("repo_ready_update_error", {
             error_message: e instanceof Error ? e.message : String(e),
             repo_id: envelope.repo_id,
             class_id: envelope.class_id
           });
-          Sentry.captureException(e, scope);
+          throw e;
         }
         recordMetric(
           adminSupabase,


### PR DESCRIPTION
Fixes #710 

Re-throw when marking a repo is_github_ready fails after the GitHub repo was created. Previously the error was swallowed and the message archived, stranding the repo at is_github_ready=false forever since nothing re-enqueues a repo whose row already exists. The retry is idempotent: createRepo handles the pre-existing repo and returns its head SHA.

Reduce the per-org create-content reservoir from 50 to 40/min to account for the extra actions/permissions API call added per repo creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for repository initialization to ensure database update failures are properly tracked and the system's retry mechanism engages correctly.

* **Chores**
  * Updated rate limiting configuration for GitHub repository creation to optimize resource efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->