### PR TITLE
Rubrics hide unless assigned

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,6 +265,18 @@ jobs:
           docker exec -i "supabase_db_${SUPABASE_PROJECT}" psql -U postgres -d postgres -c \
             "SELECT public.audit_maintain_partitions();"
 
+      # Jest integration tests that hit the local Supabase API directly
+      # (no Next.js / edge-functions needed). Convention: files named
+      # tests/unit/issue*.test.ts gate on RUN_SUPABASE_INTEGRATION_TESTS=true
+      # and self-skip otherwise — set the env var here so they actually run.
+      - name: Run Jest integration tests
+        env:
+          SUPABASE_URL: ${{ env.LOCAL_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ env.LOCAL_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ env.LOCAL_SUPABASE_SERVICE_ROLE_KEY }}
+          RUN_SUPABASE_INTEGRATION_TESTS: "true"
+        run: npx jest --runInBand --testPathPatterns "tests/unit/issue"
+
       - name: Serve Edge Functions
         run: |
           set -euo pipefail

--- a/app/course/[course_id]/assignments/[assignment_id]/finalizeSubmissionEarly.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/finalizeSubmissionEarly.tsx
@@ -37,7 +37,7 @@ export default function FinalizeSubmissionEarly({
 }) {
   const supabase = useMemo(() => createClient(), []);
   const isReadOnly = useIsReadOnly();
-  const { reviewAssignments } = useAssignmentController();
+  const assignmentController = useAssignmentController();
 
   // makes the due date for the student and all group members NOW rather than previous.  rounds back.
   // ex if something is due at 9:15pm and the student marks "finished" at 6:30pm, their deadline will be moved
@@ -81,7 +81,9 @@ export default function FinalizeSubmissionEarly({
           "Assignment not found": "This assignment could not be found. Refresh the page or contact your instructor.",
           "No active submission found":
             "You don't have an active submission to finalize. Create or resume your submission first.",
-          "Self review already assigned": "A self-review has already been assigned for this submission."
+          "Self review already assigned": "A self-review has already been assigned for this submission.",
+          "Self review rubric not configured":
+            "Self-review is enabled but no self-review rubric has been set up for this assignment. Ask your instructor to configure the self-review rubric."
         };
         const mapped = reason && friendly[reason];
         toaster.error({
@@ -100,14 +102,16 @@ export default function FinalizeSubmissionEarly({
         description: "Your submission time is set. You can continue with self-review if your course uses it."
       });
 
-      // Refresh the review_assignments controller so the self-review row
-      // created by finalize_submission_early is in cache before the UI
-      // renders the "Complete Self Review" button. Failures here are
-      // non-fatal (the row will arrive via realtime or the next page load).
+      // Refresh review_assignments and rubric controllers so the self-review
+      // row and rubric (gated by hide_unless_assigned RLS) are in cache before
+      // the UI renders the "Complete Self Review" button.
       try {
-        await reviewAssignments.refetchAll();
+        await Promise.all([
+          assignmentController.reviewAssignments.refetchAll(),
+          assignmentController.refetchAllRubricData()
+        ]);
       } catch (refetchErr) {
-        console.warn("Submission finalized, but reviewAssignments refetch failed:", refetchErr);
+        console.warn("Submission finalized, but post-finalize cache refresh failed:", refetchErr);
         toaster.create({
           type: "warning",
           title: "Self-review may take a moment to appear",

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
@@ -39,13 +39,15 @@ export default function EditAssignment() {
       form.setValue("eval_config", selfReviewSetting?.data.enabled ? "use_eval" : "base_only");
       form.setValue("deadline_offset", selfReviewSetting?.data.deadline_offset);
       form.setValue("allow_early", selfReviewSetting?.data.allow_early);
+      form.setValue("self_review_release_at", selfReviewSetting?.data.release_at ?? null);
     }
   }, [
     queryData,
     form,
     selfReviewSetting?.data.allow_early,
     selfReviewSetting?.data.deadline_offset,
-    selfReviewSetting?.data.enabled
+    selfReviewSetting?.data.enabled,
+    selfReviewSetting?.data.release_at
   ]);
 
   const onFinish = useCallback(
@@ -62,6 +64,7 @@ export default function EditAssignment() {
                 enabled: isEnabled,
                 deadline_offset: isEnabled ? values.deadline_offset : null,
                 allow_early: isEnabled ? values.allow_early : null,
+                release_at: isEnabled ? values.self_review_release_at || null : null,
                 class_id: course_id
               }
             },
@@ -88,6 +91,7 @@ export default function EditAssignment() {
         values.eval_config = undefined;
         values.allow_early = undefined;
         values.deadline_offset = undefined;
+        values.self_review_release_at = undefined;
         await form.refineCore.onFinish(values);
         await revalidateCourseDerivedCachesClient(Number.parseInt(course_id as string, 10));
         if (values.template_repo) {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -1224,6 +1224,7 @@ function InnerRubricPage() {
         description: parsedRubricFromEditor.description,
         is_private: parsedRubricFromEditor.is_private ?? false,
         cap_score_to_assignment_points: parsedRubricFromEditor.cap_score_to_assignment_points ?? false,
+        hide_unless_assigned: parsedRubricFromEditor.hide_unless_assigned ?? false,
         parts: parsedRubricFromEditor.rubric_parts.map((part, partIdx) => ({
           id: part.id,
           name: part.name,

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -16,6 +16,7 @@ import {
 import { useListTableControllerValues } from "@/lib/TableController";
 import type { RubricCheckReference } from "@/utils/supabase/DatabaseTypes";
 import {
+  Assignment,
   HydratedRubric,
   HydratedRubricCheck,
   HydratedRubricCriteria,
@@ -124,6 +125,55 @@ function hydrateRubricForReviewRoundFromController(
     controller.rubricChecksController.rows as HydratedRubricCheck[],
     controller.rubricCheckReferencesController.rows
   );
+}
+
+type AssignmentRubricFkColumn = "grading_rubric_id" | "self_review_rubric_id" | "meta_grading_rubric_id";
+
+function assignmentRubricFkForRound(
+  reviewRound: NonNullable<HydratedRubric["review_round"]>
+): AssignmentRubricFkColumn | null {
+  switch (reviewRound) {
+    case "grading-review":
+      return "grading_rubric_id";
+    case "self-review":
+      return "self_review_rubric_id";
+    case "meta-grading-review":
+      return "meta_grading_rubric_id";
+    default:
+      return null;
+  }
+}
+
+/** Prefer the loaded rubric row, then the assignment FK column for this review round. */
+function resolveExistingRubricIdForRound(
+  assignment: Assignment | undefined,
+  reviewRound: NonNullable<HydratedRubric["review_round"]>,
+  hydratedRubrics: HydratedRubric[]
+): number | undefined {
+  const fromList = hydratedRubrics.find((r) => r.review_round === reviewRound && r.id > 0)?.id;
+  if (fromList) return fromList;
+  const fkColumn = assignment ? assignmentRubricFkForRound(reviewRound) : null;
+  if (!fkColumn || !assignment) return undefined;
+  const fkId = assignment[fkColumn];
+  return fkId && fkId > 0 ? fkId : undefined;
+}
+
+async function syncAssignmentRubricFkIfNeeded(
+  assignment: Assignment,
+  reviewRound: NonNullable<HydratedRubric["review_round"]>,
+  savedRubricId: number
+) {
+  const fkColumn = assignmentRubricFkForRound(reviewRound);
+  if (!fkColumn || assignment[fkColumn] === savedRubricId) return;
+
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("assignments")
+    .update({ [fkColumn]: savedRubricId })
+    .eq("id", assignment.id);
+  if (error) {
+    throw new Error(`Rubric saved but failed to link it to the assignment: ${error.message}`);
+  }
 }
 
 /**
@@ -486,7 +536,19 @@ function InnerRubricPage() {
     (
       currentAssignmentId: string,
       currentClassId: number,
-      reviewRound: HydratedRubric["review_round"]
+      reviewRound: HydratedRubric["review_round"],
+      existingRubric?: Partial<
+        Pick<
+          HydratedRubric,
+          | "id"
+          | "name"
+          | "description"
+          | "is_private"
+          | "cap_score_to_assignment_points"
+          | "hide_unless_assigned"
+          | "created_at"
+        >
+      >
     ): HydratedRubric => {
       const roundNameProper = reviewRound
         ? reviewRound
@@ -494,20 +556,20 @@ function InnerRubricPage() {
             .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
             .join(" ")
         : "New";
-      const name = `${roundNameProper} Rubric for ${assignmentDetails?.title || "Assignment"}`;
+      const defaultName = `${roundNameProper} Rubric for ${assignmentDetails?.title || "Assignment"}`;
 
       return {
-        id: 0, // Indicates it's a new, unsaved rubric template
-        name: name,
-        description: null,
+        id: existingRubric?.id ?? 0,
+        name: existingRubric?.name ?? defaultName,
+        description: existingRubric?.description ?? null,
         assignment_id: Number(currentAssignmentId),
         class_id: currentClassId,
-        is_private: false,
+        is_private: existingRubric?.is_private ?? false,
         review_round: reviewRound,
         rubric_parts: [],
-        created_at: "", // Will be set by DB
-        cap_score_to_assignment_points: false,
-        hide_unless_assigned: false
+        created_at: existingRubric?.created_at ?? "",
+        cap_score_to_assignment_points: existingRubric?.cap_score_to_assignment_points ?? false,
+        hide_unless_assigned: existingRubric?.hide_unless_assigned ?? false
       };
     },
     [assignmentDetails?.title]
@@ -517,7 +579,8 @@ function InnerRubricPage() {
     (
       currentAssignmentId: string,
       currentClassId: number,
-      reviewRound: NonNullable<HydratedRubric["review_round"]>
+      reviewRound: NonNullable<HydratedRubric["review_round"]>,
+      existingRubricId = 0
     ): HydratedRubric => {
       const newRubricBase = YAML.parse(defaultRubric) as YmlRubricType;
       if (assignmentDetails?.title) {
@@ -532,7 +595,7 @@ function InnerRubricPage() {
         is_private: false,
         review_round: reviewRound
       });
-      hydrated.id = 0; // New template, not saved yet
+      hydrated.id = existingRubricId;
       hydrated.class_id = currentClassId;
       hydrated.assignment_id = Number(currentAssignmentId);
       hydrated.review_round = reviewRound;
@@ -540,11 +603,11 @@ function InnerRubricPage() {
       hydrated.rubric_parts.forEach((part, pIdx) => {
         part.id = -(pIdx + 1); // Negative IDs for new items not yet in DB
         part.class_id = currentClassId;
-        part.rubric_id = 0; // Will be set upon saving the main rubric
+        part.rubric_id = hydrated.id;
         part.rubric_criteria.forEach((criteria, cIdx) => {
           criteria.id = -(cIdx + 1 + pIdx * 100);
           criteria.class_id = currentClassId;
-          criteria.rubric_id = 0;
+          criteria.rubric_id = hydrated.id;
           criteria.rubric_part_id = part.id;
           criteria.rubric_checks.forEach((check, chIdx) => {
             check.id = -(chIdx + 1 + cIdx * 1000 + pIdx * 100000);
@@ -557,6 +620,27 @@ function InnerRubricPage() {
     },
     [assignmentDetails?.title]
   );
+
+  const handleCreateNewRubric = useCallback(() => {
+    if (!assignmentDetails || !activeReviewRound) return;
+    const existingId = resolveExistingRubricIdForRound(assignmentDetails, activeReviewRound, allHydratedRubrics);
+    const existingRubric = existingId ? allHydratedRubrics.find((r) => r.id === existingId) : undefined;
+    const minimal = createMinimalNewHydratedRubric(
+      assignment_id as string,
+      assignmentDetails.class_id,
+      activeReviewRound,
+      existingRubric ?? (existingId ? { id: existingId } : undefined)
+    );
+    setActiveRubric(minimal);
+    setGuiEditorEpoch((e) => e + 1);
+    setHasUnsavedChanges(true);
+    setUnsavedStatusPerTab((prev) => ({ ...prev, [activeReviewRound]: true }));
+    setStashedEditorStates((prev) => {
+      const newState = { ...prev };
+      delete newState[activeReviewRound];
+      return newState;
+    });
+  }, [assignmentDetails, activeReviewRound, assignment_id, allHydratedRubrics, createMinimalNewHydratedRubric]);
 
   const handleReviewRoundChange = useCallback(
     (newReviewRound: NonNullable<HydratedRubric["review_round"]>) => {
@@ -1117,7 +1201,16 @@ function InnerRubricPage() {
       // Identify the existing rubric (if any) for this review round; the RPC
       // distinguishes update-vs-create from the `id` field in the payload.
       const existingRubricForRound = allHydratedRubrics.find((r) => r.review_round === activeReviewRound && r.id > 0);
-      const rubricId = existingRubricForRound?.id ?? 0;
+      const resolvedExistingId = resolveExistingRubricIdForRound(
+        assignmentDetails,
+        activeReviewRound,
+        allHydratedRubrics
+      );
+      const rubricId =
+        (activeRubric && activeRubric.id > 0 ? activeRubric.id : 0) ||
+        existingRubricForRound?.id ||
+        resolvedExistingId ||
+        0;
 
       // Resolve cross-rubric YAML references against the live set of sibling
       // rubrics. We pass the resolved (referencing, referenced) pairs in the
@@ -1288,6 +1381,7 @@ function InnerRubricPage() {
 
       const freshRubric = hydrateRubricForReviewRoundFromController(assignmentController, activeReviewRound);
       if (freshRubric) {
+        await syncAssignmentRubricFkIfNeeded(assignmentDetails, activeReviewRound, freshRubric.id);
         syncEditorFromSavedRubric(freshRubric);
       }
 
@@ -1302,7 +1396,8 @@ function InnerRubricPage() {
       syncEditorFromSavedRubric,
       invalidate,
       allHydratedRubrics,
-      unsavedStatusPerTab
+      unsavedStatusPerTab,
+      activeRubric
     ]
   );
 
@@ -1339,10 +1434,13 @@ function InnerRubricPage() {
             size="xs"
             onClick={() => {
               if (assignmentDetails && activeReviewRound) {
+                const existingId =
+                  resolveExistingRubricIdForRound(assignmentDetails, activeReviewRound, allHydratedRubrics) ?? 0;
                 const demoTemplate = createNewRubricTemplate(
                   assignment_id as string,
                   assignmentDetails.class_id,
-                  activeReviewRound
+                  activeReviewRound,
+                  existingId
                 );
                 setActiveRubric(demoTemplate);
                 setGuiEditorEpoch((e) => e + 1);
@@ -1548,13 +1646,11 @@ function InnerRubricPage() {
                   />
                 </Box>
               )}
-              {viewMode === "gui" && !activeRubric && (
+              {viewMode === "gui" && !activeRubric && !isLoadingCurrentRubric && (
                 <Center h="calc(100vh - 150px)" w="100%">
-                  <VStack>
+                  <VStack gap={3}>
                     <Text>No rubric configured for this review round.</Text>
-                    <Text fontSize="sm" color="fg.muted">
-                      Load a demo template or switch to YAML to paste one in.
-                    </Text>
+                    <Button onClick={handleCreateNewRubric}>Create New Rubric</Button>
                   </VStack>
                 </Center>
               )}

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -506,7 +506,8 @@ function InnerRubricPage() {
         review_round: reviewRound,
         rubric_parts: [],
         created_at: "", // Will be set by DB
-        cap_score_to_assignment_points: false
+        cap_score_to_assignment_points: false,
+        hide_unless_assigned: false
       };
     },
     [assignmentDetails?.title]

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -769,6 +769,7 @@ function InnerRubricPage() {
             review_round: activeReviewRound, // Always force to current tab's review round
             rubric_parts: hydratedFromYaml.rubric_parts,
             cap_score_to_assignment_points: hydratedFromYaml.cap_score_to_assignment_points ?? false,
+            hide_unless_assigned: hydratedFromYaml.hide_unless_assigned ?? false,
             // Preserve ID if editing an existing rubric, otherwise it's 0 or negative from template
             id: activeRubric && activeRubric.id > 0 ? activeRubric.id : 0,
             assignment_id: Number(assignment_id),

--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -444,7 +444,7 @@ function LabDueDateSubform({ form }: { form: UseFormReturnType<Assignment> }) {
   );
 }
 
-function SelfEvaluationSubform({ form }: { form: UseFormReturnType<Assignment> }) {
+function SelfEvaluationSubform({ form, timezone }: { form: UseFormReturnType<Assignment>; timezone: string }) {
   const [withEval, setWithEval] = useState<boolean>(false);
   const [allowEarly, setAllowEarly] = useState<boolean>(form.getValues("allow_early") == true);
 
@@ -452,6 +452,7 @@ function SelfEvaluationSubform({ form }: { form: UseFormReturnType<Assignment> }
     register,
     getValues,
     watch,
+    control,
     formState: { errors }
   } = form;
 
@@ -535,6 +536,34 @@ function SelfEvaluationSubform({ form }: { form: UseFormReturnType<Assignment> }
                 <Checkbox.Label>Allow early submission</Checkbox.Label>
               </Checkbox.Root>
             </Field>
+            <Fieldset.Content>
+              <Field
+                label={`Release self-review at (${timezone}, optional)`}
+                helperText="If set, the self-review is assigned and becomes visible to all students at this exact wall-clock time, ignoring per-student due-date exceptions. Leave blank to release when the programming assignment's due date passes (current behavior). Pairs with the rubric option 'Hide from students until assigned'."
+              >
+                <Controller
+                  name="self_review_release_at"
+                  control={control}
+                  render={({ field }) => {
+                    const raw = field.value as string | null | undefined;
+                    const hasATimezoneOffset =
+                      typeof raw === "string" &&
+                      raw.length >= 6 &&
+                      (raw.charAt(raw.length - 6) === "+" || raw.charAt(raw.length - 6) === "-");
+                    const localValue =
+                      raw && hasATimezoneOffset ? new TZDate(raw, timezone).toISOString().slice(0, -13) : (raw ?? "");
+                    return (
+                      <Input
+                        type="datetime-local"
+                        value={localValue}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                        onBlur={field.onBlur}
+                      />
+                    );
+                  }}
+                />
+              </Field>
+            </Fieldset.Content>
           </>
         )}
       </CardBody>
@@ -596,7 +625,10 @@ export default function AssignmentForm({
         release_date: appendTimezoneOffset(values.release_date, timezone),
         due_date: appendTimezoneOffset(values.due_date, timezone),
         group_formation_deadline: appendTimezoneOffset(values.group_formation_deadline, timezone),
-        regrade_deadline: appendTimezoneOffset(values.regrade_deadline, timezone)
+        regrade_deadline: appendTimezoneOffset(values.regrade_deadline, timezone),
+        self_review_release_at: values.self_review_release_at
+          ? appendTimezoneOffset(values.self_review_release_at, timezone)
+          : null
       };
       try {
         await onSubmit(valuesWithDates);
@@ -841,7 +873,7 @@ export default function AssignmentForm({
             </Field>
           </Fieldset.Content>
           <GroupConfigurationSubform form={form} timezone={timezone} />
-          <SelfEvaluationSubform form={form} />
+          <SelfEvaluationSubform form={form} timezone={timezone} />
           <Fieldset.Content>
             <Field
               label={`Regrade Request Deadline (${course.time_zone})`}

--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -23,6 +23,7 @@ import { appendTimezoneOffset } from "@/lib/utils";
 import { Assignment } from "@/utils/supabase/DatabaseTypes";
 import { TZDate } from "@date-fns/tz";
 import { addMinutes } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { useList } from "@refinedev/core";
 import { UseFormReturnType } from "@refinedev/react-hook-form";
 import { useParams } from "next/navigation";
@@ -551,7 +552,9 @@ function SelfEvaluationSubform({ form, timezone }: { form: UseFormReturnType<Ass
                       raw.length >= 6 &&
                       (raw.charAt(raw.length - 6) === "+" || raw.charAt(raw.length - 6) === "-");
                     const localValue =
-                      raw && hasATimezoneOffset ? new TZDate(raw, timezone).toISOString().slice(0, -13) : (raw ?? "");
+                      raw && hasATimezoneOffset
+                        ? formatInTimeZone(raw, timezone, "yyyy-MM-dd'T'HH:mm")
+                        : (raw ?? "");
                     return (
                       <Input
                         type="datetime-local"

--- a/app/course/[course_id]/manage/assignments/new/form.tsx
+++ b/app/course/[course_id]/manage/assignments/new/form.tsx
@@ -552,9 +552,7 @@ function SelfEvaluationSubform({ form, timezone }: { form: UseFormReturnType<Ass
                       raw.length >= 6 &&
                       (raw.charAt(raw.length - 6) === "+" || raw.charAt(raw.length - 6) === "-");
                     const localValue =
-                      raw && hasATimezoneOffset
-                        ? formatInTimeZone(raw, timezone, "yyyy-MM-dd'T'HH:mm")
-                        : (raw ?? "");
+                      raw && hasATimezoneOffset ? formatInTimeZone(raw, timezone, "yyyy-MM-dd'T'HH:mm") : (raw ?? "");
                     return (
                       <Input
                         type="datetime-local"

--- a/app/course/[course_id]/manage/assignments/new/page.tsx
+++ b/app/course/[course_id]/manage/assignments/new/page.tsx
@@ -64,6 +64,7 @@ export default function NewAssignmentPage() {
               enabled: isEnabled,
               deadline_offset: isEnabled ? getValues("deadline_offset") : null,
               allow_early: isEnabled ? getValues("allow_early") : null,
+              release_at: isEnabled ? getValues("self_review_release_at") || null : null,
               class_id: course_id
             }
           },

--- a/app/course/[course_id]/manage/assignments/new/page.tsx
+++ b/app/course/[course_id]/manage/assignments/new/page.tsx
@@ -64,7 +64,10 @@ export default function NewAssignmentPage() {
               enabled: isEnabled,
               deadline_offset: isEnabled ? getValues("deadline_offset") : null,
               allow_early: isEnabled ? getValues("allow_early") : null,
-              release_at: isEnabled ? getValues("self_review_release_at") || null : null,
+              release_at:
+                isEnabled && getValues("self_review_release_at")
+                  ? new TZDate(getValues("self_review_release_at"), timezone).toISOString()
+                  : null,
               class_id: course_id
             }
           },

--- a/components/rubric-editor/RubricHeaderForm.tsx
+++ b/components/rubric-editor/RubricHeaderForm.tsx
@@ -55,6 +55,14 @@ export function RubricHeaderForm({ rubric, onChange, validationErrors }: RubricH
           </Switch>
         </Field>
       )}
+      <Field helperText="When enabled, students cannot see this rubric's contents (parts, criteria, checks) until a review on it has been assigned to them. Use this for self-review rubrics where seeing the questions before submitting would bias the student's work.">
+        <Switch
+          checked={rubric.hide_unless_assigned ?? false}
+          onCheckedChange={(details) => onChange({ ...rubric, hide_unless_assigned: details.checked })}
+        >
+          Hide from students until assigned
+        </Switch>
+      </Field>
     </Stack>
   );
 }

--- a/hooks/useAssignment.tsx
+++ b/hooks/useAssignment.tsx
@@ -17,6 +17,7 @@ import {
 import { ClassRealTimeController } from "@/lib/ClassRealTimeController";
 import type { AssignmentControllerInitialData } from "@/lib/ssrUtils";
 import TableController, {
+  type BroadcastMessage,
   useFindTableControllerValue,
   useListTableControllerValues,
   useTableControllerTableValues,
@@ -446,6 +447,7 @@ export class AssignmentController {
     TableController<"review_assignment_rubric_parts">
   > = new Map();
   private _reviewAssignmentRubricPartsRefCount: Map<number, number> = new Map();
+  private _reviewAssignmentRubricHydrationUnsubscribe: (() => void) | null = null;
 
   constructor({
     client,
@@ -578,8 +580,54 @@ export class AssignmentController {
       table: "error_pin_rules",
       classRealTimeController
     });
+
+    // Self-review rubrics with hide_unless_assigned are invisible until a
+    // review_assignments row exists. Refetch rubric controllers when one
+    // arrives so useRubric("self-review") hydrates after RLS opens up.
+    this._reviewAssignmentRubricHydrationUnsubscribe = classRealTimeController.subscribeToTable(
+      "review_assignments",
+      (message: BroadcastMessage) => {
+        if (message.operation !== "INSERT" && message.operation !== "UPDATE") return;
+        const data = message.data as
+          | {
+              assignment_id?: number;
+              assignee_profile_id?: string;
+              rubric_id?: number | null;
+            }
+          | undefined;
+        if (!data || data.assignment_id !== assignment_id) return;
+        if (data.assignee_profile_id !== classRealTimeController.profileId) return;
+        if (!this._shouldRefetchRubricsForReviewAssignment(data)) return;
+        void this.refetchAllRubricData();
+      }
+    );
+  }
+
+  /**
+   * Refetch all rubric table controllers for this assignment. Needed when RLS
+   * starts allowing rubric reads after a review_assignment is created/released.
+   */
+  async refetchAllRubricData(): Promise<void> {
+    await Promise.all([
+      this.rubricsController.refetchAll(),
+      this.rubricPartsController.refetchAll(),
+      this.rubricCriteriaController.refetchAll(),
+      this.rubricChecksController.refetchAll(),
+      this.rubricCheckReferencesController.refetchAll()
+    ]);
+  }
+
+  private _shouldRefetchRubricsForReviewAssignment(data: { rubric_id?: number | null }): boolean {
+    if (!this._assignment) return true;
+    const selfReviewRubricId = this._assignment.self_review_rubric_id;
+    if (!selfReviewRubricId) return true;
+    return data.rubric_id === selfReviewRubricId;
   }
   close() {
+    if (this._reviewAssignmentRubricHydrationUnsubscribe) {
+      this._reviewAssignmentRubricHydrationUnsubscribe();
+      this._reviewAssignmentRubricHydrationUnsubscribe = null;
+    }
     this.reviewAssignments.close();
     this.regradeRequests.close();
     this.submissions.close();

--- a/lib/PreviewAssignmentController.ts
+++ b/lib/PreviewAssignmentController.ts
@@ -25,7 +25,8 @@ export function flattenHydratedRubric(hydrated: HydratedRubric) {
     is_private: hydrated.is_private,
     review_round: hydrated.review_round,
     created_at: hydrated.created_at,
-    cap_score_to_assignment_points: hydrated.cap_score_to_assignment_points ?? false
+    cap_score_to_assignment_points: hydrated.cap_score_to_assignment_points ?? false,
+    hide_unless_assigned: hydrated.hide_unless_assigned ?? false
   };
 
   const parts: RubricPart[] = [];

--- a/lib/rubric/parse.ts
+++ b/lib/rubric/parse.ts
@@ -139,7 +139,8 @@ export function YamlRubricToHydratedRubric(
     rubric_parts: YamlPartsToHydratedParts(yaml.parts),
     is_private,
     review_round,
-    cap_score_to_assignment_points: yaml.cap_score_to_assignment_points ?? false
+    cap_score_to_assignment_points: yaml.cap_score_to_assignment_points ?? false,
+    hide_unless_assigned: yaml.hide_unless_assigned ?? false
   };
   return sanitizeHydratedRubricPoints(rubric).rubric;
 }

--- a/lib/rubric/serialize.ts
+++ b/lib/rubric/serialize.ts
@@ -105,6 +105,7 @@ export function HydratedRubricToYamlRubric(rubric: HydratedRubric, ctx?: Seriali
     name: rubric.name,
     description: valOrUndefined(rubric.description),
     parts: hydratedRubricPartToYamlRubric(rubric.rubric_parts, ctx),
-    cap_score_to_assignment_points: rubric.cap_score_to_assignment_points ?? undefined
+    cap_score_to_assignment_points: rubric.cap_score_to_assignment_points ?? undefined,
+    hide_unless_assigned: rubric.hide_unless_assigned ?? undefined
   };
 }

--- a/public/RubricSchema.json
+++ b/public/RubricSchema.json
@@ -282,6 +282,9 @@
     "description": {
       "type": "string"
     },
+    "hide_unless_assigned": {
+      "type": "boolean"
+    },
     "name": {
       "type": "string"
     },

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -988,6 +988,7 @@ export type Database = {
           deadline_offset: number | null;
           enabled: boolean;
           id: number;
+          release_at: string | null;
         };
         Insert: {
           allow_early?: boolean | null;
@@ -995,6 +996,7 @@ export type Database = {
           deadline_offset?: number | null;
           enabled?: boolean;
           id?: number;
+          release_at?: string | null;
         };
         Update: {
           allow_early?: boolean | null;
@@ -1002,6 +1004,7 @@ export type Database = {
           deadline_offset?: number | null;
           enabled?: boolean;
           id?: number;
+          release_at?: string | null;
         };
         Relationships: [
           {
@@ -7101,6 +7104,7 @@ export type Database = {
           class_id: number;
           created_at: string;
           description: string | null;
+          hide_unless_assigned: boolean;
           id: number;
           is_private: boolean;
           name: string;
@@ -7112,6 +7116,7 @@ export type Database = {
           class_id: number;
           created_at?: string;
           description?: string | null;
+          hide_unless_assigned?: boolean;
           id?: number;
           is_private?: boolean;
           name: string;
@@ -7123,6 +7128,7 @@ export type Database = {
           class_id?: number;
           created_at?: string;
           description?: string | null;
+          hide_unless_assigned?: boolean;
           id?: number;
           is_private?: boolean;
           name?: string;
@@ -11076,6 +11082,18 @@ export type Database = {
         };
         Returns: Json;
       };
+      _materialize_bare_check_regrade_comment: {
+        Args: {
+          p_author: string;
+          p_line: number;
+          p_points: number;
+          p_regrade_request_id: number;
+          p_request: Database["public"]["Tables"]["submission_regrade_requests"]["Row"];
+          p_submission_artifact_id: number;
+          p_submission_file_id: number;
+        };
+        Returns: Record<string, unknown>;
+      };
       _submission_review_is_completable: {
         Args: { p_submission_review_id: number };
         Returns: boolean;
@@ -11352,6 +11370,10 @@ export type Database = {
         | { Args: { poll__id: number }; Returns: boolean }
         | { Args: { class__id: number; poll__id: number }; Returns: boolean };
       authorizeforprofile: { Args: { profile_id: string }; Returns: boolean };
+      auto_assign_self_reviews: {
+        Args: { this_assignment_id: number; this_profile_id: string };
+        Returns: undefined;
+      };
       bulk_assign_reviews: {
         Args: {
           p_assignment_id: number;

--- a/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
+++ b/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
@@ -1,0 +1,937 @@
+-- Rubric "hide unless assigned" + self-review explicit release_at.
+--
+-- 1. rubrics.hide_unless_assigned (boolean, default false): when true, students
+--    cannot SELECT the rubric (or its parts/checks) until a review_assignments
+--    row exists for them on that rubric and that row's release_date has passed
+--    (or is NULL). Instructors/graders see rubrics unconditionally.
+--
+-- 2. assignment_self_review_settings.release_at (timestamptz nullable): when
+--    NULL (default), self-review release timing keeps current behavior --
+--    review_assignments rows are created when the assignment's due_date passes
+--    (plus per-student exceptions). When set, release happens at the explicit
+--    wall-clock time, exceptions are ignored for release timing, and the
+--    review's own due_date is computed as release_at + deadline_offset hours.
+
+----------------------------------------------------------------
+-- Schema
+----------------------------------------------------------------
+ALTER TABLE public.rubrics
+  ADD COLUMN hide_unless_assigned boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.assignment_self_review_settings
+  ADD COLUMN release_at timestamptz NULL;
+
+----------------------------------------------------------------
+-- RLS: rubrics SELECT
+-- Non-graders may only see a rubric when hide_unless_assigned = false
+-- OR they have an active (released) review_assignment for it.
+----------------------------------------------------------------
+ALTER POLICY "authorizeforclass"
+ON public.rubrics
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.user_privileges up
+    WHERE up.user_id = auth.uid()
+      AND up.class_id = rubrics.class_id
+  )
+  AND (
+    EXISTS (
+      SELECT 1
+      FROM public.user_privileges up
+      WHERE up.user_id = auth.uid()
+        AND up.class_id = rubrics.class_id
+        AND up.role IN ('instructor', 'grader')
+    )
+    OR (
+      is_private = false
+      AND (
+        hide_unless_assigned = false
+        OR EXISTS (
+          SELECT 1
+          FROM public.review_assignments ra
+          JOIN public.user_privileges up ON up.private_profile_id = ra.assignee_profile_id
+          WHERE ra.rubric_id = rubrics.id
+            AND up.user_id = auth.uid()
+            AND up.class_id = rubrics.class_id
+            AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+        )
+      )
+    )
+  )
+);
+
+----------------------------------------------------------------
+-- RLS: rubric_parts SELECT
+-- Mirror the parent rubric's gate.
+----------------------------------------------------------------
+ALTER POLICY "authorizeforclass"
+ON public.rubric_parts
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.rubrics r
+    WHERE r.id = rubric_parts.rubric_id
+      AND authorizeforclass(r.class_id)
+      AND (
+        authorizeforclassgrader(r.class_id)
+        OR (
+          r.is_private = false
+          AND (
+            r.hide_unless_assigned = false
+            OR EXISTS (
+              SELECT 1
+              FROM public.review_assignments ra
+              JOIN public.user_privileges up ON up.private_profile_id = ra.assignee_profile_id
+              WHERE ra.rubric_id = r.id
+                AND up.user_id = auth.uid()
+                AND up.class_id = r.class_id
+                AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+            )
+          )
+        )
+      )
+  )
+);
+
+----------------------------------------------------------------
+-- RLS: rubric_checks "students see only based on visibility" SELECT
+-- Same gate at the parent rubric level. Instructor/grader policy unchanged.
+----------------------------------------------------------------
+ALTER POLICY "students see only based on visibility" ON public.rubric_checks
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.rubric_criteria rc
+    JOIN public.rubrics r ON r.id = rc.rubric_id
+    WHERE rc.id = rubric_checks.rubric_criteria_id
+      AND EXISTS (
+        SELECT 1 FROM public.user_privileges up
+        WHERE up.user_id = auth.uid()
+          AND up.class_id = r.class_id
+      )
+      AND r.is_private = false
+      AND (
+        r.hide_unless_assigned = false
+        OR EXISTS (
+          SELECT 1
+          FROM public.review_assignments ra
+          JOIN public.user_privileges up ON up.private_profile_id = ra.assignee_profile_id
+          WHERE ra.rubric_id = r.id
+            AND up.user_id = auth.uid()
+            AND up.class_id = r.class_id
+            AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+        )
+      )
+      AND (
+        rubric_checks.student_visibility = 'always'
+        OR (
+          rubric_checks.student_visibility = 'if_released'
+          AND EXISTS (
+            SELECT 1
+            FROM public.submissions s
+            JOIN public.submission_reviews sr ON sr.submission_id = s.id
+            WHERE s.assignment_id = r.assignment_id
+              AND sr.released = true
+              AND (
+                EXISTS (
+                  SELECT 1 FROM public.user_privileges ur
+                  WHERE ur.user_id = auth.uid()
+                    AND ur.private_profile_id = s.profile_id
+                )
+                OR (
+                  s.assignment_group_id IS NOT NULL
+                  AND EXISTS (
+                    SELECT 1
+                    FROM public.assignment_groups_members mem
+                    JOIN public.user_privileges ur ON ur.private_profile_id = mem.profile_id
+                    WHERE mem.assignment_group_id = s.assignment_group_id
+                      AND ur.user_id = auth.uid()
+                  )
+                )
+              )
+          )
+        )
+        OR (
+          rubric_checks.student_visibility = 'if_applied'
+          AND (
+            EXISTS (
+              SELECT 1
+              FROM public.submission_comments sc
+              JOIN public.submissions s ON s.id = sc.submission_id
+              WHERE sc.rubric_check_id = rubric_checks.id
+                AND sc.released = true
+                AND (
+                  EXISTS (
+                    SELECT 1 FROM public.user_privileges ur
+                    WHERE ur.user_id = auth.uid()
+                      AND ur.private_profile_id = s.profile_id
+                  )
+                  OR (
+                    s.assignment_group_id IS NOT NULL
+                    AND EXISTS (
+                      SELECT 1
+                      FROM public.assignment_groups_members mem
+                      JOIN public.user_privileges ur ON ur.private_profile_id = mem.profile_id
+                      WHERE mem.assignment_group_id = s.assignment_group_id
+                        AND ur.user_id = auth.uid()
+                    )
+                  )
+                )
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.submission_file_comments sfc
+              JOIN public.submissions s ON s.id = sfc.submission_id
+              WHERE sfc.rubric_check_id = rubric_checks.id
+                AND sfc.released = true
+                AND (
+                  EXISTS (
+                    SELECT 1 FROM public.user_privileges ur
+                    WHERE ur.user_id = auth.uid()
+                      AND ur.private_profile_id = s.profile_id
+                  )
+                  OR (
+                    s.assignment_group_id IS NOT NULL
+                    AND EXISTS (
+                      SELECT 1
+                      FROM public.assignment_groups_members mem
+                      JOIN public.user_privileges ur ON ur.private_profile_id = mem.profile_id
+                      WHERE mem.assignment_group_id = s.assignment_group_id
+                        AND ur.user_id = auth.uid()
+                    )
+                  )
+                )
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.submission_artifact_comments sac
+              JOIN public.submissions s ON s.id = sac.submission_id
+              JOIN public.submission_reviews sr ON sr.submission_id = s.id
+              WHERE sac.rubric_check_id = rubric_checks.id
+                AND sac.released = true
+                AND (
+                  EXISTS (
+                    SELECT 1 FROM public.user_privileges ur
+                    WHERE ur.user_id = auth.uid()
+                      AND ur.private_profile_id = s.profile_id
+                  )
+                  OR (
+                    s.assignment_group_id IS NOT NULL
+                    AND EXISTS (
+                      SELECT 1
+                      FROM public.assignment_groups_members mem
+                      JOIN public.user_privileges ur ON ur.private_profile_id = mem.profile_id
+                      WHERE mem.assignment_group_id = s.assignment_group_id
+                        AND ur.user_id = auth.uid()
+                    )
+                  )
+                )
+            )
+          )
+        )
+      )
+  )
+);
+
+----------------------------------------------------------------
+-- check_assignment_deadlines_passed(): trigger auto-assign whenever
+-- either the assignment's due_date OR an explicit release_at has passed.
+----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.check_assignment_deadlines_passed()
+RETURNS void AS $$
+DECLARE
+    assignment_record public.assignments%ROWTYPE;
+    profile_record public.profiles%ROWTYPE;
+BEGIN
+    FOR assignment_record IN (
+        SELECT a.*
+        FROM public.assignments a
+        LEFT JOIN public.assignment_self_review_settings s
+          ON s.id = a.self_review_setting_id
+        WHERE a.archived_at IS NULL
+          AND (
+            -- Explicit release_at, when set, gates eligibility.
+            (s.release_at IS NOT NULL AND s.release_at <= NOW() AT TIME ZONE 'UTC')
+            -- Otherwise fall back to the original assignment due_date.
+            OR (s.release_at IS NULL AND a.due_date AT TIME ZONE 'UTC' <= NOW() AT TIME ZONE 'UTC')
+          )
+    ) LOOP
+        FOR profile_record IN (
+            SELECT * FROM public.profiles prof
+            WHERE is_private_profile = true
+              AND prof.class_id = assignment_record.class_id
+              AND EXISTS (
+                SELECT 1 FROM user_roles
+                WHERE private_profile_id = prof.id
+                  AND "role" = 'student'
+              )
+        ) LOOP
+            PERFORM auto_assign_self_reviews(assignment_record.id, profile_record.id);
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+----------------------------------------------------------------
+-- auto_assign_self_reviews(): honor release_at when set.
+-- When release_at IS NULL, behavior is unchanged (release tied to original
+-- due_date + per-student exceptions; review due_date = original due + exceptions
+-- + deadline_offset).
+-- When release_at IS NOT NULL, release gate becomes release_at <= now (exceptions
+-- are ignored for the release decision); review due_date becomes
+-- release_at + deadline_offset.
+----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.auto_assign_self_reviews(this_assignment_id bigint, this_profile_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    this_assignment public.assignments;
+    this_group_id bigint;
+    this_self_review_setting public.assignment_self_review_settings;
+    this_net_deadline_change_hours integer := 0;
+    this_net_deadline_change_minutes integer := 0;
+    this_active_submission_id bigint;
+    existing_submission_review_id bigint;
+    this_review_due_date timestamp;
+    utc_now TIMESTAMP := date_trunc('minute', now() + interval '59 second');
+BEGIN
+    SELECT * INTO this_assignment FROM public.assignments WHERE id = this_assignment_id;
+
+    IF this_assignment.id IS NULL THEN
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM user_roles
+        WHERE private_profile_id = this_profile_id
+          AND role = 'student'
+          AND class_id = this_assignment.class_id
+    ) THEN
+        RETURN;
+    END IF;
+
+    SELECT assignment_group_id INTO this_group_id
+    FROM public.assignment_groups_members
+    WHERE profile_id = this_profile_id
+      AND class_id = this_assignment.class_id
+      AND assignment_id = this_assignment.id
+    LIMIT 1;
+
+    SELECT * INTO this_self_review_setting
+    FROM public.assignment_self_review_settings
+    WHERE id = this_assignment.self_review_setting_id;
+
+    IF this_self_review_setting.enabled IS NOT TRUE THEN
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM review_assignments
+        WHERE assignment_id = this_assignment.id
+          AND assignee_profile_id = this_profile_id
+    ) THEN
+        RETURN;
+    END IF;
+
+    SELECT COALESCE(SUM("hours"), 0) INTO this_net_deadline_change_hours
+    FROM public.assignment_due_date_exceptions
+    WHERE assignment_id = this_assignment.id
+      AND (student_id = this_profile_id OR assignment_group_id = this_group_id);
+
+    SELECT COALESCE(SUM("minutes"), 0) INTO this_net_deadline_change_minutes
+    FROM public.assignment_due_date_exceptions
+    WHERE assignment_id = this_assignment.id
+      AND (student_id = this_profile_id OR assignment_group_id = this_group_id);
+
+    -- Release gate: explicit release_at, when set, ignores per-student exceptions.
+    IF this_self_review_setting.release_at IS NOT NULL THEN
+        IF this_self_review_setting.release_at AT TIME ZONE 'UTC' > utc_now THEN
+            RETURN;
+        END IF;
+    ELSE
+        IF NOT (this_assignment.due_date AT TIME ZONE 'UTC'
+                + INTERVAL '1 hour' * this_net_deadline_change_hours
+                + INTERVAL '1 minute' * this_net_deadline_change_minutes <= utc_now) THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    SELECT id INTO this_active_submission_id
+    FROM public.submissions
+    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id)
+        OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
+      AND assignment_id = this_assignment_id
+      AND is_active = true
+    LIMIT 1;
+
+    IF this_active_submission_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT id INTO existing_submission_review_id
+    FROM public.submission_reviews
+    WHERE submission_id = this_active_submission_id
+      AND class_id = this_assignment.class_id
+      AND rubric_id = this_assignment.self_review_rubric_id
+    LIMIT 1;
+
+    IF existing_submission_review_id IS NULL THEN
+        INSERT INTO submission_reviews (total_score, released, tweak, class_id, submission_id, name, rubric_id)
+        VALUES (0, false, 0, this_assignment.class_id, this_active_submission_id, 'Self Review', this_assignment.self_review_rubric_id)
+        RETURNING id INTO existing_submission_review_id;
+    END IF;
+
+    -- Self-review due_date: anchor on release_at when set (exceptions ignored),
+    -- else on original due_date + exceptions. deadline_offset still applies in both.
+    IF this_self_review_setting.release_at IS NOT NULL THEN
+        this_review_due_date := this_self_review_setting.release_at AT TIME ZONE 'UTC'
+            + (INTERVAL '1 hour' * COALESCE(this_self_review_setting.deadline_offset, 0));
+    ELSE
+        this_review_due_date := this_assignment.due_date AT TIME ZONE 'UTC'
+            + (INTERVAL '1 hour' * this_net_deadline_change_hours)
+            + (INTERVAL '1 minute' * this_net_deadline_change_minutes)
+            + (INTERVAL '1 hour' * COALESCE(this_self_review_setting.deadline_offset, 0));
+    END IF;
+
+    INSERT INTO review_assignments (
+        due_date,
+        assignee_profile_id,
+        submission_id,
+        submission_review_id,
+        assignment_id,
+        rubric_id,
+        class_id
+    )
+    VALUES (
+        this_review_due_date,
+        this_profile_id,
+        this_active_submission_id,
+        existing_submission_review_id,
+        this_assignment.id,
+        this_assignment.self_review_rubric_id,
+        this_assignment.class_id
+    );
+END;
+$$;
+
+----------------------------------------------------------------
+-- update_rubric_full RPC: accept and persist hide_unless_assigned.
+----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_rubric_full(p_rubric jsonb)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_rubric_id bigint;
+  v_class_id bigint;
+  v_assignment_id bigint;
+  v_review_round review_round;
+
+  v_is_new_rubric boolean := false;
+  v_broad_change boolean := false;
+
+  v_old_name text;
+  v_old_description text;
+  v_old_is_private boolean;
+  v_old_cap boolean;
+  v_old_hide_unless_assigned boolean;
+
+  v_new_name text;
+  v_new_description text;
+  v_new_is_private boolean;
+  v_new_cap boolean;
+  v_new_hide_unless_assigned boolean;
+
+  v_parts_added int := 0;
+  v_parts_updated int := 0;
+  v_parts_removed int := 0;
+  v_criteria_added int := 0;
+  v_criteria_updated int := 0;
+  v_criteria_removed int := 0;
+  v_checks_added int := 0;
+  v_checks_updated int := 0;
+  v_checks_removed int := 0;
+  v_checks_points_cascaded int := 0;
+  v_refs_added int := 0;
+  v_refs_removed int := 0;
+  v_reviews_recomputed int := 0;
+
+  v_part_id_map jsonb := '{}'::jsonb;
+  v_criteria_id_map jsonb := '{}'::jsonb;
+  v_check_id_map jsonb := '{}'::jsonb;
+
+  v_part jsonb;
+  v_criterion jsonb;
+  v_check jsonb;
+  v_ref jsonb;
+
+  v_input_part_id bigint;
+  v_input_criteria_id bigint;
+  v_input_check_id bigint;
+  v_part_id bigint;
+  v_criteria_id bigint;
+  v_check_id bigint;
+  v_review_id bigint;
+
+  v_points_changed_check_ids bigint[] := ARRAY[]::bigint[];
+  v_removed_check_ids bigint[] := ARRAY[]::bigint[];
+
+  v_affected_review_ids bigint[] := ARRAY[]::bigint[];
+
+  v_old_total_points int;
+  v_old_is_additive boolean;
+  v_old_is_deduction_only boolean;
+  v_old_points int;
+
+  v_changes text[] := ARRAY[]::text[];
+  v_summary text;
+BEGIN
+  v_rubric_id := NULLIF((p_rubric->>'id')::bigint, 0);
+  v_class_id := (p_rubric->>'class_id')::bigint;
+  v_assignment_id := (p_rubric->>'assignment_id')::bigint;
+  v_review_round := (p_rubric->>'review_round')::review_round;
+  v_new_name := p_rubric->>'name';
+  v_new_description := p_rubric->>'description';
+  v_new_is_private := COALESCE((p_rubric->>'is_private')::boolean, false);
+  v_new_cap := COALESCE((p_rubric->>'cap_score_to_assignment_points')::boolean, false);
+  v_new_hide_unless_assigned := COALESCE((p_rubric->>'hide_unless_assigned')::boolean, false);
+
+  IF v_class_id IS NULL THEN
+    RAISE EXCEPTION 'class_id is required';
+  END IF;
+  IF NOT public.authorizeforclassinstructor(v_class_id) THEN
+    RAISE EXCEPTION 'Not authorized to edit rubrics in this class';
+  END IF;
+  IF v_new_name IS NULL OR length(trim(v_new_name)) = 0 THEN
+    RAISE EXCEPTION 'Rubric name is required';
+  END IF;
+
+  IF v_rubric_id IS NULL THEN
+    INSERT INTO public.rubrics (
+      name, description, assignment_id, class_id, is_private, review_round,
+      cap_score_to_assignment_points, hide_unless_assigned
+    )
+    VALUES (
+      v_new_name, v_new_description, v_assignment_id, v_class_id, v_new_is_private,
+      v_review_round, v_new_cap, v_new_hide_unless_assigned
+    )
+    RETURNING id INTO v_rubric_id;
+    v_is_new_rubric := true;
+    v_broad_change := true;
+  ELSE
+    SELECT name, description, is_private, cap_score_to_assignment_points, hide_unless_assigned
+    INTO v_old_name, v_old_description, v_old_is_private, v_old_cap, v_old_hide_unless_assigned
+    FROM public.rubrics
+    WHERE id = v_rubric_id AND class_id = v_class_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Rubric % not found in class %', v_rubric_id, v_class_id;
+    END IF;
+
+    IF v_old_name IS DISTINCT FROM v_new_name
+       OR v_old_description IS DISTINCT FROM v_new_description
+       OR v_old_is_private IS DISTINCT FROM v_new_is_private
+       OR v_old_cap IS DISTINCT FROM v_new_cap
+       OR v_old_hide_unless_assigned IS DISTINCT FROM v_new_hide_unless_assigned THEN
+      UPDATE public.rubrics
+      SET name = v_new_name,
+          description = v_new_description,
+          is_private = v_new_is_private,
+          cap_score_to_assignment_points = v_new_cap,
+          hide_unless_assigned = v_new_hide_unless_assigned
+      WHERE id = v_rubric_id;
+    END IF;
+
+    IF v_old_cap IS DISTINCT FROM v_new_cap THEN
+      v_broad_change := true;
+    END IF;
+  END IF;
+
+  WITH input_ids AS (
+    SELECT (elem->>'id')::bigint AS id
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) elem
+    WHERE COALESCE((elem->>'id')::bigint, 0) > 0
+  ),
+  del AS (
+    DELETE FROM public.rubric_parts
+    WHERE rubric_id = v_rubric_id
+      AND id NOT IN (SELECT id FROM input_ids)
+    RETURNING id
+  )
+  SELECT count(*) INTO v_parts_removed FROM del;
+
+  IF v_parts_removed > 0 THEN
+    v_broad_change := true;
+  END IF;
+
+  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  LOOP
+    v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
+
+    IF v_input_part_id <= 0 THEN
+      INSERT INTO public.rubric_parts (
+        name, description, ordinal, rubric_id, class_id, assignment_id,
+        data, is_individual_grading, is_assign_to_student
+      ) VALUES (
+        v_part->>'name',
+        v_part->>'description',
+        COALESCE((v_part->>'ordinal')::int, 0),
+        v_rubric_id, v_class_id, v_assignment_id,
+        v_part->'data',
+        COALESCE((v_part->>'is_individual_grading')::boolean, false),
+        COALESCE((v_part->>'is_assign_to_student')::boolean, false)
+      ) RETURNING id INTO v_part_id;
+
+      v_part_id_map := v_part_id_map || jsonb_build_object(v_input_part_id::text, v_part_id);
+      v_parts_added := v_parts_added + 1;
+      v_broad_change := true;
+    ELSE
+      UPDATE public.rubric_parts
+      SET name = v_part->>'name',
+          description = v_part->>'description',
+          ordinal = COALESCE((v_part->>'ordinal')::int, 0),
+          data = v_part->'data',
+          is_individual_grading = COALESCE((v_part->>'is_individual_grading')::boolean, false),
+          is_assign_to_student = COALESCE((v_part->>'is_assign_to_student')::boolean, false)
+      WHERE id = v_input_part_id AND rubric_id = v_rubric_id;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Part % not in rubric %', v_input_part_id, v_rubric_id;
+      END IF;
+
+      v_part_id_map := v_part_id_map || jsonb_build_object(v_input_part_id::text, v_input_part_id);
+      v_parts_updated := v_parts_updated + 1;
+    END IF;
+  END LOOP;
+
+  WITH input_ids AS (
+    SELECT (crit->>'id')::bigint AS id
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
+         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit
+    WHERE COALESCE((crit->>'id')::bigint, 0) > 0
+  ),
+  del AS (
+    DELETE FROM public.rubric_criteria
+    WHERE rubric_id = v_rubric_id
+      AND id NOT IN (SELECT id FROM input_ids)
+    RETURNING id
+  )
+  SELECT count(*) INTO v_criteria_removed FROM del;
+
+  IF v_criteria_removed > 0 THEN
+    v_broad_change := true;
+  END IF;
+
+  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  LOOP
+    v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
+    v_part_id := COALESCE((v_part_id_map->>v_input_part_id::text)::bigint, v_input_part_id);
+
+    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    LOOP
+      v_input_criteria_id := COALESCE((v_criterion->>'id')::bigint, 0);
+
+      IF v_input_criteria_id <= 0 THEN
+        INSERT INTO public.rubric_criteria (
+          name, description, ordinal, rubric_id, rubric_part_id, class_id, assignment_id,
+          data, is_additive, is_deduction_only, total_points,
+          max_checks_per_submission, min_checks_per_submission
+        ) VALUES (
+          v_criterion->>'name',
+          v_criterion->>'description',
+          COALESCE((v_criterion->>'ordinal')::int, 0),
+          v_rubric_id, v_part_id, v_class_id, v_assignment_id,
+          v_criterion->'data',
+          COALESCE((v_criterion->>'is_additive')::boolean, false),
+          COALESCE((v_criterion->>'is_deduction_only')::boolean, false),
+          COALESCE((v_criterion->>'total_points')::int, 0),
+          NULLIF(v_criterion->>'max_checks_per_submission', '')::int,
+          NULLIF(v_criterion->>'min_checks_per_submission', '')::int
+        ) RETURNING id INTO v_criteria_id;
+
+        v_criteria_id_map := v_criteria_id_map || jsonb_build_object(v_input_criteria_id::text, v_criteria_id);
+        v_criteria_added := v_criteria_added + 1;
+        v_broad_change := true;
+      ELSE
+        SELECT total_points, is_additive, is_deduction_only
+        INTO v_old_total_points, v_old_is_additive, v_old_is_deduction_only
+        FROM public.rubric_criteria WHERE id = v_input_criteria_id;
+
+        IF v_old_total_points IS DISTINCT FROM COALESCE((v_criterion->>'total_points')::int, 0)
+           OR v_old_is_additive IS DISTINCT FROM COALESCE((v_criterion->>'is_additive')::boolean, false)
+           OR v_old_is_deduction_only IS DISTINCT FROM COALESCE((v_criterion->>'is_deduction_only')::boolean, false) THEN
+          v_broad_change := true;
+        END IF;
+
+        UPDATE public.rubric_criteria
+        SET name = v_criterion->>'name',
+            description = v_criterion->>'description',
+            ordinal = COALESCE((v_criterion->>'ordinal')::int, 0),
+            rubric_part_id = v_part_id,
+            data = v_criterion->'data',
+            is_additive = COALESCE((v_criterion->>'is_additive')::boolean, false),
+            is_deduction_only = COALESCE((v_criterion->>'is_deduction_only')::boolean, false),
+            total_points = COALESCE((v_criterion->>'total_points')::int, 0),
+            max_checks_per_submission = NULLIF(v_criterion->>'max_checks_per_submission', '')::int,
+            min_checks_per_submission = NULLIF(v_criterion->>'min_checks_per_submission', '')::int
+        WHERE id = v_input_criteria_id AND rubric_id = v_rubric_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'Criterion % not in rubric %', v_input_criteria_id, v_rubric_id;
+        END IF;
+
+        v_criteria_id_map := v_criteria_id_map || jsonb_build_object(v_input_criteria_id::text, v_input_criteria_id);
+        v_criteria_updated := v_criteria_updated + 1;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  WITH input_ids AS (
+    SELECT (chk->>'id')::bigint AS id
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
+         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit,
+         jsonb_array_elements(COALESCE(crit->'checks', '[]'::jsonb)) chk
+    WHERE COALESCE((chk->>'id')::bigint, 0) > 0
+  )
+  SELECT COALESCE(array_agg(id), ARRAY[]::bigint[]) INTO v_removed_check_ids
+  FROM public.rubric_checks
+  WHERE rubric_id = v_rubric_id
+    AND id NOT IN (SELECT id FROM input_ids);
+
+  IF array_length(v_removed_check_ids, 1) > 0 THEN
+    DELETE FROM public.rubric_checks WHERE id = ANY(v_removed_check_ids);
+    v_checks_removed := array_length(v_removed_check_ids, 1);
+    v_broad_change := true;
+  END IF;
+
+  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  LOOP
+    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    LOOP
+      v_input_criteria_id := COALESCE((v_criterion->>'id')::bigint, 0);
+      v_criteria_id := COALESCE((v_criteria_id_map->>v_input_criteria_id::text)::bigint, v_input_criteria_id);
+
+      FOR v_check IN SELECT * FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb))
+      LOOP
+        v_input_check_id := COALESCE((v_check->>'id')::bigint, 0);
+
+        IF v_input_check_id <= 0 THEN
+          INSERT INTO public.rubric_checks (
+            name, description, ordinal, rubric_criteria_id, rubric_id, class_id, assignment_id,
+            data, file, artifact, "group",
+            is_annotation, is_comment_required, is_required,
+            max_annotations, points, annotation_target, student_visibility, kpi_category
+          ) VALUES (
+            v_check->>'name',
+            v_check->>'description',
+            COALESCE((v_check->>'ordinal')::int, 0),
+            v_criteria_id, v_rubric_id, v_class_id, v_assignment_id,
+            v_check->'data',
+            v_check->>'file',
+            v_check->>'artifact',
+            v_check->>'group',
+            COALESCE((v_check->>'is_annotation')::boolean, false),
+            COALESCE((v_check->>'is_comment_required')::boolean, false),
+            COALESCE((v_check->>'is_required')::boolean, false),
+            NULLIF(v_check->>'max_annotations', '')::int,
+            COALESCE((v_check->>'points')::int, 0),
+            v_check->>'annotation_target',
+            COALESCE((v_check->>'student_visibility')::rubric_check_student_visibility, 'always'::rubric_check_student_visibility),
+            NULLIF(v_check->>'kpi_category', '')::repo_analytics_kpi_category
+          ) RETURNING id INTO v_check_id;
+
+          v_check_id_map := v_check_id_map || jsonb_build_object(v_input_check_id::text, v_check_id);
+          v_checks_added := v_checks_added + 1;
+          v_broad_change := true;
+        ELSE
+          SELECT points INTO v_old_points
+          FROM public.rubric_checks WHERE id = v_input_check_id;
+
+          IF v_old_points IS DISTINCT FROM COALESCE((v_check->>'points')::int, 0) THEN
+            v_points_changed_check_ids := array_append(v_points_changed_check_ids, v_input_check_id);
+          END IF;
+
+          UPDATE public.rubric_checks
+          SET name = v_check->>'name',
+              description = v_check->>'description',
+              ordinal = COALESCE((v_check->>'ordinal')::int, 0),
+              rubric_criteria_id = v_criteria_id,
+              data = v_check->'data',
+              file = v_check->>'file',
+              artifact = v_check->>'artifact',
+              "group" = v_check->>'group',
+              is_annotation = COALESCE((v_check->>'is_annotation')::boolean, false),
+              is_comment_required = COALESCE((v_check->>'is_comment_required')::boolean, false),
+              is_required = COALESCE((v_check->>'is_required')::boolean, false),
+              max_annotations = NULLIF(v_check->>'max_annotations', '')::int,
+              points = COALESCE((v_check->>'points')::int, 0),
+              annotation_target = v_check->>'annotation_target',
+              student_visibility = COALESCE(
+                (v_check->>'student_visibility')::rubric_check_student_visibility,
+                'always'::rubric_check_student_visibility
+              ),
+              kpi_category = NULLIF(v_check->>'kpi_category', '')::repo_analytics_kpi_category
+          WHERE id = v_input_check_id AND rubric_id = v_rubric_id;
+
+          IF NOT FOUND THEN
+            RAISE EXCEPTION 'Check % not in rubric %', v_input_check_id, v_rubric_id;
+          END IF;
+
+          v_check_id_map := v_check_id_map || jsonb_build_object(v_input_check_id::text, v_input_check_id);
+          v_checks_updated := v_checks_updated + 1;
+        END IF;
+      END LOOP;
+    END LOOP;
+  END LOOP;
+
+  IF array_length(v_points_changed_check_ids, 1) > 0 THEN
+    UPDATE public.submission_comments sc
+    SET points = rc.points
+    FROM public.rubric_checks rc
+    WHERE sc.rubric_check_id = rc.id
+      AND rc.id = ANY(v_points_changed_check_ids);
+
+    UPDATE public.submission_file_comments sfc
+    SET points = rc.points
+    FROM public.rubric_checks rc
+    WHERE sfc.rubric_check_id = rc.id
+      AND rc.id = ANY(v_points_changed_check_ids);
+
+    UPDATE public.submission_artifact_comments sac
+    SET points = rc.points
+    FROM public.rubric_checks rc
+    WHERE sac.rubric_check_id = rc.id
+      AND rc.id = ANY(v_points_changed_check_ids);
+
+    v_checks_points_cascaded := array_length(v_points_changed_check_ids, 1);
+  END IF;
+
+  CREATE TEMP TABLE IF NOT EXISTS _desired_refs (
+    referencing_check_id bigint NOT NULL,
+    referenced_check_id bigint NOT NULL
+  ) ON COMMIT DROP;
+  TRUNCATE _desired_refs;
+
+  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  LOOP
+    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    LOOP
+      FOR v_check IN SELECT * FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb))
+      LOOP
+        v_input_check_id := COALESCE((v_check->>'id')::bigint, 0);
+        v_check_id := COALESCE((v_check_id_map->>v_input_check_id::text)::bigint, v_input_check_id);
+
+        FOR v_ref IN SELECT * FROM jsonb_array_elements(COALESCE(v_check->'references', '[]'::jsonb))
+        LOOP
+          INSERT INTO _desired_refs (referencing_check_id, referenced_check_id)
+          VALUES (v_check_id, (v_ref->>'referenced_rubric_check_id')::bigint);
+        END LOOP;
+      END LOOP;
+    END LOOP;
+  END LOOP;
+
+  WITH del AS (
+    DELETE FROM public.rubric_check_references rcr
+    WHERE rcr.rubric_id = v_rubric_id
+      AND NOT EXISTS (
+        SELECT 1 FROM _desired_refs d
+        WHERE d.referencing_check_id = rcr.referencing_rubric_check_id
+          AND d.referenced_check_id = rcr.referenced_rubric_check_id
+      )
+    RETURNING id
+  )
+  SELECT count(*) INTO v_refs_removed FROM del;
+
+  WITH ins AS (
+    INSERT INTO public.rubric_check_references (
+      referencing_rubric_check_id, referenced_rubric_check_id,
+      rubric_id, class_id, assignment_id
+    )
+    SELECT d.referencing_check_id, d.referenced_check_id,
+           v_rubric_id, v_class_id, v_assignment_id
+    FROM _desired_refs d
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.rubric_check_references rcr
+      WHERE rcr.referencing_rubric_check_id = d.referencing_check_id
+        AND rcr.referenced_rubric_check_id = d.referenced_check_id
+        AND rcr.rubric_id = v_rubric_id
+    )
+    RETURNING id
+  )
+  SELECT count(*) INTO v_refs_added FROM ins;
+
+  IF v_is_new_rubric THEN
+    v_affected_review_ids := ARRAY[]::bigint[];
+  ELSIF v_broad_change THEN
+    SELECT COALESCE(array_agg(DISTINCT sr.id), ARRAY[]::bigint[])
+    INTO v_affected_review_ids
+    FROM public.submission_reviews sr
+    WHERE sr.rubric_id = v_rubric_id;
+  ELSE
+    WITH touched_check_ids AS (
+      SELECT unnest(v_points_changed_check_ids || v_removed_check_ids) AS id
+    ),
+    touched AS (
+      SELECT submission_review_id FROM public.submission_comments
+      WHERE rubric_check_id IN (SELECT id FROM touched_check_ids)
+        AND deleted_at IS NULL AND submission_review_id IS NOT NULL
+      UNION
+      SELECT submission_review_id FROM public.submission_file_comments
+      WHERE rubric_check_id IN (SELECT id FROM touched_check_ids)
+        AND deleted_at IS NULL AND submission_review_id IS NOT NULL
+      UNION
+      SELECT submission_review_id FROM public.submission_artifact_comments
+      WHERE rubric_check_id IN (SELECT id FROM touched_check_ids)
+        AND deleted_at IS NULL AND submission_review_id IS NOT NULL
+    )
+    SELECT COALESCE(array_agg(DISTINCT submission_review_id), ARRAY[]::bigint[])
+    INTO v_affected_review_ids
+    FROM touched;
+  END IF;
+
+  FOREACH v_review_id IN ARRAY v_affected_review_ids LOOP
+    PERFORM public._submission_review_recompute_scores(v_review_id);
+    v_reviews_recomputed := v_reviews_recomputed + 1;
+  END LOOP;
+
+  v_summary := CASE WHEN v_is_new_rubric THEN 'Created rubric.' ELSE 'Saved rubric.' END;
+
+  IF v_parts_added > 0 THEN v_changes := v_changes || (v_parts_added || ' part' || CASE WHEN v_parts_added = 1 THEN '' ELSE 's' END || ' added'); END IF;
+  IF v_parts_updated > 0 THEN v_changes := v_changes || (v_parts_updated || ' part' || CASE WHEN v_parts_updated = 1 THEN '' ELSE 's' END || ' updated'); END IF;
+  IF v_parts_removed > 0 THEN v_changes := v_changes || (v_parts_removed || ' part' || CASE WHEN v_parts_removed = 1 THEN '' ELSE 's' END || ' removed'); END IF;
+  IF v_criteria_added > 0 THEN v_changes := v_changes || (v_criteria_added || ' criteri' || CASE WHEN v_criteria_added = 1 THEN 'on' ELSE 'a' END || ' added'); END IF;
+  IF v_criteria_updated > 0 THEN v_changes := v_changes || (v_criteria_updated || ' criteri' || CASE WHEN v_criteria_updated = 1 THEN 'on' ELSE 'a' END || ' updated'); END IF;
+  IF v_criteria_removed > 0 THEN v_changes := v_changes || (v_criteria_removed || ' criteri' || CASE WHEN v_criteria_removed = 1 THEN 'on' ELSE 'a' END || ' removed'); END IF;
+  IF v_checks_added > 0 THEN v_changes := v_changes || (v_checks_added || ' check' || CASE WHEN v_checks_added = 1 THEN '' ELSE 's' END || ' added'); END IF;
+  IF v_checks_updated > 0 THEN v_changes := v_changes || (v_checks_updated || ' check' || CASE WHEN v_checks_updated = 1 THEN '' ELSE 's' END || ' updated'); END IF;
+  IF v_checks_removed > 0 THEN v_changes := v_changes || (v_checks_removed || ' check' || CASE WHEN v_checks_removed = 1 THEN '' ELSE 's' END || ' removed'); END IF;
+  IF v_refs_added > 0 THEN v_changes := v_changes || (v_refs_added || ' reference' || CASE WHEN v_refs_added = 1 THEN '' ELSE 's' END || ' added'); END IF;
+  IF v_refs_removed > 0 THEN v_changes := v_changes || (v_refs_removed || ' reference' || CASE WHEN v_refs_removed = 1 THEN '' ELSE 's' END || ' removed'); END IF;
+
+  IF array_length(v_changes, 1) > 0 THEN
+    v_summary := v_summary || ' ' || array_to_string(v_changes, ', ') || '.';
+  ELSIF NOT v_is_new_rubric THEN
+    v_summary := v_summary || ' No structural changes.';
+  END IF;
+
+  IF v_checks_points_cascaded > 0 THEN
+    v_summary := v_summary || ' Cascaded new points to existing comments on '
+              || v_checks_points_cascaded || ' check'
+              || CASE WHEN v_checks_points_cascaded = 1 THEN '' ELSE 's' END || '.';
+  END IF;
+
+  IF v_reviews_recomputed > 0 THEN
+    v_summary := v_summary || ' Recomputed scores on '
+              || v_reviews_recomputed || ' submission review'
+              || CASE WHEN v_reviews_recomputed = 1 THEN '' ELSE 's' END || '.';
+  END IF;
+
+  RETURN v_summary;
+END;
+$function$;

--- a/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
+++ b/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
@@ -252,7 +252,7 @@ BEGIN
         WHERE a.archived_at IS NULL
           AND (
             -- Explicit release_at, when set, gates eligibility.
-            (s.release_at IS NOT NULL AND s.release_at <= NOW() AT TIME ZONE 'UTC')
+            (s.release_at IS NOT NULL AND s.release_at <= NOW())
             -- Otherwise fall back to the original assignment due_date.
             OR (s.release_at IS NULL AND a.due_date AT TIME ZONE 'UTC' <= NOW() AT TIME ZONE 'UTC')
           )
@@ -497,9 +497,15 @@ BEGIN
   v_review_round := (p_rubric->>'review_round')::review_round;
   v_new_name := p_rubric->>'name';
   v_new_description := p_rubric->>'description';
-  v_new_is_private := COALESCE((p_rubric->>'is_private')::boolean, false);
-  v_new_cap := COALESCE((p_rubric->>'cap_score_to_assignment_points')::boolean, false);
-  v_new_hide_unless_assigned := COALESCE((p_rubric->>'hide_unless_assigned')::boolean, false);
+  v_new_is_private := CASE WHEN p_rubric ? 'is_private' THEN (p_rubric->>'is_private')::boolean END;
+  v_new_cap := CASE
+    WHEN p_rubric ? 'cap_score_to_assignment_points'
+    THEN (p_rubric->>'cap_score_to_assignment_points')::boolean
+  END;
+  v_new_hide_unless_assigned := CASE
+    WHEN p_rubric ? 'hide_unless_assigned'
+    THEN (p_rubric->>'hide_unless_assigned')::boolean
+  END;
 
   IF v_class_id IS NULL THEN
     RAISE EXCEPTION 'class_id is required';
@@ -517,8 +523,8 @@ BEGIN
       cap_score_to_assignment_points, hide_unless_assigned
     )
     VALUES (
-      v_new_name, v_new_description, v_assignment_id, v_class_id, v_new_is_private,
-      v_review_round, v_new_cap, v_new_hide_unless_assigned
+      v_new_name, v_new_description, v_assignment_id, v_class_id, COALESCE(v_new_is_private, false),
+      v_review_round, COALESCE(v_new_cap, false), COALESCE(v_new_hide_unless_assigned, false)
     )
     RETURNING id INTO v_rubric_id;
     v_is_new_rubric := true;
@@ -536,19 +542,19 @@ BEGIN
 
     IF v_old_name IS DISTINCT FROM v_new_name
        OR v_old_description IS DISTINCT FROM v_new_description
-       OR v_old_is_private IS DISTINCT FROM v_new_is_private
-       OR v_old_cap IS DISTINCT FROM v_new_cap
-       OR v_old_hide_unless_assigned IS DISTINCT FROM v_new_hide_unless_assigned THEN
+       OR (v_new_is_private IS NOT NULL AND v_old_is_private IS DISTINCT FROM v_new_is_private)
+       OR (v_new_cap IS NOT NULL AND v_old_cap IS DISTINCT FROM v_new_cap)
+       OR (v_new_hide_unless_assigned IS NOT NULL AND v_old_hide_unless_assigned IS DISTINCT FROM v_new_hide_unless_assigned) THEN
       UPDATE public.rubrics
       SET name = v_new_name,
           description = v_new_description,
-          is_private = v_new_is_private,
-          cap_score_to_assignment_points = v_new_cap,
-          hide_unless_assigned = v_new_hide_unless_assigned
+          is_private = COALESCE(v_new_is_private, is_private),
+          cap_score_to_assignment_points = COALESCE(v_new_cap, cap_score_to_assignment_points),
+          hide_unless_assigned = COALESCE(v_new_hide_unless_assigned, hide_unless_assigned)
       WHERE id = v_rubric_id;
     END IF;
 
-    IF v_old_cap IS DISTINCT FROM v_new_cap THEN
+    IF v_new_cap IS NOT NULL AND v_old_cap IS DISTINCT FROM v_new_cap THEN
       v_broad_change := true;
     END IF;
   END IF;

--- a/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
+++ b/supabase/migrations/20260522180000_rubric-hide-unless-assigned-and-self-review-release-at.sql
@@ -1,14 +1,15 @@
 -- Rubric "hide unless assigned" + self-review explicit release_at.
 --
 -- 1. rubrics.hide_unless_assigned (boolean, default false): when true, students
---    cannot SELECT the rubric (or its parts/checks) until a review_assignments
---    row exists for them on that rubric and that row's release_date has passed
---    (or is NULL). Instructors/graders see rubrics unconditionally.
+--    cannot SELECT the rubric (or its parts/criteria/checks) until a
+--    review_assignments row exists for them on that rubric and that row's
+--    release_date has passed (or is NULL). Instructors/graders see rubrics
+--    unconditionally.
 --
 -- 2. assignment_self_review_settings.release_at (timestamptz nullable): when
 --    NULL (default), self-review release timing keeps current behavior --
---    review_assignments rows are created when the assignment's due_date passes
---    (plus per-student exceptions). When set, release happens at the explicit
+--    review_assignments rows are created when the assignment's (per-student)
+--    final due date passes. When set, release happens at the explicit
 --    wall-clock time, exceptions are ignored for release timing, and the
 --    review's own due_date is computed as release_at + deadline_offset hours.
 
@@ -54,7 +55,7 @@ USING (
           WHERE ra.rubric_id = rubrics.id
             AND up.user_id = auth.uid()
             AND up.class_id = rubrics.class_id
-            AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+            AND (ra.release_date IS NULL OR ra.release_date <= now())
         )
       )
     )
@@ -86,7 +87,41 @@ USING (
               WHERE ra.rubric_id = r.id
                 AND up.user_id = auth.uid()
                 AND up.class_id = r.class_id
-                AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+                AND (ra.release_date IS NULL OR ra.release_date <= now())
+            )
+          )
+        )
+      )
+  )
+);
+
+----------------------------------------------------------------
+-- RLS: rubric_criteria SELECT
+-- Mirror the parent rubric's gate so hidden rubrics don't leak criterion
+-- names/descriptions/point totals to students before a review is assigned.
+----------------------------------------------------------------
+ALTER POLICY "authorizeforclass"
+ON public.rubric_criteria
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.rubrics r
+    WHERE r.id = rubric_criteria.rubric_id
+      AND authorizeforclass(r.class_id)
+      AND (
+        authorizeforclassgrader(r.class_id)
+        OR (
+          r.is_private = false
+          AND (
+            r.hide_unless_assigned = false
+            OR EXISTS (
+              SELECT 1
+              FROM public.review_assignments ra
+              JOIN public.user_privileges up ON up.private_profile_id = ra.assignee_profile_id
+              WHERE ra.rubric_id = r.id
+                AND up.user_id = auth.uid()
+                AND up.class_id = r.class_id
+                AND (ra.release_date IS NULL OR ra.release_date <= now())
             )
           )
         )
@@ -120,7 +155,7 @@ USING (
           WHERE ra.rubric_id = r.id
             AND up.user_id = auth.uid()
             AND up.class_id = r.class_id
-            AND (ra.release_date IS NULL OR ra.release_date <= timezone('utc', now()))
+            AND (ra.release_date IS NULL OR ra.release_date <= now())
         )
       )
       AND (
@@ -235,167 +270,135 @@ USING (
 );
 
 ----------------------------------------------------------------
--- check_assignment_deadlines_passed(): trigger auto-assign whenever
--- either the assignment's due_date OR an explicit release_at has passed.
-----------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public.check_assignment_deadlines_passed()
-RETURNS void AS $$
-DECLARE
-    assignment_record public.assignments%ROWTYPE;
-    profile_record public.profiles%ROWTYPE;
-BEGIN
-    FOR assignment_record IN (
-        SELECT a.*
-        FROM public.assignments a
-        LEFT JOIN public.assignment_self_review_settings s
-          ON s.id = a.self_review_setting_id
-        WHERE a.archived_at IS NULL
-          AND (
-            -- Explicit release_at, when set, gates eligibility.
-            (s.release_at IS NOT NULL AND s.release_at <= NOW())
-            -- Otherwise fall back to the original assignment due_date.
-            OR (s.release_at IS NULL AND a.due_date AT TIME ZONE 'UTC' <= NOW() AT TIME ZONE 'UTC')
-          )
-    ) LOOP
-        FOR profile_record IN (
-            SELECT * FROM public.profiles prof
-            WHERE is_private_profile = true
-              AND prof.class_id = assignment_record.class_id
-              AND EXISTS (
-                SELECT 1 FROM user_roles
-                WHERE private_profile_id = prof.id
-                  AND "role" = 'student'
-              )
-        ) LOOP
-            PERFORM auto_assign_self_reviews(assignment_record.id, profile_record.id);
-        END LOOP;
-    END LOOP;
-END;
-$$ LANGUAGE plpgsql;
-
-----------------------------------------------------------------
--- auto_assign_self_reviews(): honor release_at when set.
--- When release_at IS NULL, behavior is unchanged (release tied to original
--- due_date + per-student exceptions; review due_date = original due + exceptions
--- + deadline_offset).
--- When release_at IS NOT NULL, release gate becomes release_at <= now (exceptions
--- are ignored for the release decision); review due_date becomes
+-- check_assignment_deadlines_passed(): self-review auto-assignment.
+--
+-- Rebased on the optimized CTE version (20251006232741): keeps
+-- calculate_final_due_date (per-student/lab final due dates), the
+-- disabled-student filter, the self_review_rubric_id guard, and the
+-- 30-day/7-day window. Adds explicit release_at handling: when set, release
+-- gates on release_at (exceptions ignored) and the review due_date is
 -- release_at + deadline_offset.
 ----------------------------------------------------------------
-CREATE OR REPLACE FUNCTION public.auto_assign_self_reviews(this_assignment_id bigint, this_profile_id uuid)
-RETURNS void
-LANGUAGE plpgsql
-SECURITY DEFINER
-AS $$
-DECLARE
-    this_assignment public.assignments;
-    this_group_id bigint;
-    this_self_review_setting public.assignment_self_review_settings;
-    this_net_deadline_change_hours integer := 0;
-    this_net_deadline_change_minutes integer := 0;
-    this_active_submission_id bigint;
-    existing_submission_review_id bigint;
-    this_review_due_date timestamp;
-    utc_now TIMESTAMP := date_trunc('minute', now() + interval '59 second');
+CREATE OR REPLACE FUNCTION "public"."check_assignment_deadlines_passed"() RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
 BEGIN
-    SELECT * INTO this_assignment FROM public.assignments WHERE id = this_assignment_id;
+    WITH eligible_assignments AS MATERIALIZED (
+        -- Find assignments with self-review enabled AND recent deadlines.
+        -- Window covers due_date OR explicit release_at in [NOW()-30d, NOW()+7d].
+        SELECT
+            a.id AS assignment_id,
+            a.class_id,
+            a.self_review_rubric_id,
+            ars.deadline_offset,
+            ars.release_at
+        FROM assignments a
+        INNER JOIN assignment_self_review_settings ars ON ars.id = a.self_review_setting_id
+        WHERE a.archived_at IS NULL
+            AND ars.enabled = true
+            AND a.self_review_rubric_id IS NOT NULL
+            AND (
+                a.due_date BETWEEN (NOW() - INTERVAL '30 days') AND (NOW() + INTERVAL '7 days')
+                OR (
+                    ars.release_at IS NOT NULL
+                    AND ars.release_at BETWEEN (NOW() - INTERVAL '30 days') AND (NOW() + INTERVAL '7 days')
+                )
+            )
+    ),
+    students_without_review_assignments AS MATERIALIZED (
+        -- Pre-filter (student, assignment) pairs without a review assignment.
+        SELECT DISTINCT
+            ur.private_profile_id AS student_profile_id,
+            ur.class_id,
+            ea.assignment_id,
+            ea.self_review_rubric_id,
+            ea.deadline_offset,
+            ea.release_at
+        FROM user_roles ur
+        CROSS JOIN eligible_assignments ea
+        WHERE ur.role = 'student'
+            AND ur.disabled = false
+            AND ur.class_id = ea.class_id
+            AND NOT EXISTS (
+                SELECT 1 FROM review_assignments ra
+                WHERE ra.assignment_id = ea.assignment_id
+                    AND ra.assignee_profile_id = ur.private_profile_id
+            )
+    ),
+    students_past_deadline AS (
+        -- Individual submissions.
+        SELECT DISTINCT
+            sw.assignment_id,
+            sw.class_id,
+            sw.self_review_rubric_id,
+            sw.deadline_offset,
+            sw.release_at,
+            sw.student_profile_id,
+            s.id AS submission_id,
+            NULL::bigint AS assignment_group_id
+        FROM students_without_review_assignments sw
+        INNER JOIN submissions s ON (
+            s.assignment_id = sw.assignment_id
+            AND s.profile_id = sw.student_profile_id
+            AND s.is_active = true
+            AND s.assignment_group_id IS NULL
+        )
+        WHERE (
+            (sw.release_at IS NOT NULL AND sw.release_at <= NOW())
+            OR (
+                sw.release_at IS NULL
+                AND public.calculate_final_due_date(sw.assignment_id, sw.student_profile_id, NULL) <= NOW()
+            )
+        )
 
-    IF this_assignment.id IS NULL THEN
-        RETURN;
-    END IF;
+        UNION ALL
 
-    IF NOT EXISTS (
-        SELECT 1 FROM user_roles
-        WHERE private_profile_id = this_profile_id
-          AND role = 'student'
-          AND class_id = this_assignment.class_id
-    ) THEN
-        RETURN;
-    END IF;
-
-    SELECT assignment_group_id INTO this_group_id
-    FROM public.assignment_groups_members
-    WHERE profile_id = this_profile_id
-      AND class_id = this_assignment.class_id
-      AND assignment_id = this_assignment.id
-    LIMIT 1;
-
-    SELECT * INTO this_self_review_setting
-    FROM public.assignment_self_review_settings
-    WHERE id = this_assignment.self_review_setting_id;
-
-    IF this_self_review_setting.enabled IS NOT TRUE THEN
-        RETURN;
-    END IF;
-
-    IF EXISTS (
-        SELECT 1 FROM review_assignments
-        WHERE assignment_id = this_assignment.id
-          AND assignee_profile_id = this_profile_id
-    ) THEN
-        RETURN;
-    END IF;
-
-    SELECT COALESCE(SUM("hours"), 0) INTO this_net_deadline_change_hours
-    FROM public.assignment_due_date_exceptions
-    WHERE assignment_id = this_assignment.id
-      AND (student_id = this_profile_id OR assignment_group_id = this_group_id);
-
-    SELECT COALESCE(SUM("minutes"), 0) INTO this_net_deadline_change_minutes
-    FROM public.assignment_due_date_exceptions
-    WHERE assignment_id = this_assignment.id
-      AND (student_id = this_profile_id OR assignment_group_id = this_group_id);
-
-    -- Release gate: explicit release_at, when set, ignores per-student exceptions.
-    IF this_self_review_setting.release_at IS NOT NULL THEN
-        IF this_self_review_setting.release_at AT TIME ZONE 'UTC' > utc_now THEN
-            RETURN;
-        END IF;
-    ELSE
-        IF NOT (this_assignment.due_date AT TIME ZONE 'UTC'
-                + INTERVAL '1 hour' * this_net_deadline_change_hours
-                + INTERVAL '1 minute' * this_net_deadline_change_minutes <= utc_now) THEN
-            RETURN;
-        END IF;
-    END IF;
-
-    SELECT id INTO this_active_submission_id
-    FROM public.submissions
-    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id)
-        OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
-      AND assignment_id = this_assignment_id
-      AND is_active = true
-    LIMIT 1;
-
-    IF this_active_submission_id IS NULL THEN
-        RETURN;
-    END IF;
-
-    SELECT id INTO existing_submission_review_id
-    FROM public.submission_reviews
-    WHERE submission_id = this_active_submission_id
-      AND class_id = this_assignment.class_id
-      AND rubric_id = this_assignment.self_review_rubric_id
-    LIMIT 1;
-
-    IF existing_submission_review_id IS NULL THEN
+        -- Group submissions.
+        SELECT DISTINCT
+            sw.assignment_id,
+            sw.class_id,
+            sw.self_review_rubric_id,
+            sw.deadline_offset,
+            sw.release_at,
+            agm.profile_id AS student_profile_id,
+            s.id AS submission_id,
+            s.assignment_group_id
+        FROM students_without_review_assignments sw
+        INNER JOIN assignment_groups_members agm ON (
+            agm.profile_id = sw.student_profile_id
+            AND agm.assignment_id = sw.assignment_id
+        )
+        INNER JOIN submissions s ON (
+            s.assignment_group_id = agm.assignment_group_id
+            AND s.assignment_id = agm.assignment_id
+            AND s.is_active = true
+        )
+        WHERE (
+            (sw.release_at IS NOT NULL AND sw.release_at <= NOW())
+            OR (
+                sw.release_at IS NULL
+                AND public.calculate_final_due_date(sw.assignment_id, agm.profile_id, s.assignment_group_id) <= NOW()
+            )
+        )
+    ),
+    missing_submission_reviews AS (
+        -- Create any missing submission reviews first.
         INSERT INTO submission_reviews (total_score, released, tweak, class_id, submission_id, name, rubric_id)
-        VALUES (0, false, 0, this_assignment.class_id, this_active_submission_id, 'Self Review', this_assignment.self_review_rubric_id)
-        RETURNING id INTO existing_submission_review_id;
-    END IF;
-
-    -- Self-review due_date: anchor on release_at when set (exceptions ignored),
-    -- else on original due_date + exceptions. deadline_offset still applies in both.
-    IF this_self_review_setting.release_at IS NOT NULL THEN
-        this_review_due_date := this_self_review_setting.release_at AT TIME ZONE 'UTC'
-            + (INTERVAL '1 hour' * COALESCE(this_self_review_setting.deadline_offset, 0));
-    ELSE
-        this_review_due_date := this_assignment.due_date AT TIME ZONE 'UTC'
-            + (INTERVAL '1 hour' * this_net_deadline_change_hours)
-            + (INTERVAL '1 minute' * this_net_deadline_change_minutes)
-            + (INTERVAL '1 hour' * COALESCE(this_self_review_setting.deadline_offset, 0));
-    END IF;
-
+        SELECT
+            0, false, 0,
+            spd.class_id,
+            spd.submission_id,
+            'Self Review',
+            spd.self_review_rubric_id
+        FROM students_past_deadline spd
+        WHERE NOT EXISTS (
+            SELECT 1 FROM submission_reviews sr
+            WHERE sr.submission_id = spd.submission_id
+                AND sr.rubric_id = spd.self_review_rubric_id
+        )
+        RETURNING id, submission_id, rubric_id, class_id
+    )
+    -- Create review assignments for ALL students past deadline.
     INSERT INTO review_assignments (
         due_date,
         assignee_profile_id,
@@ -405,8 +408,205 @@ BEGIN
         rubric_id,
         class_id
     )
