### PR TITLE
Fix: preserve group repos with submissions when dissolving empty groups

### DIFF
--- a/app/course/[course_id]/manage/assignments/new/page.tsx
+++ b/app/course/[course_id]/manage/assignments/new/page.tsx
@@ -23,7 +23,7 @@ export default function NewAssignmentPage() {
     refineCoreProps: { resource: "assignments", action: "create" },
     defaultValues: {
       allow_not_graded_submissions: true,
-      permit_empty_submissions: true,
+      permit_empty_submissions: false,
       require_tokens_before_due_date: true
     }
   });
@@ -99,7 +99,7 @@ export default function NewAssignmentPage() {
             max_late_tokens: getValues("max_late_tokens") || null,
             require_tokens_before_due_date: getValues("require_tokens_before_due_date") !== false,
             allow_not_graded_submissions: getValues("allow_not_graded_submissions"),
-            permit_empty_submissions: getValues("permit_empty_submissions") !== false,
+            permit_empty_submissions: getValues("permit_empty_submissions") === true,
             total_points: getValues("total_points"),
             template_repo: getValues("template_repo"),
             submission_files: getValues("submission_files"),

--- a/supabase/migrations/20260531120000_preserve_group_repos_with_submissions.sql
+++ b/supabase/migrations/20260531120000_preserve_group_repos_with_submissions.sql
@@ -1,0 +1,398 @@
+-- Fix: dissolving an empty group must NOT delete its repository (and the repo's
+-- check runs) when submissions reference that repo. Previously Phase 2b
+-- unconditionally deleted public.repository_check_runs and public.repositories
+-- for any empty group, which violated submissions_repository_check_run_id_fkey
+-- (and submissions_repository_id_fkey) when the group had graded/active work:
+--
+--   23503: update or delete on table "repository_check_runs" violates foreign
+--   key constraint "submissions_repository_check_run_id_fkey" on table "submissions"
+--
+-- This surfaced when instructors formed groups on a group-optional assignment
+-- after submissions had started: a single-member group whose student was moved
+-- into a real group became empty, and its repo (holding that student's
+-- submissions) was then torn down.
+--
+-- New behavior: only delete the repo (and its check runs) when the group has NO
+-- submissions. If any submission references the group or its repos, preserve the
+-- group, its repository, check runs, and submission history intact, and leave its
+-- GitHub permissions untouched.
+
+CREATE OR REPLACE FUNCTION public.publish_assignment_group_changes(
+    p_class_id       bigint,
+    p_assignment_id  bigint,
+    -- groups_to_create: array of {name, member_ids}
+    p_groups_to_create jsonb DEFAULT '[]'::jsonb,
+    -- moves_to_fulfill: array of {profile_id, old_group_id, new_group_id}
+    p_moves_to_fulfill jsonb DEFAULT '[]'::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_caller_profile_id uuid;
+    v_course_slug       text;
+    v_github_org        text;
+    v_template_repo     text;
+    v_latest_sha        text;
+    v_assignment_slug   text;
+
+    v_group             jsonb;
+    v_move              jsonb;
+    v_group_name        text;
+    v_new_group_id      bigint;
+    v_member_id         uuid;
+    v_member_ids        jsonb;
+
+    v_old_gid           bigint;
+    v_new_gid           bigint;
+    v_profile_id        uuid;
+    v_empty_gid         bigint;
+
+    v_membership_id     bigint;
+    v_repo_record       record;
+
+    -- collect affected group IDs so we can do one permission sync per repo
+    v_affected_groups   bigint[] := '{}';
+    v_deleted_groups    bigint[] := '{}';
+    -- empty groups we intentionally keep (they have submissions); excluded from
+    -- the permission sync so their preserved repo's GitHub access is left as-is
+    v_preserved_groups  bigint[] := '{}';
+
+    v_groups_created    integer := 0;
+    v_members_added     integer := 0;
+    v_members_moved     integer := 0;
+    v_groups_dissolved  integer := 0;
+    v_syncs_enqueued    integer := 0;
+    v_errors            jsonb[] := '{}';
+BEGIN
+    -- ── auth ──────────────────────────────────────────────────────────────
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+    IF NOT public.authorizeforclassinstructor(p_class_id) THEN
+        RAISE EXCEPTION 'Only instructors can publish group changes';
+    END IF;
+
+    -- look up caller's profile for added_by
+    SELECT private_profile_id INTO v_caller_profile_id
+    FROM public.user_roles
+    WHERE user_id = auth.uid()
+      AND class_id = p_class_id
+      AND role = 'instructor'
+    LIMIT 1;
+
+    -- ── class + assignment metadata (one query) ──────────────────────────
+    SELECT c.slug, c.github_org, a.slug, a.template_repo, a.latest_template_sha
+    INTO   v_course_slug, v_github_org, v_assignment_slug, v_template_repo, v_latest_sha
+    FROM   public.assignments a
+    JOIN   public.classes c ON c.id = a.class_id
+    WHERE  a.id = p_assignment_id AND a.class_id = p_class_id;
+
+    IF v_course_slug IS NULL THEN
+        RAISE EXCEPTION 'Assignment % not found in class %', p_assignment_id, p_class_id;
+    END IF;
+
+    -- ══════════════════════════════════════════════════════════════════════
+    -- Phase 1: process moves on existing groups
+    -- ══════════════════════════════════════════════════════════════════════
+    FOR v_move IN SELECT * FROM jsonb_array_elements(p_moves_to_fulfill)
+    LOOP
+        v_profile_id := (v_move->>'profile_id')::uuid;
+        v_old_gid    := (v_move->>'old_group_id')::bigint;   -- nullable
+        v_new_gid    := (v_move->>'new_group_id')::bigint;   -- nullable
+
+        BEGIN
+            -- validate group IDs belong to assignment before any mutations
+            IF v_old_gid IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM public.assignment_groups
+                WHERE id = v_old_gid
+                  AND assignment_id = p_assignment_id
+                  AND class_id = p_class_id
+            ) THEN
+                v_errors := array_append(v_errors, jsonb_build_object(
+                    'profile_id', v_profile_id,
+                    'error', format('Group %s does not belong to assignment %s', v_old_gid, p_assignment_id)
+                ));
+                CONTINUE;
+            END IF;
+            IF v_new_gid IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM public.assignment_groups
+                WHERE id = v_new_gid
+                  AND assignment_id = p_assignment_id
+                  AND class_id = p_class_id
+            ) THEN
+                v_errors := array_append(v_errors, jsonb_build_object(
+                    'profile_id', v_profile_id,
+                    'error', format('Group %s does not belong to assignment %s', v_new_gid, p_assignment_id)
+                ));
+                CONTINUE;
+            END IF;
+
+            -- remove from old group
+            IF v_old_gid IS NOT NULL THEN
+                SELECT id INTO v_membership_id
+                FROM public.assignment_groups_members
+                WHERE assignment_group_id = v_old_gid
+                  AND profile_id = v_profile_id
+                  AND class_id = p_class_id;
+
+                IF v_membership_id IS NULL THEN
+                    v_errors := array_append(v_errors, jsonb_build_object(
+                        'profile_id', v_profile_id,
+                        'error', format('Student not in group %s', v_old_gid)
+                    ));
+                    CONTINUE;
+                END IF;
+
+                DELETE FROM public.assignment_groups_members WHERE id = v_membership_id;
+                v_affected_groups := array_append(v_affected_groups, v_old_gid);
+            END IF;
+
+            -- add to new group
+            IF v_new_gid IS NOT NULL THEN
+                IF v_old_gid IS NULL THEN
+                    -- moving from no-group into a group: deactivate individual submissions
+                    UPDATE public.submissions
+                    SET is_active = false
+                    WHERE assignment_id = p_assignment_id
+                      AND profile_id = v_profile_id;
+                END IF;
+
+                INSERT INTO public.assignment_groups_members
+                    (assignment_group_id, profile_id, assignment_id, class_id, added_by)
+                VALUES
+                    (v_new_gid, v_profile_id, p_assignment_id, p_class_id, v_caller_profile_id);
+
+                v_affected_groups := array_append(v_affected_groups, v_new_gid);
+            END IF;
+
+            v_members_moved := v_members_moved + 1;
+
+        EXCEPTION WHEN OTHERS THEN
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'profile_id', v_profile_id,
+                'error', SQLERRM
+            ));
+        END;
+    END LOOP;
+
+    -- ══════════════════════════════════════════════════════════════════════
+    -- Phase 2: create new groups and add their initial members
+    -- ══════════════════════════════════════════════════════════════════════
+    FOR v_group IN SELECT * FROM jsonb_array_elements(p_groups_to_create)
+    LOOP
+        v_group_name := trim(v_group->>'name');
+        v_member_ids := v_group->'member_ids';
+
+        BEGIN
+            -- validate name
+            IF v_group_name = '' OR v_group_name IS NULL THEN
+                RAISE EXCEPTION 'Group name cannot be empty';
+            END IF;
+            IF length(v_group_name) > 36 THEN
+                RAISE EXCEPTION 'Group name too long (max 36 chars)';
+            END IF;
+            IF v_group_name !~ '^[a-zA-Z0-9_-]+$' THEN
+                RAISE EXCEPTION 'Group name must be alphanumeric, hyphens, or underscores';
+            END IF;
+
+            -- uniqueness
+            IF EXISTS (
+                SELECT 1 FROM public.assignment_groups
+                WHERE assignment_id = p_assignment_id AND lower(name) = lower(v_group_name)
+            ) THEN
+                RAISE EXCEPTION 'Group "%" already exists', v_group_name;
+            END IF;
+
+            -- create the group
+            INSERT INTO public.assignment_groups (name, assignment_id, class_id)
+            VALUES (v_group_name, p_assignment_id, p_class_id)
+            RETURNING id INTO v_new_group_id;
+
+            v_groups_created := v_groups_created + 1;
+
+            -- enqueue repo creation (with empty usernames; permission sync below)
+            IF v_template_repo IS NOT NULL AND v_template_repo != '' AND v_github_org IS NOT NULL THEN
+                PERFORM public.enqueue_github_create_repo(
+                    p_class_id,
+                    v_github_org,
+                    v_course_slug || '-' || v_assignment_slug || '-group-' || v_group_name,
+                    v_template_repo,
+                    v_course_slug,
+                    '{}'::text[],
+                    false,
+                    'batch-group-create-' || v_new_group_id::text,
+                    p_assignment_id,
+                    null::uuid,
+                    v_new_group_id,
+                    v_latest_sha
+                );
+            END IF;
+
+            -- add members
+            IF v_member_ids IS NOT NULL AND jsonb_array_length(v_member_ids) > 0 THEN
+                FOR v_member_id IN
+                    SELECT (value#>>'{}')::uuid FROM jsonb_array_elements(v_member_ids) AS value
+                LOOP
+                    -- deactivate individual submissions when first entering a group
+                    UPDATE public.submissions
+                    SET is_active = false
+                    WHERE assignment_id = p_assignment_id
+                      AND profile_id = v_member_id;
+
+                    INSERT INTO public.assignment_groups_members
+                        (assignment_group_id, profile_id, assignment_id, class_id, added_by)
+                    VALUES
+                        (v_new_group_id, v_member_id, p_assignment_id, p_class_id, v_caller_profile_id);
+
+                    v_members_added := v_members_added + 1;
+                END LOOP;
+            END IF;
+
+            v_affected_groups := array_append(v_affected_groups, v_new_group_id);
+
+        EXCEPTION WHEN OTHERS THEN
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'group_name', v_group_name,
+                'error', SQLERRM
+            ));
+        END;
+    END LOOP;
+
+    -- ══════════════════════════════════════════════════════════════════════
+    -- Phase 2b: dissolve empty groups (batch-final state after moves + creates)
+    -- ══════════════════════════════════════════════════════════════════════
+    FOR v_empty_gid IN
+        SELECT ag.id
+        FROM public.assignment_groups ag
+        WHERE ag.assignment_id = p_assignment_id
+          AND ag.class_id = p_class_id
+          AND NOT EXISTS (
+              SELECT 1 FROM public.assignment_groups_members agm
+              WHERE agm.assignment_group_id = ag.id
+          )
+    LOOP
+        -- Preserve groups that have submissions. Their repo holds graded/active
+        -- work and is referenced by submissions (repository_id and
+        -- repository_check_run_id), so deleting it would violate those FKs and
+        -- destroy history. Keep the group, repo, check runs, and submissions
+        -- intact; only fully dissolve groups whose repos have no submissions.
+        IF EXISTS (
+            SELECT 1 FROM public.submissions s
+            WHERE s.assignment_group_id = v_empty_gid
+        ) OR EXISTS (
+            SELECT 1
+            FROM public.submissions s
+            JOIN public.repositories r ON r.id = s.repository_id
+            WHERE r.assignment_group_id = v_empty_gid
+        ) THEN
+            v_preserved_groups := array_append(v_preserved_groups, v_empty_gid);
+            CONTINUE;
+        END IF;
+
+        DELETE FROM public.assignment_group_invitations
+        WHERE assignment_group_id = v_empty_gid;
+        DELETE FROM public.assignment_group_join_request
+        WHERE assignment_group_id = v_empty_gid;
+
+        FOR v_repo_record IN
+            SELECT r.id, r.repository
+            FROM public.repositories r
+            WHERE r.assignment_group_id = v_empty_gid
+              AND r.repository IS NOT NULL
+              AND position('/' in r.repository) > 0
+        LOOP
+            IF v_github_org IS NOT NULL THEN
+                PERFORM public.enqueue_github_archive_repo(
+                    p_class_id,
+                    v_github_org,
+                    split_part(v_repo_record.repository, '/', 2),
+                    'batch-dissolve-' || v_empty_gid::text
+                );
+            END IF;
+            DELETE FROM public.repository_check_runs WHERE repository_id = v_repo_record.id;
+            DELETE FROM public.repositories WHERE id = v_repo_record.id;
+        END LOOP;
+
+        DELETE FROM public.assignment_groups WHERE id = v_empty_gid;
+        v_deleted_groups := array_append(v_deleted_groups, v_empty_gid);
+        v_groups_dissolved := v_groups_dissolved + 1;
+    END LOOP;
+
+    -- ══════════════════════════════════════════════════════════════════════
+    -- Phase 3: enqueue ONE permission sync per affected repo
+    -- ══════════════════════════════════════════════════════════════════════
+    -- Deduplicate and exclude dissolved + preserved groups
+    FOR v_repo_record IN
+        SELECT DISTINCT r.id           AS repo_id,
+               r.repository,
+               r.assignment_group_id,
+               r.is_github_ready
+        FROM   unnest(v_affected_groups) AS gid(g)
+        JOIN   public.repositories r ON r.assignment_group_id = gid.g
+        WHERE  NOT (gid.g = ANY(v_deleted_groups))
+          AND  NOT (gid.g = ANY(v_preserved_groups))
+    LOOP
+        BEGIN
+            IF NOT v_repo_record.is_github_ready THEN
+                CONTINUE;  -- will be synced when create_repo finishes
+            END IF;
+
+            DECLARE
+                v_usernames text[];
+            BEGIN
+                SELECT coalesce(array_remove(array_agg(u.github_username), NULL), '{}')
+                INTO v_usernames
+                FROM public.assignment_groups_members agm
+                JOIN public.user_roles ur ON ur.private_profile_id = agm.profile_id
+                JOIN public.users u ON u.user_id = ur.user_id
+                WHERE agm.assignment_group_id = v_repo_record.assignment_group_id
+                  AND ur.class_id = p_class_id
+                  AND ur.role = 'student'
+                  AND ur.github_org_confirmed = true
+                  AND u.github_username IS NOT NULL
+                  AND u.github_username != '';
+
+                IF v_repo_record.repository IS NOT NULL AND position('/' in v_repo_record.repository) > 0 THEN
+                    PERFORM public.enqueue_github_sync_repo_permissions(
+                        p_class_id,
+                        v_github_org,
+                        split_part(v_repo_record.repository, '/', 2),
+                        v_course_slug,
+                        coalesce(v_usernames, '{}'),
+                        'batch-publish-' || p_assignment_id::text || '-g' || v_repo_record.assignment_group_id::text
+                    );
+                    v_syncs_enqueued := v_syncs_enqueued + 1;
+                END IF;
+            END;
+        EXCEPTION WHEN OTHERS THEN
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'repository_id', v_repo_record.repo_id,
+                'error', SQLERRM
+            ));
+        END;
+    END LOOP;
+
+    RETURN jsonb_build_object(
+        'groups_created',   v_groups_created,
+        'members_added',    v_members_added,
+        'members_moved',    v_members_moved,
+        'groups_dissolved', v_groups_dissolved,
+        'syncs_enqueued',   v_syncs_enqueued,
+        'errors',           to_jsonb(v_errors)
+    );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.publish_assignment_group_changes(bigint, bigint, jsonb, jsonb) FROM public;
+GRANT EXECUTE ON FUNCTION public.publish_assignment_group_changes(bigint, bigint, jsonb, jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.publish_assignment_group_changes IS
+'Atomically publish all staged group changes (new groups + member moves) for an
+assignment in a single database call.  Validates inputs, creates groups, moves
+members, dissolves empty groups, enqueues repo creation and ONE permission sync
+per affected repo.  Replaces N sequential edge-function round-trips.  Empty groups
+whose repositories still have submissions are preserved (repo + check runs +
+submissions kept intact) rather than deleted, to avoid FK violations and history loss.';

--- a/supabase/migrations/20260531120000_preserve_group_repos_with_submissions.sql
+++ b/supabase/migrations/20260531120000_preserve_group_repos_with_submissions.sql
@@ -396,3 +396,10 @@ members, dissolves empty groups, enqueues repo creation and ONE permission sync
 per affected repo.  Replaces N sequential edge-function round-trips.  Empty groups
 whose repositories still have submissions are preserved (repo + check runs +
 submissions kept intact) rather than deleted, to avoid FK violations and history loss.';
+
+-- Make "prohibit submissions that match the handout" the default for new
+-- assignments. Empty (handout-matching) submissions create throwaway individual
+-- submissions/repos that later complicate group formation (see above), so default
+-- to rejecting them. Existing assignments keep their current setting.
+ALTER TABLE public.assignments
+  ALTER COLUMN permit_empty_submissions SET DEFAULT false;


### PR DESCRIPTION
## Problem

Instructors forming groups on a **group-optional** assignment *after submissions had started* hit:

```
23503: update or delete on table "repository_check_runs" violates foreign key
constraint "submissions_repository_check_run_id_fkey" on table "submissions"
```

When a student who had already submitted (with their own single-member group + repo) is moved into a real group, their old group goes empty. The `publish_assignment_group_changes` RPC's "dissolve empty groups" phase then deleted that group's `repository_check_runs` and `repository` — but the student's submissions still reference them (`submissions.repository_check_run_id` / `submissions.repository_id` have no `ON DELETE`), so the delete fails.

The check-run delete was never meaningful on its own — it's just a prerequisite for deleting the repo (`repository_check_runs.repository_id` FKs `repositories`). The real bug was tearing down a repo that still holds submissions.

## Fix

In Phase 2b, only fully dissolve an empty group when it has **no** submissions. If any submission references the group or its repos, preserve the group, repo, check runs, and submission history intact (and exclude it from the Phase 3 permission re-sync so its GitHub access is left untouched). This avoids both the FK violation and silent loss of graded work.

Single-file `CREATE OR REPLACE` migration; the rest of the function body is unchanged.

## Notes

- The legacy `assignment-group-instructor-move-student` edge function has the same delete-repo-on-empty logic but **no UI callers** anymore (the groups page uses this RPC), so the live path is fully covered.
- Not yet run against local Supabase; the change is additive and mirrors the existing `v_deleted_groups` pattern in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an integrity violation that could occur when managing assignment groups
  * Groups containing submissions are now preserved during group management operations, preventing unintended data loss and improving group lifecycle management
  * Updated the default setting for "permit empty submissions" to false for all newly created assignments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also in this PR: prohibit handout-matching submissions by default

To reduce the incidence of the problem above, new assignments now default to **prohibiting** empty (handout-matching) submissions (`permit_empty_submissions` defaults to `false`). These throwaway individual submissions/repos are what later block group dissolution. Changed the column default, the new-assignment form default, and the insert coercion. **Existing assignments keep their current setting.** Folded into the same migration.