### PR TITLE
Refactor bulk invitations: remove auto-expiry, dedupe profiles (#322, #390)

### DIFF
--- a/app/admin/sis-sync/page.tsx
+++ b/app/admin/sis-sync/page.tsx
@@ -18,7 +18,7 @@ interface SISClass {
   sync_enabled: boolean;
   total_invitations: number;
   pending_invitations: number;
-  expired_invitations: number;
+  dropped_invitations: number;
 }
 
 export default function SISSyncPage() {
@@ -271,9 +271,9 @@ export default function SISSyncPage() {
                             {class_.pending_invitations} pending
                           </Badge>
                         )}
-                        {class_.expired_invitations > 0 && (
+                        {class_.dropped_invitations > 0 && (
                           <Badge size="sm" colorPalette="red">
-                            {class_.expired_invitations} expired
+                            {class_.dropped_invitations} dropped
                           </Badge>
                         )}
                         {class_.total_invitations === 0 && (

--- a/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
@@ -197,7 +197,7 @@ export default function EnrollmentsTable() {
         .select("*")
         .eq("class_id", parseInt(course_id as string))
         .neq("status", "accepted")
-        .neq("status", "expired")
+        .neq("status", "dropped")
         .order("created_at", { ascending: false });
 
       if (error) throw error;
@@ -289,21 +289,14 @@ export default function EnrollmentsTable() {
         cell: ({ row }) => {
           if (row.original.type === "invitation") {
             const invitation = row.original;
-            const isExpired = invitation.expires_at && new Date(invitation.expires_at) < new Date();
             const statusColor =
-              invitation.status === "pending"
-                ? isExpired
-                  ? "orange.500"
-                  : "blue.500"
-                : invitation.status === "accepted"
-                  ? "green.500"
-                  : "red.500";
+              invitation.status === "pending" ? "blue.500" : invitation.status === "accepted" ? "green.500" : "red.500";
 
             return (
               <Flex alignItems="center" gap={2}>
                 <Icon as={FaClock} color={statusColor} />
                 <Text color={statusColor} fontWeight="medium">
-                  {invitation.status === "pending" && isExpired ? "Expired" : invitation.status}
+                  {invitation.status}
                 </Text>
               </Flex>
             );
@@ -333,9 +326,7 @@ export default function EnrollmentsTable() {
 
           if (row.original.type === "invitation") {
             const invitation = row.original;
-            const isExpired = invitation.expires_at && new Date(invitation.expires_at) < new Date();
-            const status = invitation.status === "pending" && isExpired ? "Expired" : invitation.status;
-            return values.includes(status.toLowerCase());
+            return values.includes(invitation.status.toLowerCase());
           }
           if (row.original.disabled) {
             return values.includes("dropped");
@@ -749,9 +740,7 @@ export default function EnrollmentsTable() {
         cell: ({ row }) => {
           if (row.original.type === "invitation") {
             const invitation = row.original;
-            const isPending = invitation.status === "pending";
-            const isExpired = invitation.expires_at && new Date(invitation.expires_at) < new Date();
-            const canCancel = isPending && !isExpired;
+            const canCancel = invitation.status === "pending";
 
             return (
               <HStack gap={2} justifyContent="center">
@@ -768,7 +757,7 @@ export default function EnrollmentsTable() {
                 )}
                 {!canCancel && (
                   <Text fontSize="sm" color="gray.500">
-                    {isExpired ? "Expired" : invitation.status}
+                    {invitation.status}
                   </Text>
                 )}
               </HStack>
@@ -996,9 +985,7 @@ export default function EnrollmentsTable() {
       // Get status
       let status = "Enrolled";
       if (original.type === "invitation") {
-        const invitation = original;
-        const isExpired = invitation.expires_at && new Date(invitation.expires_at) < new Date();
-        status = invitation.status === "pending" && isExpired ? "Expired" : invitation.status;
+        status = original.status;
       }
       if ("disabled" in original && original.disabled) {
         status = "Dropped";
@@ -1183,7 +1170,6 @@ export default function EnrollmentsTable() {
                                     { label: "Pending", value: "pending" },
                                     { label: "Accepted", value: "accepted" },
                                     { label: "Cancelled", value: "cancelled" },
-                                    { label: "Expired", value: "Expired" },
                                     { label: "Dropped", value: "Dropped" }
                                   ]}
                                   placeholder="Filter by status..."

--- a/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/enrollmentsTable.tsx
@@ -1168,7 +1168,6 @@ export default function EnrollmentsTable() {
                                   options={[
                                     { label: "Enrolled", value: "Enrolled" },
                                     { label: "Pending", value: "pending" },
-                                    { label: "Accepted", value: "accepted" },
                                     { label: "Cancelled", value: "cancelled" },
                                     { label: "Dropped", value: "Dropped" }
                                   ]}

--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -490,7 +490,6 @@ export type CreateInvitationResponse = {
     name?: string;
     status: string;
     created_at: string;
-    expires_at: string;
     class_section_id?: number;
     lab_section_id?: number;
   }>;

--- a/supabase/functions/_shared/InvitationUtils.ts
+++ b/supabase/functions/_shared/InvitationUtils.ts
@@ -32,7 +32,6 @@ export interface InvitationResult {
   name?: string;
   status: string;
   created_at: string;
-  expires_at: string;
   class_section_id?: number;
   lab_section_id?: number;
 }
@@ -246,7 +245,6 @@ async function processInvitation(
         name,
         status,
         created_at,
-        expires_at,
         class_section_id,
         lab_section_id
       `
@@ -288,7 +286,6 @@ async function processInvitation(
         name: createdInvitation.name || undefined,
         status: createdInvitation.status,
         created_at: createdInvitation.created_at,
-        expires_at: createdInvitation.expires_at || "",
         class_section_id: createdInvitation.class_section_id || undefined,
         lab_section_id: createdInvitation.lab_section_id || undefined
       }

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -5117,7 +5117,6 @@ export type Database = {
           class_section_id: number | null;
           created_at: string;
           email: string | null;
-          expires_at: string | null;
           id: number;
           invited_by: string | null;
           lab_section_id: number | null;
@@ -5137,7 +5136,6 @@ export type Database = {
           class_section_id?: number | null;
           created_at?: string;
           email?: string | null;
-          expires_at?: string | null;
           id?: number;
           invited_by?: string | null;
           lab_section_id?: number | null;
@@ -5157,7 +5155,6 @@ export type Database = {
           class_section_id?: number | null;
           created_at?: string;
           email?: string | null;
-          expires_at?: string | null;
           id?: number;
           invited_by?: string | null;
           lab_section_id?: number | null;
@@ -11169,7 +11166,7 @@ export type Database = {
         Returns: {
           class_id: number;
           class_name: string;
-          expired_invitations: number;
+          dropped_invitations: number;
           last_sync_message: string;
           last_sync_status: string;
           last_sync_time: string;
@@ -12356,6 +12353,10 @@ export type Database = {
       merge_class_feature_as_service_role: {
         Args: { p_class_id: number; p_enabled: boolean; p_name: string };
         Returns: undefined;
+      };
+      merge_duplicate_class_enrollments: {
+        Args: { p_class_id?: number };
+        Returns: number;
       };
       only_calendar_or_discord_ids_changed: {
         Args: { new_row: Database["public"]["Tables"]["classes"]["Row"] };

--- a/supabase/functions/course-import-sis/index.ts
+++ b/supabase/functions/course-import-sis/index.ts
@@ -12,11 +12,11 @@ import * as Sentry from "npm:@sentry/deno";
 type SISSycEnrollmentResult = {
   success: boolean;
   class_id: number;
-  expire_missing: boolean;
+  drop_missing: boolean;
   counts: {
     invitations_created: number;
     invitations_updated: number;
-    invitations_expired: number;
+    invitations_dropped: number;
     invitations_reactivated: number;
     enrollments_created: number;
     enrollments_updated: number;
@@ -781,7 +781,7 @@ export async function syncSISClasses(_supabase: SupabaseClient<Database>, classI
         p_class_id: classData.id,
         p_roster_data: rosterPayload,
         p_sync_options: {
-          expire_missing: true,
+          drop_missing: true,
           section_updates: sectionUpdates
         }
       });
@@ -792,13 +792,13 @@ export async function syncSISClasses(_supabase: SupabaseClient<Database>, classI
 
       const syncResult = syncData as unknown as SISSycEnrollmentResult;
       const newInvitationsCount = syncResult.counts.invitations_created;
-      const expiredInvitationsCount = syncResult.counts.invitations_expired;
+      const droppedInvitationsCount = syncResult.counts.invitations_dropped;
       const disabledUsersCount = syncResult.counts.enrollments_disabled;
       const reenabledUsersCount = syncResult.counts.enrollments_reenabled;
       const updatedMetadataCount = sectionUpdates.length;
 
       // Update sync status for all processed sections
-      const syncMessage = `Synced ${rosterResults.length} sections. New invitations: ${newInvitationsCount}, Expired: ${expiredInvitationsCount}, Re-enabled: ${reenabledUsersCount}`;
+      const syncMessage = `Synced ${rosterResults.length} sections. New invitations: ${newInvitationsCount}, Dropped: ${droppedInvitationsCount}, Re-enabled: ${reenabledUsersCount}`;
 
       // Update status for class sections
       for (const section of enabledClassSections) {
@@ -844,7 +844,7 @@ export async function syncSISClasses(_supabase: SupabaseClient<Database>, classI
           classId: classData.id,
           crnCount: rosterResults.length,
           newInvitations: newInvitationsCount,
-          expiredInvitations: expiredInvitationsCount,
+          droppedInvitations: droppedInvitationsCount,
           disabledUsers: disabledUsersCount,
           reenabledUsers: reenabledUsersCount,
           updatedMetadata: updatedMetadataCount

--- a/supabase/functions/invitation-create/index.ts
+++ b/supabase/functions/invitation-create/index.ts
@@ -19,7 +19,6 @@ interface CreateInvitationResponse {
     name?: string;
     status: string;
     created_at: string;
-    expires_at: string;
     class_section_id?: number;
     lab_section_id?: number;
   }>;

--- a/supabase/migrations/20260522120000_invitations_remove_expiry_rename_dropped.sql
+++ b/supabase/migrations/20260522120000_invitations_remove_expiry_rename_dropped.sql
@@ -1,0 +1,25 @@
+-- #322: Remove the time-based auto-expiry from invitations and rename the
+-- "expired" status to "dropped". After this migration:
+--   * invitations have no expires_at column and never auto-expire by age
+--   * status='dropped' means exactly "removed from the SIS roster"
+--     (previously this was overloaded onto the word "expired")
+--
+-- The function bodies that read expires_at / set status='expired' are redefined
+-- in a later migration in this same batch; plpgsql does not validate column
+-- references until execution, so dropping the column here is safe.
+
+-- 1) Drop the time-based expiry column and its index.
+DROP INDEX IF EXISTS public.idx_invitations_expires_at;
+ALTER TABLE public.invitations DROP COLUMN IF EXISTS expires_at;
+
+-- 2) Rename the status value 'expired' -> 'dropped'.
+--    Widen the CHECK first so the data UPDATE is legal, then migrate data.
+ALTER TABLE public.invitations DROP CONSTRAINT IF EXISTS invitations_status_check;
+ALTER TABLE public.invitations
+  ADD CONSTRAINT invitations_status_check
+  CHECK (status IN ('pending', 'accepted', 'dropped', 'cancelled'));
+
+UPDATE public.invitations SET status = 'dropped' WHERE status = 'expired';
+
+COMMENT ON COLUMN public.invitations.status IS
+  'Status of invitation: pending, accepted, dropped (removed from SIS roster), or cancelled';

--- a/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
+++ b/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
@@ -32,6 +32,25 @@ DECLARE
   v_best_role public.app_role;
   v_any_active boolean;
 BEGIN
+  -- Discover every profiles(id) foreign key once (the catalog does not change
+  -- mid-run), rather than re-querying information_schema for each losing row.
+  DROP TABLE IF EXISTS tmp_profile_fks;
+  CREATE TEMP TABLE tmp_profile_fks (table_schema text, table_name text, column_name text) ON COMMIT DROP;
+  INSERT INTO tmp_profile_fks (table_schema, table_name, column_name)
+  SELECT tc.table_schema, tc.table_name, kcu.column_name
+  FROM information_schema.table_constraints tc
+  JOIN information_schema.key_column_usage kcu
+    ON kcu.constraint_name = tc.constraint_name
+   AND kcu.constraint_schema = tc.constraint_schema
+  JOIN information_schema.constraint_column_usage ccu
+    ON ccu.constraint_name = tc.constraint_name
+   AND ccu.constraint_schema = tc.constraint_schema
+  WHERE tc.constraint_type = 'FOREIGN KEY'
+    AND ccu.table_schema = 'public'
+    AND ccu.table_name = 'profiles'
+    AND ccu.column_name = 'id'
+    AND NOT (tc.table_schema = 'public' AND tc.table_name = 'user_roles');
+
   FOR grp IN
     SELECT ur.user_id, ur.class_id
     FROM public.user_roles ur
@@ -70,20 +89,7 @@ BEGIN
       -- losing row we are about to delete) from the loser's profiles onto the
       -- canonical profiles. On a unique/FK collision the loser's row is redundant
       -- duplicate data, so we drop it instead.
-      FOR fk IN
-        SELECT tc.table_schema, tc.table_name, kcu.column_name
-        FROM information_schema.table_constraints tc
-        JOIN information_schema.key_column_usage kcu
-          ON kcu.constraint_name = tc.constraint_name
-         AND kcu.constraint_schema = tc.constraint_schema
-        JOIN information_schema.constraint_column_usage ccu
-          ON ccu.constraint_name = tc.constraint_name
-         AND ccu.constraint_schema = tc.constraint_schema
-        WHERE tc.constraint_type = 'FOREIGN KEY'
-          AND ccu.table_schema = 'public'
-          AND ccu.table_name = 'profiles'
-          AND ccu.column_name = 'id'
-          AND NOT (tc.table_schema = 'public' AND tc.table_name = 'user_roles')
+      FOR fk IN SELECT table_schema, table_name, column_name FROM tmp_profile_fks
       LOOP
         -- private profile references
         BEGIN
@@ -91,6 +97,8 @@ BEGIN
             fk.table_schema, fk.table_name, fk.column_name, fk.column_name)
           USING v_canon_private, loser.private_profile_id;
         EXCEPTION WHEN unique_violation OR foreign_key_violation THEN
+          RAISE NOTICE 'merge_duplicate_class_enrollments: dropping conflicting rows in %.% (%) referencing loser private profile %',
+            fk.table_schema, fk.table_name, fk.column_name, loser.private_profile_id;
           EXECUTE format('DELETE FROM %I.%I WHERE %I = $1',
             fk.table_schema, fk.table_name, fk.column_name)
           USING loser.private_profile_id;
@@ -102,6 +110,8 @@ BEGIN
             fk.table_schema, fk.table_name, fk.column_name, fk.column_name)
           USING v_canon_public, loser.public_profile_id;
         EXCEPTION WHEN unique_violation OR foreign_key_violation THEN
+          RAISE NOTICE 'merge_duplicate_class_enrollments: dropping conflicting rows in %.% (%) referencing loser public profile %',
+            fk.table_schema, fk.table_name, fk.column_name, loser.public_profile_id;
           EXECUTE format('DELETE FROM %I.%I WHERE %I = $1',
             fk.table_schema, fk.table_name, fk.column_name)
           USING loser.public_profile_id;

--- a/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
+++ b/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
@@ -1,0 +1,141 @@
+-- #390 / #387: A student must have at most one enrollment (and therefore one
+-- public+private profile pair) per class. Historically several code paths
+-- (the invitation-accept trigger, create_user_role_for_existing_user, and the
+-- auto-accept trigger's "create role" branch) could each mint a fresh profile
+-- pair for the same (user, class), producing duplicate rows in the gradebook.
+--
+-- This migration:
+--   1. Provides merge_duplicate_class_enrollments(): collapses duplicate
+--      (user_id, class_id) enrollments onto a single canonical row, repointing
+--      every profiles(id) foreign key from the losing profiles to the canonical
+--      ones, then deleting the losing enrollments and profiles.
+--   2. Runs it across all classes to clean up existing data.
+--   3. Adds a partial unique index so a second *active* enrollment for the same
+--      (user, class) can never be created again.
+--
+-- The function is idempotent: re-running it when no duplicates exist is a no-op.
+
+CREATE OR REPLACE FUNCTION public.merge_duplicate_class_enrollments(p_class_id bigint DEFAULT NULL)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_merged integer := 0;
+  grp RECORD;
+  loser RECORD;
+  fk RECORD;
+  v_canon_role_id bigint;
+  v_canon_private uuid;
+  v_canon_public uuid;
+  v_best_role public.app_role;
+  v_any_active boolean;
+BEGIN
+  FOR grp IN
+    SELECT ur.user_id, ur.class_id
+    FROM public.user_roles ur
+    WHERE p_class_id IS NULL OR ur.class_id = p_class_id
+    GROUP BY ur.user_id, ur.class_id
+    HAVING count(*) > 1
+  LOOP
+    -- Canonical row = the one whose private profile carries the most real data
+    -- (submissions), preferring active rows, then the oldest row.
+    SELECT ur.id, ur.private_profile_id, ur.public_profile_id
+      INTO v_canon_role_id, v_canon_private, v_canon_public
+    FROM public.user_roles ur
+    WHERE ur.user_id = grp.user_id AND ur.class_id = grp.class_id
+    ORDER BY
+      (SELECT count(*) FROM public.submissions s WHERE s.profile_id = ur.private_profile_id) DESC,
+      COALESCE(ur.disabled, false) ASC,
+      ur.id ASC
+    LIMIT 1;
+
+    -- Strongest role and whether any duplicate was active: the survivor adopts both.
+    SELECT
+      (ARRAY_AGG(ur.role ORDER BY
+        CASE ur.role WHEN 'instructor' THEN 3 WHEN 'grader' THEN 2 ELSE 1 END DESC))[1],
+      bool_or(NOT COALESCE(ur.disabled, false))
+      INTO v_best_role, v_any_active
+    FROM public.user_roles ur
+    WHERE ur.user_id = grp.user_id AND ur.class_id = grp.class_id;
+
+    FOR loser IN
+      SELECT ur.id, ur.private_profile_id, ur.public_profile_id
+      FROM public.user_roles ur
+      WHERE ur.user_id = grp.user_id AND ur.class_id = grp.class_id
+        AND ur.id <> v_canon_role_id
+    LOOP
+      -- Repoint every profiles(id) foreign key (except user_roles itself, whose
+      -- losing row we are about to delete) from the loser's profiles onto the
+      -- canonical profiles. On a unique/FK collision the loser's row is redundant
+      -- duplicate data, so we drop it instead.
+      FOR fk IN
+        SELECT tc.table_schema, tc.table_name, kcu.column_name
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+          ON kcu.constraint_name = tc.constraint_name
+         AND kcu.constraint_schema = tc.constraint_schema
+        JOIN information_schema.constraint_column_usage ccu
+          ON ccu.constraint_name = tc.constraint_name
+         AND ccu.constraint_schema = tc.constraint_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND ccu.table_schema = 'public'
+          AND ccu.table_name = 'profiles'
+          AND ccu.column_name = 'id'
+          AND NOT (tc.table_schema = 'public' AND tc.table_name = 'user_roles')
+      LOOP
+        -- private profile references
+        BEGIN
+          EXECUTE format('UPDATE %I.%I SET %I = $1 WHERE %I = $2',
+            fk.table_schema, fk.table_name, fk.column_name, fk.column_name)
+          USING v_canon_private, loser.private_profile_id;
+        EXCEPTION WHEN unique_violation OR foreign_key_violation THEN
+          EXECUTE format('DELETE FROM %I.%I WHERE %I = $1',
+            fk.table_schema, fk.table_name, fk.column_name)
+          USING loser.private_profile_id;
+        END;
+
+        -- public profile references
+        BEGIN
+          EXECUTE format('UPDATE %I.%I SET %I = $1 WHERE %I = $2',
+            fk.table_schema, fk.table_name, fk.column_name, fk.column_name)
+          USING v_canon_public, loser.public_profile_id;
+        EXCEPTION WHEN unique_violation OR foreign_key_violation THEN
+          EXECUTE format('DELETE FROM %I.%I WHERE %I = $1',
+            fk.table_schema, fk.table_name, fk.column_name)
+          USING loser.public_profile_id;
+        END;
+      END LOOP;
+
+      DELETE FROM public.user_roles WHERE id = loser.id;
+      DELETE FROM public.profiles WHERE id IN (loser.private_profile_id, loser.public_profile_id);
+
+      v_merged := v_merged + 1;
+    END LOOP;
+
+    -- Survivor adopts the strongest role and stays active if any duplicate was.
+    UPDATE public.user_roles
+    SET role = v_best_role,
+        disabled = CASE WHEN v_any_active THEN false ELSE disabled END
+    WHERE id = v_canon_role_id;
+  END LOOP;
+
+  RETURN v_merged;
+END;
+$$;
+
+COMMENT ON FUNCTION public.merge_duplicate_class_enrollments(bigint) IS
+  'Collapses duplicate (user_id, class_id) enrollments onto one canonical profile pair, repointing all profiles(id) FKs. Idempotent. Pass a class_id to scope, or NULL for all classes.';
+
+REVOKE ALL ON FUNCTION public.merge_duplicate_class_enrollments(bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.merge_duplicate_class_enrollments(bigint) TO postgres;
+GRANT EXECUTE ON FUNCTION public.merge_duplicate_class_enrollments(bigint) TO service_role;
+
+-- Clean up existing duplicates before enforcing the invariant.
+SELECT public.merge_duplicate_class_enrollments(NULL);
+
+-- Enforce: at most one active enrollment per (user, class) going forward.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_one_active_per_class
+  ON public.user_roles (user_id, class_id)
+  WHERE disabled = false;

--- a/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
+++ b/supabase/migrations/20260522120001_dedupe_enrollment_profiles.sql
@@ -5,15 +5,19 @@
 -- pair for the same (user, class), producing duplicate rows in the gradebook.
 --
 -- This migration:
---   1. Provides merge_duplicate_class_enrollments(): collapses duplicate
---      (user_id, class_id) enrollments onto a single canonical row, repointing
---      every profiles(id) foreign key from the losing profiles to the canonical
---      ones, then deleting the losing enrollments and profiles.
---   2. Runs it across all classes to clean up existing data.
---   3. Adds a partial unique index so a second *active* enrollment for the same
+--   1. Adds a partial unique index so a second *active* enrollment for the same
 --      (user, class) can never be created again.
+--   2. Provides merge_duplicate_class_enrollments() as an OPT-IN manual cleanup
+--      tool: it collapses duplicate (user_id, class_id) enrollments onto a single
+--      canonical row, repointing every profiles(id) foreign key from the losing
+--      profiles to the canonical ones, then deleting the losing enrollments and
+--      profiles. It is NOT run automatically -- existing records are left as-is.
+--      Run `SELECT public.merge_duplicate_class_enrollments(<class_id>);` (or NULL
+--      for all classes) by hand if duplicates ever need collapsing.
 --
 -- The function is idempotent: re-running it when no duplicates exist is a no-op.
+-- Note: this only handles same-account (user_id, class_id) duplicates; duplicates
+-- spread across two separate accounts for one person are not touched.
 
 CREATE OR REPLACE FUNCTION public.merge_duplicate_class_enrollments(p_class_id bigint DEFAULT NULL)
 RETURNS integer
@@ -142,10 +146,9 @@ REVOKE ALL ON FUNCTION public.merge_duplicate_class_enrollments(bigint) FROM PUB
 GRANT EXECUTE ON FUNCTION public.merge_duplicate_class_enrollments(bigint) TO postgres;
 GRANT EXECUTE ON FUNCTION public.merge_duplicate_class_enrollments(bigint) TO service_role;
 
--- Clean up existing duplicates before enforcing the invariant.
-SELECT public.merge_duplicate_class_enrollments(NULL);
-
 -- Enforce: at most one active enrollment per (user, class) going forward.
+-- Existing data already satisfies this (no duplicate active (user, class) pairs),
+-- so no backfill is run; the merge function above is available for manual use.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_user_roles_one_active_per_class
   ON public.user_roles (user_id, class_id)
   WHERE disabled = false;

--- a/supabase/migrations/20260522120002_invitation_enrollment_functions.sql
+++ b/supabase/migrations/20260522120002_invitation_enrollment_functions.sql
@@ -1,0 +1,736 @@
+-- Redefine the invitation/enrollment functions to their final form for #322 and #390:
+--   * No invitation expires_at / time-based expiry anywhere.
+--   * status 'expired' is renamed to 'dropped' (drop-from-roster) throughout.
+--   * Every code path that materialises an enrollment reuses the existing
+--     (user, class) profile pair instead of minting a new one, so a student can
+--     never end up with two profiles (two gradebook rows) in one class. This is
+--     backed by idx_user_roles_one_active_per_class.
+
+-- =============================================================================
+-- create_invitation: no expires_at; reuse an already-enrolled user's profiles.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.create_invitation(
+  p_class_id bigint,
+  p_role public.app_role,
+  p_sis_user_id integer,
+  p_email text DEFAULT NULL,
+  p_name text DEFAULT NULL,
+  p_invited_by uuid DEFAULT auth.uid(),
+  p_class_section_id bigint DEFAULT NULL,
+  p_lab_section_id bigint DEFAULT NULL,
+  p_sis_managed boolean DEFAULT true
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_public_profile_id uuid;
+    v_private_profile_id uuid;
+    v_invitation_id bigint;
+    v_display_name text;
+    v_adjective text;
+    v_noun text;
+    v_number integer;
+    v_public_name text;
+BEGIN
+    IF NOT (public.authorizeforclassinstructor(p_class_id) OR public.authorize_for_admin()) THEN
+        RAISE EXCEPTION 'Only instructors or admins can create invitations for this class';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM public.invitations
+        WHERE class_id = p_class_id AND sis_user_id = p_sis_user_id AND status = 'pending'
+    ) THEN
+        RAISE EXCEPTION 'Invitation already exists for this user in this class';
+    END IF;
+
+    v_display_name := COALESCE(p_name, split_part(p_email, '@', 1), p_sis_user_id::text);
+
+    -- If this SIS user is already enrolled in the class, reuse that enrollment's
+    -- profile pair so the invitation does not create a duplicate profile (#390).
+    SELECT ur.public_profile_id, ur.private_profile_id
+      INTO v_public_profile_id, v_private_profile_id
+    FROM public.user_roles ur
+    JOIN public.users u ON u.user_id = ur.user_id
+    WHERE u.sis_user_id = p_sis_user_id
+      AND ur.class_id = p_class_id
+    LIMIT 1;
+
+    IF v_private_profile_id IS NULL THEN
+        -- Generate a collision-resistant random name for the public profile.
+        DECLARE
+            v_attempts integer := 0;
+            v_exists boolean := true;
+        BEGIN
+            WHILE v_attempts < 20 LOOP
+                SELECT word INTO v_adjective FROM public.name_generation_words
+                WHERE is_adjective = true ORDER BY random() LIMIT 1;
+                SELECT word INTO v_noun FROM public.name_generation_words
+                WHERE is_noun = true ORDER BY random() LIMIT 1;
+                v_number := floor(random() * 1000)::integer;
+                v_public_name := COALESCE(v_adjective, 'random') || '-' || COALESCE(v_noun, 'user') || '-' || v_number;
+                SELECT EXISTS (
+                    SELECT 1 FROM public.profiles WHERE class_id = p_class_id AND name = v_public_name
+                ) INTO v_exists;
+                IF NOT v_exists THEN EXIT; END IF;
+                v_attempts := v_attempts + 1;
+            END LOOP;
+            IF v_exists THEN
+                v_public_name := v_public_name || '-' || substr(md5(random()::text || clock_timestamp()::text), 1, 6);
+            END IF;
+        END;
+
+        INSERT INTO public.profiles (name, class_id, is_private_profile)
+        VALUES (v_public_name, p_class_id, false)
+        RETURNING id INTO v_public_profile_id;
+
+        INSERT INTO public.profiles (name, class_id, is_private_profile)
+        VALUES (v_display_name, p_class_id, true)
+        RETURNING id INTO v_private_profile_id;
+    END IF;
+
+    INSERT INTO public.invitations (
+        class_id, role, sis_user_id, email, name,
+        public_profile_id, private_profile_id, invited_by,
+        class_section_id, lab_section_id, sis_managed, status,
+        created_at, updated_at
+    ) VALUES (
+        p_class_id, p_role, p_sis_user_id, p_email, p_name,
+        v_public_profile_id, v_private_profile_id, p_invited_by,
+        p_class_section_id, p_lab_section_id, p_sis_managed, 'pending',
+        NOW(), NOW()
+    ) RETURNING id INTO v_invitation_id;
+
+    RETURN v_invitation_id;
+END;
+$$;
+
+-- =============================================================================
+-- create_user_role_for_existing_user: reuse the existing (user, class)
+-- enrollment + profiles if present (reactivating it) instead of creating a
+-- second profile pair.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.create_user_role_for_existing_user(
+    p_user_id uuid,
+    p_class_id bigint,
+    p_role public.app_role,
+    p_name text,
+    p_sis_id integer DEFAULT NULL
+) RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    v_user_role_id bigint;
+    v_existing_role_id bigint;
+    v_private_profile_id uuid;
+    v_public_profile_id uuid;
+    v_user_name text;
+    v_avatar_url text;
+    v_public_name text;
+    v_adjective text;
+    v_noun text;
+    v_number integer;
+    v_secure_seed text;
+BEGIN
+    IF NOT (authorize_for_admin() OR authorizeforclassinstructor(p_class_id)) THEN
+        RAISE EXCEPTION 'Access denied: Instructor or admin role required';
+    END IF;
+
+    SELECT name INTO v_user_name FROM public.users WHERE user_id = p_user_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'User with ID % not found', p_user_id;
+    END IF;
+    v_user_name := COALESCE(p_name, v_user_name, 'Unknown User');
+
+    -- Reuse an existing enrollment for this (user, class) rather than creating a
+    -- duplicate profile pair (#390). Reactivate it if it was disabled.
+    SELECT id INTO v_existing_role_id
+    FROM public.user_roles
+    WHERE user_id = p_user_id AND class_id = p_class_id
+    LIMIT 1;
+
+    IF v_existing_role_id IS NOT NULL THEN
+        UPDATE public.user_roles SET disabled = false WHERE id = v_existing_role_id;
+        RETURN v_existing_role_id;
+    END IF;
+
+    BEGIN
+        v_secure_seed := encode(digest(p_user_id::text || 'pawtograder_avatar_salt_2024', 'sha256'), 'hex');
+    EXCEPTION WHEN undefined_function THEN
+        v_secure_seed := md5(p_user_id::text || 'pawtograder_avatar_salt_2024');
+    END;
+
+    v_avatar_url := COALESCE(
+        (SELECT avatar_url FROM public.users WHERE user_id = p_user_id),
+        'https://api.dicebear.com/9.x/initials/svg?seed=' || v_secure_seed
+    );
+
+    INSERT INTO public.profiles (name, avatar_url, class_id, is_private_profile)
+    VALUES (v_user_name, v_avatar_url, p_class_id, true)
+    RETURNING id INTO v_private_profile_id;
+
+    SELECT word INTO v_adjective FROM public.name_generation_words
+    WHERE is_adjective = true ORDER BY random() LIMIT 1;
+    SELECT word INTO v_noun FROM public.name_generation_words
+    WHERE is_noun = true ORDER BY random() LIMIT 1;
+    v_number := floor(random() * 1000)::integer;
+    v_public_name := COALESCE(v_adjective, 'random') || '-' || COALESCE(v_noun, 'user') || '-' || v_number;
+
+    INSERT INTO public.profiles (name, avatar_url, class_id, is_private_profile)
+    VALUES (
+        v_public_name,
+        'https://api.dicebear.com/9.x/identicon/svg?seed=' || v_secure_seed,
+        p_class_id,
+        false
+    )
+    RETURNING id INTO v_public_profile_id;
+
+    INSERT INTO public.user_roles (
+        user_id, class_id, role, canvas_id,
+        private_profile_id, public_profile_id, disabled
+    )
+    VALUES (
+        p_user_id, p_class_id, p_role, p_sis_id,
+        v_private_profile_id, v_public_profile_id, false
+    )
+    RETURNING id INTO v_user_role_id;
+
+    RETURN v_user_role_id;
+END;
+$$;
+
+-- =============================================================================
+-- handle_user_sis_id_update: drop the expires_at gates (no time-based expiry).
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.handle_user_sis_id_update()
+RETURNS TRIGGER AS $$
+BEGIN
+    SET LOCAL search_path = pg_catalog, public;
+
+    IF OLD.sis_user_id IS NULL AND NEW.sis_user_id IS NOT NULL THEN
+        INSERT INTO public.user_roles (
+            user_id, class_id, role,
+            public_profile_id, private_profile_id, invitation_id,
+            class_section_id, lab_section_id, disabled, canvas_id
+        )
+        SELECT
+            NEW.user_id, i.class_id, i.role,
+            i.public_profile_id, i.private_profile_id, i.id,
+            i.class_section_id, i.lab_section_id, false, NEW.sis_user_id::numeric
+        FROM public.invitations i
+        WHERE i.sis_user_id = NEW.sis_user_id
+          AND i.status = 'pending'
+          AND NOT EXISTS (
+              SELECT 1 FROM public.user_roles ur
+              WHERE ur.user_id = NEW.user_id AND ur.class_id = i.class_id
+          );
+
+        UPDATE public.user_roles
+        SET
+            role = CASE
+                WHEN i.role = 'instructor' THEN 'instructor'
+                WHEN i.role = 'grader' AND user_roles.role != 'instructor' THEN 'grader'
+                ELSE user_roles.role
+            END,
+            invitation_id = i.id,
+            class_section_id = i.class_section_id,
+            lab_section_id = i.lab_section_id,
+            disabled = false,
+            canvas_id = NEW.sis_user_id::numeric
+        FROM public.invitations i
+        WHERE user_roles.user_id = NEW.user_id
+          AND user_roles.class_id = i.class_id
+          AND i.sis_user_id = NEW.sis_user_id
+          AND i.status = 'pending'
+          AND (i.role = 'instructor' OR (i.role = 'grader' AND user_roles.role = 'student'));
+
+        UPDATE public.invitations
+        SET status = 'accepted', accepted_at = NOW(), updated_at = NOW()
+        WHERE sis_user_id = NEW.sis_user_id
+          AND status = 'pending';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================================================
+-- auto_accept_invitation_if_user_exists: when the user already has ANY
+-- enrollment in the class, upgrade/refresh that one row instead of inserting a
+-- second (which would create a duplicate profile and now also violate
+-- idx_user_roles_one_active_per_class).
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.auto_accept_invitation_if_user_exists()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_existing_role_id bigint;
+  v_existing_role public.app_role;
+  v_new_role public.app_role;
+BEGIN
+  IF NEW.status = 'pending' AND NEW.sis_user_id IS NOT NULL THEN
+    SELECT u.user_id INTO v_user_id
+    FROM public.users u
+    WHERE u.sis_user_id = NEW.sis_user_id;
+
+    IF v_user_id IS NOT NULL THEN
+      -- Match on (user, class) only -- never create a second enrollment for the
+      -- same user in the same class regardless of role.
+      SELECT ur.id, ur.role INTO v_existing_role_id, v_existing_role
+      FROM public.user_roles ur
+      WHERE ur.user_id = v_user_id
+        AND ur.class_id = NEW.class_id
+      ORDER BY COALESCE(ur.disabled, false) ASC, ur.id ASC
+      LIMIT 1;
+
+      IF v_existing_role_id IS NOT NULL THEN
+        -- Upgrade role (never downgrade), refresh sections, reactivate, link.
+        v_new_role := CASE
+          WHEN v_existing_role = 'instructor' OR NEW.role = 'instructor' THEN 'instructor'
+          WHEN v_existing_role = 'grader' OR NEW.role = 'grader' THEN 'grader'
+          ELSE 'student'
+        END;
+
+        UPDATE public.user_roles
+        SET class_section_id = NEW.class_section_id,
+            lab_section_id = NEW.lab_section_id,
+            invitation_id = NEW.id,
+            role = v_new_role,
+            disabled = false
+        WHERE id = v_existing_role_id;
+      ELSE
+        INSERT INTO public.user_roles (
+          user_id, class_id, role,
+          public_profile_id, private_profile_id,
+          class_section_id, lab_section_id,
+          disabled, invitation_date, invitation_id
+        ) VALUES (
+          v_user_id, NEW.class_id, NEW.role,
+          NEW.public_profile_id, NEW.private_profile_id,
+          NEW.class_section_id, NEW.lab_section_id,
+          false, null, NEW.id
+        );
+      END IF;
+
+      UPDATE public.invitations
+      SET status = 'accepted', accepted_at = NOW(), updated_at = NOW()
+      WHERE id = NEW.id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Reactivation trigger now fires on 'dropped' -> 'pending' (was 'expired').
+DROP TRIGGER IF EXISTS trigger_auto_accept_invitation_on_reactivation ON public.invitations;
+CREATE TRIGGER trigger_auto_accept_invitation_on_reactivation
+AFTER UPDATE ON public.invitations
+FOR EACH ROW
+WHEN (OLD.status = 'dropped' AND NEW.status = 'pending')
+EXECUTE FUNCTION public.auto_accept_invitation_if_user_exists();
+
+-- =============================================================================
+-- admin_get_sis_sync_status: rename expired_invitations -> dropped_invitations.
+-- Renaming a RETURNS TABLE output column requires dropping the function first.
+-- =============================================================================
+DROP FUNCTION IF EXISTS public.admin_get_sis_sync_status();
+CREATE OR REPLACE FUNCTION public.admin_get_sis_sync_status()
+RETURNS TABLE("class_id" bigint, "class_name" text, "term" integer, "sis_sections_count" bigint, "last_sync_time" timestamp with time zone, "last_sync_status" text, "last_sync_message" text, "sync_enabled" boolean, "total_invitations" bigint, "pending_invitations" bigint, "dropped_invitations" bigint)
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF NOT authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        c.id as class_id,
+        c.name as class_name,
+        c.term,
+        sync_summary.sis_sections_count,
+        sync_summary.last_sync_time,
+        sync_summary.last_sync_status,
+        sync_summary.last_sync_message,
+        COALESCE(sync_summary.sync_enabled, false) as sync_enabled,
+        COALESCE(invite_stats.total_invitations, 0) as total_invitations,
+        COALESCE(invite_stats.pending_invitations, 0) as pending_invitations,
+        COALESCE(invite_stats.dropped_invitations, 0) as dropped_invitations
+    FROM public.classes c
+    LEFT JOIN (
+        SELECT
+            invitations.class_id,
+            COUNT(*) as total_invitations,
+            COUNT(*) FILTER (WHERE invitations.status = 'pending') as pending_invitations,
+            COUNT(*) FILTER (WHERE invitations.status = 'dropped') as dropped_invitations
+        FROM public.invitations
+        GROUP BY invitations.class_id
+    ) invite_stats ON c.id = invite_stats.class_id
+    LEFT JOIN (
+        SELECT
+            sss.course_id,
+            COUNT(*) as sis_sections_count,
+            MAX(sss.last_sync_time) as last_sync_time,
+            (SELECT sss2.last_sync_status FROM public.sis_sync_status sss2
+             WHERE sss2.course_id = sss.course_id
+             ORDER BY sss2.last_sync_time DESC NULLS LAST LIMIT 1) as last_sync_status,
+            (SELECT sss2.last_sync_message FROM public.sis_sync_status sss2
+             WHERE sss2.course_id = sss.course_id
+             ORDER BY sss2.last_sync_time DESC NULLS LAST LIMIT 1) as last_sync_message,
+            (BOOL_OR(sss.sync_enabled) AND NOT COALESCE(c_inner.archived, false)) as sync_enabled
+        FROM public.sis_sync_status sss
+        INNER JOIN public.classes c_inner ON c_inner.id = sss.course_id
+        GROUP BY sss.course_id, c_inner.archived
+    ) sync_summary ON c.id = sync_summary.course_id
+    WHERE sync_summary.course_id IS NOT NULL
+    ORDER BY c.term DESC, c.name;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.admin_get_sis_sync_status() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.admin_get_sis_sync_status() TO service_role;
+
+-- =============================================================================
+-- sis_sync_enrollment: rename expire_missing -> drop_missing and the 'expired'
+-- status / invitations_expired count -> 'dropped' / invitations_dropped.
+-- (Functionally identical to the prior version otherwise.)
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.sis_sync_enrollment(p_class_id bigint, p_roster_data jsonb, p_sync_options jsonb DEFAULT '{}'::jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public'
+AS $$
+DECLARE
+  v_result jsonb;
+  v_drop_missing boolean := COALESCE((p_sync_options ->> 'drop_missing')::boolean, true);
+  v_admin_user_id uuid;
+  v_section_updates jsonb := COALESCE(p_sync_options -> 'section_updates', '[]'::jsonb);
+  v_invitations_dropped integer := 0;
+  v_enrollments_disabled integer := 0;
+  v_enrollments_reenabled integer := 0;
+  v_rows integer := 0;
+BEGIN
+  IF NOT (public.authorizeforclassinstructor(p_class_id) OR public.authorize_for_admin()) THEN
+    RAISE EXCEPTION 'Access denied: instructor or admin required';
+  END IF;
+
+  SELECT ur.user_id INTO v_admin_user_id
+  FROM public.user_roles ur
+  WHERE ur.role = 'admin' AND COALESCE(ur.disabled, false) = false
+  ORDER BY ur.id ASC LIMIT 1;
+
+  IF v_admin_user_id IS NULL THEN
+    SELECT u.user_id INTO v_admin_user_id
+    FROM public.users u WHERE u.email = 'system@example.com' LIMIT 1;
+    IF v_admin_user_id IS NULL THEN
+      INSERT INTO public.users (user_id, email, name)
+      VALUES (md5(random()::text || clock_timestamp()::text)::uuid, 'system@example.com', 'System')
+      RETURNING user_id INTO v_admin_user_id;
+    END IF;
+  END IF;
+
+  CREATE TEMP TABLE tmp_sis_roster (
+    sis_user_id integer NOT NULL, name text, role public.app_role NOT NULL,
+    class_section_crn integer, lab_section_crn integer
+  ) ON COMMIT DROP;
+
+  INSERT INTO tmp_sis_roster (sis_user_id, name, role, class_section_crn, lab_section_crn)
+  SELECT (r.sis_user_id)::integer, NULLIF(btrim(r.name), ''), (r.role)::public.app_role,
+    NULLIF((r.class_section_crn)::text, '')::integer, NULLIF((r.lab_section_crn)::text, '')::integer
+  FROM jsonb_to_recordset(COALESCE(p_roster_data, '[]'::jsonb)) AS r(
+    sis_user_id integer, name text, role text, class_section_crn integer, lab_section_crn integer
+  );
+
+  CREATE TEMP TABLE tmp_enabled_class_sections (id bigint PRIMARY KEY) ON COMMIT DROP;
+  CREATE TEMP TABLE tmp_enabled_lab_sections (id bigint PRIMARY KEY) ON COMMIT DROP;
+
+  INSERT INTO tmp_enabled_class_sections (id)
+  SELECT cs.id FROM public.class_sections cs
+  WHERE cs.class_id = p_class_id AND cs.sis_crn IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.sis_sync_status sss
+      WHERE sss.course_id = p_class_id AND sss.course_section_id = cs.id AND sss.sync_enabled = false
+    );
+
+  INSERT INTO tmp_enabled_lab_sections (id)
+  SELECT ls.id FROM public.lab_sections ls
+  WHERE ls.class_id = p_class_id AND ls.sis_crn IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM public.sis_sync_status sss
+      WHERE sss.course_id = p_class_id AND sss.lab_section_id = ls.id AND sss.sync_enabled = false
+    );
+
+  CREATE TEMP TABLE tmp_sis_roster_resolved (
+    sis_user_id integer PRIMARY KEY, name text, role public.app_role NOT NULL,
+    class_section_id bigint, lab_section_id bigint
+  ) ON COMMIT DROP;
+
+  INSERT INTO tmp_sis_roster_resolved (sis_user_id, name, role, class_section_id, lab_section_id)
+  SELECT r.sis_user_id, r.name, r.role, cs.id, ls.id
+  FROM tmp_sis_roster r
+  LEFT JOIN public.class_sections cs ON cs.class_id = p_class_id AND cs.sis_crn = r.class_section_crn
+  LEFT JOIN public.lab_sections ls ON ls.class_id = p_class_id AND ls.sis_crn = r.lab_section_crn;
+
+  IF jsonb_typeof(v_section_updates) = 'array' AND jsonb_array_length(v_section_updates) > 0 THEN
+    CREATE TEMP TABLE tmp_section_updates (
+      section_type text NOT NULL, sis_crn integer NOT NULL, meeting_location text, meeting_times text,
+      campus text, day_of_week public.day_of_week, start_time time, end_time time
+    ) ON COMMIT DROP;
+
+    INSERT INTO tmp_section_updates(section_type, sis_crn, meeting_location, meeting_times, campus, day_of_week, start_time, end_time)
+    SELECT u.section_type, (u.sis_crn)::integer, u.meeting_location, u.meeting_times, u.campus,
+      NULLIF(u.day_of_week, '')::public.day_of_week, NULLIF(u.start_time, '')::time, NULLIF(u.end_time, '')::time
+    FROM jsonb_to_recordset(v_section_updates) AS u(
+      section_type text, sis_crn integer, meeting_location text, meeting_times text,
+      campus text, day_of_week text, start_time text, end_time text
+    );
+
+    UPDATE public.class_sections cs
+    SET meeting_location = COALESCE(u.meeting_location, cs.meeting_location),
+        meeting_times = COALESCE(u.meeting_times, cs.meeting_times),
+        campus = COALESCE(u.campus, cs.campus)
+    FROM tmp_section_updates u
+    WHERE u.section_type = 'class' AND cs.class_id = p_class_id AND cs.sis_crn = u.sis_crn
+      AND cs.id IN (SELECT id FROM tmp_enabled_class_sections)
+      AND (
+        cs.meeting_location IS DISTINCT FROM COALESCE(u.meeting_location, cs.meeting_location)
+        OR cs.meeting_times IS DISTINCT FROM COALESCE(u.meeting_times, cs.meeting_times)
+        OR cs.campus IS DISTINCT FROM COALESCE(u.campus, cs.campus)
+      );
+
+    UPDATE public.lab_sections ls
+    SET meeting_location = COALESCE(u.meeting_location, ls.meeting_location),
+        meeting_times = COALESCE(u.meeting_times, ls.meeting_times),
+        campus = COALESCE(u.campus, ls.campus),
+        day_of_week = COALESCE(u.day_of_week, ls.day_of_week),
+        start_time = COALESCE(u.start_time, ls.start_time),
+        end_time = COALESCE(u.end_time, ls.end_time)
+    FROM tmp_section_updates u
+    WHERE u.section_type = 'lab' AND ls.class_id = p_class_id AND ls.sis_crn = u.sis_crn
+      AND ls.id IN (SELECT id FROM tmp_enabled_lab_sections)
+      AND (
+        ls.meeting_location IS DISTINCT FROM COALESCE(u.meeting_location, ls.meeting_location)
+        OR ls.meeting_times IS DISTINCT FROM COALESCE(u.meeting_times, ls.meeting_times)
+        OR ls.campus IS DISTINCT FROM COALESCE(u.campus, ls.campus)
+        OR ls.day_of_week IS DISTINCT FROM COALESCE(u.day_of_week, ls.day_of_week)
+        OR ls.start_time IS DISTINCT FROM COALESCE(u.start_time, ls.start_time)
+        OR ls.end_time IS DISTINCT FROM COALESCE(u.end_time, ls.end_time)
+      );
+  END IF;
+
+  CREATE TEMP TABLE tmp_change_counts (
+    invitations_created integer NOT NULL DEFAULT 0,
+    invitations_updated integer NOT NULL DEFAULT 0,
+    invitations_dropped integer NOT NULL DEFAULT 0,
+    invitations_reactivated integer NOT NULL DEFAULT 0,
+    enrollments_created integer NOT NULL DEFAULT 0,
+    enrollments_updated integer NOT NULL DEFAULT 0,
+    enrollments_disabled integer NOT NULL DEFAULT 0,
+    enrollments_reenabled integer NOT NULL DEFAULT 0,
+    enrollments_adopted integer NOT NULL DEFAULT 0
+  ) ON COMMIT DROP;
+  INSERT INTO tmp_change_counts DEFAULT VALUES;
+
+  DECLARE
+    rec RECORD;
+    v_user_role_id bigint;
+    v_new_role public.app_role;
+    v_current_prec integer;
+    v_incoming_prec integer;
+    v_is_manual boolean;
+    v_existing_inv public.invitations%ROWTYPE;
+    v_inv_id bigint;
+  BEGIN
+    -- 2) Enroll existing users (no current user_role) directly and set sections
+    FOR rec IN
+      SELECT r.sis_user_id, r.name, r.role, r.class_section_id, r.lab_section_id, u.user_id AS existing_user_id
+      FROM tmp_sis_roster_resolved r
+      JOIN public.users u ON u.sis_user_id = r.sis_user_id
+      LEFT JOIN public.user_roles ur ON ur.class_id = p_class_id AND ur.user_id = u.user_id
+      WHERE ur.id IS NULL
+    LOOP
+      v_user_role_id := public.create_user_role_for_existing_user(
+        rec.existing_user_id, p_class_id, rec.role, rec.name, rec.sis_user_id
+      );
+
+      UPDATE public.user_roles
+      SET class_section_id = rec.class_section_id, lab_section_id = rec.lab_section_id,
+          disabled = false, sis_sync_opt_out = false
+      WHERE id = v_user_role_id;
+
+      UPDATE tmp_change_counts SET enrollments_created = enrollments_created + 1 WHERE true;
+
+      UPDATE public.invitations
+      SET status = 'accepted', accepted_at = COALESCE(accepted_at, now()), updated_at = now()
+      WHERE class_id = p_class_id AND sis_user_id = rec.sis_user_id
+        AND status IN ('pending', 'dropped');
+    END LOOP;
+
+    -- 3) Update existing enrollments for users present in roster
+    FOR rec IN
+      SELECT r.sis_user_id, r.name, r.role AS incoming_role,
+        r.class_section_id AS incoming_class_section_id, r.lab_section_id AS incoming_lab_section_id,
+        u.user_id, u.sis_user_id AS users_sis_user_id, ur.id AS user_role_id,
+        ur.role AS current_role, ur.disabled, ur.canvas_id,
+        COALESCE(ur.sis_sync_opt_out, false) AS sis_sync_opt_out
+      FROM tmp_sis_roster_resolved r
+      JOIN public.users u ON u.sis_user_id = r.sis_user_id
+      JOIN public.user_roles ur ON ur.class_id = p_class_id AND ur.user_id = u.user_id
+    LOOP
+      IF rec.sis_sync_opt_out THEN CONTINUE; END IF;
+
+      v_is_manual := rec.canvas_id IS NULL;
+      v_current_prec := CASE rec.current_role WHEN 'instructor' THEN 3 WHEN 'grader' THEN 2 ELSE 1 END;
+      v_incoming_prec := CASE rec.incoming_role WHEN 'instructor' THEN 3 WHEN 'grader' THEN 2 ELSE 1 END;
+      v_new_role := CASE WHEN v_incoming_prec > v_current_prec THEN rec.incoming_role ELSE rec.current_role END;
+
+      IF v_is_manual THEN
+        UPDATE public.user_roles
+        SET canvas_id = rec.sis_user_id::numeric, role = v_new_role,
+            class_section_id = rec.incoming_class_section_id, lab_section_id = rec.incoming_lab_section_id,
+            disabled = false
+        WHERE id = rec.user_role_id;
+        UPDATE tmp_change_counts SET enrollments_adopted = enrollments_adopted + 1 WHERE true;
+      ELSE
+        UPDATE public.user_roles
+        SET role = v_new_role, class_section_id = rec.incoming_class_section_id,
+            lab_section_id = rec.incoming_lab_section_id, disabled = false
+        WHERE id = rec.user_role_id
+          AND (
+            role IS DISTINCT FROM v_new_role OR
+            class_section_id IS DISTINCT FROM rec.incoming_class_section_id OR
+            lab_section_id IS DISTINCT FROM rec.incoming_lab_section_id OR
+            disabled = true
+          );
+        GET DIAGNOSTICS v_rows = ROW_COUNT;
+        IF v_rows > 0 THEN
+          UPDATE tmp_change_counts SET enrollments_updated = enrollments_updated + 1 WHERE true;
+        END IF;
+      END IF;
+
+      IF rec.disabled = true THEN
+        v_enrollments_reenabled := v_enrollments_reenabled + 1;
+      END IF;
+
+      UPDATE public.invitations i
+      SET sis_managed = true, role = v_new_role,
+          class_section_id = rec.incoming_class_section_id, lab_section_id = rec.incoming_lab_section_id,
+          status = CASE WHEN i.status = 'dropped' THEN 'pending' ELSE i.status END,
+          updated_at = now()
+      WHERE i.class_id = p_class_id AND i.sis_user_id = rec.sis_user_id
+        AND i.status IN ('pending', 'dropped')
+        AND (i.sis_managed = false OR i.status = 'dropped');
+
+      UPDATE public.invitations i
+      SET status = 'accepted', accepted_at = COALESCE(i.accepted_at, now()), updated_at = now()
+      WHERE i.class_id = p_class_id AND i.sis_user_id = rec.sis_user_id
+        AND i.status = 'pending' AND i.sis_managed = true;
+    END LOOP;
+
+    -- 4) Create/Update invitations for users without accounts
+    FOR rec IN
+      SELECT r.sis_user_id, r.name, r.role, r.class_section_id, r.lab_section_id
+      FROM tmp_sis_roster_resolved r
+      LEFT JOIN public.users u ON u.sis_user_id = r.sis_user_id
+      WHERE u.user_id IS NULL
+    LOOP
+      SELECT * INTO v_existing_inv
+      FROM public.invitations i
+      WHERE i.class_id = p_class_id AND i.sis_user_id = rec.sis_user_id
+      LIMIT 1;
+
+      IF FOUND THEN
+        UPDATE public.invitations i
+        SET sis_managed = true, role = rec.role, name = COALESCE(rec.name, i.name),
+            class_section_id = rec.class_section_id, lab_section_id = rec.lab_section_id,
+            status = CASE WHEN i.status = 'dropped' THEN 'pending' ELSE i.status END,
+            updated_at = now()
+        WHERE i.id = v_existing_inv.id AND i.status IN ('pending', 'dropped');
+
+        IF v_existing_inv.status = 'dropped' THEN
+          UPDATE tmp_change_counts SET invitations_reactivated = invitations_reactivated + 1 WHERE true;
+        ELSE
+          UPDATE tmp_change_counts SET invitations_updated = invitations_updated + 1 WHERE true;
+        END IF;
+      ELSE
+        v_inv_id := public.create_invitation(
+          p_class_id, rec.role, rec.sis_user_id, NULL, rec.name,
+          v_admin_user_id, rec.class_section_id, rec.lab_section_id, true
+        );
+        PERFORM v_inv_id;
+        UPDATE tmp_change_counts SET invitations_created = invitations_created + 1 WHERE true;
+      END IF;
+    END LOOP;
+  END;
+
+  -- 5) Handle missing users (drop from SIS): drop invitations + disable enrollments (SIS-managed only)
+  IF v_drop_missing THEN
+    WITH present AS (SELECT sis_user_id FROM tmp_sis_roster_resolved)
+    UPDATE public.invitations i
+    SET status = 'dropped', updated_at = now()
+    WHERE i.class_id = p_class_id AND i.sis_managed = true
+      AND i.status IN ('pending', 'accepted')
+      AND NOT EXISTS (SELECT 1 FROM present p WHERE p.sis_user_id = i.sis_user_id)
+      AND (i.class_section_id IS NULL OR i.class_section_id IN (SELECT id FROM tmp_enabled_class_sections))
+      AND (i.lab_section_id IS NULL OR i.lab_section_id IN (SELECT id FROM tmp_enabled_lab_sections));
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    v_invitations_dropped := v_rows;
+
+    WITH present AS (SELECT sis_user_id FROM tmp_sis_roster_resolved),
+    candidates AS (
+      SELECT ur.id
+      FROM public.user_roles ur
+      JOIN public.users u ON u.user_id = ur.user_id
+      LEFT JOIN public.invitations inv ON inv.id = ur.invitation_id
+      WHERE ur.class_id = p_class_id
+        AND COALESCE(ur.disabled, false) = false
+        AND COALESCE(ur.sis_sync_opt_out, false) = false
+        AND u.sis_user_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM present p WHERE p.sis_user_id = u.sis_user_id)
+        AND (
+          (inv.id IS NOT NULL AND inv.sis_managed = true) OR
+          (ur.canvas_id IS NOT NULL AND ur.canvas_id = u.sis_user_id::numeric)
+        )
+        AND (ur.class_section_id IS NULL OR ur.class_section_id IN (SELECT id FROM tmp_enabled_class_sections))
+        AND (ur.lab_section_id IS NULL OR ur.lab_section_id IN (SELECT id FROM tmp_enabled_lab_sections))
+    )
+    UPDATE public.user_roles ur SET disabled = true WHERE ur.id IN (SELECT id FROM candidates);
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    v_enrollments_disabled := v_rows;
+  END IF;
+
+  SELECT jsonb_build_object(
+    'success', true,
+    'class_id', p_class_id,
+    'drop_missing', v_drop_missing,
+    'counts', jsonb_build_object(
+      'invitations_created', (SELECT invitations_created FROM tmp_change_counts),
+      'invitations_updated', (SELECT invitations_updated FROM tmp_change_counts),
+      'invitations_dropped', v_invitations_dropped,
+      'invitations_reactivated', (SELECT invitations_reactivated FROM tmp_change_counts),
+      'enrollments_created', (SELECT enrollments_created FROM tmp_change_counts),
+      'enrollments_updated', (SELECT enrollments_updated FROM tmp_change_counts),
+      'enrollments_disabled', v_enrollments_disabled,
+      'enrollments_reenabled', v_enrollments_reenabled,
+      'enrollments_adopted', (SELECT enrollments_adopted FROM tmp_change_counts)
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sis_sync_enrollment(bigint, jsonb, jsonb) IS
+  'Atomically applies an SIS roster sync for a class. drop_missing drops invitations and disables enrollments for students no longer on the roster. Reuses existing profiles (one enrollment per user per class).';

--- a/supabase/migrations/20260522120002_invitation_enrollment_functions.sql
+++ b/supabase/migrations/20260522120002_invitation_enrollment_functions.sql
@@ -173,12 +173,30 @@ BEGIN
     VALUES (v_user_name, v_avatar_url, p_class_id, true)
     RETURNING id INTO v_private_profile_id;
 
-    SELECT word INTO v_adjective FROM public.name_generation_words
-    WHERE is_adjective = true ORDER BY random() LIMIT 1;
-    SELECT word INTO v_noun FROM public.name_generation_words
-    WHERE is_noun = true ORDER BY random() LIMIT 1;
-    v_number := floor(random() * 1000)::integer;
-    v_public_name := COALESCE(v_adjective, 'random') || '-' || COALESCE(v_noun, 'user') || '-' || v_number;
+    -- Generate a public pseudonym, retrying to avoid reusing another student's
+    -- name in this class (matches create_invitation; profiles has no unique
+    -- (class_id, name) constraint, so this is a UX nicety, not a hard requirement).
+    DECLARE
+        v_attempts integer := 0;
+        v_exists boolean := true;
+    BEGIN
+        WHILE v_attempts < 20 LOOP
+            SELECT word INTO v_adjective FROM public.name_generation_words
+            WHERE is_adjective = true ORDER BY random() LIMIT 1;
+            SELECT word INTO v_noun FROM public.name_generation_words
+            WHERE is_noun = true ORDER BY random() LIMIT 1;
+            v_number := floor(random() * 1000)::integer;
+            v_public_name := COALESCE(v_adjective, 'random') || '-' || COALESCE(v_noun, 'user') || '-' || v_number;
+            SELECT EXISTS (
+                SELECT 1 FROM public.profiles WHERE class_id = p_class_id AND name = v_public_name
+            ) INTO v_exists;
+            IF NOT v_exists THEN EXIT; END IF;
+            v_attempts := v_attempts + 1;
+        END LOOP;
+        IF v_exists THEN
+            v_public_name := v_public_name || '-' || substr(md5(random()::text || clock_timestamp()::text), 1, 6);
+        END IF;
+    END;
 
     INSERT INTO public.profiles (name, avatar_url, class_id, is_private_profile)
     VALUES (
@@ -667,7 +685,6 @@ BEGIN
           p_class_id, rec.role, rec.sis_user_id, NULL, rec.name,
           v_admin_user_id, rec.class_section_id, rec.lab_section_id, true
         );
-        PERFORM v_inv_id;
         UPDATE tmp_change_counts SET invitations_created = invitations_created + 1 WHERE true;
       END IF;
     END LOOP;

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -361,13 +361,19 @@ export async function getEnrollmentRowsForSisUser(
     lab_section_id: number | null;
   }>
 > {
-  const { data: user } = await supabase.from("users").select("user_id").eq("sis_user_id", sis_user_id).maybeSingle();
+  const { data: user, error: userError } = await supabase
+    .from("users")
+    .select("user_id")
+    .eq("sis_user_id", sis_user_id)
+    .maybeSingle();
+  if (userError) throw new Error(`getEnrollmentRowsForSisUser: failed to fetch user: ${userError.message}`);
   if (!user?.user_id) return [];
-  const { data: rows } = await supabase
+  const { data: rows, error: rowsError } = await supabase
     .from("user_roles")
     .select("id, role, disabled, private_profile_id, public_profile_id, class_section_id, lab_section_id")
     .eq("class_id", class_id)
     .eq("user_id", user.user_id);
+  if (rowsError) throw new Error(`getEnrollmentRowsForSisUser: failed to fetch user_roles: ${rowsError.message}`);
   return (rows ?? []) as Array<{
     id: number;
     role: string;

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -245,11 +245,11 @@ export type SimulatedSISRosterEntry = {
 export type SISSyncEnrollmentResult = {
   success: boolean;
   class_id: number;
-  expire_missing: boolean;
+  drop_missing: boolean;
   counts: {
     invitations_created: number;
     invitations_updated: number;
-    invitations_expired: number;
+    invitations_dropped: number;
     invitations_reactivated: number;
     enrollments_created: number;
     enrollments_updated: number;
@@ -262,12 +262,12 @@ export type SISSyncEnrollmentResult = {
 export async function simulateSISSync({
   class_id,
   roster,
-  expire_missing = true,
+  drop_missing = true,
   section_updates
 }: {
   class_id: number;
   roster: SimulatedSISRosterEntry[];
-  expire_missing?: boolean;
+  drop_missing?: boolean;
   section_updates?: Array<{
     section_type: "class" | "lab";
     sis_crn: number;
@@ -283,7 +283,7 @@ export async function simulateSISSync({
     p_class_id: class_id,
     p_roster_data: roster,
     p_sync_options: {
-      expire_missing,
+      drop_missing,
       section_updates: section_updates ?? []
     }
   });
@@ -341,6 +341,42 @@ export async function getEnrollmentState(
   }
 
   return { user: user ?? undefined, user_role, invitation: invitation ?? null };
+}
+
+/**
+ * Returns ALL user_roles for the account with this sis_user_id in a class (not
+ * just one). Used to assert there are no duplicate enrollments/profiles (#390).
+ */
+export async function getEnrollmentRowsForSisUser(
+  class_id: number,
+  sis_user_id: number
+): Promise<
+  Array<{
+    id: number;
+    role: string;
+    disabled: boolean;
+    private_profile_id: string;
+    public_profile_id: string;
+    class_section_id: number | null;
+    lab_section_id: number | null;
+  }>
+> {
+  const { data: user } = await supabase.from("users").select("user_id").eq("sis_user_id", sis_user_id).maybeSingle();
+  if (!user?.user_id) return [];
+  const { data: rows } = await supabase
+    .from("user_roles")
+    .select("id, role, disabled, private_profile_id, public_profile_id, class_section_id, lab_section_id")
+    .eq("class_id", class_id)
+    .eq("user_id", user.user_id);
+  return (rows ?? []) as Array<{
+    id: number;
+    role: string;
+    disabled: boolean;
+    private_profile_id: string;
+    public_profile_id: string;
+    class_section_id: number | null;
+    lab_section_id: number | null;
+  }>;
 }
 
 export async function setUserSisId(user_id: string, sis_user_id: number) {

--- a/tests/e2e/bulk-invite-import.test.tsx
+++ b/tests/e2e/bulk-invite-import.test.tsx
@@ -38,6 +38,8 @@ test.describe("Bulk CSV invitation import (#322)", () => {
       supabase.from("invitations") as unknown as { select: (c: string) => Promise<{ error: unknown }> }
     ).select("expires_at");
     expect(error).not.toBeNull();
+    const message = String((error as { message?: string } | null)?.message ?? error);
+    expect(message.toLowerCase()).toContain("expires_at");
   });
 
   test("SIS-ID mode creates a pending, manually-managed invitation for an unknown user", async () => {

--- a/tests/e2e/bulk-invite-import.test.tsx
+++ b/tests/e2e/bulk-invite-import.test.tsx
@@ -1,0 +1,136 @@
+import { test, expect } from "../global-setup";
+import {
+  createClass,
+  createUserInClass,
+  createUsersInClass,
+  getEnrollmentState,
+  getEnrollmentRowsForSisUser,
+  setUserSisId,
+  supabase
+} from "./TestingUtils";
+
+type BulkImportResult = {
+  enrolled_directly: number;
+  invitations_created: number;
+  reactivated: number;
+  errors: Array<{ identifier: string | number; error: string }>;
+};
+
+async function bulkImport(
+  class_id: number,
+  mode: "sis_id" | "email",
+  rows: Array<{ email?: string; name: string; role?: string; sis_id?: number; sis_sync_opt_out?: boolean }>
+): Promise<BulkImportResult> {
+  const { data, error } = await supabase.rpc("bulk_csv_import_enrollment", {
+    p_class_id: class_id,
+    p_import_mode: mode,
+    p_enrollment_data: rows,
+    p_notify: false
+  });
+  if (error) throw new Error(`bulk_csv_import_enrollment failed: ${error.message}`);
+  return data as unknown as BulkImportResult;
+}
+
+test.describe("Bulk CSV invitation import (#322)", () => {
+  test("invitations no longer have an expires_at column (auto-expiry removed)", async () => {
+    // The column is dropped at the DB level; selecting it must error.
+    const { error } = await (
+      supabase.from("invitations") as unknown as { select: (c: string) => Promise<{ error: unknown }> }
+    ).select("expires_at");
+    expect(error).not.toBeNull();
+  });
+
+  test("SIS-ID mode creates a pending, manually-managed invitation for an unknown user", async () => {
+    const course = await createClass({ name: "E2E Bulk - SIS New User" });
+    const sis_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
+
+    const result = await bulkImport(course.id, "sis_id", [{ sis_id, name: "Brand New", role: "student" }]);
+    expect(result.invitations_created).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const state = await getEnrollmentState(course.id, sis_id);
+    expect(state.invitation?.status).toBe("pending");
+    expect(state.invitation?.sis_managed).toBe(false); // manual import
+  });
+
+  test("SIS-ID mode reactivates an already-enrolled user without creating a new profile", async () => {
+    const course = await createClass({ name: "E2E Bulk - SIS Reactivate" });
+    const student = await createUserInClass({
+      role: "student",
+      class_id: course.id,
+      useMagicLink: true,
+      name: "Returning Student"
+    });
+    const sis_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
+    await setUserSisId(student.user_id, sis_id);
+    await supabase
+      .from("user_roles")
+      .update({ disabled: true })
+      .eq("class_id", course.id)
+      .eq("user_id", student.user_id);
+
+    const result = await bulkImport(course.id, "sis_id", [{ sis_id, name: "Returning Student", role: "student" }]);
+    expect(result.reactivated).toBe(1);
+    expect(result.invitations_created).toBe(0);
+
+    const rows = await getEnrollmentRowsForSisUser(course.id, sis_id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].disabled).toBe(false);
+    expect(rows[0].private_profile_id).toBe(student.private_profile_id); // reused, not duplicated
+  });
+
+  test("SIS-ID mode enrolls an existing account (not yet in this class) with exactly one profile", async () => {
+    const course = await createClass({ name: "E2E Bulk - SIS Enroll Existing" });
+    const other = await createClass({ name: "E2E Bulk - SIS Enroll Existing Other" });
+    const [student] = await createUsersInClass([
+      { role: "student", class_id: other.id, useMagicLink: true, name: "Existing Account" }
+    ]);
+    const sis_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
+    await setUserSisId(student.user_id, sis_id);
+
+    const result = await bulkImport(course.id, "sis_id", [{ sis_id, name: "Existing Account", role: "student" }]);
+    expect(result.enrolled_directly).toBe(1);
+
+    const rows = await getEnrollmentRowsForSisUser(course.id, sis_id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].disabled).toBe(false);
+  });
+
+  test("email mode collects per-row errors without aborting the good rows", async () => {
+    const course = await createClass({ name: "E2E Bulk - Email Mixed" });
+    const suffix = Math.random().toString(36).substring(2, 8);
+    const goodEmail = `bulk-good-${suffix}@pawtograder.net`;
+    const badEmail = `bulk-bad-${suffix}@gmail.com`; // unsupported domain
+
+    const result = await bulkImport(course.id, "email", [
+      { email: goodEmail, name: "Good Domain", role: "student" },
+      { email: badEmail, name: "Bad Domain", role: "student" }
+    ]);
+
+    expect(result.enrolled_directly).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(String(result.errors[0].identifier)).toBe(badEmail);
+
+    // The good user really was enrolled.
+    const { data: enrolled } = await supabase
+      .from("user_roles")
+      .select("id, users!inner(email)")
+      .eq("class_id", course.id)
+      .eq("users.email", goodEmail);
+    expect(enrolled).toHaveLength(1);
+  });
+
+  test("an invalid import mode raises and writes nothing", async () => {
+    const course = await createClass({ name: "E2E Bulk - Invalid Mode" });
+    const { error } = await supabase.rpc("bulk_csv_import_enrollment", {
+      p_class_id: course.id,
+      p_import_mode: "nonsense",
+      p_enrollment_data: [{ sis_id: 999, name: "Nope" }],
+      p_notify: false
+    });
+    expect(error).not.toBeNull();
+
+    const { data: invitations } = await supabase.from("invitations").select("id").eq("class_id", course.id);
+    expect(invitations).toHaveLength(0);
+  });
+});

--- a/tests/e2e/enrollment-dedup.test.tsx
+++ b/tests/e2e/enrollment-dedup.test.tsx
@@ -118,6 +118,8 @@ test.describe("Enrollment de-duplication (#390/#387)", () => {
       disabled: false
     });
     expect(error).not.toBeNull(); // idx_user_roles_one_active_per_class blocks it
+    expect(error?.code).toBe("23505"); // unique_violation
+    expect(error?.message ?? "").toContain("idx_user_roles_one_active_per_class");
   });
 
   test("merge_duplicate_class_enrollments collapses a pre-existing duplicate profile", async () => {

--- a/tests/e2e/enrollment-dedup.test.tsx
+++ b/tests/e2e/enrollment-dedup.test.tsx
@@ -1,0 +1,187 @@
+import { test, expect } from "../global-setup";
+import {
+  createClass,
+  createClassWithSISSections,
+  createUserInClass,
+  createUsersInClass,
+  simulateSISSync,
+  getEnrollmentState,
+  getEnrollmentRowsForSisUser,
+  setUserSisId,
+  supabase
+} from "./TestingUtils";
+
+// Covers #390 (a student must never get a second profile / enrollment in one
+// class) and #387 (its gradebook double-row symptom), plus the backfill that
+// merges any pre-existing duplicates and the unique-index guard.
+test.describe("Enrollment de-duplication (#390/#387)", () => {
+  test("invitation for an already-enrolled user upgrades the existing enrollment, never duplicates the profile", async () => {
+    const course = await createClass({ name: "E2E Dedup - Invite Upgrade" });
+    const student = await createUserInClass({
+      role: "student",
+      class_id: course.id,
+      useMagicLink: true,
+      name: "Upgrade Me"
+    });
+
+    const sis_user_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
+    await setUserSisId(student.user_id, sis_user_id);
+
+    // Manually invite the same person as a grader. The AFTER INSERT auto-accept
+    // trigger used to INSERT a second user_role (a fresh profile pair) here.
+    const { error } = await supabase.rpc("create_invitation", {
+      p_class_id: course.id,
+      p_role: "grader",
+      p_sis_user_id: sis_user_id,
+      p_name: "Upgrade Me",
+      p_email: undefined,
+      p_invited_by: undefined,
+      p_class_section_id: undefined,
+      p_lab_section_id: undefined,
+      p_sis_managed: false
+    });
+    if (error) throw new Error(`create_invitation failed: ${error.message}`);
+
+    const rows = await getEnrollmentRowsForSisUser(course.id, sis_user_id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].role).toBe("grader"); // upgraded in place
+    expect(rows[0].private_profile_id).toBe(student.private_profile_id); // profile reused
+    expect(rows[0].public_profile_id).toBe(student.public_profile_id);
+
+    const state = await getEnrollmentState(course.id, sis_user_id);
+    expect(state.invitation?.status).toBe("accepted");
+  });
+
+  test("SIS section move keeps a single enrollment and profile", async () => {
+    const course = await createClass({ name: "E2E Dedup - Section Move" });
+    await createClassWithSISSections({
+      class_id: course.id,
+      class_section_crns: [41111, 41112],
+      lab_section_crns: []
+    });
+
+    // Existing account (enrolled elsewhere) so the SIS sync enrolls them here.
+    const other = await createClass({ name: "E2E Dedup - Section Move Other" });
+    const [student] = await createUsersInClass([
+      { role: "student", class_id: other.id, useMagicLink: true, name: "Mover" }
+    ]);
+    const sis_user_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
+    await setUserSisId(student.user_id, sis_user_id);
+
+    await simulateSISSync({
+      class_id: course.id,
+      roster: [{ sis_user_id, name: "Mover", role: "student", class_section_crn: 41111 }]
+    });
+    let rows = await getEnrollmentRowsForSisUser(course.id, sis_user_id);
+    expect(rows).toHaveLength(1);
+    const profileAfterFirst = rows[0].private_profile_id;
+    const sectionA = rows[0].class_section_id;
+
+    // Move to the other section.
+    await simulateSISSync({
+      class_id: course.id,
+      roster: [{ sis_user_id, name: "Mover", role: "student", class_section_crn: 41112 }]
+    });
+    rows = await getEnrollmentRowsForSisUser(course.id, sis_user_id);
+    expect(rows).toHaveLength(1); // no duplicate enrollment
+    expect(rows[0].private_profile_id).toBe(profileAfterFirst); // same profile reused
+    expect(rows[0].class_section_id).not.toBe(sectionA); // section updated in place
+    expect(rows[0].disabled).toBe(false);
+  });
+
+  test("a second active enrollment for the same (user, class) is rejected by the unique index", async () => {
+    const course = await createClass({ name: "E2E Dedup - Unique Guard" });
+    const student = await createUserInClass({
+      role: "student",
+      class_id: course.id,
+      useMagicLink: true,
+      name: "Only Once"
+    });
+
+    const { data: priv } = await supabase
+      .from("profiles")
+      .insert({ class_id: course.id, name: `guard-priv-${Date.now()}`, is_private_profile: true })
+      .select("id")
+      .single();
+    const { data: pub } = await supabase
+      .from("profiles")
+      .insert({ class_id: course.id, name: `guard-pub-${Date.now()}`, is_private_profile: false })
+      .select("id")
+      .single();
+
+    const { error } = await supabase.from("user_roles").insert({
+      user_id: student.user_id,
+      class_id: course.id,
+      role: "grader",
+      private_profile_id: priv!.id,
+      public_profile_id: pub!.id,
+      disabled: false
+    });
+    expect(error).not.toBeNull(); // idx_user_roles_one_active_per_class blocks it
+  });
+
+  test("merge_duplicate_class_enrollments collapses a pre-existing duplicate profile", async () => {
+    const course = await createClass({ name: "E2E Dedup - Backfill Merge" });
+    const student = await createUserInClass({
+      role: "student",
+      class_id: course.id,
+      useMagicLink: true,
+      name: "Doubled Student"
+    });
+
+    // Seed a historical duplicate: a second (disabled, different-role) enrollment
+    // with its own profile pair, mimicking data created before the guard existed.
+    const { data: priv2 } = await supabase
+      .from("profiles")
+      .insert({ class_id: course.id, name: `dup-priv-${Date.now()}`, is_private_profile: true })
+      .select("id")
+      .single();
+    const { data: pub2 } = await supabase
+      .from("profiles")
+      .insert({ class_id: course.id, name: `dup-pub-${Date.now()}`, is_private_profile: false })
+      .select("id")
+      .single();
+    const { error: seedErr } = await supabase.from("user_roles").insert({
+      user_id: student.user_id,
+      class_id: course.id,
+      role: "grader",
+      private_profile_id: priv2!.id,
+      public_profile_id: pub2!.id,
+      disabled: true
+    });
+    if (seedErr) throw new Error(`failed to seed duplicate: ${seedErr.message}`);
+
+    // Sanity: two rows exist before the merge.
+    const before = await supabase
+      .from("user_roles")
+      .select("id")
+      .eq("class_id", course.id)
+      .eq("user_id", student.user_id);
+    expect(before.data).toHaveLength(2);
+
+    const { data: merged, error: mergeErr } = await supabase.rpc("merge_duplicate_class_enrollments", {
+      p_class_id: course.id
+    });
+    if (mergeErr) throw new Error(`merge failed: ${mergeErr.message}`);
+    expect(merged).toBe(1);
+
+    const after = await supabase
+      .from("user_roles")
+      .select("id, role, disabled, private_profile_id, public_profile_id")
+      .eq("class_id", course.id)
+      .eq("user_id", student.user_id);
+    expect(after.data).toHaveLength(1);
+    // Canonical = the active original; it adopts the strongest role and stays active.
+    expect(after.data![0].private_profile_id).toBe(student.private_profile_id);
+    expect(after.data![0].role).toBe("grader");
+    expect(after.data![0].disabled).toBe(false);
+
+    // The losing profile pair is gone.
+    const { data: leftover } = await supabase.from("profiles").select("id").in("id", [priv2!.id, pub2!.id]);
+    expect(leftover).toHaveLength(0);
+
+    // Idempotent: re-running finds nothing to merge.
+    const { data: mergedAgain } = await supabase.rpc("merge_duplicate_class_enrollments", { p_class_id: course.id });
+    expect(mergedAgain).toBe(0);
+  });
+});

--- a/tests/e2e/sis-import.test.tsx
+++ b/tests/e2e/sis-import.test.tsx
@@ -42,7 +42,7 @@ test.describe("SIS Import (RPC)", () => {
     expect(state.invitation?.lab_section_id).not.toBeNull();
   });
 
-  test("expires invitation on drop then reactivates on re-add to different section", async () => {
+  test("drops invitation on drop then reactivates on re-add to different section", async () => {
     const course = await createClass({ name: "E2E SIS Import - Invite Drop Readd" });
     await createClassWithSISSections({
       class_id: course.id,
@@ -71,10 +71,10 @@ test.describe("SIS Import (RPC)", () => {
     const firstClassSection = state.invitation?.class_section_id;
     const firstLabSection = state.invitation?.lab_section_id;
 
-    // Drop -> invitation expires
+    // Drop -> invitation marked dropped
     await simulateSISSync({ class_id: course.id, roster: [] });
     state = await getEnrollmentState(course.id, sis_user_id);
-    expect(state.invitation?.status).toBe("expired");
+    expect(state.invitation?.status).toBe("dropped");
 
     // Re-add different section -> invitation becomes pending and section ids update
     await simulateSISSync({
@@ -402,7 +402,7 @@ test.describe("SIS Import (RPC)", () => {
         }
       ],
       p_sync_options: {
-        expire_missing: true,
+        drop_missing: true,
         section_updates: [
           {
             section_type: "lab",
@@ -463,10 +463,10 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
   test.describe.configure({ mode: "serial" });
 
   // =========================================================================
-  // 1. expire_missing: false option
+  // 1. drop_missing: false option
   // =========================================================================
-  test("does NOT expire invitations or disable enrollments when expire_missing=false", async () => {
-    const course = await createClass({ name: "E2E SIS - No Expire Missing" });
+  test("does NOT drop invitations or disable enrollments when drop_missing=false", async () => {
+    const course = await createClass({ name: "E2E SIS - No Drop Missing" });
     await createClassWithSISSections({ class_id: course.id, class_section_crns: [33333], lab_section_crns: [] });
 
     // User 1: will get invitation
@@ -476,7 +476,7 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
       role: "student",
       class_id: course.id,
       useMagicLink: true,
-      name: "No Expire Student"
+      name: "No Drop Student"
     });
     const sis_user_id_2 = Math.floor(1_000_000_000 + Math.random() * 100_000);
     await setUserSisId(student.user_id, sis_user_id_2);
@@ -495,17 +495,17 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
     expect(state1.invitation?.status).toBe("pending");
     expect(state2.user_role?.disabled).toBe(false);
 
-    // Sync with empty roster BUT expire_missing=false
+    // Sync with empty roster BUT drop_missing=false
     await simulateSISSync({
       class_id: course.id,
       roster: [],
-      expire_missing: false
+      drop_missing: false
     });
 
     // Both should remain unchanged
     state1 = await getEnrollmentState(course.id, sis_user_id_1);
     state2 = await getEnrollmentState(course.id, sis_user_id_2);
-    expect(state1.invitation?.status).toBe("pending"); // NOT expired
+    expect(state1.invitation?.status).toBe("pending"); // NOT dropped
     expect(state2.user_role?.disabled).toBe(false); // NOT disabled
   });
 
@@ -738,10 +738,10 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
   });
 
   // =========================================================================
-  // 5. Non-SIS invitation NOT expired on drop
+  // 5. Non-SIS invitation NOT dropped on drop
   // =========================================================================
-  test("does NOT expire non-SIS-managed invitation on drop", async () => {
-    const course = await createClass({ name: "E2E SIS - Non-SIS Invite No Expire" });
+  test("does NOT drop non-SIS-managed invitation on drop", async () => {
+    const course = await createClass({ name: "E2E SIS - Non-SIS Invite No Drop" });
     await createClassWithSISSections({ class_id: course.id, class_section_crns: [20001], lab_section_crns: [] });
 
     const sis_user_id = Math.floor(1_000_000_000 + Math.random() * 100_000);
@@ -766,7 +766,7 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
     // Sync with empty roster (user not in SIS)
     await simulateSISSync({ class_id: course.id, roster: [] });
 
-    // Should NOT be expired because sis_managed=false
+    // Should NOT be dropped because sis_managed=false
     state = await getEnrollmentState(course.id, sis_user_id);
     expect(state.invitation?.status).toBe("pending");
   });
@@ -1051,9 +1051,9 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
   });
 
   // =========================================================================
-  // 14. Reactivates expired invitation and updates sections
+  // 14. Reactivates dropped invitation and updates sections
   // =========================================================================
-  test("reactivates expired invitation with updated section data", async () => {
+  test("reactivates dropped invitation with updated section data", async () => {
     const course = await createClass({ name: "E2E SIS - Reactivate With New Section" });
     const { classSections } = await createClassWithSISSections({
       class_id: course.id,
@@ -1072,10 +1072,10 @@ test.describe("SIS Import (RPC) - Additional Coverage", () => {
     let state = await getEnrollmentState(course.id, sis_user_id);
     expect(state.invitation?.class_section_id).toBe(classSections[0].id);
 
-    // Expire by dropping
+    // Drop by dropping
     await simulateSISSync({ class_id: course.id, roster: [] });
     state = await getEnrollmentState(course.id, sis_user_id);
-    expect(state.invitation?.status).toBe("expired");
+    expect(state.invitation?.status).toBe("dropped");
 
     // Reactivate in section 2
     const result = await simulateSISSync({

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -5117,7 +5117,6 @@ export type Database = {
           class_section_id: number | null;
           created_at: string;
           email: string | null;
-          expires_at: string | null;
           id: number;
           invited_by: string | null;
           lab_section_id: number | null;
@@ -5137,7 +5136,6 @@ export type Database = {
           class_section_id?: number | null;
           created_at?: string;
           email?: string | null;
-          expires_at?: string | null;
           id?: number;
           invited_by?: string | null;
           lab_section_id?: number | null;
@@ -5157,7 +5155,6 @@ export type Database = {
           class_section_id?: number | null;
           created_at?: string;
           email?: string | null;
-          expires_at?: string | null;
           id?: number;
           invited_by?: string | null;
           lab_section_id?: number | null;
@@ -11169,7 +11166,7 @@ export type Database = {
         Returns: {
           class_id: number;
           class_name: string;
-          expired_invitations: number;
+          dropped_invitations: number;
           last_sync_message: string;
           last_sync_status: string;
           last_sync_time: string;
@@ -12356,6 +12353,10 @@ export type Database = {
       merge_class_feature_as_service_role: {
         Args: { p_class_id: number; p_enabled: boolean; p_name: string };
         Returns: undefined;
+      };
+      merge_duplicate_class_enrollments: {
+        Args: { p_class_id?: number };
+        Returns: number;
       };
       only_calendar_or_discord_ids_changed: {
         Args: { new_row: Database["public"]["Tables"]["classes"]["Row"] };


### PR DESCRIPTION
## Summary

Fixes **#322** and **#390** (root cause of **#387**).

### #322 — remove invitation auto-expiry
- Drop `invitations.expires_at` and all 30-day age checks (no more time-based expiry).
- Rename the `"expired"` status to `"dropped"` everywhere, including the DB: the `status` value + `CHECK` constraint, `sis_sync_enrollment`'s `expire_missing`→`drop_missing` option and `invitations_expired`→`invitations_dropped` count, and `admin_get_sis_sync_status`'s `expired_invitations`→`dropped_invitations`. "Dropped" now means exactly "removed from the SIS roster" (set only by SIS sync).
- (The "one RPC instead of one-by-one client calls" part of #322 already shipped as `bulk_csv_import_enrollment` in #563.)

### #390 — one profile per student per class (root cause of #387's duplicate gradebook rows)
- Add partial unique index `idx_user_roles_one_active_per_class` on `user_roles (user_id, class_id) WHERE disabled = false`.
- Every enrollment path (`create_invitation`, `create_user_role_for_existing_user`, `handle_user_sis_id_update`, `auto_accept_invitation_if_user_exists`, `sis_sync_enrollment`) now **reuses the existing (user, class) profile pair** instead of minting a new one. The auto-accept trigger's old "insert a second role" branch — which created the duplicate rows — now upgrades the existing enrollment in place.
- New re-runnable, catalog-driven `merge_duplicate_class_enrollments()` backfills existing duplicates by repointing every `profiles(id)` FK onto the canonical profile, then deleting the losers. The migration runs it across all classes before adding the unique index.

### Consumers
Updated `course-import-sis`, `InvitationUtils`, `invitation-create`, the admin SIS-sync page, and `enrollmentsTable` (removed the time-based "Expired" UI). Type files were edited by hand for the invitation/RPC changes only — a full local regen produced ~24k lines of unrelated schema drift, so that was intentionally avoided.

## Test plan

- [x] `npx playwright test tests/e2e/sis-import.test.tsx` — 30 existing SIS tests pass (updated for the rename)
- [x] `npx playwright test tests/e2e/bulk-invite-import.test.tsx` — 6 new bulk-CSV-import tests (transactional resilience, no-duplicate-profile, expiry column gone)
- [x] `npx playwright test tests/e2e/enrollment-dedup.test.tsx` — 4 new tests (section-move/role-upgrade dedup, unique-index enforcement, backfill merge + idempotency)
- [x] `tsc --noEmit` clean (one pre-existing, unrelated error in `active-submission-gradebook-db.spec.ts`)
- [ ] Deno `typecheck:functions` not run locally (Deno not available); edge edits were field removals/renames only

## ⚠️ Migration note

`merge_duplicate_class_enrollments()` is **destructive** (deletes losing profiles/enrollments). It is idempotent and tested, but run it against a staging snapshot first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitations now use explicit status management (pending, accepted, dropped, cancelled) instead of time-based auto-expiration
  * Enhanced deduplication of user enrollments to consolidate duplicate profile pairs
  
* **Bug Fixes**
  * Updated invitation status display and cancellation logic to reflect current status accurately
  * SIS roster removals now correctly mark missing students' invitations as "dropped"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->