### PR TITLE
Fix rubric preview dropping items with duplicate or sentinel IDs (#198)

### DIFF
--- a/lib/PreviewAssignmentController.ts
+++ b/lib/PreviewAssignmentController.ts
@@ -8,6 +8,12 @@ import { TablesThatHaveAnIDField } from "@/lib/TableController";
  *
  * Ensures all foreign keys are correctly set to match the parent rubric's ID,
  * which is critical for hook predicates to work correctly.
+ *
+ * Preview rubrics frequently contain items with sentinel IDs (-1, 0) for newly added
+ * elements, or transient duplicate IDs while the user is editing the YAML. Because
+ * the consuming hooks (useListTableControllerValues) key rows by `id` in a Map,
+ * collisions silently drop entries — so we remap any duplicate or non-positive IDs
+ * to fresh synthetic negative IDs and rewrite parent/child foreign keys to match.
  */
 export function flattenHydratedRubric(hydrated: HydratedRubric) {
   const rubric: Rubric = {
@@ -26,9 +32,26 @@ export function flattenHydratedRubric(hydrated: HydratedRubric) {
   const criteria: RubricCriteria[] = [];
   const checks: RubricCheck[] = [];
 
+  const seenPartIds = new Set<number>();
+  const seenCriteriaIds = new Set<number>();
+  const seenCheckIds = new Set<number>();
+  // Use a counter well below any plausible real DB id so synthetic ids never collide
+  // with real ones (which are positive auto-increment ints).
+  let nextSyntheticId = -1_000_000;
+  const allocId = (id: number, seen: Set<number>) => {
+    if (id > 0 && !seen.has(id)) {
+      seen.add(id);
+      return id;
+    }
+    const synthetic = nextSyntheticId--;
+    seen.add(synthetic);
+    return synthetic;
+  };
+
   for (const part of hydrated.rubric_parts) {
+    const partId = allocId(part.id, seenPartIds);
     parts.push({
-      id: part.id,
+      id: partId,
       name: part.name,
       description: part.description,
       ordinal: part.ordinal,
@@ -42,8 +65,9 @@ export function flattenHydratedRubric(hydrated: HydratedRubric) {
     });
 
     for (const crit of part.rubric_criteria) {
+      const critId = allocId(crit.id, seenCriteriaIds);
       criteria.push({
-        id: crit.id,
+        id: critId,
         name: crit.name,
         description: crit.description,
         ordinal: crit.ordinal,
@@ -54,15 +78,16 @@ export function flattenHydratedRubric(hydrated: HydratedRubric) {
         max_checks_per_submission: crit.max_checks_per_submission,
         min_checks_per_submission: crit.min_checks_per_submission,
         rubric_id: hydrated.id, // Use parent rubric's ID
-        rubric_part_id: part.id,
+        rubric_part_id: partId,
         class_id: hydrated.class_id,
         assignment_id: hydrated.assignment_id,
         created_at: crit.created_at
       });
 
       for (const check of crit.rubric_checks) {
+        const checkId = allocId(check.id, seenCheckIds);
         checks.push({
-          id: check.id,
+          id: checkId,
           name: check.name,
           description: check.description,
           ordinal: check.ordinal,
@@ -78,7 +103,7 @@ export function flattenHydratedRubric(hydrated: HydratedRubric) {
           annotation_target: check.annotation_target,
           student_visibility: check.student_visibility ?? "always",
           rubric_id: hydrated.id, // Use parent rubric's ID
-          rubric_criteria_id: crit.id,
+          rubric_criteria_id: critId,
           class_id: hydrated.class_id,
           assignment_id: hydrated.assignment_id,
           kpi_category: check.kpi_category,

--- a/tests/unit/rubric/preview-flatten.test.ts
+++ b/tests/unit/rubric/preview-flatten.test.ts
@@ -1,0 +1,200 @@
+import { flattenHydratedRubric } from "@/lib/PreviewAssignmentController";
+import type {
+  HydratedRubric,
+  HydratedRubricCheck,
+  HydratedRubricCriteria,
+  HydratedRubricPart
+} from "@/utils/supabase/DatabaseTypes";
+
+function makeCheck(overrides: Partial<HydratedRubricCheck> = {}): HydratedRubricCheck {
+  return {
+    id: -1,
+    name: "check",
+    description: null,
+    ordinal: 0,
+    rubric_id: 0,
+    assignment_id: 0,
+    class_id: 0,
+    created_at: "",
+    data: null,
+    rubric_criteria_id: 0,
+    file: null,
+    artifact: null,
+    group: null,
+    is_annotation: false,
+    is_comment_required: false,
+    is_required: false,
+    max_annotations: null,
+    points: 0,
+    annotation_target: null,
+    student_visibility: "always",
+    kpi_category: null,
+    ...overrides
+  } as HydratedRubricCheck;
+}
+
+function makeCriteria(overrides: Partial<HydratedRubricCriteria> = {}): HydratedRubricCriteria {
+  return {
+    id: -1,
+    name: "crit",
+    description: null,
+    ordinal: 0,
+    rubric_id: 0,
+    rubric_part_id: 0,
+    assignment_id: 0,
+    class_id: 0,
+    created_at: "",
+    data: null,
+    is_additive: false,
+    is_deduction_only: false,
+    total_points: 0,
+    max_checks_per_submission: null,
+    min_checks_per_submission: null,
+    rubric_checks: [makeCheck()],
+    ...overrides
+  } as HydratedRubricCriteria;
+}
+
+function makePart(overrides: Partial<HydratedRubricPart> = {}): HydratedRubricPart {
+  return {
+    id: -1,
+    name: "part",
+    description: null,
+    ordinal: 0,
+    rubric_id: 0,
+    assignment_id: 0,
+    class_id: 0,
+    created_at: "",
+    data: null,
+    is_individual_grading: false,
+    is_assign_to_student: false,
+    rubric_criteria: [makeCriteria()],
+    ...overrides
+  } as HydratedRubricPart;
+}
+
+function makeRubric(parts: HydratedRubricPart[]): HydratedRubric {
+  return {
+    id: 1,
+    name: "r",
+    description: null,
+    assignment_id: 1,
+    class_id: 1,
+    is_private: false,
+    review_round: "grading-review",
+    created_at: "",
+    cap_score_to_assignment_points: false,
+    rubric_parts: parts
+  } as HydratedRubric;
+}
+
+describe("flattenHydratedRubric — duplicate / sentinel ID handling (issue #198)", () => {
+  it("assigns unique synthetic ids to multiple new parts that share id=-1", () => {
+    const hydrated = makeRubric([
+      makePart({ id: -1, name: "A" }),
+      makePart({ id: -1, name: "B" }),
+      makePart({ id: -1, name: "C" })
+    ]);
+
+    const { parts } = flattenHydratedRubric(hydrated);
+
+    expect(parts).toHaveLength(3);
+    const ids = parts.map((p) => p.id);
+    expect(new Set(ids).size).toBe(3);
+    // Sentinel inputs must not survive — every id should be strictly negative & unique.
+    for (const id of ids) {
+      expect(id).toBeLessThan(0);
+    }
+    expect(parts.map((p) => p.name)).toEqual(["A", "B", "C"]);
+  });
+
+  it("assigns unique synthetic ids when criteria within a part share duplicate ids", () => {
+    const hydrated = makeRubric([
+      makePart({
+        id: 100,
+        rubric_criteria: [
+          makeCriteria({ id: 7, name: "x" }),
+          makeCriteria({ id: 7, name: "y" }), // duplicate of first criteria
+          makeCriteria({ id: -1, name: "z" })
+        ]
+      })
+    ]);
+
+    const { parts, criteria } = flattenHydratedRubric(hydrated);
+
+    expect(criteria).toHaveLength(3);
+    const ids = criteria.map((c) => c.id);
+    expect(new Set(ids).size).toBe(3);
+    // The first occurrence of a positive id is preserved.
+    expect(criteria[0].id).toBe(7);
+    expect(criteria[1].id).toBeLessThan(0);
+    expect(criteria[2].id).toBeLessThan(0);
+    // Foreign keys must point at the (remapped) parent.
+    const partId = parts[0].id;
+    for (const c of criteria) {
+      expect(c.rubric_part_id).toBe(partId);
+    }
+  });
+
+  it("rewrites check.rubric_criteria_id to match the remapped criteria id", () => {
+    const hydrated = makeRubric([
+      makePart({
+        id: -1,
+        rubric_criteria: [
+          makeCriteria({
+            id: -1,
+            rubric_checks: [makeCheck({ id: -1, name: "ck1" }), makeCheck({ id: -1, name: "ck2" })]
+          }),
+          makeCriteria({
+            id: -1,
+            rubric_checks: [makeCheck({ id: -1, name: "ck3" })]
+          })
+        ]
+      })
+    ]);
+
+    const { criteria, checks } = flattenHydratedRubric(hydrated);
+
+    expect(checks).toHaveLength(3);
+    // All checks unique.
+    expect(new Set(checks.map((c) => c.id)).size).toBe(3);
+    // First two checks belong to first criteria; third to the second.
+    expect(checks[0].rubric_criteria_id).toBe(criteria[0].id);
+    expect(checks[1].rubric_criteria_id).toBe(criteria[0].id);
+    expect(checks[2].rubric_criteria_id).toBe(criteria[1].id);
+    expect(criteria[0].id).not.toBe(criteria[1].id);
+  });
+
+  it("preserves real positive ids unchanged when they are unique", () => {
+    const hydrated = makeRubric([
+      makePart({
+        id: 10,
+        rubric_criteria: [
+          makeCriteria({
+            id: 20,
+            rubric_checks: [makeCheck({ id: 30 })]
+          })
+        ]
+      })
+    ]);
+
+    const { parts, criteria, checks } = flattenHydratedRubric(hydrated);
+
+    expect(parts[0].id).toBe(10);
+    expect(criteria[0].id).toBe(20);
+    expect(criteria[0].rubric_part_id).toBe(10);
+    expect(checks[0].id).toBe(30);
+    expect(checks[0].rubric_criteria_id).toBe(20);
+  });
+
+  it("treats id=0 as a sentinel and replaces it with a unique synthetic id", () => {
+    const hydrated = makeRubric([makePart({ id: 0, name: "A" }), makePart({ id: 0, name: "B" })]);
+
+    const { parts } = flattenHydratedRubric(hydrated);
+
+    expect(new Set(parts.map((p) => p.id)).size).toBe(2);
+    for (const p of parts) {
+      expect(p.id).toBeLessThan(0);
+    }
+  });
+});


### PR DESCRIPTION
The preview pipeline keys rows by id in a Map, so multiple new items sharing id=-1 (or transient duplicates while editing the YAML) collided and silently collapsed to one entry. Remap any duplicate or non-positive id to a unique synthetic negative id in flattenHydratedRubric, and rewrite child foreign keys to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate identifiers in rubric parts, criteria, and checks could cause collisions when displaying assignment previews, ensuring each element receives a unique identifier.

* **Tests**
  * Added comprehensive unit test coverage for rubric element identifier handling, including scenarios with duplicate and invalid identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->