-    VALUES (
-        this_review_due_date,
+    SELECT
+        CASE
+            WHEN spd.release_at IS NOT NULL
+                THEN spd.release_at + (INTERVAL '1 hour' * spd.deadline_offset)
+            ELSE public.calculate_final_due_date(spd.assignment_id, spd.student_profile_id, spd.assignment_group_id)
+                + (INTERVAL '1 hour' * spd.deadline_offset)
+        END,
+        spd.student_profile_id,
+        spd.submission_id,
+        sr.id,
+        spd.assignment_id,
+        spd.self_review_rubric_id,
+        spd.class_id
+    FROM students_past_deadline spd
+    INNER JOIN submission_reviews sr ON (
+        sr.submission_id = spd.submission_id
+        AND sr.rubric_id = spd.self_review_rubric_id
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.check_assignment_deadlines_passed() IS
+    'Optimized function to create self-review assignments when assignment deadlines pass. Uses CTEs for better performance. Honors assignment_self_review_settings.release_at: when set, gates release on release_at (ignoring exceptions) and sets the review due_date to release_at + deadline_offset; otherwise uses calculate_final_due_date.';
+
+----------------------------------------------------------------
+-- finalize_submission_early(): honor release_at.
+--
+-- Rebased on 20250703014545. When the assignment has an explicit
+-- self-review release_at, an early finalize still must not surface a
+-- hide_unless_assigned rubric before release_at: the created
+-- review_assignment gets release_date = release_at (gating visibility via
+-- RLS) and due_date = release_at + deadline_offset. When release_at IS NULL,
+-- behavior is unchanged (release_date NULL, due_date = now + deadline_offset).
+----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION finalize_submission_early(
+    this_assignment_id bigint,
+    this_profile_id uuid
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    this_assignment public.assignments;
+    this_group_id bigint;
+    this_self_review_setting public.assignment_self_review_settings;
+    this_active_submission_id bigint;
+    existing_submission_review_id bigint;
+    hours_to_subtract integer;
+    minutes_to_subtract integer;
+    utc_now TIMESTAMP := date_trunc('minute', now() + interval '59 second');
+BEGIN
+    -- Get the assignment first
+    SELECT * INTO this_assignment FROM public.assignments WHERE id = this_assignment_id;
+
+    -- Check if assignment exists
+    IF this_assignment.id IS NULL THEN
+        RETURN json_build_object('success', false, 'error', 'Assignment not found');
+    END IF;
+
+    -- Confirm this is a private profile for a student in this class, else abort
+    IF NOT EXISTS (
+        SELECT 1 FROM user_roles
+        WHERE private_profile_id = this_profile_id
+        AND role = 'student'
+        AND class_id = this_assignment.class_id
+        AND user_id = auth.uid()
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Not authorized');
+    END IF;
+
+    -- Get the group of the student for this assignment
+    SELECT assignment_group_id INTO this_group_id
+    FROM public.assignment_groups_members
+    WHERE profile_id = this_profile_id
+    AND class_id = this_assignment.class_id
+    AND assignment_id = this_assignment.id
+    LIMIT 1;
+
+    -- Get the self review setting
+    SELECT * INTO this_self_review_setting
+    FROM public.assignment_self_review_settings
+    WHERE id = this_assignment.self_review_setting_id;
+
+    -- If self reviews are not enabled for this assignment, abort
+    IF this_self_review_setting.enabled IS NOT TRUE THEN
+        RETURN json_build_object('success', false, 'error', 'Self reviews not enabled for this assignment');
+    END IF;
+
+    -- Check if there's already a negative due date exception (already finalized)
+    IF EXISTS (
+        SELECT 1 FROM assignment_due_date_exceptions
+        WHERE assignment_id = this_assignment_id
+        AND (
+            (student_id = this_profile_id AND hours < 0) OR
+            (assignment_group_id = this_group_id AND hours < 0)
+        )
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Submission already finalized');
+    END IF;
+
+    -- Calculate hours and minutes to subtract
+    hours_to_subtract := -1 * EXTRACT(EPOCH FROM (this_assignment.due_date - utc_now)) / 3600;
+    minutes_to_subtract := -1 * (EXTRACT(EPOCH FROM (this_assignment.due_date - utc_now)) % 3600) / 60;
+
+    -- Insert the negative due date exception
+    IF this_group_id IS NOT NULL THEN
+        INSERT INTO assignment_due_date_exceptions (
+            class_id,
+            assignment_id,
+            assignment_group_id,
+            creator_id,
+            hours,
+            minutes,
+            tokens_consumed
+        ) VALUES (
+            this_assignment.class_id,
+            this_assignment_id,
+            this_group_id,
+            this_profile_id,
+            hours_to_subtract,
+            minutes_to_subtract,
+            0
+        );
+    ELSE
+        INSERT INTO assignment_due_date_exceptions (
+            class_id,
+            assignment_id,
+            student_id,
+            creator_id,
+            hours,
+            minutes,
+            tokens_consumed
+        ) VALUES (
+            this_assignment.class_id,
+            this_assignment_id,
+            this_profile_id,
+            this_profile_id,
+            hours_to_subtract,
+            minutes_to_subtract,
+            0
+        );
+    END IF;
+
+    -- Get the active submission id for this profile
+    SELECT id INTO this_active_submission_id
+    FROM public.submissions
+    WHERE ((profile_id IS NOT NULL AND profile_id = this_profile_id) OR (assignment_group_id IS NOT NULL AND assignment_group_id = this_group_id))
+    AND assignment_id = this_assignment_id
+    AND is_active = true
+    LIMIT 1;
+
+    -- If active submission does not exist, abort
+    IF this_active_submission_id IS NULL THEN
+        RETURN json_build_object('success', false, 'error', 'No active submission found');
+    END IF;
+
+    -- Check if there's already a review assignment for this student for this assignment
+    IF EXISTS (
+        SELECT 1 FROM review_assignments
+        WHERE assignment_id = this_assignment.id
+        AND assignee_profile_id = this_profile_id
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Self review already assigned');
+    END IF;
+
+    -- Create or get existing submission review
+    SELECT id INTO existing_submission_review_id
+    FROM public.submission_reviews
+    WHERE submission_id = this_active_submission_id
+    AND class_id = this_assignment.class_id
+    AND rubric_id = this_assignment.self_review_rubric_id
+    LIMIT 1;
+
+    IF existing_submission_review_id IS NULL THEN
+        INSERT INTO submission_reviews (total_score, released, tweak, class_id, submission_id, name, rubric_id)
+        VALUES (0, false, 0, this_assignment.class_id, this_active_submission_id, 'Self Review', this_assignment.self_review_rubric_id)
+        RETURNING id INTO existing_submission_review_id;
+    END IF;
+
+    -- Create the review assignment. When release_at is set, keep the rubric
+    -- hidden until release_at by setting release_date, and anchor the review
+    -- due_date on release_at; otherwise preserve the early-finalize behavior.
+    INSERT INTO review_assignments (
+        due_date,
+        release_date,
+        assignee_profile_id,
+        submission_id,
+        submission_review_id,
+        assignment_id,
+        rubric_id,
+        class_id
+    ) VALUES (
+        CASE
+            WHEN this_self_review_setting.release_at IS NOT NULL
+                THEN this_self_review_setting.release_at + (INTERVAL '1 hour' * this_self_review_setting.deadline_offset)
+            ELSE utc_now + (INTERVAL '1 hour' * this_self_review_setting.deadline_offset)
+        END,
+        this_self_review_setting.release_at,
         this_profile_id,
         this_active_submission_id,
         existing_submission_review_id,
@@ -414,11 +614,20 @@ BEGIN
         this_assignment.self_review_rubric_id,
         this_assignment.class_id
     );
+
+    RETURN json_build_object('success', true, 'message', 'Submission finalized and self review assigned');
 END;
 $$;
 
+GRANT EXECUTE ON FUNCTION finalize_submission_early(bigint, uuid) TO authenticated;
+
 ----------------------------------------------------------------
 -- update_rubric_full RPC: accept and persist hide_unless_assigned.
+--
+-- Rebased on 20260520140000 (foreign-id remapping + FK-safe leaf→root
+-- deletes). Adds hide_unless_assigned: defaults to false on insert; on update
+-- only overwrites when the key is present (COALESCE), so a stale caller that
+-- omits the flag can't silently unhide a rubric.
 ----------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.update_rubric_full(p_rubric jsonb)
 RETURNS text
@@ -460,7 +669,9 @@ DECLARE
   v_refs_added int := 0;
   v_refs_removed int := 0;
   v_reviews_recomputed int := 0;
+  v_foreign_ids_remapped int := 0;
 
+  -- Input map key -> real DB id, after insert/update phases.
   v_part_id_map jsonb := '{}'::jsonb;
   v_criteria_id_map jsonb := '{}'::jsonb;
   v_check_id_map jsonb := '{}'::jsonb;
@@ -478,9 +689,15 @@ DECLARE
   v_check_id bigint;
   v_review_id bigint;
 
+  v_part_ord int;
+  v_crit_ord int;
+  v_check_ord int;
+  v_part_map_key text;
+  v_criteria_map_key text;
+  v_check_map_key text;
+
   v_points_changed_check_ids bigint[] := ARRAY[]::bigint[];
   v_removed_check_ids bigint[] := ARRAY[]::bigint[];
-
   v_affected_review_ids bigint[] := ARRAY[]::bigint[];
 
   v_old_total_points int;
@@ -497,11 +714,10 @@ BEGIN
   v_review_round := (p_rubric->>'review_round')::review_round;
   v_new_name := p_rubric->>'name';
   v_new_description := p_rubric->>'description';
-  v_new_is_private := CASE WHEN p_rubric ? 'is_private' THEN (p_rubric->>'is_private')::boolean END;
-  v_new_cap := CASE
-    WHEN p_rubric ? 'cap_score_to_assignment_points'
-    THEN (p_rubric->>'cap_score_to_assignment_points')::boolean
-  END;
+  v_new_is_private := COALESCE((p_rubric->>'is_private')::boolean, false);
+  v_new_cap := COALESCE((p_rubric->>'cap_score_to_assignment_points')::boolean, false);
+  -- NULL when the key is absent: only overwrite hide_unless_assigned on update
+  -- when the caller actually sent it.
   v_new_hide_unless_assigned := CASE
     WHEN p_rubric ? 'hide_unless_assigned'
     THEN (p_rubric->>'hide_unless_assigned')::boolean
@@ -523,8 +739,8 @@ BEGIN
       cap_score_to_assignment_points, hide_unless_assigned
     )
     VALUES (
-      v_new_name, v_new_description, v_assignment_id, v_class_id, COALESCE(v_new_is_private, false),
-      v_review_round, COALESCE(v_new_cap, false), COALESCE(v_new_hide_unless_assigned, false)
+      v_new_name, v_new_description, v_assignment_id, v_class_id, v_new_is_private,
+      v_review_round, v_new_cap, COALESCE(v_new_hide_unless_assigned, false)
     )
     RETURNING id INTO v_rubric_id;
     v_is_new_rubric := true;
@@ -542,32 +758,85 @@ BEGIN
 
     IF v_old_name IS DISTINCT FROM v_new_name
        OR v_old_description IS DISTINCT FROM v_new_description
-       OR (v_new_is_private IS NOT NULL AND v_old_is_private IS DISTINCT FROM v_new_is_private)
-       OR (v_new_cap IS NOT NULL AND v_old_cap IS DISTINCT FROM v_new_cap)
+       OR v_old_is_private IS DISTINCT FROM v_new_is_private
+       OR v_old_cap IS DISTINCT FROM v_new_cap
        OR (v_new_hide_unless_assigned IS NOT NULL AND v_old_hide_unless_assigned IS DISTINCT FROM v_new_hide_unless_assigned) THEN
       UPDATE public.rubrics
       SET name = v_new_name,
           description = v_new_description,
-          is_private = COALESCE(v_new_is_private, is_private),
-          cap_score_to_assignment_points = COALESCE(v_new_cap, cap_score_to_assignment_points),
+          is_private = v_new_is_private,
+          cap_score_to_assignment_points = v_new_cap,
           hide_unless_assigned = COALESCE(v_new_hide_unless_assigned, hide_unless_assigned)
       WHERE id = v_rubric_id;
     END IF;
 
-    IF v_new_cap IS NOT NULL AND v_old_cap IS DISTINCT FROM v_new_cap THEN
+    IF v_old_cap IS DISTINCT FROM v_new_cap THEN
       v_broad_change := true;
     END IF;
   END IF;
 
-  WITH input_ids AS (
+  ----------------------------------------------------------------
+  -- Phase 0: deletes (leaf → root). FKs on rubric_criteria→parts and
+  -- rubric_checks→criteria are NO ACTION, so we must remove checks before
+  -- criteria before parts. rubric_check_references CASCADE when checks go.
+  ----------------------------------------------------------------
+  WITH input_check_ids AS (
+    SELECT (chk->>'id')::bigint AS id
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
+         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit,
+         jsonb_array_elements(COALESCE(crit->'checks', '[]'::jsonb)) chk
+    WHERE COALESCE((chk->>'id')::bigint, 0) > 0
+      AND EXISTS (
+        SELECT 1 FROM public.rubric_checks rc
+        WHERE rc.id = (chk->>'id')::bigint AND rc.rubric_id = v_rubric_id
+      )
+  )
+  SELECT COALESCE(array_agg(id), ARRAY[]::bigint[]) INTO v_removed_check_ids
+  FROM public.rubric_checks
+  WHERE rubric_id = v_rubric_id
+    AND id NOT IN (SELECT id FROM input_check_ids);
+
+  IF array_length(v_removed_check_ids, 1) > 0 THEN
+    DELETE FROM public.rubric_checks WHERE id = ANY(v_removed_check_ids);
+    v_checks_removed := array_length(v_removed_check_ids, 1);
+    v_broad_change := true;
+  END IF;
+
+  WITH input_criteria_ids AS (
+    SELECT (crit->>'id')::bigint AS id
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
+         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit
+    WHERE COALESCE((crit->>'id')::bigint, 0) > 0
+      AND EXISTS (
+        SELECT 1 FROM public.rubric_criteria rc
+        WHERE rc.id = (crit->>'id')::bigint AND rc.rubric_id = v_rubric_id
+      )
+  ),
+  del AS (
+    DELETE FROM public.rubric_criteria
+    WHERE rubric_id = v_rubric_id
+      AND id NOT IN (SELECT id FROM input_criteria_ids)
+    RETURNING id
+  )
+  SELECT count(*) INTO v_criteria_removed FROM del;
+
+  IF v_criteria_removed > 0 THEN
+    v_broad_change := true;
+  END IF;
+
+  WITH input_part_ids AS (
     SELECT (elem->>'id')::bigint AS id
     FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) elem
     WHERE COALESCE((elem->>'id')::bigint, 0) > 0
+      AND EXISTS (
+        SELECT 1 FROM public.rubric_parts rp
+        WHERE rp.id = (elem->>'id')::bigint AND rp.rubric_id = v_rubric_id
+      )
   ),
   del AS (
     DELETE FROM public.rubric_parts
     WHERE rubric_id = v_rubric_id
-      AND id NOT IN (SELECT id FROM input_ids)
+      AND id NOT IN (SELECT id FROM input_part_ids)
     RETURNING id
   )
   SELECT count(*) INTO v_parts_removed FROM del;
@@ -576,11 +845,39 @@ BEGIN
     v_broad_change := true;
   END IF;
 
-  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  ----------------------------------------------------------------
+  -- Phase 1: upsert parts.
+  ----------------------------------------------------------------
+  FOR v_part, v_part_ord IN
+    SELECT elem, ord::int
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
   LOOP
     v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
 
-    IF v_input_part_id <= 0 THEN
+    IF v_input_part_id > 0
+       AND EXISTS (
+         SELECT 1 FROM public.rubric_parts
+         WHERE id = v_input_part_id AND rubric_id = v_rubric_id
+       ) THEN
+      v_part_map_key := v_input_part_id::text;
+
+      UPDATE public.rubric_parts
+      SET name = v_part->>'name',
+          description = v_part->>'description',
+          ordinal = COALESCE((v_part->>'ordinal')::int, 0),
+          data = v_part->'data',
+          is_individual_grading = COALESCE((v_part->>'is_individual_grading')::boolean, false),
+          is_assign_to_student = COALESCE((v_part->>'is_assign_to_student')::boolean, false)
+      WHERE id = v_input_part_id AND rubric_id = v_rubric_id;
+
+      v_part_id := v_input_part_id;
+      v_parts_updated := v_parts_updated + 1;
+    ELSE
+      IF v_input_part_id > 0 THEN
+        v_foreign_ids_remapped := v_foreign_ids_remapped + 1;
+      END IF;
+      v_part_map_key := 'new_part_' || v_part_ord::text;
+
       INSERT INTO public.rubric_parts (
         name, description, ordinal, rubric_id, class_id, assignment_id,
         data, is_individual_grading, is_assign_to_student
@@ -594,77 +891,45 @@ BEGIN
         COALESCE((v_part->>'is_assign_to_student')::boolean, false)
       ) RETURNING id INTO v_part_id;
 
-      v_part_id_map := v_part_id_map || jsonb_build_object(v_input_part_id::text, v_part_id);
       v_parts_added := v_parts_added + 1;
       v_broad_change := true;
-    ELSE
-      UPDATE public.rubric_parts
-      SET name = v_part->>'name',
-          description = v_part->>'description',
-          ordinal = COALESCE((v_part->>'ordinal')::int, 0),
-          data = v_part->'data',
-          is_individual_grading = COALESCE((v_part->>'is_individual_grading')::boolean, false),
-          is_assign_to_student = COALESCE((v_part->>'is_assign_to_student')::boolean, false)
-      WHERE id = v_input_part_id AND rubric_id = v_rubric_id;
-
-      IF NOT FOUND THEN
-        RAISE EXCEPTION 'Part % not in rubric %', v_input_part_id, v_rubric_id;
-      END IF;
-
-      v_part_id_map := v_part_id_map || jsonb_build_object(v_input_part_id::text, v_input_part_id);
-      v_parts_updated := v_parts_updated + 1;
     END IF;
+
+    v_part_id_map := v_part_id_map || jsonb_build_object(v_part_map_key, v_part_id);
   END LOOP;
 
-  WITH input_ids AS (
-    SELECT (crit->>'id')::bigint AS id
-    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
-         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit
-    WHERE COALESCE((crit->>'id')::bigint, 0) > 0
-  ),
-  del AS (
-    DELETE FROM public.rubric_criteria
-    WHERE rubric_id = v_rubric_id
-      AND id NOT IN (SELECT id FROM input_ids)
-    RETURNING id
-  )
-  SELECT count(*) INTO v_criteria_removed FROM del;
-
-  IF v_criteria_removed > 0 THEN
-    v_broad_change := true;
-  END IF;
-
-  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  ----------------------------------------------------------------
+  -- Phase 2: upsert criteria.
+  ----------------------------------------------------------------
+  FOR v_part, v_part_ord IN
+    SELECT elem, ord::int
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
   LOOP
     v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
-    v_part_id := COALESCE((v_part_id_map->>v_input_part_id::text)::bigint, v_input_part_id);
+    IF v_input_part_id > 0
+       AND EXISTS (
+         SELECT 1 FROM public.rubric_parts
+         WHERE id = v_input_part_id AND rubric_id = v_rubric_id
+       ) THEN
+      v_part_map_key := v_input_part_id::text;
+    ELSE
+      v_part_map_key := 'new_part_' || v_part_ord::text;
+    END IF;
+    v_part_id := (v_part_id_map->>v_part_map_key)::bigint;
 
-    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    FOR v_criterion, v_crit_ord IN
+      SELECT elem, ord::int
+      FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
     LOOP
       v_input_criteria_id := COALESCE((v_criterion->>'id')::bigint, 0);
 
-      IF v_input_criteria_id <= 0 THEN
-        INSERT INTO public.rubric_criteria (
-          name, description, ordinal, rubric_id, rubric_part_id, class_id, assignment_id,
-          data, is_additive, is_deduction_only, total_points,
-          max_checks_per_submission, min_checks_per_submission
-        ) VALUES (
-          v_criterion->>'name',
-          v_criterion->>'description',
-          COALESCE((v_criterion->>'ordinal')::int, 0),
-          v_rubric_id, v_part_id, v_class_id, v_assignment_id,
-          v_criterion->'data',
-          COALESCE((v_criterion->>'is_additive')::boolean, false),
-          COALESCE((v_criterion->>'is_deduction_only')::boolean, false),
-          COALESCE((v_criterion->>'total_points')::int, 0),
-          NULLIF(v_criterion->>'max_checks_per_submission', '')::int,
-          NULLIF(v_criterion->>'min_checks_per_submission', '')::int
-        ) RETURNING id INTO v_criteria_id;
+      IF v_input_criteria_id > 0
+         AND EXISTS (
+           SELECT 1 FROM public.rubric_criteria
+           WHERE id = v_input_criteria_id AND rubric_id = v_rubric_id
+         ) THEN
+        v_criteria_map_key := v_input_criteria_id::text;
 
-        v_criteria_id_map := v_criteria_id_map || jsonb_build_object(v_input_criteria_id::text, v_criteria_id);
-        v_criteria_added := v_criteria_added + 1;
-        v_broad_change := true;
-      ELSE
         SELECT total_points, is_additive, is_deduction_only
         INTO v_old_total_points, v_old_is_additive, v_old_is_deduction_only
         FROM public.rubric_criteria WHERE id = v_input_criteria_id;
@@ -688,74 +953,86 @@ BEGIN
             min_checks_per_submission = NULLIF(v_criterion->>'min_checks_per_submission', '')::int
         WHERE id = v_input_criteria_id AND rubric_id = v_rubric_id;
 
-        IF NOT FOUND THEN
-          RAISE EXCEPTION 'Criterion % not in rubric %', v_input_criteria_id, v_rubric_id;
-        END IF;
-
-        v_criteria_id_map := v_criteria_id_map || jsonb_build_object(v_input_criteria_id::text, v_input_criteria_id);
+        v_criteria_id := v_input_criteria_id;
         v_criteria_updated := v_criteria_updated + 1;
+      ELSE
+        IF v_input_criteria_id > 0 THEN
+          v_foreign_ids_remapped := v_foreign_ids_remapped + 1;
+        END IF;
+        v_criteria_map_key := 'new_crit_' || v_part_ord::text || '_' || v_crit_ord::text;
+
+        INSERT INTO public.rubric_criteria (
+          name, description, ordinal, rubric_id, rubric_part_id, class_id, assignment_id,
+          data, is_additive, is_deduction_only, total_points,
+          max_checks_per_submission, min_checks_per_submission
+        ) VALUES (
+          v_criterion->>'name',
+          v_criterion->>'description',
+          COALESCE((v_criterion->>'ordinal')::int, 0),
+          v_rubric_id, v_part_id, v_class_id, v_assignment_id,
+          v_criterion->'data',
+          COALESCE((v_criterion->>'is_additive')::boolean, false),
+          COALESCE((v_criterion->>'is_deduction_only')::boolean, false),
+          COALESCE((v_criterion->>'total_points')::int, 0),
+          NULLIF(v_criterion->>'max_checks_per_submission', '')::int,
+          NULLIF(v_criterion->>'min_checks_per_submission', '')::int
+        ) RETURNING id INTO v_criteria_id;
+
+        v_criteria_added := v_criteria_added + 1;
+        v_broad_change := true;
       END IF;
+
+      v_criteria_id_map := v_criteria_id_map || jsonb_build_object(v_criteria_map_key, v_criteria_id);
     END LOOP;
   END LOOP;
 
-  WITH input_ids AS (
-    SELECT (chk->>'id')::bigint AS id
-    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) part,
-         jsonb_array_elements(COALESCE(part->'criteria', '[]'::jsonb)) crit,
-         jsonb_array_elements(COALESCE(crit->'checks', '[]'::jsonb)) chk
-    WHERE COALESCE((chk->>'id')::bigint, 0) > 0
-  )
-  SELECT COALESCE(array_agg(id), ARRAY[]::bigint[]) INTO v_removed_check_ids
-  FROM public.rubric_checks
-  WHERE rubric_id = v_rubric_id
-    AND id NOT IN (SELECT id FROM input_ids);
-
-  IF array_length(v_removed_check_ids, 1) > 0 THEN
-    DELETE FROM public.rubric_checks WHERE id = ANY(v_removed_check_ids);
-    v_checks_removed := array_length(v_removed_check_ids, 1);
-    v_broad_change := true;
-  END IF;
-
-  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  ----------------------------------------------------------------
+  -- Phase 3: upsert checks.
+  ----------------------------------------------------------------
+  FOR v_part, v_part_ord IN
+    SELECT elem, ord::int
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
   LOOP
-    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
+    IF v_input_part_id > 0
+       AND EXISTS (
+         SELECT 1 FROM public.rubric_parts
+         WHERE id = v_input_part_id AND rubric_id = v_rubric_id
+       ) THEN
+      v_part_map_key := v_input_part_id::text;
+    ELSE
+      v_part_map_key := 'new_part_' || v_part_ord::text;
+    END IF;
+
+    FOR v_criterion, v_crit_ord IN
+      SELECT elem, ord::int
+      FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
     LOOP
       v_input_criteria_id := COALESCE((v_criterion->>'id')::bigint, 0);
-      v_criteria_id := COALESCE((v_criteria_id_map->>v_input_criteria_id::text)::bigint, v_input_criteria_id);
+      IF v_input_criteria_id > 0
+         AND EXISTS (
+           SELECT 1 FROM public.rubric_criteria
+           WHERE id = v_input_criteria_id AND rubric_id = v_rubric_id
+         ) THEN
+        v_criteria_map_key := v_input_criteria_id::text;
+      ELSE
+        v_criteria_map_key := 'new_crit_' || v_part_ord::text || '_' || v_crit_ord::text;
+      END IF;
+      v_criteria_id := (v_criteria_id_map->>v_criteria_map_key)::bigint;
 
-      FOR v_check IN SELECT * FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb))
+      FOR v_check, v_check_ord IN
+        SELECT elem, ord::int
+        FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
       LOOP
         v_input_check_id := COALESCE((v_check->>'id')::bigint, 0);
 
-        IF v_input_check_id <= 0 THEN
-          INSERT INTO public.rubric_checks (
-            name, description, ordinal, rubric_criteria_id, rubric_id, class_id, assignment_id,
-            data, file, artifact, "group",
-            is_annotation, is_comment_required, is_required,
-            max_annotations, points, annotation_target, student_visibility, kpi_category
-          ) VALUES (
-            v_check->>'name',
-            v_check->>'description',
-            COALESCE((v_check->>'ordinal')::int, 0),
-            v_criteria_id, v_rubric_id, v_class_id, v_assignment_id,
-            v_check->'data',
-            v_check->>'file',
-            v_check->>'artifact',
-            v_check->>'group',
-            COALESCE((v_check->>'is_annotation')::boolean, false),
-            COALESCE((v_check->>'is_comment_required')::boolean, false),
-            COALESCE((v_check->>'is_required')::boolean, false),
-            NULLIF(v_check->>'max_annotations', '')::int,
-            COALESCE((v_check->>'points')::int, 0),
-            v_check->>'annotation_target',
-            COALESCE((v_check->>'student_visibility')::rubric_check_student_visibility, 'always'::rubric_check_student_visibility),
-            NULLIF(v_check->>'kpi_category', '')::repo_analytics_kpi_category
-          ) RETURNING id INTO v_check_id;
+        IF v_input_check_id > 0
+           AND EXISTS (
+             SELECT 1 FROM public.rubric_checks
+             WHERE id = v_input_check_id AND rubric_id = v_rubric_id
+           ) THEN
+          v_check_map_key := v_input_check_id::text;
 
-          v_check_id_map := v_check_id_map || jsonb_build_object(v_input_check_id::text, v_check_id);
-          v_checks_added := v_checks_added + 1;
-          v_broad_change := true;
-        ELSE
           SELECT points INTO v_old_points
           FROM public.rubric_checks WHERE id = v_input_check_id;
 
@@ -785,13 +1062,43 @@ BEGIN
               kpi_category = NULLIF(v_check->>'kpi_category', '')::repo_analytics_kpi_category
           WHERE id = v_input_check_id AND rubric_id = v_rubric_id;
 
-          IF NOT FOUND THEN
-            RAISE EXCEPTION 'Check % not in rubric %', v_input_check_id, v_rubric_id;
-          END IF;
-
-          v_check_id_map := v_check_id_map || jsonb_build_object(v_input_check_id::text, v_input_check_id);
+          v_check_id := v_input_check_id;
           v_checks_updated := v_checks_updated + 1;
+        ELSE
+          IF v_input_check_id > 0 THEN
+            v_foreign_ids_remapped := v_foreign_ids_remapped + 1;
+          END IF;
+          v_check_map_key := 'new_check_' || v_part_ord::text || '_' || v_crit_ord::text || '_' || v_check_ord::text;
+
+          INSERT INTO public.rubric_checks (
+            name, description, ordinal, rubric_criteria_id, rubric_id, class_id, assignment_id,
+            data, file, artifact, "group",
+            is_annotation, is_comment_required, is_required,
+            max_annotations, points, annotation_target, student_visibility, kpi_category
+          ) VALUES (
+            v_check->>'name',
+            v_check->>'description',
+            COALESCE((v_check->>'ordinal')::int, 0),
+            v_criteria_id, v_rubric_id, v_class_id, v_assignment_id,
+            v_check->'data',
+            v_check->>'file',
+            v_check->>'artifact',
+            v_check->>'group',
+            COALESCE((v_check->>'is_annotation')::boolean, false),
+            COALESCE((v_check->>'is_comment_required')::boolean, false),
+            COALESCE((v_check->>'is_required')::boolean, false),
+            NULLIF(v_check->>'max_annotations', '')::int,
+            COALESCE((v_check->>'points')::int, 0),
+            v_check->>'annotation_target',
+            COALESCE((v_check->>'student_visibility')::rubric_check_student_visibility, 'always'::rubric_check_student_visibility),
+            NULLIF(v_check->>'kpi_category', '')::repo_analytics_kpi_category
+          ) RETURNING id INTO v_check_id;
+
+          v_checks_added := v_checks_added + 1;
+          v_broad_change := true;
         END IF;
+
+        v_check_id_map := v_check_id_map || jsonb_build_object(v_check_map_key, v_check_id);
       END LOOP;
     END LOOP;
   END LOOP;
@@ -818,20 +1125,60 @@ BEGIN
     v_checks_points_cascaded := array_length(v_points_changed_check_ids, 1);
   END IF;
 
+  ----------------------------------------------------------------
+  -- Phase 4: rubric_check_references.
+  ----------------------------------------------------------------
   CREATE TEMP TABLE IF NOT EXISTS _desired_refs (
     referencing_check_id bigint NOT NULL,
     referenced_check_id bigint NOT NULL
   ) ON COMMIT DROP;
   TRUNCATE _desired_refs;
 
-  FOR v_part IN SELECT * FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb))
+  FOR v_part, v_part_ord IN
+    SELECT elem, ord::int
+    FROM jsonb_array_elements(COALESCE(p_rubric->'parts', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
   LOOP
-    FOR v_criterion IN SELECT * FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb))
+    v_input_part_id := COALESCE((v_part->>'id')::bigint, 0);
+    IF v_input_part_id > 0
+       AND EXISTS (
+         SELECT 1 FROM public.rubric_parts
+         WHERE id = v_input_part_id AND rubric_id = v_rubric_id
+       ) THEN
+      v_part_map_key := v_input_part_id::text;
+    ELSE
+      v_part_map_key := 'new_part_' || v_part_ord::text;
+    END IF;
+
+    FOR v_criterion, v_crit_ord IN
+      SELECT elem, ord::int
+      FROM jsonb_array_elements(COALESCE(v_part->'criteria', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
     LOOP
-      FOR v_check IN SELECT * FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb))
+      v_input_criteria_id := COALESCE((v_criterion->>'id')::bigint, 0);
+      IF v_input_criteria_id > 0
+         AND EXISTS (
+           SELECT 1 FROM public.rubric_criteria
+           WHERE id = v_input_criteria_id AND rubric_id = v_rubric_id
+         ) THEN
+        v_criteria_map_key := v_input_criteria_id::text;
+      ELSE
+        v_criteria_map_key := 'new_crit_' || v_part_ord::text || '_' || v_crit_ord::text;
+      END IF;
+
+      FOR v_check, v_check_ord IN
+        SELECT elem, ord::int
+        FROM jsonb_array_elements(COALESCE(v_criterion->'checks', '[]'::jsonb)) WITH ORDINALITY AS t(elem, ord)
       LOOP
         v_input_check_id := COALESCE((v_check->>'id')::bigint, 0);
