### PR TITLE
fix: self-heal stale-bundle "reading 'call'" errors on deploy skew

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import "@uiw/react-md-editor/markdown-editor.css";
 import { ColorModeWatcher } from "@/components/ui/color-mode";
 import { LiveAnnouncer } from "@/components/ui/live-announcer";
 import SkipNav from "@/components/ui/skip-nav";
+import StaleBundleRecovery from "@/components/StaleBundleRecovery";
 import { Toaster } from "@/components/ui/toaster";
 const defaultUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
 
@@ -37,6 +38,7 @@ export default async function RootLayout({
             <ClientOnly>
               <Toaster />
               <ColorModeWatcher />
+              <StaleBundleRecovery />
             </ClientOnly>
             <LiveAnnouncer>{children}</LiveAnnouncer>
           </Theme>

--- a/components/StaleBundleRecovery.tsx
+++ b/components/StaleBundleRecovery.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { installStaleBundleRecovery } from "@/lib/staleBundleRecovery";
+
+/**
+ * Mounts the global stale-bundle (deploy-skew) recovery listeners. Rendered once
+ * from the root layout. Renders nothing; see `lib/staleBundleRecovery.ts` for the
+ * detection + reload logic. Installed from a client component (rather than the
+ * client-instrumentation entry) so it runs through the normal React/webpack
+ * module graph and reliably registers on every hard navigation.
+ */
+export default function StaleBundleRecovery() {
+  useEffect(() => {
+    return installStaleBundleRecovery();
+  }, []);
+  return null;
+}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,6 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 import posthog from "posthog-js";
 
+// NOTE: stale-bundle recovery is installed from `<StaleBundleRecovery />` in the
+// root layout (a normal client component), NOT here. The client-instrumentation
+// entry is loaded through a special Next path whose module graph is fragile —
+// importing an extra module here can make the whole entry fail to evaluate
+// (silently taking Sentry + PostHog init down with it). The `beforeSend` filter
+// below stays here because it needs no extra imports.
+
 if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
@@ -117,6 +124,19 @@ Sentry.init({
           exception.value?.includes("failed")
         ) {
           return null; // Discard chunk load errors
+        }
+        // Discard the stale-bundle sibling of ChunkLoadError: a deploy lands
+        // mid-session, the chunk file loads (200) but the loaded webpack runtime
+        // is missing the requested module factory, so `__webpack_require__` hits
+        // `undefined.call(...)`. `installStaleBundleRecovery()` reloads to self-heal;
+        // this just keeps the transient deploy-skew event out of Sentry. Gated on
+        // the webpack-runtime stack so genuine `reading 'call'` bugs still report.
+        if (exception.type === "TypeError" && exception.value?.includes("reading 'call'")) {
+          const frames = exception.stacktrace?.frames ?? [];
+          const fromWebpackRuntime = frames.some((f) => /webpack[-.]/.test(f.filename ?? ""));
+          if (fromWebpackRuntime) {
+            return null;
+          }
         }
         if ("message" in exception) {
           const message = exception.message as string;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -131,7 +131,10 @@ Sentry.init({
         // `undefined.call(...)`. `installStaleBundleRecovery()` reloads to self-heal;
         // this just keeps the transient deploy-skew event out of Sentry. Gated on
         // the webpack-runtime stack so genuine `reading 'call'` bugs still report.
-        if (exception.type === "TypeError" && exception.value?.includes("reading 'call'")) {
+        if (
+          exception.type === "TypeError" &&
+          /reading 'call'|undefined is not an object \(evaluating '[^']*\.call'\)/.test(exception.value ?? "")
+        ) {
           const frames = exception.stacktrace?.frames ?? [];
           const fromWebpackRuntime = frames.some((f) => /webpack[-.]/.test(f.filename ?? ""));
           if (fromWebpackRuntime) {

--- a/lib/staleBundleRecovery.ts
+++ b/lib/staleBundleRecovery.ts
@@ -59,8 +59,7 @@ export function isStaleBundleError(error: unknown): boolean {
   //   Safari:  undefined is not an object
   const factoryMissing =
     /Cannot read propert(?:y|ies) of undefined \(reading '(?:call|default)'\)/.test(message) ||
-    /undefined is not an object \(evaluating '[^']*\.call'\)/.test(message) ||
-    /undefined is not a function/.test(message);
+    /undefined is not an object \(evaluating '[^']*\.call'\)/.test(message);
 
   if (factoryMissing) {
     // Only treat it as a stale bundle when the throw comes from the webpack
@@ -128,15 +127,19 @@ export function installStaleBundleRecovery(options: { reload?: () => void } = {}
 
   const onRejection = (event: PromiseRejectionEvent) => {
     if (!isStaleBundleError(event.reason)) return;
-    // Mark handled so it doesn't surface as a fatal unhandled rejection / Sentry noise.
-    event.preventDefault();
-    recoverFromStaleBundle(reload);
+    const didRecover = recoverFromStaleBundle(reload);
+    if (didRecover) {
+      // Mark handled so it doesn't surface as a fatal unhandled rejection / Sentry noise.
+      event.preventDefault();
+    }
   };
 
   const onError = (event: ErrorEvent) => {
     if (!isStaleBundleError(event.error ?? event.message)) return;
-    event.preventDefault();
-    recoverFromStaleBundle(reload);
+    const didRecover = recoverFromStaleBundle(reload);
+    if (didRecover) {
+      event.preventDefault();
+    }
   };
 
   window.addEventListener("unhandledrejection", onRejection);

--- a/lib/staleBundleRecovery.ts
+++ b/lib/staleBundleRecovery.ts
@@ -1,0 +1,149 @@
+/**
+ * Self-healing for stale client bundles (deploy skew).
+ *
+ * When a new build is deployed while a tab is still open, the page's webpack
+ * runtime + chunk manifest are from the *old* build, but the server now serves
+ * the *new* build's assets. Two failure modes follow, both triggered most often
+ * by the App Router prefetching navbar links on window-focus:
+ *
+ *   1. A chunk file 404s  → `ChunkLoadError: Loading chunk N failed`.
+ *      (Already filtered from Sentry in `instrumentation-client.ts`.)
+ *
+ *   2. A chunk file loads (HTTP 200) but the loaded webpack runtime's module
+ *      table no longer has the factory for a module id the chunk asks for, so
+ *      `__webpack_require__` does `__webpack_modules__[id].call(...)` on
+ *      `undefined` →  `TypeError: Cannot read properties of undefined (reading 'call')`.
+ *      This is the variant seen at `/course/:course_id/discussion/:root_id`
+ *      when the staff nav prefetched the `manage/surveys` page chunk. It is a
+ *      *plain TypeError*, not a ChunkLoadError, so nothing recognized it: it
+ *      bubbled up as an unhandled promise rejection with no recovery.
+ *
+ * Both are unrecoverable in the current document — the only fix is to fetch the
+ * new build. This module detects either shape and force-reloads exactly once
+ * (guarded against reload loops), so a deploy mid-session self-heals instead of
+ * leaving the user with a dead navigation and a noisy Sentry report.
+ */
+
+const RELOAD_GUARD_KEY = "pawtograder:stale-bundle-reloaded-at";
+// Don't reload more than once per cooldown window — if a reload doesn't clear
+// the error (e.g. the new bundle is genuinely broken, or it's a false match),
+// we must not trap the user in an infinite reload loop.
+const RELOAD_COOLDOWN_MS = 30_000;
+
+/**
+ * True when `error` looks like a stale-bundle / chunk-load failure rather than a
+ * genuine application bug. Conservative on purpose: the missing-module-factory
+ * TypeError is only treated as stale-bundle when its stack points at the webpack
+ * runtime / Next chunk files, so unrelated `reading 'call'` TypeErrors in app
+ * code are left alone.
+ */
+export function isStaleBundleError(error: unknown): boolean {
+  if (!error) return false;
+
+  // Unwrap common wrappers (PromiseRejectionEvent.reason is already passed in by
+  // the caller; here we only see Error-likes / strings).
+  const name = (error as { name?: string })?.name ?? "";
+  const message = typeof error === "string" ? error : ((error as { message?: string })?.message ?? "");
+  const stack = (error as { stack?: string })?.stack ?? "";
+
+  // Mode 1: the classic chunk 404.
+  if (name === "ChunkLoadError") return true;
+  if (/Loading chunk [^\s]+ failed/i.test(message)) return true;
+  if (/Loading CSS chunk [^\s]+ failed/i.test(message)) return true;
+  if (/ChunkLoadError/.test(message)) return true;
+
+  // Mode 2: the missing-module-factory error from `__webpack_require__`.
+  // Cover the cross-browser phrasings of "reading a property of undefined":
+  //   Chrome:  Cannot read properties of undefined (reading 'call')
+  //   Firefox: undefined is not an object (evaluating '... .call')   /  "x is undefined"
+  //   Safari:  undefined is not an object
+  const factoryMissing =
+    /Cannot read propert(?:y|ies) of undefined \(reading '(?:call|default)'\)/.test(message) ||
+    /undefined is not an object \(evaluating '[^']*\.call'\)/.test(message) ||
+    /undefined is not a function/.test(message);
+
+  if (factoryMissing) {
+    // Only treat it as a stale bundle when the throw comes from the webpack
+    // *runtime* itself (`webpack-<hash>.js` / `__webpack_require__` / the module
+    // factory call). That's what distinguishes a missing module-table entry from
+    // an ordinary `x.call(...)` bug in product code — the latter throws from an
+    // app chunk with no webpack-runtime frame, so it must keep reporting. (Don't
+    // match the generic `_next/static/chunks/` path: every app chunk lives there.)
+    const looksLikeWebpackRuntime =
+      /webpack[-.]/i.test(stack) || /__webpack_require__/.test(stack) || /options\.factory/.test(stack);
+    if (looksLikeWebpackRuntime) return true;
+  }
+
+  return false;
+}
+
+function hasRecentlyReloaded(): boolean {
+  try {
+    const raw = window.sessionStorage.getItem(RELOAD_GUARD_KEY);
+    if (!raw) return false;
+    const last = Number(raw);
+    if (!Number.isFinite(last)) return false;
+    return Date.now() - last < RELOAD_COOLDOWN_MS;
+  } catch {
+    // sessionStorage can throw (private mode / blocked storage). Fail safe by
+    // assuming we have NOT reloaded, so a real deploy skew still self-heals; the
+    // browser's own reload throttling backstops any loop.
+    return false;
+  }
+}
+
+function markReloaded(): void {
+  try {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    /* ignore */
+  }
+}
+
+// Reload from the server (not the bf-cache) so we pull the new manifest+chunks.
+// `window.location.reload` is non-configurable in jsdom, so the reload action is
+// injectable to keep `recoverFromStaleBundle` testable.
+const defaultReload = () => window.location.reload();
+
+/**
+ * Recover from a detected stale-bundle error by force-reloading once. Returns
+ * true if a reload was scheduled, false if suppressed by the loop guard.
+ */
+export function recoverFromStaleBundle(reload: () => void = defaultReload): boolean {
+  if (typeof window === "undefined") return false;
+  if (hasRecentlyReloaded()) return false;
+  markReloaded();
+  reload();
+  return true;
+}
+
+/**
+ * Install global listeners that detect stale-bundle errors (from prefetch or
+ * navigation) and self-heal. Safe to call once at client startup; no-ops on the
+ * server. Returns an uninstall function (used by tests).
+ */
+export function installStaleBundleRecovery(options: { reload?: () => void } = {}): () => void {
+  if (typeof window === "undefined") return () => {};
+  const reload = options.reload ?? defaultReload;
+
+  const onRejection = (event: PromiseRejectionEvent) => {
+    if (!isStaleBundleError(event.reason)) return;
+    // Mark handled so it doesn't surface as a fatal unhandled rejection / Sentry noise.
+    event.preventDefault();
+    recoverFromStaleBundle(reload);
+  };
+
+  const onError = (event: ErrorEvent) => {
+    if (!isStaleBundleError(event.error ?? event.message)) return;
+    event.preventDefault();
+    recoverFromStaleBundle(reload);
+  };
+
+  window.addEventListener("unhandledrejection", onRejection);
+  window.addEventListener("error", onError);
+
+  return () => {
+    window.removeEventListener("unhandledrejection", onRejection);
+    window.removeEventListener("error", onError);
+  };
+}

--- a/tests/unit/stale-bundle-recovery.test.ts
+++ b/tests/unit/stale-bundle-recovery.test.ts
@@ -1,0 +1,90 @@
+import { isStaleBundleError, installStaleBundleRecovery } from "@/lib/staleBundleRecovery";
+
+describe("isStaleBundleError", () => {
+  it("matches the production missing-module-factory TypeError from the webpack runtime", () => {
+    // This is the exact error from the Sentry report at
+    // /course/:course_id/discussion/:root_id (staff nav prefetching the surveys chunk).
+    const err = new TypeError("Cannot read properties of undefined (reading 'call')");
+    err.stack =
+      "TypeError: Cannot read properties of undefined (reading 'call')\n" +
+      "    at a (app:///_next/static/chunks/webpack-e29a8de3f44271e6.js:1:526)\n" +
+      "    at 25309 (app:///_next/static/chunks/app/course/[course_id]/manage/surveys/page-a272b1fe930816c2.js:1:1860)\n" +
+      "    at a (app:///_next/static/chunks/webpack-e29a8de3f44271e6.js:1:526)";
+    expect(isStaleBundleError(err)).toBe(true);
+  });
+
+  it("matches a classic ChunkLoadError", () => {
+    const err = new Error("Loading chunk 25309 failed.");
+    err.name = "ChunkLoadError";
+    expect(isStaleBundleError(err)).toBe(true);
+  });
+
+  it("matches the Firefox phrasing of the missing-factory error when stack is webpack", () => {
+    const err = new TypeError("undefined is not an object (evaluating 'n.call')");
+    err.stack = "x@app:///_next/static/chunks/webpack-abc.js:1:1";
+    expect(isStaleBundleError(err)).toBe(true);
+  });
+
+  it("does NOT match a genuine 'reading call' TypeError from application code", () => {
+    const err = new TypeError("Cannot read properties of undefined (reading 'call')");
+    err.stack =
+      "TypeError: Cannot read properties of undefined (reading 'call')\n" +
+      "    at MyComponent (app:///_next/static/chunks/app/course/foo/SomeComponent.tsx:10:5)";
+    // No webpack-runtime frame → treat as a real bug, keep reporting it.
+    expect(isStaleBundleError(err)).toBe(false);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isStaleBundleError(new Error("Network request failed"))).toBe(false);
+    expect(isStaleBundleError(undefined)).toBe(false);
+    expect(isStaleBundleError(null)).toBe(false);
+  });
+});
+
+describe("installStaleBundleRecovery", () => {
+  let reloadCalls: number;
+  const reload = () => {
+    reloadCalls += 1;
+  };
+
+  beforeEach(() => {
+    reloadCalls = 0;
+    window.sessionStorage.clear();
+  });
+
+  function dispatchRejection(reason: unknown) {
+    const event = new Event("unhandledrejection") as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", { value: reason });
+    let prevented = false;
+    event.preventDefault = () => {
+      prevented = true;
+    };
+    window.dispatchEvent(event);
+    return prevented;
+  }
+
+  it("reloads once and preventDefaults on a stale-bundle unhandled rejection", () => {
+    const uninstall = installStaleBundleRecovery({ reload });
+    const err = new TypeError("Cannot read properties of undefined (reading 'call')");
+    err.stack = "at a (app:///_next/static/chunks/webpack-x.js:1:526)";
+
+    const prevented1 = dispatchRejection(err);
+    expect(prevented1).toBe(true);
+    expect(reloadCalls).toBe(1);
+
+    // Loop guard: a second stale-bundle error within the cooldown must NOT reload again.
+    const prevented2 = dispatchRejection(err);
+    expect(prevented2).toBe(true);
+    expect(reloadCalls).toBe(1);
+
+    uninstall();
+  });
+
+  it("leaves unrelated rejections alone", () => {
+    const uninstall = installStaleBundleRecovery({ reload });
+    const prevented = dispatchRejection(new Error("some real bug"));
+    expect(prevented).toBe(false);
+    expect(reloadCalls).toBe(0);
+    uninstall();
+  });
+});

--- a/tests/unit/stale-bundle-recovery.test.ts
+++ b/tests/unit/stale-bundle-recovery.test.ts
@@ -74,7 +74,7 @@ describe("installStaleBundleRecovery", () => {
 
     // Loop guard: a second stale-bundle error within the cooldown must NOT reload again.
     const prevented2 = dispatchRejection(err);
-    expect(prevented2).toBe(true);
+    expect(prevented2).toBe(false);
     expect(reloadCalls).toBe(1);
 
     uninstall();


### PR DESCRIPTION
Production Sentry reported an unhandled rejection on /course/:course_id/discussion/:root_id:

  TypeError: Cannot read properties of undefined (reading 'call')
    at a (…/webpack-….js)          // __webpack_require__
    at 25309 (…/manage/surveys/page-….js)

It fires during the staff-nav route prefetch burst on window-focus (the breadcrumbs show resubscribe_all_begin + window_focus right before the throw, after the tab idled ~4 min). The surveys RSC request returns 200 — the chunk loads — but the open tab's webpack runtime no longer has the module factory the chunk asks for, so __webpack_require__ does `__webpack_modules__[id].call(...)` on undefined. That's the deploy-skew sibling of ChunkLoadError: a new build landed mid-session and the stale runtime + the freshly served chunks disagree.

The codebase already filters the ChunkLoadError ("Loading chunk N failed") variant from Sentry, but this 200-but-missing-factory variant is a plain TypeError, so nothing recognized it — it bubbled up as a dead, unrecoverable unhandled rejection.

Fix:
- lib/staleBundleRecovery.ts: detect both stale-bundle shapes (ChunkLoadError + the missing-factory TypeError, gated on a webpack-runtime stack so genuine `x.call()` bugs still report) and recover with a single sessionStorage-guarded hard reload to pull the fresh manifest+chunks. No reload loops.
- components/StaleBundleRecovery.tsx mounts it from the root layout. (Installing it from instrumentation-client.ts made that special client-instrumentation entry fail to evaluate, silently taking Sentry + PostHog init down — so it's wired via a normal client component instead.)
- instrumentation-client.ts: also drop the missing-factory TypeError from Sentry in beforeSend, next to the existing ChunkLoadError filter, so transient deploy skew stops creating noise.
- tests/unit/stale-bundle-recovery.test.ts: asserts detection against the exact production error + stack, the false-positive guard, and reload-once behavior.

Verified against a local production build + seeded class: the exact error as a real unhandled rejection now triggers one reload and recovers; normal navigation and Sentry/PostHog init are unaffected.