### PR TITLE
e2e: fix latent flakies at root cause (rubric GUI toggle, viewport clicks, filter clear)

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -290,6 +290,11 @@ function InnerRubricPage() {
 
   const debounceTimeoutRef = useRef<NodeJS.Timeout>();
   const guiEditorRef = useRef<RubricGuiEditorHandle>(null);
+  // Live Monaco editor instance. The React `value` state only updates when Monaco's
+  // onChange fires (and after a re-render), so it lags the model whenever content was
+  // just written. Reading getValue() off this ref gives the authoritative current text
+  // at the moment of a view-mode toggle, independent of onChange/debounce timing.
+  const monacoEditorRef = useRef<{ getValue: () => string } | null>(null);
   const pendingGuiRubricRef = useRef<HydratedRubric | null>(null);
   const [guiEditorEpoch, setGuiEditorEpoch] = useState(0);
   const viewModeRef = useRef(viewMode);
@@ -813,7 +818,12 @@ function InnerRubricPage() {
     (next: "gui" | "source") => {
       if (next === viewMode) return;
       if (next === "gui") {
-        if (!value || value.trim() === "") {
+        // Validate against the LIVE editor content, not the debounced `value` state.
+        // `value` only catches up after Monaco's onChange fires and React re-renders, so a
+        // toggle fired right after the model changed (e.g. paste-then-click) would otherwise
+        // validate stale text — wrongly switching to GUI on YAML that should be rejected.
+        const liveValue = monacoEditorRef.current?.getValue() ?? value;
+        if (!liveValue || liveValue.trim() === "") {
           // Empty YAML means the rubric was wiped. Clear the hydrated state too so the GUI
           // doesn't resurrect whatever was previously in activeRubric / rubricForSidebar.
           setActiveRubric(undefined);
@@ -823,7 +833,7 @@ function InnerRubricPage() {
           return;
         }
         try {
-          const parsed = YAML.parse(value) as YmlRubricType;
+          const parsed = YAML.parse(liveValue) as YmlRubricType;
           const hydrated = YamlRubricToHydratedRubric(parsed, {
             assignment_id: Number(assignment_id),
             is_private: false,
@@ -1571,6 +1581,9 @@ function InnerRubricPage() {
                   defaultLanguage="yaml"
                   path={`rubric-${activeReviewRound || "new"}.yml`}
                   beforeMount={handleEditorWillMount}
+                  onMount={(editor) => {
+                    monacoEditorRef.current = editor;
+                  }}
                   value={value}
                   theme={colorMode === "dark" ? "vs-dark" : "vs"}
                   onValidate={(markers) => {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rubric/page.tsx
@@ -849,6 +849,17 @@ function InnerRubricPage() {
           setGuiEditorEpoch((e) => e + 1);
           setRubricForSidebar(hydrated);
           setError(undefined);
+          // Record the YAML we just validated so the source buffer and dirty-state
+          // bookkeeping reflect what the GUI now shows. We read `liveValue` straight off
+          // the editor, which can be ahead of the debounced `value` state; without syncing
+          // here, pasting valid YAML and immediately switching to GUI would leave
+          // `value`/`hasUnsavedChanges` stale (the source-mode dirty effect is skipped in
+          // GUI mode), so Save would stay disabled even though the rubric changed. Normalize
+          // through HydratedRubricToYamlRubric so it matches the snapshot form that
+          // applyGuiUnsavedStatus diffs against.
+          const consumedYaml = YAML.stringify(HydratedRubricToYamlRubric(hydrated, { allRubrics: allHydratedRubrics }));
+          setValue(consumedYaml);
+          applyGuiUnsavedStatus(hydrated, consumedYaml);
           persistViewMode("gui");
         } catch (e) {
           toaster.error({
@@ -870,7 +881,9 @@ function InnerRubricPage() {
       activeReviewRound,
       assignmentDetails,
       activeRubric,
-      flushPendingGuiSync
+      flushPendingGuiSync,
+      applyGuiUnsavedStatus,
+      allHydratedRubrics
     ]
   );
 

--- a/components/ui/code-file.tsx
+++ b/components/ui/code-file.tsx
@@ -386,6 +386,11 @@ export default function CodeFile({ file, embedded = false, language = "source.ja
       m={embedded ? 0 : 2}
       w="100%"
       css={containerCss}
+      // Syntax highlighting (@wooorm/starry-night) loads asynchronously; until it
+      // resolves the code renders as plain text and then re-renders tokenized. This
+      // flag flips to "true" only once the highlighted tree is rendered, giving visual
+      // tests a deterministic signal to wait on so screenshots don't race the re-render.
+      data-syntax-highlighted={starryNight ? "true" : "false"}
     >
       {content}
     </Box>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,16 +53,6 @@ export default defineConfig({
     // baseURL: 'https://nix.dev.pawtograder.net',
     baseURL: process.env.BASE_URL || "http://localhost:3000",
 
-    // Tolerate TLS-intercepting egress proxies. Some CI/dev networks MITM outbound
-    // HTTPS with a corporate CA that the system (and WebKit) trusts but Chromium's
-    // bundled root store does not — so Chromium rejects third-party assets the app
-    // loads over HTTPS (the Monaco editor loader from cdn.jsdelivr.net, dicebear
-    // avatars) with ERR_CERT_AUTHORITY_INVALID. That makes window.monaco never
-    // initialize and every Monaco-backed test (rubric editor, flashcards, gradebook
-    // expression builder) fail on Chromium only. This is a no-op where certificates
-    // validate normally (e.g. clean CI), so it cannot mask app-origin regressions.
-    ignoreHTTPSErrors: true,
-
     screenshot: "only-on-failure",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,6 +53,16 @@ export default defineConfig({
     // baseURL: 'https://nix.dev.pawtograder.net',
     baseURL: process.env.BASE_URL || "http://localhost:3000",
 
+    // Tolerate TLS-intercepting egress proxies. Some CI/dev networks MITM outbound
+    // HTTPS with a corporate CA that the system (and WebKit) trusts but Chromium's
+    // bundled root store does not — so Chromium rejects third-party assets the app
+    // loads over HTTPS (the Monaco editor loader from cdn.jsdelivr.net, dicebear
+    // avatars) with ERR_CERT_AUTHORITY_INVALID. That makes window.monaco never
+    // initialize and every Monaco-backed test (rubric editor, flashcards, gradebook
+    // expression builder) fail on Chromium only. This is a no-op where certificates
+    // validate normally (e.g. clean CI), so it cannot mask app-origin regressions.
+    ignoreHTTPSErrors: true,
+
     screenshot: "only-on-failure",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/tests/e2e/VisualTestUtils.ts
+++ b/tests/e2e/VisualTestUtils.ts
@@ -62,24 +62,46 @@ export async function waitForVisualIdle(page: Page) {
   });
   await waitForFonts(page);
 
-  // position:sticky elements (notably the "Grading for <student>" / "Applies to" scope
-  // banner in the rubric sidebar, components/ui/rubric-sidebar.tsx) get "stuck" at a
-  // scroll-dependent offset while Playwright scrolls to tile a full-page screenshot, so
-  // they overlay different content on each run (a moving "assigned to student" overlay).
-  // Sticky is in normal flow, so pinning it to static keeps the same layout/height but
-  // removes the scroll-dependent float, making full-page captures deterministic. Scoped
-  // to sticky only — fixed overlays (modals, the floating help widget) are handled by
-  // their own data-visual-test="removed" masking and are left intact.
+  // Wait for images to finish loading. Avatars (PersonName -> dicebear <img>) in comment
+  // threads load asynchronously; when an avatar's intrinsic size lands it nudges the
+  // surrounding layout by ~1px, shifting e.g. the regrade comment box between runs. Bounded
+  // (5s) and non-fatal so a slow/broken image source can't hang the scan.
   await page
-    .evaluate(() => {
-      document.querySelectorAll<HTMLElement>("*").forEach((el) => {
-        if (getComputedStyle(el).position === "sticky") {
-          el.style.setProperty("position", "static", "important");
-        }
-      });
-    })
+    .waitForFunction(() => Array.from(document.images).every((img) => img.complete), undefined, { timeout: 5_000 })
     .catch(() => {
-      /* navigation/context race — proceed without the sticky neutralization */
+      /* a slow/broken image — proceed rather than block the capture */
+    });
+
+  // Async content (rubric checks, regrade status lines, comment threads — all loaded via
+  // realtime/TableControllers) can keep growing the page after networkidle resolves. That
+  // shifts the full-page screenshot height AND the vertical position of everything below
+  // the still-growing region, so the same screenshot differs run-to-run (observed: ±292px
+  // page-height swings and ~1px shifts of the regrade comment box). Wait for the document
+  // height to stop changing — three consecutive equal samples — before capturing, with an
+  // ~8s cap so a genuinely live page can't hang the scan.
+  await page
+    .evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          let last = -1;
+          let stable = 0;
+          let iterations = 0;
+          const check = () => {
+            const h = document.documentElement.scrollHeight;
+            if (h === last) {
+              if (++stable >= 3) return resolve();
+            } else {
+              stable = 0;
+              last = h;
+            }
+            if (++iterations > 40) return resolve();
+            setTimeout(check, 200);
+          };
+          check();
+        })
+    )
+    .catch(() => {
+      /* navigation/context race — proceed without the height-settle wait */
     });
 
   // Code files (components/ui/code-file.tsx) render plain text first, then re-render
@@ -148,6 +170,44 @@ export async function stabilizeRubricSidebar(page: Page, rubricName: string | Re
   await waitForStableLocator(rubricRegion);
 }
 
+/**
+ * Pin every position:sticky element to static. Sticky banners (e.g. the "Grading for
+ * <student>" rubric scope banner) get "stuck" at a scroll-dependent offset while Playwright
+ * scrolls to tile a full-page screenshot, overlaying different content each run. Sticky is
+ * in normal flow, so this keeps layout/height identical and only removes the scroll-float.
+ * The original inline value is stashed so {@link restoreStickyPositions} can revert it after
+ * capture — the override must not leak into post-screenshot interactions in the same test.
+ */
+async function freezeStickyPositions(page: Page) {
+  await page
+    .evaluate(() => {
+      document.querySelectorAll<HTMLElement>("*").forEach((el) => {
+        if (getComputedStyle(el).position === "sticky") {
+          el.setAttribute("data-vt-prev-position", el.style.position || "");
+          el.style.setProperty("position", "static", "important");
+        }
+      });
+    })
+    .catch(() => {
+      /* navigation/context race — nothing to freeze */
+    });
+}
+
+async function restoreStickyPositions(page: Page) {
+  await page
+    .evaluate(() => {
+      document.querySelectorAll<HTMLElement>("[data-vt-prev-position]").forEach((el) => {
+        const prev = el.getAttribute("data-vt-prev-position") || "";
+        el.removeAttribute("data-vt-prev-position");
+        if (prev) el.style.position = prev;
+        else el.style.removeProperty("position");
+      });
+    })
+    .catch(() => {
+      /* page may be gone (end of test) — nothing to restore */
+    });
+}
+
 export async function visualScreenshot(page: Page, name: string, options: VisualScreenshotOptions = {}) {
   const { stabilizeRubric, beforeScreenshot, ...argosOptions } = options;
 
@@ -156,14 +216,21 @@ export async function visualScreenshot(page: Page, name: string, options: Visual
     await stabilizeRubricSidebar(page, stabilizeRubric);
   }
 
-  return argosScreenshot(page, name, {
-    ...argosOptions,
-    beforeScreenshot: async (api) => {
-      await waitForVisualIdle(page);
-      if (stabilizeRubric) {
-        await stabilizeRubricSidebar(page, stabilizeRubric);
+  try {
+    return await argosScreenshot(page, name, {
+      ...argosOptions,
+      beforeScreenshot: async (api) => {
+        await waitForVisualIdle(page);
+        if (stabilizeRubric) {
+          await stabilizeRubricSidebar(page, stabilizeRubric);
+        }
+        // Neutralize sticky positioning immediately before the capture; reverted in the
+        // finally below so it can't affect later interactions/assertions in the same test.
+        await freezeStickyPositions(page);
+        await beforeScreenshot?.(api);
       }
-      await beforeScreenshot?.(api);
-    }
-  });
+    });
+  } finally {
+    await restoreStickyPositions(page);
+  }
 }

--- a/tests/e2e/VisualTestUtils.ts
+++ b/tests/e2e/VisualTestUtils.ts
@@ -62,6 +62,41 @@ export async function waitForVisualIdle(page: Page) {
   });
   await waitForFonts(page);
 
+  // position:sticky elements (notably the "Grading for <student>" / "Applies to" scope
+  // banner in the rubric sidebar, components/ui/rubric-sidebar.tsx) get "stuck" at a
+  // scroll-dependent offset while Playwright scrolls to tile a full-page screenshot, so
+  // they overlay different content on each run (a moving "assigned to student" overlay).
+  // Sticky is in normal flow, so pinning it to static keeps the same layout/height but
+  // removes the scroll-dependent float, making full-page captures deterministic. Scoped
+  // to sticky only — fixed overlays (modals, the floating help widget) are handled by
+  // their own data-visual-test="removed" masking and are left intact.
+  await page
+    .evaluate(() => {
+      document.querySelectorAll<HTMLElement>("*").forEach((el) => {
+        if (getComputedStyle(el).position === "sticky") {
+          el.style.setProperty("position", "static", "important");
+        }
+      });
+    })
+    .catch(() => {
+      /* navigation/context race — proceed without the sticky neutralization */
+    });
+
+  // Code files (components/ui/code-file.tsx) render plain text first, then re-render
+  // with @wooorm/starry-night syntax highlighting once it loads asynchronously.
+  // Capturing mid-load produces per-glyph diffs across the whole code column. If any
+  // code file on the page is still un-highlighted, wait for it to finish before the
+  // screenshot. Bounded + non-fatal: a file with no tokenizable content still flips
+  // the flag to "true", and the catch covers pages without code files.
+  const codeFiles = page.locator("[data-syntax-highlighted]");
+  if ((await codeFiles.count()) > 0) {
+    await expect(page.locator('[data-syntax-highlighted="false"]'))
+      .toHaveCount(0, { timeout: 10_000 })
+      .catch(() => {
+        // Highlighter import can fail offline; fall through rather than block the scan.
+      });
+  }
+
   const transientText = [
     "Loading analytics...",
     "Loading surveys...",

--- a/tests/e2e/course-regrade-dashboard.test.tsx
+++ b/tests/e2e/course-regrade-dashboard.test.tsx
@@ -121,17 +121,23 @@ test.describe("Course-wide manage regrade requests", () => {
     await expect(onlyRow.getByText(ASSIGN_B_TITLE)).toHaveCount(0);
 
     // The Status filter defaults to ["opened", "escalated"] (server-enforced),
-    // so draft and resolved rows are hidden. Clearing it reveals all 3.
+    // so draft and resolved rows are hidden. Clearing both pills reveals all 3.
     // react-select removes the rightmost selected pill on Backspace when the
-    // input is empty; two presses clear the two default-selected statuses.
+    // input is empty. Removing a pill flips `statusFilter`, which re-queries the
+    // table server-side and re-renders the control; under webkit a Backspace
+    // fired during that re-render is silently dropped, so two blind presses can
+    // leave one pill (and one row) behind. Re-press, re-focusing each time,
+    // until the filter is fully cleared and all 3 rows are loaded — this drives
+    // toward the observed end state instead of assuming both keystrokes land.
     const statusFilterCombobox = page
       .getByText("Filter by Status:", { exact: true })
       .locator("..")
       .getByRole("combobox");
-    await statusFilterCombobox.focus();
-    await statusFilterCombobox.press("Backspace");
-    await statusFilterCombobox.press("Backspace");
-    await expect(dataRows).toHaveCount(3);
+    await expect(async () => {
+      await statusFilterCombobox.focus();
+      await statusFilterCombobox.press("Backspace");
+      await expect(dataRows).toHaveCount(3, { timeout: 1500 });
+    }).toPass({ timeout: 20_000, intervals: [250, 500, 1000] });
 
     const openedRow = page.getByRole("row").filter({ hasText: ASSIGN_A_TITLE }).filter({ hasText: "Pending" });
     const openLink = openedRow.getByRole("link", { name: "Open" });

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -506,10 +506,16 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     // the comment stream loads via realtime and races the screenshot, which
     // caused a 64px page-height delta between runs.
     {
+      // These are stabilization waits to ensure the realtime comment stream has
+      // rendered before the screenshot (see note above) — not uniqueness checks.
+      // The just-posted escalation comment briefly renders twice (optimistic insert
+      // + the realtime echo of the same row) before they dedupe, which tripped a
+      // strict-mode "resolved to 2 elements" on getByText. Scope to .first() so the
+      // wait means "at least one copy has rendered", independent of that transient.
       const appealRegion = page.getByLabel("Grading checks on line 4");
-      await expect(appealRegion.getByText(REGRADE_COMMENT)).toBeVisible();
-      await expect(appealRegion.getByText(REGRADE_RESOLUTION)).toBeVisible();
-      await expect(appealRegion.getByText(REGRADE_ESCALATION)).toBeVisible();
+      await expect(appealRegion.getByText(REGRADE_COMMENT).first()).toBeVisible();
+      await expect(appealRegion.getByText(REGRADE_RESOLUTION).first()).toBeVisible();
+      await expect(appealRegion.getByText(REGRADE_ESCALATION).first()).toBeVisible();
     }
     await visualScreenshot(page, "Students can appeal their regrade request");
     await page.getByRole("button", { name: "Escalate Request" }).click();

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -100,6 +100,17 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
   test.describe.configure({ mode: "serial" });
 
   test("Students can submit self-review", async ({ page }) => {
+    // This test does a lot inside the default 60s budget: magic-link login, finalize
+    // submission early, a DB-truth poll that can legitimately spend up to 30s waiting
+    // for the self-review review_assignments row to materialize (see toPass below),
+    // then ~6 right-click annotation/check interactions and an axe scan. Under webkit
+    // CI load the poll can eat most of the budget, leaving the annotation steps to tip
+    // the cumulative runtime past 60s mid-interaction (observed: click on the
+    // "Add a comment about this line" textbox timing out the whole test). This isn't a
+    // race to paper over — the work is genuinely long — so give it the same headroom
+    // the equally-heavy grading test below already uses. Because this is the first test
+    // in a serial describe, its timeout flaking forces a retry of the entire group.
+    test.slow();
     await loginAsUser(page, student!, course);
     await expect(page.getByRole("heading", { name: /Upcoming Assignments|Assignment Grading Overview/ })).toBeVisible();
     await page.locator("#primary-nav").getByRole("link").filter({ hasText: "Assignments" }).click();
@@ -155,7 +166,11 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
       el.scrollIntoView({ block: "start", behavior: "instant" });
     });
 
-    await page.getByText("public int doMath(int a, int").click({
+    const doMathLineSelfReview = page.getByText("public int doMath(int a, int");
+    // Same out-of-viewport hazard as the grading-review test below: ensure the line is
+    // scrolled into view before the right-click so the context menu opens deterministically.
+    await doMathLineSelfReview.scrollIntoViewIfNeeded();
+    await doMathLineSelfReview.click({
       button: "right"
     });
 
@@ -306,6 +321,13 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
     await page.getByRole("button", { name: "Files" }).click();
     const doMathLine = page.getByText("public int doMath(int a, int");
     await expect(doMathLine).toBeVisible();
+    // toBeVisible() only requires a non-empty bounding box, not that the element is in
+    // the viewport — in a long code file this line frequently renders below the fold.
+    // click({ force: true }) skips actionability checks but STILL needs the element in
+    // the viewport to resolve click coordinates, so it intermittently failed with
+    // "Element is outside of the viewport". Scroll it into view first so the (forced)
+    // click is deterministic regardless of where the file's scroll position settles.
+    await doMathLine.scrollIntoViewIfNeeded();
     await doMathLine.click({ force: true });
 
     const rubricSidebar = page.locator(`#rubric-${assignment!.grading_rubric_id}`);

--- a/tests/e2e/rubric-editor-gui.test.tsx
+++ b/tests/e2e/rubric-editor-gui.test.tsx
@@ -427,40 +427,23 @@ test.describe("Rubric editor GUI", () => {
     ].join("\n");
     await setMonacoValue(page, invalidYaml);
 
-    // setMonacoValue already waited for Monaco and wrote the model. The
-    // editor's onChange commits that text to React state (rebuilding the
-    // handleViewModeChange closure the GUI button reads) and then debounces
-    // a parse ~1s later. Clicking GUI before that settles runs against the
-    // stale YAML, wrongly succeeds, and switches to GUI — making the source
-    // region disappear. The "Preview paused while typing" banner that
-    // tracks the debounce is mounted in a different layout column and
-    // isn't always observable from the test context, so we can't hang the
-    // wait off it.
+    // The mutex (is_individual_grading + is_assign_to_student on the same part) is
+    // rejected by YamlRubricToHydratedRubric, so switching to GUI must be refused.
     //
-    // Instead, wrap the toggle + assertion together in toPass. On each
-    // retry we re-ensure we're in source mode, click GUI, and assert the
-    // toggle was refused. If an attempt fires before the YAML parse
-    // settles, the toggle accidentally succeeds (source region gone),
-    // the assertion fails, toPass switches back to source and retries.
-    // Once the parse-debounce has run, the toggle is refused and the
-    // assertion sticks.
-    await expect(async () => {
-      // If we're currently in GUI mode (e.g. a previous attempt succeeded
-      // incorrectly), switch back to source first so the GUI button is
-      // actually a toggle target.
-      const sourceVisible = await rubricEditor(page)
-        .getByRole("region", { name: "Rubric YAML Source" })
-        .isVisible()
-        .catch(() => false);
-      if (!sourceVisible) {
-        await rubricEditor(page).getByRole("button", { name: "YAML source" }).click();
-      }
-      await rubricEditor(page).getByRole("button", { name: "GUI" }).click();
-      await expect(rubricEditor(page).getByRole("region", { name: "Rubric YAML Source" })).toBeVisible({
-        timeout: 1000
-      });
-      await expect(rubricEditor(page).getByRole("region", { name: /^Part 1:/ })).toHaveCount(0);
-    }).toPass({ timeout: 20_000, intervals: [500, 1000, 1500] });
+    // This used to be flaky: handleViewModeChange validated the debounced React `value`
+    // state, which only catches up ~1s after the model changes. Clicking GUI before that
+    // settled validated the *stale* (valid) default YAML, wrongly succeeded, and switched
+    // to GUI. The fix makes handleViewModeChange validate the LIVE Monaco model
+    // (editor.getValue()) at click time, so the just-written invalid YAML is always what
+    // gets checked — no debounce dependency. A single immediate click is therefore enough
+    // to deterministically prove the toggle is refused.
+    await rubricEditor(page).getByRole("button", { name: "GUI" }).click();
+
+    // Toggle refused: the YAML source region stays mounted and no GUI Part region appears.
+    // (If the stale-value regression returned, the click would switch to GUI and hide the
+    // source region, failing toBeVisible.)
+    await expect(rubricEditor(page).getByRole("region", { name: "Rubric YAML Source" })).toBeVisible();
+    await expect(rubricEditor(page).getByRole("region", { name: /^Part 1:/ })).toHaveCount(0);
   });
 
   test("References round-trip through GUI and YAML", async ({ page }) => {

--- a/tests/e2e/rubric-editor-gui.test.tsx
+++ b/tests/e2e/rubric-editor-gui.test.tsx
@@ -439,9 +439,17 @@ test.describe("Rubric editor GUI", () => {
     // to deterministically prove the toggle is refused.
     await rubricEditor(page).getByRole("button", { name: "GUI" }).click();
 
-    // Toggle refused: the YAML source region stays mounted and no GUI Part region appears.
-    // (If the stale-value regression returned, the click would switch to GUI and hide the
-    // source region, failing toBeVisible.)
+    // Assert a *post-click* effect, not just the pre-click source state (which would hold
+    // even if the click were dropped/no-op). The refusal raises a "Cannot switch to GUI"
+    // toast (handleViewModeChange's catch block), proving the toggle was attempted AND
+    // actively rejected. Assert the toast node was created (toBeAttached) rather than
+    // visible — Chakra toasts auto-dismiss to hidden within seconds but the node lingers,
+    // so a visibility check races the dismiss animation. .first() because the responsive
+    // mobile+desktop layout copies render the toast in more than one portal.
+    await expect(page.getByText("Cannot switch to GUI").first()).toBeAttached();
+    // And the toggle had no effect: the YAML source region stays mounted and no GUI Part
+    // region appears. (If the stale-value regression returned, the click would switch to
+    // GUI and hide the source region, failing toBeVisible.)
     await expect(rubricEditor(page).getByRole("region", { name: "Rubric YAML Source" })).toBeVisible();
     await expect(rubricEditor(page).getByRole("region", { name: /^Part 1:/ })).toHaveCount(0);
   });


### PR DESCRIPTION
Triaged the worst latent e2e flakies and fixed each at the **root cause** (no time-delay band-aids). Validated across **3 WebKit + 3 Chromium** full runs (CI parallelism, retries=2) plus heavy targeted repetition.

## Product fix
- **Rubric editor GUI/YAML toggle** (`rubric-editor-gui:405` [webkit]): `handleViewModeChange` validated the *debounced* React `value`, which lags the live Monaco model. Clicking **GUI** right after writing YAML validated stale (valid) text and wrongly switched, hiding the source region. Now validates **live editor content** (`editor.getValue()` captured via `onMount`), independent of onChange/debounce timing.

## Test fixes
- **pseudonymous-grading:297** [webkit]: the `doMath` code line often renders below the fold. `toBeVisible()` passes for out-of-viewport elements, but `click({ force: true })` still needs viewport coords → intermittent *"Element is outside of the viewport."* Now `scrollIntoViewIfNeeded()` before the click (and the sibling right-click).
- **pseudonymous-grading:102**: heavy first serial test (login + 30s DB poll + ~6 annotations + axe) could exceed the default 60s budget under load and retry the whole serial group → `test.slow()` (matches sibling `:193`).
- **course-regrade-dashboard:107** [webkit]: two blind `Backspace` presses cleared the status filter; the 2nd raced the server re-query/re-render and got dropped → `toHaveCount(3)` saw 1. Re-press inside `toPass` until the filter actually clears.
- **grading:512**: just-posted comment double-renders transiently (optimistic + realtime echo), tripping strict-mode on *stabilization* waits → `.first()`.
- **rubric-editor-gui:405**: simplified the mutex test to a single deterministic click now that the product reads live editor content (removes the stale-value `toPass` workaround).

## Infra
- `playwright.config.ts`: `ignoreHTTPSErrors: true` so **Chromium** can load the Monaco CDN loader through TLS-intercepting egress proxies. Without it Chromium failed *every* Monaco-backed test with `ERR_CERT_AUTHORITY_INVALID`; no-op where certs validate (e.g. CI).

## Validation
All named flakies + course-regrade + grading **green on attempt 0 across all 3 WebKit + 3 Chromium full runs**. Targeted: rubric 18× webkit / 8× chromium, simplified rubric 8/8 both browsers, course-regrade 8/8, pseudonymous file 3/3 post-fix, grading 2/2.

## Not addressed (environmental, not code flakies)
- `create-submission.test.tsx` — needs a real GitHub App locally (clone auth).
- Gradebook recalc cluster — local pgmq/worker pipeline doesn't fully complete (`WorkerAlreadyRetired` mid-batch); passes in CI. (Separately, a stray untracked `gradebook-column-recalculate/deno.lock` v5 was breaking the worker's *boot* locally — removed during triage; not part of this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix rubric editor YAML validation when switching between source and GUI by reading the live editor value, parsing/normalizing YAML, restoring the editor content, and correctly syncing GUI dirty state.

* **Tests**
  * Made e2e tests more reliable (regrade dashboard, grading, pseudonymous grading, rubric GUI) by improving retry/selector behavior, scroll handling, and timing.
  * Improved visual test stability and screenshot determinism (wait for images/height stability; freeze/restore sticky elements).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pawtograder/platform/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->