-        v_check_id := COALESCE((v_check_id_map->>v_input_check_id::text)::bigint, v_input_check_id);
+        IF v_input_check_id > 0
+           AND EXISTS (
+             SELECT 1 FROM public.rubric_checks
+             WHERE id = v_input_check_id AND rubric_id = v_rubric_id
+           ) THEN
+          v_check_map_key := v_input_check_id::text;
+        ELSE
+          v_check_map_key := 'new_check_' || v_part_ord::text || '_' || v_crit_ord::text || '_' || v_check_ord::text;
+        END IF;
+        v_check_id := (v_check_id_map->>v_check_map_key)::bigint;
 
         FOR v_ref IN SELECT * FROM jsonb_array_elements(COALESCE(v_check->'references', '[]'::jsonb))
         LOOP
@@ -926,6 +1273,10 @@ BEGIN
     v_summary := v_summary || ' No structural changes.';
   END IF;
 
+  IF v_foreign_ids_remapped > 0 THEN
+    v_summary := v_summary || ' ' || v_foreign_ids_remapped || ' item(s) with unrecognized ids treated as new.';
+  END IF;
+
   IF v_checks_points_cascaded > 0 THEN
     v_summary := v_summary || ' Cascaded new points to existing comments on '
               || v_checks_points_cascaded || ' check'
