### PR TITLE
fix(lab-sections): hard-delete lab sections so instructors can delete them

### DIFF
--- a/app/course/[course_id]/manage/course/lab-sections/page.tsx
+++ b/app/course/[course_id]/manage/course/lab-sections/page.tsx
@@ -810,7 +810,12 @@ function LabSectionsTable() {
     async (id: number) => {
       setIsDeleting(true);
       try {
-        await controller.labSections.delete(id);
+        // lab_sections is hard-deleted: the table has no `deleted_at` column, and
+        // its foreign keys are designed for it (lab_section_meetings/lab_section_leaders
+        // cascade, user_roles.lab_section_id is set null). Using the soft-delete
+        // delete() here issued an `UPDATE ... SET deleted_at` against a non-existent
+        // column, which always errored and left the section undeletable.
+        await controller.labSections.hardDelete(id);
         toaster.success({
           title: "Lab section deleted successfully"
         });
@@ -959,12 +964,17 @@ function LabSectionsTable() {
         cell: ({ row }) => (
           <HStack gap={2}>
             <Tooltip content="Manage meetings">
-              <Button size="sm" variant="ghost" onClick={() => openMeetingsModal(row.original)}>
+              <Button
+                size="sm"
+                variant="ghost"
+                aria-label="Manage meetings"
+                onClick={() => openMeetingsModal(row.original)}
+              >
                 <FaCalendar />
               </Button>
             </Tooltip>
             <Tooltip content="Edit lab section">
-              <Button size="sm" variant="ghost" onClick={() => handleEdit(row.original)}>
+              <Button size="sm" variant="ghost" aria-label="Edit lab section" onClick={() => handleEdit(row.original)}>
                 <FaEdit />
               </Button>
             </Tooltip>

--- a/tests/e2e/lab-sections.test.tsx
+++ b/tests/e2e/lab-sections.test.tsx
@@ -187,4 +187,110 @@ test.describe("Lab Sections Page", () => {
     await expect(page.locator(`text=${labSectionDescription}`).first()).toBeVisible();
     await expect(page.getByText("No lab sections created yet.")).not.toBeVisible();
   });
+  test("Instructors can edit a lab section", async ({ page }) => {
+    // Edit a pre-seeded section. Use "<Lab Section 15>" — its name is not a
+    // substring of any other seeded section's name, so the row filter below is
+    // unambiguous (unlike e.g. "<Lab Section 1>", which is a substring of 10-19).
+    const originalName = "<Lab Section 15>";
+    const updatedDescription = "Edited via e2e test";
+    const row = page.getByRole("row").filter({ hasText: originalName });
+    await expect(row).toBeVisible();
+    await row.getByRole("button", { name: "Edit lab section" }).click();
+
+    // The shared modal renders "Edit Lab Section" when initialData is present.
+    await expect(page.getByText("Edit Lab Section")).toBeVisible();
+    await page.getByPlaceholder("Optional description").fill(updatedDescription);
+    // The submit button reads "Update" in edit mode (vs "Create" when creating).
+    await page.getByRole("button", { name: "Update" }).click();
+
+    await expect(page.getByText("Edit Lab Section")).toBeHidden();
+    // The edited description is rendered back in the table for that section.
+    await expect(row.getByText(updatedDescription)).toBeVisible();
+  });
+  test("Instructors can delete a lab section", async ({ page }) => {
+    // Regression test for "instructors unable to delete a lab section":
+    // TableController.delete() soft-deletes via `UPDATE ... SET deleted_at`, but
+    // lab_sections has no deleted_at column, so the delete always errored and the
+    // section stayed. The page now uses hardDelete(); this test asserts the row is
+    // both removed from the table AND gone from the database.
+    const deletableName = "<Lab Section To Delete>";
+    const { data: created, error } = await supabase
+      .from("lab_sections")
+      .insert({
+        name: deletableName,
+        day_of_week: "monday",
+        class_id: course.id,
+        start_time: "09:00",
+        end_time: "10:00"
+      })
+      .select("*")
+      .single();
+    if (error) {
+      throw new Error(`Failed to create lab section to delete: ${error.message}`);
+    }
+    const { error: leaderError } = await supabase.from("lab_section_leaders").insert({
+      lab_section_id: created.id,
+      profile_id: instructor1!.private_profile_id,
+      class_id: course.id
+    });
+    if (leaderError) {
+      throw new Error(`Failed to create lab section leader: ${leaderError.message}`);
+    }
+
+    // The section is inserted while this page is already open and subscribed, so
+    // the realtime INSERT should deliver it live. Fall back to a single reload
+    // (by which time the async SSR cache invalidation has landed) if it doesn't.
+    const row = page.locator(`#lab-section-row-${created.id}`);
+    try {
+      await expect(row).toBeVisible({ timeout: 15_000 });
+    } catch {
+      await page.reload();
+      await expect(page.getByText("Loading lab sections...")).toBeHidden();
+      await expect(row).toBeVisible({ timeout: 30_000 });
+    }
+    await expect(row.getByText(deletableName, { exact: true })).toBeVisible();
+
+    // Open the delete confirmation popover (trigger aria-label "Delete lab section")
+    // and confirm (confirm IconButton aria-label "Confirm action").
+    await row.getByRole("button", { name: "Delete lab section" }).click();
+    await page.getByRole("button", { name: "Confirm action" }).click();
+
+    // The user-visible success signal is the row leaving the table. (The success
+    // toast is intentionally not asserted — it auto-dismisses and is racy.)
+    await expect(page.locator(`#lab-section-row-${created.id}`)).toHaveCount(0);
+
+    // Hard delete: the row no longer exists in the database (not merely flagged).
+    // The table removes the row optimistically, so poll until the server-side
+    // DELETE has committed rather than racing it with a single query.
+    await expect
+      .poll(async () => {
+        const { data, error: fetchError } = await supabase.from("lab_sections").select("id").eq("id", created.id);
+        if (fetchError) {
+          throw new Error(`Failed to query lab section after delete: ${fetchError.message}`);
+        }
+        return data?.length ?? 0;
+      })
+      .toBe(0);
+  });
+  test("Instructors can cancel a lab section meeting", async ({ page }) => {
+    // Meetings are auto-generated between the class start/end dates (2035) by the
+    // sync_lab_section_meetings trigger, so a seeded section has scheduled meetings.
+    // "<Lab Section 16>" is not a substring of any other seeded section name.
+    const sectionName = "<Lab Section 16>";
+    const row = page.getByRole("row").filter({ hasText: sectionName });
+    await expect(row).toBeVisible();
+    await row.getByRole("button", { name: "Manage meetings" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(`Manage Meetings - ${sectionName}`)).toBeVisible();
+    // Each generated meeting starts "Scheduled" with a "Cancel" action.
+    const firstCancel = dialog.getByRole("button", { name: "Cancel", exact: true }).first();
+    await expect(firstCancel).toBeVisible();
+    await firstCancel.click();
+
+    // The durable signal is the row flipping to "Cancelled" with a "Restore" action
+    // (the "Meeting cancelled" toast auto-dismisses and is racy to assert).
+    await expect(dialog.getByText("Cancelled").first()).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Restore", exact: true }).first()).toBeVisible();
+  });
 });

--- a/tests/e2e/lab-sections.test.tsx
+++ b/tests/e2e/lab-sections.test.tsx
@@ -243,7 +243,9 @@ test.describe("Lab Sections Page", () => {
     const row = page.locator(`#lab-section-row-${created.id}`);
     try {
       await expect(row).toBeVisible({ timeout: 15_000 });
-    } catch {
+    } catch (err) {
+      const matcherResult = (err as { matcherResult?: { name?: string } } | null)?.matcherResult;
+      if (!matcherResult || matcherResult.name !== "toBeVisible") throw err;
       await page.reload();
       await expect(page.getByText("Loading lab sections...")).toBeHidden();
       await expect(row).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
The instructor delete handler called TableController.delete(), which soft-deletes via `UPDATE ... SET deleted_at`. lab_sections has no deleted_at column, so every delete failed with PGRST204 ("Could not find the 'deleted_at' column") and surfaced as "Error deleting lab section" — the section was never removed.

Switch to hardDelete(). Hard delete is the intended semantics here: all FKs referencing lab_sections cascade (meetings, leaders, SIS sync) or set null (user_roles, invitations), the instructors_manage_lab_sections RLS policy is FOR ALL, and the admin_delete_lab_section RPC already hard-deletes.

Also add aria-labels to the icon-only "Manage meetings" / "Edit" action buttons (accessibility + test targeting), and extend the e2e suite to cover edit, delete (asserts the row leaves the table and is removed from the DB), and cancelling a meeting.

Fixes #808 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lab section meetings can now be canceled with a "Restore" action available

* **Improvements**
  * Enhanced accessibility in the lab section management interface

* **Tests**
  * Added comprehensive end-to-end test coverage for lab section workflows, including editing descriptions, deletion, and meeting cancellation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->