### PR TITLE
fix(seed): don't write .env.local into the read-only /app WORKDIR

### DIFF
--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -102,11 +102,11 @@ fi
 # Phase 4 — run the realistic seeder
 # -----------------------------------------------------------------------------
 echo "[seed] running scripts/SeedDB.ts --template ${SEED_TEMPLATE}"
-# SeedDB.ts reads dotenv from .env.local; we feed SUPABASE_URL etc. via
-# the environment instead. Write a minimal .env.local so dotenv's silent
-# load doesn't tank when the file is missing.
-: > .env.local
-
+# SeedDB.ts loads config from the environment (fed by the K8s Secret), not from
+# a file. Its dotenv.config({ path: ".env.local", quiet: true }) silently
+# tolerates a missing .env.local — so DON'T create one here: the image runs as
+# USER node but WORKDIR /app is root-owned, and writing into it fails with
+# "Permission denied", which aborts the whole seed.
 npx tsx scripts/SeedDB.ts --template "${SEED_TEMPLATE}"
 
 echo "[seed] done"


### PR DESCRIPTION
## Problem

Preview deploys fail at the post-upgrade seed hook with:

```
/usr/local/bin/run-seed: line 108: .env.local: Permission denied
```

→ `job pawtograder-seed-* failed: BackoffLimitExceeded` → `helm --wait-for-jobs` marks the whole deploy failed. (Web/edge/migrations all come up fine; only the seed hook dies.)

## Root cause

The seeder image runs as `USER node`, but `WORKDIR /app` is **root-owned** — the Dockerfile `--chown=node:node`s the copied *contents*, not the directory itself. So `node` can't create a new file in `/app`, and `: > .env.local` fails with `EACCES`, aborting the seed.

## Fix

Drop the `: > .env.local` write. It was never needed:
- `SeedDB.ts` reads all config from the environment (fed by the K8s Secret).
- Its `dotenv.config({ path: ".env.local", quiet: true })` silently tolerates a missing file (no throw, no warning).

Verified: bash syntax OK; this was the only write into the read-only CWD.

## Note

Takes effect once the seeder image is rebuilt from a branch containing this fix. Existing `pr-*` seeder images still carry the bug until they pick up the new staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)