### PR TITLE
Add flaky E2E triage agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,7 @@
       "devDependencies": {
         "@argos-ci/playwright": "^6.0.4",
         "@axe-core/playwright": "^4.11.2",
+        "@cursor/sdk": "^1.0.13",
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.26.0",
         "@faker-js/faker": "^9.9.0",
@@ -1971,6 +1972,13 @@
       "integrity": "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==",
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
@@ -2198,6 +2206,46 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node/node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -2336,6 +2384,101 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.13.tgz",
+      "integrity": "sha512-w6MWkgOTL6yb6GV/4Odx7QcamQgqhzX/CzcMBkqiiOPTPuEWItWrgA0qdivchm5YJXTt+LZkFSEQ/Ti44hVbfg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "sqlite3": "^5.1.7",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.13",
+        "@cursor/sdk-darwin-x64": "1.0.13",
+        "@cursor/sdk-linux-arm64": "1.0.13",
+        "@cursor/sdk-linux-x64": "1.0.13",
+        "@cursor/sdk-win32-x64": "1.0.13"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.13.tgz",
+      "integrity": "sha512-zHRTNtVRHw4KSAEFmtO0Av7jv9D60DrB+pygVNWGyKtRR44fcwtRHuLAJmO4HThxQw7MMvUJuAaNmCQxzHtPDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.13.tgz",
+      "integrity": "sha512-7XsIkMKp6h/4W9zBx02Py1euJLAJVxlkwmm9GSoUjc+3hfFvHY/R/WTbX2TFgF4g1vOAq/HM7GmXBXq+e4M4+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.13.tgz",
+      "integrity": "sha512-bDgfPPgc84gUn3k+Iiq5OLZozzM0UYZdKbQ821pbZy1OPWTFaSkjXsoAB6xqf9wALWyW1eQxOC4RprPBLoy+yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.13.tgz",
+      "integrity": "sha512-BTccnB5hVqK8Y0778oql6gbk7kIIlzQrBqt5QNLJpwBidjjde/mlvAajVB9hB3a29jelOwm0gJjMsLfqTkEPdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.13.tgz",
+      "integrity": "sha512-GxWlwj4G513EfGmvPVBa4y+vNn9B5Cj+npu8fVcJ0P+U9sruhgo4pvqGbWxkn5EIKbpGoraLq9QB4nFeoT1uRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@date-fns/tz": {
       "version": "1.2.0",
@@ -3330,6 +3473,16 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "license": "MIT"
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
@@ -3376,6 +3529,14 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@giphy/colors": {
       "version": "1.0.1",
@@ -5829,6 +5990,18 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
     "node_modules/@npmcli/git": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-5.0.8.tgz",
@@ -5847,6 +6020,89 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@npmcli/move-file/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@npmcli/package-json": {
@@ -11261,6 +11517,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
     "node_modules/@stefanprobst/remark-excerpt": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@stefanprobst/remark-excerpt/-/remark-excerpt-2.0.2.tgz",
@@ -15005,6 +15278,14 @@
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "license": "BSD-3-Clause"
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -15121,6 +15402,21 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -15362,6 +15658,14 @@
         "extend": "^3.0.2"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/archiver": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
@@ -15449,6 +15753,38 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -16207,6 +16543,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -16612,6 +16958,149 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -17168,6 +17657,17 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/clean-webpack-plugin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-4.0.0.tgz",
@@ -17542,6 +18042,17 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/color2k": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
@@ -17707,6 +18218,14 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/console-table-printer": {
       "version": "2.14.6",
@@ -18899,6 +19418,16 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "license": "MIT"
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -19144,6 +19673,14 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -19524,6 +20061,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -19559,6 +20106,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -20770,6 +21330,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.1.2",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
@@ -21191,6 +21761,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -21772,6 +22349,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/geist": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
@@ -21957,6 +22564,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true,
       "license": "MIT"
     },
@@ -22363,6 +22977,14 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -23303,6 +23925,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/inflection": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.2.tgz",
@@ -23515,6 +24145,17 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -23892,6 +24533,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -26527,6 +27176,63 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -27915,6 +28621,151 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -27954,6 +28805,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -28176,6 +29034,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
@@ -28362,6 +29227,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -28490,6 +29375,124 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/node-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/node-gyp/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -28520,6 +29523,23 @@
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/normalize-package-data": {
@@ -28628,6 +29648,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -30103,6 +31141,34 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/preferred-pm": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.4.tgz",
@@ -30457,6 +31523,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -30647,6 +31724,39 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rc9": {
@@ -33782,6 +34892,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -34103,6 +35221,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -34163,6 +35328,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smtp-address-parser": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/smtp-address-parser/-/smtp-address-parser-1.0.10.tgz",
@@ -34174,6 +35351,38 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/source-map": {
@@ -34271,6 +35480,31 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -34279,6 +35513,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stable-hash": {
@@ -35292,6 +36554,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -36075,6 +37357,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typanion": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
@@ -36516,6 +37811,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
       }
     },
     "node_modules/unist-builder": {
@@ -37650,6 +38967,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e": "npx playwright test",
+    "triage:flaky-e2e": "npx tsx scripts/FlakyTestTriageAgent.ts",
     "test:e2e:local": "cross-env BASE_URL=http://localhost:3000 npx playwright test",
     "test:k6:build": "webpack --config webpack.k6.config.js",
     "test:k6:submissions-api": "npm run test:k6:build && k6 run dist/k6-tests/submissions-api.js -e SUPABASE_URL=$SUPABASE_URL -e SUPABASE_SERVICE_ROLE_KEY=$SUPABASE_SERVICE_ROLE_KEY -e END_TO_END_SECRET=$END_TO_END_SECRET ",
@@ -156,6 +157,7 @@
   "devDependencies": {
     "@argos-ci/playwright": "^6.0.4",
     "@axe-core/playwright": "^4.11.2",
+    "@cursor/sdk": "^1.0.13",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.26.0",
     "@faker-js/faker": "^9.9.0",

--- a/scripts/FlakyTestTriageAgent.ts
+++ b/scripts/FlakyTestTriageAgent.ts
@@ -1,0 +1,932 @@
+#!/usr/bin/env npx tsx
+/* eslint-disable no-console */
+import { Agent, type SDKMessage } from "@cursor/sdk";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import sharp from "sharp";
+
+const requireFromWorkspace = createRequire(`${process.cwd()}/package.json`);
+
+type CliOptions = {
+  suiteRuns: number;
+  diagnosticReruns: number;
+  validationReruns: number;
+  maxCandidates: number;
+  workers?: number;
+  baseUrl?: string;
+  model: string;
+  reportDir: string;
+  projects: string[];
+  grep?: string;
+  dryRun: boolean;
+  skipRepair: boolean;
+  help: boolean;
+};
+
+type PlaywrightReport = {
+  config?: { rootDir?: string };
+  suites?: PlaywrightSuite[];
+  errors?: PlaywrightError[];
+};
+
+type PlaywrightSuite = {
+  title?: string;
+  file?: string;
+  line?: number;
+  suites?: PlaywrightSuite[];
+  specs?: PlaywrightSpec[];
+};
+
+type PlaywrightSpec = {
+  title: string;
+  file?: string;
+  line?: number;
+  tests?: PlaywrightTest[];
+};
+
+type PlaywrightTest = {
+  projectName?: string;
+  status?: string;
+  expectedStatus?: string;
+  results?: PlaywrightResult[];
+};
+
+type PlaywrightResult = {
+  status?: string;
+  duration?: number;
+  retry?: number;
+  error?: PlaywrightError;
+  errors?: PlaywrightError[];
+  attachments?: PlaywrightAttachment[];
+  stdout?: PlaywrightOutput[];
+  stderr?: PlaywrightOutput[];
+};
+
+type PlaywrightError = {
+  message?: string;
+  stack?: string;
+  value?: string;
+};
+
+type PlaywrightAttachment = {
+  name: string;
+  path?: string;
+  contentType?: string;
+};
+
+type PlaywrightOutput = string | { text?: string; buffer?: string };
+
+type TestObservation = {
+  key: string;
+  file: string;
+  line?: number;
+  title: string;
+  projectName?: string;
+  status: "passed" | "failed" | "skipped";
+  durationMs: number;
+  errors: string[];
+  attachments: AttachmentEvidence[];
+};
+
+type AttachmentEvidence = {
+  name: string;
+  originalPath: string;
+  copiedPath?: string;
+  contentType?: string;
+  sha256?: string;
+};
+
+type PlaywrightRun = {
+  label: string;
+  exitCode: number;
+  command: string;
+  rawLogPath: string;
+  jsonPath?: string;
+  observations: TestObservation[];
+  parseError?: string;
+  reportErrors: string[];
+};
+
+type Candidate = {
+  key: string;
+  file: string;
+  line?: number;
+  title: string;
+  projectName?: string;
+  suiteStatuses: TestObservation["status"][];
+  diagnosticStatuses: TestObservation["status"][];
+  classification: "flaky" | "stable-failure";
+  visual: VisualEvidence;
+  sampleErrors: string[];
+};
+
+type VisualEvidence = {
+  suspected: boolean;
+  reason?: string;
+  imageDiffs: ImageDiff[];
+  attachments: AttachmentEvidence[];
+};
+
+type ImageDiff = {
+  attachmentName: string;
+  firstImage: string;
+  secondImage: string;
+  width?: number;
+  height?: number;
+  differingPixels?: number;
+  diffRatio?: number;
+  note?: string;
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    suiteRuns: 3,
+    diagnosticReruns: 8,
+    validationReruns: 5,
+    maxCandidates: 10,
+    model: "composer-2.5",
+    reportDir: path.join("artifacts", "flaky-test-triage", timestamp()),
+    projects: [],
+    dryRun: false,
+    skipRepair: false,
+    help: false
+  };
+
+  const readValue = (args: string[], index: number, flag: string) => {
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return value;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--suite-runs":
+        options.suiteRuns = parsePositiveInt(readValue(argv, i++, arg), arg);
+        break;
+      case "--diagnostic-reruns":
+        options.diagnosticReruns = parsePositiveInt(readValue(argv, i++, arg), arg);
+        break;
+      case "--validation-reruns":
+        options.validationReruns = parsePositiveInt(readValue(argv, i++, arg), arg);
+        break;
+      case "--max-candidates":
+        options.maxCandidates = parsePositiveInt(readValue(argv, i++, arg), arg);
+        break;
+      case "--workers":
+        options.workers = parsePositiveInt(readValue(argv, i++, arg), arg);
+        break;
+      case "--base-url":
+        options.baseUrl = readValue(argv, i++, arg);
+        break;
+      case "--model":
+        options.model = readValue(argv, i++, arg);
+        break;
+      case "--report-dir":
+        options.reportDir = readValue(argv, i++, arg);
+        break;
+      case "--project":
+        options.projects.push(readValue(argv, i++, arg));
+        break;
+      case "--grep":
+        options.grep = readValue(argv, i++, arg);
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--skip-repair":
+        options.skipRepair = true;
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Flaky E2E triage agent
+
+Runs the complete Playwright E2E suite repeatedly, diagnoses flaky tests,
+diffs visual image artifacts when available, and hands the evidence to a
+local Cursor SDK agent to repair the system under test or the flaky test.
+
+Usage:
+  npm run triage:flaky-e2e -- [options]
+
+Options:
+  --suite-runs <n>          Complete suite runs before repair (default: 3)
+  --diagnostic-reruns <n>   Targeted reruns per candidate (default: 8)
+  --validation-reruns <n>   Targeted reruns after repair (default: 5)
+  --max-candidates <n>      Candidate tests sent to the agent (default: 10)
+  --workers <n>             Override Playwright workers
+  --base-url <url>          BASE_URL for Playwright
+  --project <name>          Repeatable Playwright project filter
+  --grep <pattern>          Optional Playwright grep filter
+  --model <id>              Cursor model (default: composer-2.5)
+  --report-dir <path>       Triage artifact directory
+  --dry-run                 Collect evidence and write the repair prompt only
+  --skip-repair             Collect evidence without invoking Cursor
+`);
+}
+
+function parsePositiveInt(value: string, flag: string) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+async function runPlaywright(
+  label: string,
+  options: CliOptions,
+  extraArgs: string[],
+  runDir: string
+): Promise<PlaywrightRun> {
+  await mkdir(runDir, { recursive: true });
+  const jsonPath = path.join(runDir, "playwright-report.json");
+  const configPath = path.join(runDir, "playwright.triage.config.ts");
+  await writeFile(configPath, buildPlaywrightConfig(jsonPath, path.join(runDir, "playwright-html-report")));
+
+  const args = [
+    "playwright",
+    "test",
+    "--config",
+    configPath,
+    "--retries=0",
+    "--output",
+    path.join(runDir, "test-results")
+  ];
+  if (options.workers) {
+    args.push("--workers", String(options.workers));
+  }
+  for (const project of options.projects) {
+    args.push("--project", project);
+  }
+  if (options.grep) {
+    args.push("--grep", options.grep);
+  }
+  args.push(...extraArgs);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ARGOS_TOKEN: process.env.ARGOS_TOKEN ?? "",
+    PW_TEST_HTML_REPORT_OPEN: "never"
+  };
+  if (options.baseUrl) {
+    env.BASE_URL = options.baseUrl;
+  }
+
+  const command = `npx ${args.map(shellQuote).join(" ")}`;
+  console.log(`\n[${label}] ${command}`);
+  const child = spawn("npx", args, {
+    cwd: process.cwd(),
+    env,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stdout += text;
+    process.stdout.write(text);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    const text = chunk.toString();
+    stderr += text;
+    process.stderr.write(text);
+  });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+
+  const rawLogPath = path.join(runDir, "playwright.raw.log");
+  await writeFile(rawLogPath, stdout + stderr);
+
+  const parsed: { report?: PlaywrightReport; error?: string } = existsSync(jsonPath)
+    ? { report: JSON.parse(await readFile(jsonPath, "utf8")) as PlaywrightReport }
+    : parsePlaywrightJson(stdout);
+  if (!parsed.report) {
+    return {
+      label,
+      exitCode,
+      command,
+      rawLogPath,
+      observations: [],
+      parseError: parsed.error,
+      reportErrors: parsed.error ? [parsed.error] : []
+    };
+  }
+
+  const observations = await flattenReport(parsed.report, runDir);
+
+  return {
+    label,
+    exitCode,
+    command,
+    rawLogPath,
+    jsonPath,
+    observations,
+    reportErrors: collectReportErrors(parsed.report)
+  };
+}
+
+function buildPlaywrightConfig(jsonPath: string, htmlReportPath: string) {
+  const argosReporter = requireFromWorkspace.resolve("@argos-ci/playwright/reporter");
+  return `import baseConfig from ${JSON.stringify(path.resolve("playwright.config.ts"))};
+
+export default {
+  ...baseConfig,
+  testDir: ${JSON.stringify(path.resolve("tests/e2e"))},
+  reporter: [
+    ["line"],
+    ["json", { outputFile: ${JSON.stringify(path.resolve(jsonPath))} }],
+    [${JSON.stringify(argosReporter)}, { uploadToArgos: false, token: "" }],
+    ["html", { outputFolder: ${JSON.stringify(path.resolve(htmlReportPath))}, open: "never" }]
+  ]
+};
+`;
+}
+
+function shellQuote(value: string) {
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function parsePlaywrightJson(output: string): { report?: PlaywrightReport; error?: string } {
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end <= start) {
+    return { error: "Playwright JSON reporter did not emit a JSON object" };
+  }
+  try {
+    return { report: JSON.parse(output.slice(start, end + 1)) as PlaywrightReport };
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function flattenReport(report: PlaywrightReport, runDir: string): Promise<TestObservation[]> {
+  const observations: TestObservation[] = [];
+
+  const visitSuite = async (suite: PlaywrightSuite, parentTitles: string[]) => {
+    const suiteTitles = suite.title ? [...parentTitles, suite.title] : parentTitles;
+    for (const childSuite of suite.suites ?? []) {
+      await visitSuite(childSuite, suiteTitles);
+    }
+    for (const spec of suite.specs ?? []) {
+      const titlePath = [...suiteTitles, spec.title].filter(Boolean);
+      for (const testCase of spec.tests ?? []) {
+        const resultStatuses = testCase.results?.map((result) => result.status ?? "unknown") ?? [];
+        const failedResults = testCase.results?.filter((result) => isFailureStatus(result.status)) ?? [];
+        const status = statusFromTest(testCase, resultStatuses);
+        const file = spec.file ?? suite.file ?? "unknown";
+        const line = spec.line ?? suite.line;
+        const projectName = testCase.projectName;
+        const errors = collectErrors(failedResults.length > 0 ? failedResults : (testCase.results ?? []));
+        const attachments = await collectAttachments(testCase.results ?? [], runDir);
+        const title = titlePath.join(" › ");
+        observations.push({
+          key: buildTestKey(file, line, title, projectName),
+          file,
+          line,
+          title,
+          projectName,
+          status,
+          durationMs: (testCase.results ?? []).reduce((sum, result) => sum + (result.duration ?? 0), 0),
+          errors,
+          attachments
+        });
+      }
+    }
+  };
+
+  for (const suite of report.suites ?? []) {
+    await visitSuite(suite, []);
+  }
+
+  return observations;
+}
+
+function statusFromTest(testCase: PlaywrightTest, resultStatuses: string[]): TestObservation["status"] {
+  if (testCase.status === "skipped" || resultStatuses.every((status) => status === "skipped")) {
+    return "skipped";
+  }
+  if (testCase.status === "expected" || resultStatuses.some((status) => status === "passed")) {
+    return "passed";
+  }
+  return "failed";
+}
+
+function isFailureStatus(status: string | undefined) {
+  return status === "failed" || status === "timedOut" || status === "interrupted";
+}
+
+function collectErrors(results: PlaywrightResult[]) {
+  const messages: string[] = [];
+  for (const result of results) {
+    for (const error of [result.error, ...(result.errors ?? [])]) {
+      const text = [error?.message, error?.value, error?.stack].filter(Boolean).join("\n");
+      if (text) messages.push(text);
+    }
+    messages.push(...collectOutput(result.stderr));
+  }
+  return Array.from(new Set(messages)).slice(0, 6);
+}
+
+function collectReportErrors(report: PlaywrightReport) {
+  return (report.errors ?? [])
+    .map((error) => [error.message, error.value, error.stack].filter(Boolean).join("\n"))
+    .filter(Boolean);
+}
+
+function collectOutput(output: PlaywrightOutput[] | undefined) {
+  return (output ?? [])
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      if (entry.text) return entry.text;
+      if (entry.buffer) return Buffer.from(entry.buffer, "base64").toString();
+      return "";
+    })
+    .filter(Boolean);
+}
+
+async function collectAttachments(results: PlaywrightResult[], runDir: string): Promise<AttachmentEvidence[]> {
+  const attachments: AttachmentEvidence[] = [];
+  const attachmentDir = path.join(runDir, "attachments");
+  for (const result of results) {
+    for (const attachment of result.attachments ?? []) {
+      if (!attachment.path) continue;
+      const originalPath = path.resolve(attachment.path);
+      const evidence: AttachmentEvidence = {
+        name: attachment.name,
+        originalPath,
+        contentType: attachment.contentType
+      };
+      if (existsSync(originalPath)) {
+        await mkdir(attachmentDir, { recursive: true });
+        const extension = path.extname(originalPath);
+        const copiedPath = path.join(
+          attachmentDir,
+          `${sanitizeFileName(attachment.name)}-${attachments.length}${extension}`
+        );
+        const bytes = await readFile(originalPath);
+        await writeFile(copiedPath, bytes);
+        evidence.copiedPath = copiedPath;
+        evidence.sha256 = createHash("sha256").update(bytes).digest("hex");
+      }
+      attachments.push(evidence);
+    }
+  }
+  return attachments;
+}
+
+function sanitizeFileName(value: string) {
+  return value.replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "") || "attachment";
+}
+
+function buildTestKey(file: string, line: number | undefined, title: string, projectName: string | undefined) {
+  const location = line ? `${file}:${line}` : file;
+  return [projectName, location, title].filter(Boolean).join(" › ");
+}
+
+function groupObservations(runs: PlaywrightRun[]) {
+  const grouped = new Map<string, TestObservation[]>();
+  for (const run of runs) {
+    for (const observation of run.observations) {
+      const current = grouped.get(observation.key) ?? [];
+      current.push(observation);
+      grouped.set(observation.key, current);
+    }
+  }
+  return grouped;
+}
+
+async function identifyCandidates(suiteRuns: PlaywrightRun[], diagnosticRuns: PlaywrightRun[]): Promise<Candidate[]> {
+  const suiteGrouped = groupObservations(suiteRuns);
+  const diagnosticGrouped = groupObservations(diagnosticRuns);
+  const keys = new Set<string>();
+  for (const [key, observations] of suiteGrouped.entries()) {
+    if (observations.some((observation) => observation.status === "failed")) {
+      keys.add(key);
+    }
+  }
+  for (const [key, observations] of diagnosticGrouped.entries()) {
+    if (observations.some((observation) => observation.status === "failed")) {
+      keys.add(key);
+    }
+  }
+
+  const candidates: Candidate[] = [];
+  for (const key of keys) {
+    const suiteObservations = suiteGrouped.get(key) ?? [];
+    const diagnosticObservations = diagnosticGrouped.get(key) ?? [];
+    const allObservations = [...suiteObservations, ...diagnosticObservations];
+    if (allObservations.length === 0) continue;
+    const statuses = allObservations.map((observation) => observation.status);
+    const classification = statuses.includes("passed") && statuses.includes("failed") ? "flaky" : "stable-failure";
+    const first = allObservations[0];
+    candidates.push({
+      key,
+      file: first.file,
+      line: first.line,
+      title: first.title,
+      projectName: first.projectName,
+      suiteStatuses: suiteObservations.map((observation) => observation.status),
+      diagnosticStatuses: diagnosticObservations.map((observation) => observation.status),
+      classification,
+      visual: await collectVisualEvidence(allObservations),
+      sampleErrors: Array.from(new Set(allObservations.flatMap((observation) => observation.errors))).slice(0, 5)
+    });
+  }
+
+  return candidates.sort((a, b) => {
+    if (a.classification !== b.classification) return a.classification === "flaky" ? -1 : 1;
+    if (a.visual.suspected !== b.visual.suspected) return a.visual.suspected ? -1 : 1;
+    return a.key.localeCompare(b.key);
+  });
+}
+
+async function collectVisualEvidence(observations: TestObservation[]): Promise<VisualEvidence> {
+  const allAttachments = observations.flatMap((observation) => observation.attachments);
+  const imageAttachments = allAttachments.filter(isImageAttachment);
+  const text = observations
+    .flatMap((observation) => observation.errors)
+    .join("\n")
+    .toLowerCase();
+  const textSuggestsVisual =
+    text.includes("screenshot") || text.includes("snapshot") || text.includes("argos") || text.includes("pixel");
+  const imageDiffs = await diffImageAttachments(imageAttachments);
+
+  return {
+    suspected: textSuggestsVisual || imageDiffs.length > 0,
+    reason: textSuggestsVisual
+      ? "Failure output mentions screenshot/snapshot/Argos/pixel comparison"
+      : imageDiffs.length > 0
+        ? "Image attachments with matching names differed across reruns"
+        : undefined,
+    imageDiffs,
+    attachments: imageAttachments
+  };
+}
+
+function isImageAttachment(attachment: AttachmentEvidence) {
+  return Boolean(
+    attachment.copiedPath &&
+      (attachment.contentType?.startsWith("image/") || /\.(png|jpe?g|webp)$/i.test(attachment.copiedPath))
+  );
+}
+
+async function diffImageAttachments(attachments: AttachmentEvidence[]): Promise<ImageDiff[]> {
+  const byName = new Map<string, AttachmentEvidence[]>();
+  for (const attachment of attachments) {
+    const current = byName.get(attachment.name) ?? [];
+    current.push(attachment);
+    byName.set(attachment.name, current);
+  }
+
+  const diffs: ImageDiff[] = [];
+  for (const [name, namedAttachments] of byName.entries()) {
+    const unique = uniqueBy(namedAttachments, (attachment) => attachment.sha256 ?? attachment.copiedPath ?? "");
+    if (unique.length < 2) continue;
+    for (let i = 1; i < unique.length; i++) {
+      const first = unique[0].copiedPath;
+      const second = unique[i].copiedPath;
+      if (!first || !second) continue;
+      diffs.push(await diffImages(name, first, second));
+      if (diffs.length >= 8) return diffs;
+    }
+  }
+  return diffs;
+}
+
+function uniqueBy<T>(items: T[], keyFn: (item: T) => string) {
+  const seen = new Set<string>();
+  const unique: T[] = [];
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    unique.push(item);
+  }
+  return unique;
+}
+
+async function diffImages(attachmentName: string, firstImage: string, secondImage: string): Promise<ImageDiff> {
+  try {
+    const first = await sharp(firstImage).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+    const second = await sharp(secondImage).ensureAlpha().raw().toBuffer({ resolveWithObject: true });
+    if (first.info.width !== second.info.width || first.info.height !== second.info.height) {
+      return {
+        attachmentName,
+        firstImage,
+        secondImage,
+        width: first.info.width,
+        height: first.info.height,
+        note: `dimension mismatch: ${first.info.width}x${first.info.height} vs ${second.info.width}x${second.info.height}`
+      };
+    }
+
+    let differingPixels = 0;
+    const channels = first.info.channels;
+    for (let offset = 0; offset < first.data.length; offset += channels) {
+      let pixelDiffers = false;
+      for (let channel = 0; channel < channels; channel++) {
+        if (first.data[offset + channel] !== second.data[offset + channel]) {
+          pixelDiffers = true;
+          break;
+        }
+      }
+      if (pixelDiffers) differingPixels++;
+    }
+    const totalPixels = first.info.width * first.info.height;
+    return {
+      attachmentName,
+      firstImage,
+      secondImage,
+      width: first.info.width,
+      height: first.info.height,
+      differingPixels,
+      diffRatio: totalPixels === 0 ? 0 : differingPixels / totalPixels
+    };
+  } catch (error) {
+    return {
+      attachmentName,
+      firstImage,
+      secondImage,
+      note: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
+function diagnosticArgsFor(candidate: Pick<Candidate, "file" | "title" | "projectName">) {
+  const args = [candidate.file, "--grep", regexpEscape(candidate.title.split(" › ").at(-1) ?? candidate.title)];
+  if (candidate.projectName) {
+    args.push("--project", candidate.projectName);
+  }
+  return args;
+}
+
+function regexpEscape(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function writeSummary(
+  options: CliOptions,
+  suiteRuns: PlaywrightRun[],
+  diagnosticRuns: PlaywrightRun[],
+  candidates: Candidate[]
+) {
+  await mkdir(options.reportDir, { recursive: true });
+  const summaryPath = path.join(options.reportDir, "summary.json");
+  await writeFile(
+    summaryPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        options,
+        suiteRuns: suiteRuns.map(summarizeRun),
+        diagnosticRuns: diagnosticRuns.map(summarizeRun),
+        candidates
+      },
+      null,
+      2
+    )
+  );
+  return summaryPath;
+}
+
+function summarizeRun(run: PlaywrightRun) {
+  return {
+    label: run.label,
+    exitCode: run.exitCode,
+    command: run.command,
+    rawLogPath: run.rawLogPath,
+    jsonPath: run.jsonPath,
+    parseError: run.parseError,
+    reportErrors: run.reportErrors.slice(0, 5),
+    totals: {
+      passed: run.observations.filter((observation) => observation.status === "passed").length,
+      failed: run.observations.filter((observation) => observation.status === "failed").length,
+      skipped: run.observations.filter((observation) => observation.status === "skipped").length
+    }
+  };
+}
+
+function buildRepairPrompt(summaryPath: string, candidates: Candidate[], options: CliOptions) {
+  const visualGuidance = `
+Visual flake repair rules:
+- Prefer fixing nondeterminism in the system under test: deterministic ordering, stable clocks, race-free loading, deterministic data, and explicit readiness waits.
+- If the only volatile piece is an intentionally variable value in a screenshot, follow the existing pattern: add data-visual-test="transparent" plus an appropriate data-visual-placeholder in the rendered component.
+- Whenever masking a value for screenshots, add or preserve a Playwright assertion immediately before the visualScreenshot call that proves the real value is correct and visible. Do not mask without a behavioral assertion.
+- Do not update screenshots or visual baselines merely to hide nondeterminism.
+`;
+
+  return `You are the Pawtograder flaky E2E triage agent.
+
+Goal:
+Root-cause and repair the flaky Playwright E2E tests found by this triage run. Fix the system under test when the app is nondeterministic or racy. Only repair the test when the app behavior is correct and the test is brittle.
+
+Evidence:
+- Triage summary JSON: ${summaryPath}
+- Candidate tests:
+${candidates
+  .map((candidate, index) => {
+    const visual = candidate.visual.suspected
+      ? `visual suspected: ${candidate.visual.reason}; diffs=${candidate.visual.imageDiffs.length}`
+      : "visual not suspected";
+    return `${index + 1}. ${candidate.classification.toUpperCase()} ${candidate.key}
+   suite statuses: ${candidate.suiteStatuses.join(", ") || "none"}
+   diagnostic statuses: ${candidate.diagnosticStatuses.join(", ") || "none"}
+   ${visual}
+   sample errors: ${candidate.sampleErrors.map((message) => oneLine(message).slice(0, 350)).join(" | ") || "none"}`;
+  })
+  .join("\n")}
+
+Run and repair policy:
+- Read the JSON evidence and raw logs referenced from it.
+- Inspect the failing tests and the app code they exercise.
+- For each true flake, identify the root cause before editing.
+- Prefer app fixes over weakening tests.
+- After edits, run the targeted Playwright command(s) repeatedly. Use at least ${options.validationReruns} validation reruns for each repaired candidate, and run broader checks when the change could affect shared behavior.
+- Leave a concise summary of root cause, repair, and validation output.
+${visualGuidance}`;
+}
+
+function oneLine(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+async function runCursorRepairAgent(prompt: string, options: CliOptions) {
+  if (!process.env.CURSOR_API_KEY) {
+    throw new Error("CURSOR_API_KEY is required unless --dry-run or --skip-repair is set");
+  }
+
+  const agent = await Agent.create({
+    apiKey: process.env.CURSOR_API_KEY,
+    model: {
+      id: options.model,
+      params: [{ id: "thinking", value: "high" }]
+    },
+    local: { cwd: process.cwd() }
+  });
+
+  try {
+    const run = await agent.send(prompt);
+    for await (const event of run.stream()) {
+      printSdkEvent(event);
+    }
+    const result = await run.wait();
+    if (result.status !== "finished") {
+      throw new Error(`Cursor repair agent ended with status ${result.status}`);
+    }
+  } finally {
+    await agent[Symbol.asyncDispose]?.();
+  }
+}
+
+function printSdkEvent(event: SDKMessage) {
+  if (event.type === "assistant") {
+    for (const block of event.message.content) {
+      if (block.type === "text") process.stdout.write(block.text);
+    }
+  } else if (event.type === "tool_call") {
+    const status = event.status === "completed" ? "done" : event.status;
+    console.log(`\n[cursor:${status}] ${event.name}`);
+  } else if (event.type === "status" && event.message) {
+    console.log(`\n[cursor:${event.status}] ${event.message}`);
+  } else if (event.type === "task" && event.text) {
+    console.log(`\n[cursor:task] ${event.text}`);
+  }
+}
+
+async function runValidation(options: CliOptions, candidates: Candidate[]) {
+  const validationRuns: PlaywrightRun[] = [];
+  for (const candidate of candidates) {
+    for (let i = 0; i < options.validationReruns; i++) {
+      validationRuns.push(
+        await runPlaywright(
+          `validation-${sanitizeFileName(candidate.key)}-${i + 1}`,
+          options,
+          diagnosticArgsFor(candidate),
+          path.join(options.reportDir, "validation", sanitizeFileName(candidate.key), String(i + 1))
+        )
+      );
+    }
+  }
+  const validationPath = path.join(options.reportDir, "validation-summary.json");
+  await writeFile(
+    validationPath,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        runs: validationRuns.map(summarizeRun)
+      },
+      null,
+      2
+    )
+  );
+  return validationRuns;
+}
+
+async function listRunDirs(root: string) {
+  if (!existsSync(root)) return [];
+  const entries = await readdir(root);
+  const dirs: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry);
+    if ((await stat(entryPath)).isDirectory()) dirs.push(entryPath);
+  }
+  return dirs;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  await mkdir(options.reportDir, { recursive: true });
+  const suiteRuns: PlaywrightRun[] = [];
+  for (let i = 0; i < options.suiteRuns; i++) {
+    suiteRuns.push(
+      await runPlaywright(`suite-${i + 1}`, options, [], path.join(options.reportDir, "suite", String(i + 1)))
+    );
+  }
+
+  const initialCandidates = await identifyCandidates(suiteRuns, []);
+  const diagnosticRuns: PlaywrightRun[] = [];
+  for (const candidate of initialCandidates.slice(0, options.maxCandidates)) {
+    for (let i = 0; i < options.diagnosticReruns; i++) {
+      diagnosticRuns.push(
+        await runPlaywright(
+          `diagnostic-${sanitizeFileName(candidate.key)}-${i + 1}`,
+          options,
+          diagnosticArgsFor(candidate),
+          path.join(options.reportDir, "diagnostic", sanitizeFileName(candidate.key), String(i + 1))
+        )
+      );
+    }
+  }
+
+  const candidates = (await identifyCandidates(suiteRuns, diagnosticRuns)).slice(0, options.maxCandidates);
+  const summaryPath = await writeSummary(options, suiteRuns, diagnosticRuns, candidates);
+  const prompt = buildRepairPrompt(summaryPath, candidates, options);
+  const promptPath = path.join(options.reportDir, "cursor-repair-prompt.md");
+  await writeFile(promptPath, prompt);
+
+  console.log(`\nTriage summary: ${summaryPath}`);
+  console.log(`Cursor repair prompt: ${promptPath}`);
+  console.log(`Run directories: ${(await listRunDirs(options.reportDir)).join(", ")}`);
+  const runnerFailures = [...suiteRuns, ...diagnosticRuns].filter(
+    (run) => run.exitCode !== 0 && run.observations.length === 0
+  );
+  if (runnerFailures.length > 0) {
+    throw new Error(
+      `Playwright failed before reporting test observations; see ${runnerFailures
+        .map((run) => run.rawLogPath)
+        .join(", ")}`
+    );
+  }
+  if (candidates.length === 0) {
+    console.log("No failed or flaky tests were observed.");
+    return;
+  }
+
+  if (options.dryRun || options.skipRepair) {
+    console.log(options.dryRun ? "Dry run complete; Cursor repair agent was not invoked." : "Repair skipped.");
+    return;
+  }
+
+  await runCursorRepairAgent(prompt, options);
+  const validationRuns = await runValidation(options, candidates);
+  const failedValidation = validationRuns.filter((run) => run.exitCode !== 0);
+  if (failedValidation.length > 0) {
+    throw new Error(`${failedValidation.length} validation run(s) still failed; see ${options.reportDir}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a TypeScript flaky E2E triage agent powered by `@cursor/sdk`.
- Run repeated Playwright suite/targeted reruns, preserve Argos visual artifacts, diff image attachments, and generate a repair prompt.
- Add `npm run triage:flaky-e2e` for invoking the agent.

## Testing
- `npm run format`
- `npm run triage:flaky-e2e -- --help`
- `npx eslint scripts/FlakyTestTriageAgent.ts`
- `npx tsc --noEmit --pretty false --target ESNext --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck scripts/FlakyTestTriageAgent.ts`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe2c5e65-1dd2-40ee-a76f-d209457733ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe2c5e65-1dd2-40ee-a76f-d209457733ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