@@ -941,3 +1292,6 @@ BEGIN
   RETURN v_summary;
 END;
 $function$;
+
+COMMENT ON FUNCTION public.update_rubric_full(jsonb) IS
+  'Atomically apply a hydrated rubric (top-level fields + parts/criteria/checks/references) in one transaction, cascade points changes to existing comments, recompute affected submission_reviews, and return a friendly summary. Positive ids not owned by the target rubric are inserted as new rows (copy/paste YAML). Removes checks before criteria before parts to satisfy FK constraints. Persists hide_unless_assigned (default false on insert; only overwritten on update when the key is present).';

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -479,10 +479,15 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 // Helper function to create a Supabase client authenticated as a specific user
 export async function createAuthenticatedClient(testingUser: TestingUser): Promise<SupabaseClient<Database>> {
-  // Create a separate Supabase client for the user (using anon key)
+  // Create a separate Supabase client for the user (using anon key).
+  // persistSession/autoRefreshToken are off so concurrent clients in the same
+  // process don't clobber each other via the default shared GoTrue storage —
+  // otherwise the second setSession would override the first, leaving both
+  // clients authenticated as whoever logged in last.
   const userSupabase = createClient<Database>(
     process.env.SUPABASE_URL!,
-    (process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)!
+    (process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)!,
+    { auth: { persistSession: false, autoRefreshToken: false } }
   );
 
   // Generate magic link using admin client

--- a/tests/e2e/active-submission-gradebook-db.spec.ts
+++ b/tests/e2e/active-submission-gradebook-db.spec.ts
@@ -46,7 +46,7 @@ test.describe("active submission gradebook recalculation", () => {
       assignment_slug: `e2e-active-submission-${suffix}`
     });
     assignmentId = assignment.id;
-    assignmentSlug = assignment.slug;
+    assignmentSlug = assignment.slug ?? "";
 
     const gradebookColumn = await getAssignmentGradebookColumn(classId, assignmentSlug);
     gradebookId = gradebookColumn.gradebook_id;

--- a/tests/unit/rubric/cli-export-shape.test.ts
+++ b/tests/unit/rubric/cli-export-shape.test.ts
@@ -56,6 +56,7 @@ function makeRubric(
     is_private: false,
     review_round: reviewRound,
     cap_score_to_assignment_points: false,
+    hide_unless_assigned: false,
     rubric_parts: [
       {
         id: id * 10,

--- a/tests/unit/rubric/points.test.ts
+++ b/tests/unit/rubric/points.test.ts
@@ -65,6 +65,7 @@ function rubric(parts: HydratedRubricPart[]): HydratedRubric {
     review_round: "grading-review",
     created_at: "",
     cap_score_to_assignment_points: false,
+    hide_unless_assigned: false,
     rubric_parts: parts
   };
 }

--- a/tests/unit/rubric/pointsSanitize.test.ts
+++ b/tests/unit/rubric/pointsSanitize.test.ts
@@ -22,6 +22,7 @@ describe("sanitizeHydratedRubricPoints", () => {
       is_private: false,
       review_round: "grading-review" as const,
       cap_score_to_assignment_points: false,
+      hide_unless_assigned: false,
       created_at: "",
       rubric_parts: [
         {

--- a/tests/unit/rubric/references.test.ts
+++ b/tests/unit/rubric/references.test.ts
@@ -44,6 +44,7 @@ function makeRubric(
     is_private: false,
     review_round: reviewRound,
     cap_score_to_assignment_points: false,
+    hide_unless_assigned: false,
     rubric_parts: [
       {
         id: id * 10,

--- a/tests/unit/rubric/serialize.test.ts
+++ b/tests/unit/rubric/serialize.test.ts
@@ -115,6 +115,7 @@ describe("HydratedRubricToYamlRubric — references emission", () => {
       is_private: false,
       review_round: reviewRound,
       cap_score_to_assignment_points: false,
+      hide_unless_assigned: false,
       rubric_parts: [
         {
           id: id * 10,
@@ -219,6 +220,7 @@ describe("HydratedRubricToYamlRubric — sort by ordinal", () => {
       is_private: false,
       review_round: "grading-review",
       cap_score_to_assignment_points: false,
+      hide_unless_assigned: false,
       rubric_parts: [
         {
           id: 1,

--- a/utils/supabase/DatabaseTypes.d.ts
+++ b/utils/supabase/DatabaseTypes.d.ts
@@ -777,10 +777,12 @@ export type YmlRubricType = Omit<
   | "review_round"
   | "is_private"
   | "cap_score_to_assignment_points"
+  | "hide_unless_assigned"
 > & {
   parts: YmlRubricPartType[];
   description?: string;
   cap_score_to_assignment_points?: boolean;
+  hide_unless_assigned?: boolean;
 };
 export type YmlRubricPartType = Omit<
   HydratedRubricPart,

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -988,6 +988,7 @@ export type Database = {
           deadline_offset: number | null;
           enabled: boolean;
           id: number;
+          release_at: string | null;
         };
         Insert: {
           allow_early?: boolean | null;
@@ -995,6 +996,7 @@ export type Database = {
           deadline_offset?: number | null;
           enabled?: boolean;
           id?: number;
+          release_at?: string | null;
         };
         Update: {
           allow_early?: boolean | null;
@@ -1002,6 +1004,7 @@ export type Database = {
           deadline_offset?: number | null;
           enabled?: boolean;
           id?: number;
+          release_at?: string | null;
         };
         Relationships: [
           {
@@ -7101,6 +7104,7 @@ export type Database = {
           class_id: number;
           created_at: string;
           description: string | null;
+          hide_unless_assigned: boolean;
           id: number;
           is_private: boolean;
           name: string;
@@ -7112,6 +7116,7 @@ export type Database = {
           class_id: number;
           created_at?: string;
           description?: string | null;
+          hide_unless_assigned?: boolean;
           id?: number;
           is_private?: boolean;
           name: string;
@@ -7123,6 +7128,7 @@ export type Database = {
           class_id?: number;
           created_at?: string;
           description?: string | null;
+          hide_unless_assigned?: boolean;
           id?: number;
           is_private?: boolean;
           name?: string;
@@ -11076,6 +11082,18 @@ export type Database = {
         };
         Returns: Json;
       };
+      _materialize_bare_check_regrade_comment: {
+        Args: {
+          p_author: string;
+          p_line: number;
+          p_points: number;
+          p_regrade_request_id: number;
+          p_request: Database["public"]["Tables"]["submission_regrade_requests"]["Row"];
+          p_submission_artifact_id: number;
+          p_submission_file_id: number;
+        };
+        Returns: Record<string, unknown>;
+      };
       _submission_review_is_completable: {
         Args: { p_submission_review_id: number };
         Returns: boolean;
@@ -11352,6 +11370,10 @@ export type Database = {
         | { Args: { poll__id: number }; Returns: boolean }
         | { Args: { class__id: number; poll__id: number }; Returns: boolean };
       authorizeforprofile: { Args: { profile_id: string }; Returns: boolean };
+      auto_assign_self_reviews: {
+        Args: { this_assignment_id: number; this_profile_id: string };
+        Returns: undefined;
+      };
       bulk_assign_reviews: {
         Args: {
           p_assignment_id: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instructors can hide rubrics from students until a review is assigned (UI switch added).
  * Timezone-aware scheduling for self-evaluation release dates; release times are stored and used when creating assignments.
  * Rubric editor: demo/load/create flows improved (reuse IDs/rounds) and an empty-state action to create new rubrics.

* **Bug Fixes**
  * Rubric save/load now reliably resolves and syncs rubric IDs for active review rounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #325 and fixes #535