### PR TITLE
feat(assignments): re-grade late commits after a deadline extension

### DIFF
--- a/app/course/[course_id]/manage/assignments/[assignment_id]/assignmentDashboard.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/assignmentDashboard.tsx
@@ -36,9 +36,10 @@ import {
   Text,
   VStack
 } from "@chakra-ui/react";
+import { DeadlineRegradeBatch, fetchOpenRegradeBatch } from "@/lib/deadlineRegrade";
 import NextLink from "next/link";
 import { useParams } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import AssignmentsTable from "./assignmentsTable";
 import GradingStatusPanel from "./GradingStatusPanel";
 import RubricReport from "./RubricReport";
@@ -204,6 +205,22 @@ export default function AssignmentDashboard({ tableController }: AssignmentDashb
   // Cohort pushed from the rubric report to filter the submissions table (button or drill-in).
   const [tableCohort, setTableCohort] = useState<{ ids: number[]; label: string } | null>(null);
 
+  // Open "re-grade late commits" review session for this assignment, if any.
+  const [regradeBatch, setRegradeBatch] = useState<DeadlineRegradeBatch | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchOpenRegradeBatch(supabase, Number(assignment_id))
+      .then((b) => {
+        if (!cancelled) setRegradeBatch(b);
+      })
+      .catch(() => {
+        /* non-fatal */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase, assignment_id]);
+
   // Distinct section / lab names for the filter control.
   const { classSections, labSections } = useMemo(() => collectSectionOptions(rows), [rows]);
 
@@ -226,8 +243,25 @@ export default function AssignmentDashboard({ tableController }: AssignmentDashb
 
   const repositoriesHref = `/course/${course_id}/manage/assignments/${assignment_id}/repositories`;
 
+  const regradeHref = `/course/${course_id}/manage/assignments/${assignment_id}/regrade-late-commits`;
+
   return (
     <VStack align="stretch" gap={8} p={4}>
+      {regradeBatch && (
+        <CardRoot borderColor="border.warning" bg="bg.warning">
+          <CardBody>
+            <HStack justify="space-between" wrap="wrap" gap={3}>
+              <Text fontSize="sm">
+                The deadline was extended on this assignment. There are late commits awaiting your review for
+                re-grading.
+              </Text>
+              <Button asChild size="sm" colorPalette="orange">
+                <NextLink href={regradeHref}>Review late commits</NextLink>
+              </Button>
+            </HStack>
+          </CardBody>
+        </CardRoot>
+      )}
       <GradingStatusPanel
         rows={rows}
         assignmentId={Number(assignment_id)}

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
@@ -2,14 +2,15 @@
 
 import { toaster } from "@/components/ui/toaster";
 import { assignmentGroupCopyGroupsFromAssignment, githubRepoConfigureWebhook } from "@/lib/edgeFunctions";
+import { enumerateDeadlineRegradeCandidates, fetchRegradeCandidates } from "@/lib/deadlineRegrade";
 import { revalidateCourseDerivedCachesClient } from "@/lib/revalidateCourseDerivedCachesClient";
 import { createClient } from "@/utils/supabase/client";
 import { Assignment, SelfReviewSettings } from "@/utils/supabase/DatabaseTypes";
-import { Box, Heading } from "@chakra-ui/react";
+import { Box, Button, Dialog, Heading, Text } from "@chakra-ui/react";
 import { useOne, useUpdate } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
-import { useParams } from "next/navigation";
-import { useCallback, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { FieldValues } from "react-hook-form";
 import AssignmentForm from "../../new/form";
 
@@ -23,6 +24,9 @@ export default function EditAssignment() {
   const { reset, refineCore } = form;
   const queryData = refineCore.query?.data?.data;
   const { mutate: update } = useUpdate();
+  const router = useRouter();
+  // When the deadline is extended, offer to review late commits for re-grading.
+  const [regradePrompt, setRegradePrompt] = useState<{ batchId: number; count: number } | null>(null);
 
   useEffect(() => {
     if (queryData) {
@@ -109,6 +113,30 @@ export default function EditAssignment() {
           description: "The assignment has been successfully updated.",
           type: "success"
         });
+
+        // If the deadline moved later, offer to re-grade late commits. This is
+        // best-effort: any failure here must not fail the assignment update.
+        try {
+          const oldDue = data?.data.due_date;
+          const newDue = values.due_date as string | undefined;
+          if (oldDue && newDue && new Date(newDue).getTime() > new Date(oldDue).getTime()) {
+            const batchId = await enumerateDeadlineRegradeCandidates(supabase, {
+              assignment_id: Number.parseInt(assignment_id as string),
+              old_due_date: oldDue
+            });
+            const rows = await fetchRegradeCandidates(supabase, batchId);
+            if (rows.length > 0) {
+              setRegradePrompt({ batchId, count: rows.length });
+            }
+          }
+        } catch (regradeError) {
+          // Surface softly; the deadline change itself succeeded.
+          toaster.create({
+            title: "Could not scan for late commits",
+            description: regradeError instanceof Error ? regradeError.message : "Unknown error",
+            type: "warning"
+          });
+        }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "An unknown error occurred.";
         toaster.create({
@@ -118,7 +146,7 @@ export default function EditAssignment() {
         });
       }
     },
-    [form.refineCore, assignment_id, course_id, data?.data.self_review_setting_id, update]
+    [form.refineCore, assignment_id, course_id, data?.data.self_review_setting_id, data?.data.due_date, update]
   );
 
   if (form.refineCore.query?.error) {
@@ -128,6 +156,44 @@ export default function EditAssignment() {
     <Box>
       <Heading size="md">Edit Assignment</Heading>
       <AssignmentForm form={form} onSubmit={onFinish} />
+
+      <Dialog.Root open={regradePrompt !== null} onOpenChange={(d) => !d.open && setRegradePrompt(null)}>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Re-grade late commits?</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <Text>
+                You extended this assignment&apos;s deadline. {regradePrompt?.count} student
+                {regradePrompt?.count === 1 ? "" : "s"}/group(s) pushed a commit after the old deadline that was never
+                graded. Would you like to review those commits and decide which to accept for grading? You&apos;ll see a
+                before/after score and nothing changes until you promote a commit.
+              </Text>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="ghost" onClick={() => setRegradePrompt(null)}>
+                Not now
+              </Button>
+              <Button
+                colorPalette="blue"
+                onClick={() => {
+                  const batchId = regradePrompt?.batchId;
+                  setRegradePrompt(null);
+                  if (batchId) {
+                    router.push(
+                      `/course/${course_id}/manage/assignments/${assignment_id}/regrade-late-commits?batch=${batchId}`
+                    );
+                  }
+                }}
+              >
+                Review late commits
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>
     </Box>
   );
 }

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/regrade-late-commits/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/regrade-late-commits/page.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import Link from "@/components/ui/link";
+import { toaster, Toaster } from "@/components/ui/toaster";
+import { TimeZoneAwareDate } from "@/components/TimeZoneAwareDate";
+import {
+  applyDeadlineRegrade,
+  DeadlineRegradeBatch,
+  DeadlineRegradeCandidate,
+  dismissDeadlineRegradeBatch,
+  fetchOpenRegradeBatch,
+  fetchRegradeBatchById,
+  fetchRegradeCandidates,
+  skipDeadlineRegrade,
+  stageCandidate
+} from "@/lib/deadlineRegrade";
+import { createClient } from "@/utils/supabase/client";
+import { Badge, Box, Button, Code, Dialog, Heading, HStack, Spinner, Table, Text, VStack } from "@chakra-ui/react";
+import { useParams, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type Busy = Record<number, "staging" | "applying" | "skipping" | undefined>;
+
+function scoreText(s: number | null): string {
+  return s === null || s === undefined ? "—" : `${s}`;
+}
+
+function DeltaBadge({ current, next }: { current: number | null; next: number | null }) {
+  if (current === null || current === undefined || next === null || next === undefined) {
+    return <Badge colorPalette="gray">n/a</Badge>;
+  }
+  const delta = next - current;
+  if (delta > 0) return <Badge colorPalette="green">+{delta}</Badge>;
+  if (delta < 0) return <Badge colorPalette="red">{delta}</Badge>;
+  return <Badge colorPalette="gray">0</Badge>;
+}
+
+export default function RegradeLateCommitsPage() {
+  const { course_id, assignment_id } = useParams();
+  const searchParams = useSearchParams();
+  const supabase = useMemo(() => createClient(), []);
+
+  const [batch, setBatch] = useState<DeadlineRegradeBatch | null>(null);
+  const [candidates, setCandidates] = useState<DeadlineRegradeCandidate[]>([]);
+  const [names, setNames] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<Busy>({});
+  const [confirmLower, setConfirmLower] = useState<DeadlineRegradeCandidate | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const batchParam = searchParams.get("batch");
+
+  const loadNames = useCallback(
+    async (rows: DeadlineRegradeCandidate[]) => {
+      const profileIds = Array.from(new Set(rows.map((r) => r.profile_id).filter(Boolean))) as string[];
+      const groupIds = Array.from(new Set(rows.map((r) => r.assignment_group_id).filter(Boolean))) as number[];
+      const map: Record<string, string> = {};
+      if (profileIds.length) {
+        const { data } = await supabase.from("profiles").select("id, name").in("id", profileIds);
+        (data ?? []).forEach((p) => {
+          if (p.id) map[`p:${p.id}`] = p.name ?? p.id;
+        });
+      }
+      if (groupIds.length) {
+        const { data } = await supabase.from("assignment_groups").select("id, name").in("id", groupIds);
+        (data ?? []).forEach((g) => {
+          map[`g:${g.id}`] = g.name ?? `Group ${g.id}`;
+        });
+      }
+      setNames(map);
+    },
+    [supabase]
+  );
+
+  const refresh = useCallback(
+    async (b: DeadlineRegradeBatch | null) => {
+      if (!b) return;
+      const rows = await fetchRegradeCandidates(supabase, b.id);
+      setCandidates(rows);
+      await loadNames(rows);
+    },
+    [supabase, loadNames]
+  );
+
+  // Initial load: resolve the batch (from ?batch= or the latest open batch).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let b: DeadlineRegradeBatch | null = null;
+        if (batchParam) {
+          b = await fetchRegradeBatchById(supabase, Number(batchParam));
+        } else {
+          b = await fetchOpenRegradeBatch(supabase, Number(assignment_id));
+        }
+        if (cancelled) return;
+        setBatch(b);
+        await refresh(b);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load regrade batch");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase, assignment_id, batchParam, refresh]);
+
+  // Poll while any candidate is still grading.
+  useEffect(() => {
+    const anyGrading = candidates.some((c) => c.staged_status === "grading");
+    if (anyGrading && !pollRef.current) {
+      pollRef.current = setInterval(() => {
+        void refresh(batch);
+      }, 5000);
+    } else if (!anyGrading && pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [candidates, batch, refresh]);
+
+  const nameFor = useCallback(
+    (c: DeadlineRegradeCandidate) =>
+      c.assignment_group_id
+        ? (names[`g:${c.assignment_group_id}`] ?? `Group ${c.assignment_group_id}`)
+        : (names[`p:${c.profile_id}`] ?? c.profile_id ?? "Unknown"),
+    [names]
+  );
+
+  const setRowBusy = (id: number, state: Busy[number]) => setBusy((prev) => ({ ...prev, [id]: state }));
+
+  const handleStage = useCallback(
+    async (c: DeadlineRegradeCandidate) => {
+      setRowBusy(c.id, "staging");
+      try {
+        await stageCandidate(supabase, c);
+        toaster.create({
+          title: "Grading started",
+          description: `Grading ${c.sha.slice(0, 7)} for ${nameFor(c)}`,
+          type: "info"
+        });
+        await refresh(batch);
+      } catch (e) {
+        toaster.error({ title: "Could not start grading", description: e instanceof Error ? e.message : String(e) });
+      } finally {
+        setRowBusy(c.id, undefined);
+      }
+    },
+    [supabase, batch, refresh, nameFor]
+  );
+
+  const doApply = useCallback(
+    async (c: DeadlineRegradeCandidate) => {
+      setRowBusy(c.id, "applying");
+      try {
+        const res = await applyDeadlineRegrade(supabase, c.id);
+        toaster.create({
+          title: "Promoted",
+          description: `${nameFor(c)}: ${scoreText(res.old_score ?? null)} → ${scoreText(res.new_score ?? null)}. The student was notified.`,
+          type: "success"
+        });
+        await refresh(batch);
+      } catch (e) {
+        toaster.error({ title: "Could not promote", description: e instanceof Error ? e.message : String(e) });
+      } finally {
+        setRowBusy(c.id, undefined);
+      }
+    },
+    [supabase, batch, refresh, nameFor]
+  );
+
+  const handleApply = useCallback(
+    async (c: DeadlineRegradeCandidate) => {
+      // Lower scores are allowed but require an explicit per-row confirmation.
+      const lowers = c.current_score !== null && c.staged_score !== null && c.staged_score < c.current_score;
+      if (lowers) {
+        setConfirmLower(c);
+        return;
+      }
+      await doApply(c);
+    },
+    [doApply]
+  );
+
+  const handleSkip = useCallback(
+    async (c: DeadlineRegradeCandidate) => {
+      setRowBusy(c.id, "skipping");
+      try {
+        await skipDeadlineRegrade(supabase, c.id);
+        await refresh(batch);
+      } catch (e) {
+        toaster.error({ title: "Could not skip", description: e instanceof Error ? e.message : String(e) });
+      } finally {
+        setRowBusy(c.id, undefined);
+      }
+    },
+    [supabase, batch, refresh]
+  );
+
+  const handleStageAll = useCallback(async () => {
+    const pending = candidates.filter((c) => c.decision === "pending" && c.staged_status === "none");
+    for (const c of pending) {
+      // Sequential to avoid hammering the workflow-dispatch API.
+      await handleStage(c);
+    }
+  }, [candidates, handleStage]);
+
+  const handleFinish = useCallback(
+    async (status: "dismissed" | "applied") => {
+      if (!batch) return;
+      try {
+        await dismissDeadlineRegradeBatch(supabase, batch.id, status);
+        toaster.create({ title: status === "applied" ? "Review completed" : "Dismissed", type: "info" });
+        setBatch({ ...batch, status });
+      } catch (e) {
+        toaster.error({ title: "Could not close batch", description: e instanceof Error ? e.message : String(e) });
+      }
+    },
+    [supabase, batch]
+  );
+
+  const submissionsBase = `/course/${course_id}/assignments/${assignment_id}/submissions`;
+
+  if (loading) {
+    return (
+      <Box p={6}>
+        <Spinner /> <Text as="span">Loading late commits…</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={6}>
+        <Text color="fg.error">{error}</Text>
+      </Box>
+    );
+  }
+
+  if (!batch) {
+    return (
+      <Box p={6}>
+        <Heading size="md" mb={2}>
+          Re-grade late commits
+        </Heading>
+        <Text color="fg.muted">
+          There is no open review for this assignment. Extend the deadline in the assignment editor to start one.
+        </Text>
+      </Box>
+    );
+  }
+
+  const pendingCount = candidates.filter((c) => c.decision === "pending").length;
+
+  return (
+    <VStack align="stretch" gap={4} p={4}>
+      <Toaster />
+      <Box>
+        <Heading size="md">Re-grade late commits after deadline extension</Heading>
+        <Text fontSize="sm" color="fg.muted">
+          Original deadline <TimeZoneAwareDate date={batch.old_due_date} /> → new deadline{" "}
+          <TimeZoneAwareDate date={batch.new_due_date} />. {candidates.length} student
+          {candidates.length === 1 ? "" : "s"}/group(s) pushed a commit in this window. Grading a commit creates a
+          preview score; nothing changes a real grade until you press <b>Promote</b>.
+        </Text>
+      </Box>
+
+      <HStack>
+        <Button size="sm" variant="subtle" onClick={handleStageAll} disabled={batch.status !== "open"}>
+          Grade all ungraded
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          colorPalette="green"
+          onClick={() => handleFinish("applied")}
+          disabled={batch.status !== "open"}
+        >
+          Finish review
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => handleFinish("dismissed")} disabled={batch.status !== "open"}>
+          Dismiss
+        </Button>
+        {batch.status !== "open" && <Badge colorPalette="gray">{batch.status}</Badge>}
+        <Text fontSize="sm" color="fg.muted">
+          {pendingCount} pending
+        </Text>
+      </HStack>
+
+      <Table.Root size="sm" variant="outline">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Student / Group</Table.ColumnHeader>
+            <Table.ColumnHeader>Candidate commit</Table.ColumnHeader>
+            <Table.ColumnHeader>Pushed</Table.ColumnHeader>
+            <Table.ColumnHeader>Current score</Table.ColumnHeader>
+            <Table.ColumnHeader>New score</Table.ColumnHeader>
+            <Table.ColumnHeader>Δ</Table.ColumnHeader>
+            <Table.ColumnHeader>Actions</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {candidates.map((c) => {
+            const rowBusy = busy[c.id];
+            const isApplied = c.decision === "applied";
+            const isSkipped = c.decision === "skipped";
+            const graded = c.staged_status === "graded" && c.staged_submission_id !== null;
+            return (
+              <Table.Row key={c.id} opacity={isSkipped ? 0.5 : 1}>
+                <Table.Cell>{nameFor(c)}</Table.Cell>
+                <Table.Cell>
+                  <VStack align="start" gap={0}>
+                    <Code fontSize="xs">{c.sha.slice(0, 7)}</Code>
+                    <Text fontSize="xs" color="fg.muted" lineClamp={1} maxW="260px">
+                      {c.commit_message ?? ""}
+                    </Text>
+                  </VStack>
+                </Table.Cell>
+                <Table.Cell>{c.commit_date ? <TimeZoneAwareDate date={c.commit_date} /> : "—"}</Table.Cell>
+                <Table.Cell>
+                  {c.current_submission_id ? (
+                    <Link href={`${submissionsBase}/${c.current_submission_id}/files`}>
+                      {scoreText(c.current_score)}
+                    </Link>
+                  ) : (
+                    <Text color="fg.muted">no submission</Text>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  {c.staged_status === "grading" ? (
+                    <HStack gap={1}>
+                      <Spinner size="xs" />
+                      <Text fontSize="xs" color="fg.muted">
+                        grading…
+                      </Text>
+                    </HStack>
+                  ) : graded ? (
+                    <Link href={`${submissionsBase}/${c.staged_submission_id}/files`}>{scoreText(c.staged_score)}</Link>
+                  ) : (
+                    <Text color="fg.muted">—</Text>
+                  )}
+                </Table.Cell>
+                <Table.Cell>
+                  {graded ? <DeltaBadge current={c.current_score} next={c.staged_score} /> : null}
+                </Table.Cell>
+                <Table.Cell>
+                  {isApplied ? (
+                    <Badge colorPalette="green">promoted</Badge>
+                  ) : isSkipped ? (
+                    <Badge colorPalette="gray">skipped</Badge>
+                  ) : batch.status !== "open" ? (
+                    <Text fontSize="xs" color="fg.muted">
+                      closed
+                    </Text>
+                  ) : (
+                    <HStack gap={2}>
+                      {!graded && (
+                        <Button
+                          size="xs"
+                          variant="subtle"
+                          loading={rowBusy === "staging" || c.staged_status === "grading"}
+                          onClick={() => handleStage(c)}
+                        >
+                          Grade
+                        </Button>
+                      )}
+                      {graded && (
+                        <Button
+                          size="xs"
+                          colorPalette="green"
+                          loading={rowBusy === "applying"}
+                          onClick={() => handleApply(c)}
+                        >
+                          Promote
+                        </Button>
+                      )}
+                      <Button size="xs" variant="ghost" loading={rowBusy === "skipping"} onClick={() => handleSkip(c)}>
+                        Skip
+                      </Button>
+                    </HStack>
+                  )}
+                </Table.Cell>
+              </Table.Row>
+            );
+          })}
+          {candidates.length === 0 && (
+            <Table.Row>
+              <Table.Cell colSpan={7}>
+                <Text color="fg.muted" p={2}>
+                  No students pushed a commit between the old and new deadline.
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          )}
+        </Table.Body>
+      </Table.Root>
+
+      {/* Lower-score confirmation */}
+      <Dialog.Root open={confirmLower !== null} onOpenChange={(d) => !d.open && setConfirmLower(null)}>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Promote a lower score?</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              {confirmLower && (
+                <Text>
+                  Promoting this commit for <b>{nameFor(confirmLower)}</b> will change their autograder score from{" "}
+                  <b>{scoreText(confirmLower.current_score)}</b> down to <b>{scoreText(confirmLower.staged_score)}</b>.
+                  The student will be notified. Continue?
+                </Text>
+              )}
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button variant="ghost" onClick={() => setConfirmLower(null)}>
+                Cancel
+              </Button>
+              <Button
+                colorPalette="red"
+                onClick={async () => {
+                  const c = confirmLower;
+                  setConfirmLower(null);
+                  if (c) await doApply(c);
+                }}
+              >
+                Promote anyway
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Dialog.Root>
+    </VStack>
+  );
+}

--- a/components/notifications/notification-teaser.tsx
+++ b/components/notifications/notification-teaser.tsx
@@ -256,6 +256,20 @@ export type RegradeRequestNotification = NotificationEnvelope & {
       }
   );
 
+// Sent when an instructor promotes a late commit to be the student's active
+// submission after extending the deadline (deadline-extension regrade flow).
+export type SubmissionRegradedNotification = NotificationEnvelope & {
+  type: "submission_regraded";
+  action: "promoted_after_extension";
+  submission_id: number;
+  old_submission_id: number | null;
+  assignment_id: number;
+  old_score: number | null;
+  new_score: number | null;
+  regraded_by: string;
+  regraded_by_name: string;
+};
+
 // function truncateString(str: string, maxLength: number) {
 //   if (str.length <= maxLength) {
 //     return str;
@@ -513,6 +527,36 @@ function RegradeRequestNotificationTeaser({ notification }: { notification: Noti
   );
 }
 
+function SubmissionRegradedNotificationTeaser({ notification }: { notification: Notification }) {
+  const body = notification.body as SubmissionRegradedNotification;
+  const regrader = useUserProfile(body.regraded_by);
+
+  const formatScore = (s: number | null) => (s === null || s === undefined ? "?" : `${s}`);
+  const delta =
+    body.old_score !== null && body.old_score !== undefined && body.new_score !== null && body.new_score !== undefined
+      ? body.new_score - body.old_score
+      : null;
+  const direction = delta === null ? "" : delta > 0 ? " (↑)" : delta < 0 ? " (↓)" : " (no change)";
+
+  if (!regrader) {
+    return <Skeleton height="40px" width="100%" />;
+  }
+
+  return (
+    <HStack align="flex-start" gap="3">
+      <Avatar.Root size="sm" flexShrink="0">
+        <Avatar.Image src={regrader?.avatar_url} alt="" />
+        <Avatar.Fallback fontSize="xs">{regrader?.name?.charAt(0)}</Avatar.Fallback>
+      </Avatar.Root>
+      <VStack align="flex-start" gap="1" flex="1">
+        <Markdown style={NOTIFICATION_BODY_STYLE}>
+          {`**${body.regraded_by_name}** accepted a later commit for grading after extending the deadline. Your autograder score changed from **${formatScore(body.old_score)}** to **${formatScore(body.new_score)}**${direction}.`}
+        </Markdown>
+      </VStack>
+    </HStack>
+  );
+}
+
 function SystemNotificationTeaser({ notification }: { notification: Notification }) {
   const body = notification.body as SystemNotification;
 
@@ -595,6 +639,9 @@ function getNotificationUrl(notification: Notification, course_id: string): stri
   } else if (body.type === "regrade_request") {
     const regradeBody = body as RegradeRequestNotification;
     return `/course/${course_id}/assignments/${regradeBody.assignment_id}/submissions/${regradeBody.submission_id}/files#regrade-request-${regradeBody.regrade_request_id}`;
+  } else if (body.type === "submission_regraded") {
+    const regradedBody = body as SubmissionRegradedNotification;
+    return `/course/${course_id}/assignments/${regradedBody.assignment_id}/submissions/${regradedBody.submission_id}/files`;
   }
 
   // Email notifications and assignment group member notifications don't have specific URLs
@@ -714,6 +761,8 @@ export default function NotificationTeaser({
     teaser = <SystemNotificationTeaser notification={notification} />;
   } else if (body.type === "regrade_request") {
     teaser = <RegradeRequestNotificationTeaser notification={notification} />;
+  } else if (body.type === "submission_regraded") {
+    teaser = <SubmissionRegradedNotificationTeaser notification={notification} />;
   } else {
     teaser = <Markdown>{`*Unknown notification type: ${body.type}*`}</Markdown>;
   }

--- a/lib/deadlineRegrade.ts
+++ b/lib/deadlineRegrade.ts
@@ -1,0 +1,215 @@
+import { Database } from "@/utils/supabase/SupabaseTypes";
+import { SupabaseClient } from "@supabase/supabase-js";
+import { triggerWorkflow } from "./edgeFunctions";
+
+// NOTE: The deadline-regrade tables and RPCs are introduced in migration
+// 20260604120000_regrade-late-commits-after-extension.sql. Until `npm run
+// client-local` regenerates utils/supabase/SupabaseTypes.d.ts, these names are
+// not in the generated `Database` type, so the rpc()/from() calls below are
+// cast. Once types are regenerated the `as never` / local interfaces can be
+// dropped in favor of generated types.
+
+export type RegradeBatchStatus = "open" | "applied" | "dismissed" | "superseded";
+export type RegradeStagedStatus = "none" | "grading" | "graded" | "error";
+export type RegradeDecision = "pending" | "applied" | "skipped";
+
+export interface DeadlineRegradeBatch {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  class_id: number;
+  assignment_id: number;
+  created_by: string | null;
+  old_due_date: string;
+  new_due_date: string;
+  status: RegradeBatchStatus;
+}
+
+export interface DeadlineRegradeCandidate {
+  id: number;
+  created_at: string;
+  updated_at: string;
+  batch_id: number;
+  class_id: number;
+  assignment_id: number;
+  profile_id: string | null;
+  assignment_group_id: number | null;
+  repository_id: number;
+  repository: string;
+  sha: string;
+  commit_message: string | null;
+  commit_date: string | null;
+  current_submission_id: number | null;
+  current_score: number | null;
+  staged_submission_id: number | null;
+  staged_score: number | null;
+  staged_status: RegradeStagedStatus;
+  staged_triggered_at: string | null;
+  decision: RegradeDecision;
+}
+
+type AnyClient = SupabaseClient<Database>;
+// Helper to access the not-yet-typed rpc/from surface for the new tables/RPCs.
+// Once `npm run client-local` regenerates the Database type these casts can go away.
+type UntypedQuery = {
+  select: (cols: string) => UntypedQuery;
+  eq: (col: string, val: unknown) => UntypedQuery;
+  order: (col: string, opts: { ascending: boolean }) => UntypedQuery;
+  limit: (n: number) => UntypedQuery;
+  maybeSingle: () => Promise<{ data: unknown; error: { message: string } | null }>;
+  then: Promise<{ data: unknown; error: { message: string } | null }>["then"];
+};
+type UntypedClient = {
+  rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>;
+  from: (table: string) => UntypedQuery;
+};
+
+function untyped(supabase: AnyClient): UntypedClient {
+  return supabase as unknown as UntypedClient;
+}
+
+/**
+ * Enumerate the students/groups whose latest push fell in the window between the
+ * old and new (effective) deadlines. Creates a batch and its candidate rows and
+ * returns the new batch id.
+ */
+export async function enumerateDeadlineRegradeCandidates(
+  supabase: AnyClient,
+  params: { assignment_id: number; old_due_date: string }
+): Promise<number> {
+  const { data, error } = await untyped(supabase).rpc("enumerate_deadline_regrade_candidates", {
+    p_assignment_id: params.assignment_id,
+    p_old_due_date: params.old_due_date
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data as number;
+}
+
+/** Mark a candidate as "grading" right after its staged grading workflow is triggered. */
+export async function regradeSetCandidateGrading(supabase: AnyClient, candidateId: number): Promise<void> {
+  const { error } = await untyped(supabase).rpc("regrade_set_candidate_grading", {
+    p_candidate_id: candidateId
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+/**
+ * Trigger staged grading for a candidate commit: dispatch the grading workflow
+ * with stage_only=true (so the resulting submission is graded but not active),
+ * then mark the candidate as grading.
+ */
+export async function stageCandidate(
+  supabase: AnyClient,
+  candidate: Pick<DeadlineRegradeCandidate, "id" | "repository" | "sha" | "class_id">
+): Promise<void> {
+  await triggerWorkflow(
+    {
+      repository: candidate.repository,
+      sha: candidate.sha,
+      class_id: candidate.class_id,
+      stage_only: true
+    },
+    supabase
+  );
+  await regradeSetCandidateGrading(supabase, candidate.id);
+}
+
+/** Promote a candidate's staged submission to active and notify the student(s). */
+export async function applyDeadlineRegrade(
+  supabase: AnyClient,
+  candidateId: number
+): Promise<{
+  status: string;
+  old_submission_id?: number;
+  new_submission_id?: number;
+  old_score?: number;
+  new_score?: number;
+}> {
+  const { data, error } = await untyped(supabase).rpc("apply_deadline_regrade", {
+    p_candidate_id: candidateId
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data as { status: string };
+}
+
+/** Mark a candidate as skipped (instructor chose not to promote it). */
+export async function skipDeadlineRegrade(supabase: AnyClient, candidateId: number): Promise<void> {
+  const { error } = await untyped(supabase).rpc("skip_deadline_regrade", {
+    p_candidate_id: candidateId
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+/** Close a batch (dismissed by default, or "applied" when the instructor finishes). */
+export async function dismissDeadlineRegradeBatch(
+  supabase: AnyClient,
+  batchId: number,
+  status: "dismissed" | "applied" = "dismissed"
+): Promise<void> {
+  const { error } = await untyped(supabase).rpc("dismiss_deadline_regrade_batch", {
+    p_batch_id: batchId,
+    p_status: status
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+/** Fetch the candidate rows for a batch, ordered by student name-ish (commit date desc). */
+export async function fetchRegradeCandidates(
+  supabase: AnyClient,
+  batchId: number
+): Promise<DeadlineRegradeCandidate[]> {
+  const { data, error } = await untyped(supabase)
+    .from("deadline_regrade_candidates")
+    .select("*")
+    .eq("batch_id", batchId)
+    .order("id", { ascending: true });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return (data ?? []) as unknown as DeadlineRegradeCandidate[];
+}
+
+/** Fetch a single batch by id. */
+export async function fetchRegradeBatchById(
+  supabase: AnyClient,
+  batchId: number
+): Promise<DeadlineRegradeBatch | null> {
+  const { data, error } = await untyped(supabase)
+    .from("deadline_regrade_batches")
+    .select("*")
+    .eq("id", batchId)
+    .maybeSingle();
+  if (error) {
+    throw new Error(error.message);
+  }
+  return (data ?? null) as unknown as DeadlineRegradeBatch | null;
+}
+
+/** Fetch the most recent open batch for an assignment, if any (for the dashboard banner). */
+export async function fetchOpenRegradeBatch(
+  supabase: AnyClient,
+  assignmentId: number
+): Promise<DeadlineRegradeBatch | null> {
+  const { data, error } = await untyped(supabase)
+    .from("deadline_regrade_batches")
+    .select("*")
+    .eq("assignment_id", assignmentId)
+    .eq("status", "open")
+    .order("id", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) {
+    throw new Error(error.message);
+  }
+  return (data ?? null) as unknown as DeadlineRegradeBatch | null;
+}

--- a/supabase/functions/_shared/FunctionTypes.d.ts
+++ b/supabase/functions/_shared/FunctionTypes.d.ts
@@ -310,6 +310,9 @@ export type AutograderTriggerGradingWorkflowRequest = {
   repository: string;
   sha: string;
   class_id: number;
+  // When true, a submission created from this trigger is marked is_staged=true
+  // (deadline-extension regrade preview) instead of becoming the active submission.
+  stage_only?: boolean;
 };
 export type AutograderTriggerGradingWorkflowResponse = {
   message: string;

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -849,6 +849,13 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         (hasRealCheckRun && checkRun.commit_message && checkRun.commit_message.toUpperCase().includes("#NOT-GRADED")) ||
         false;
 
+      // A staged submission (deadline-extension regrade preview) is graded but
+      // never auto-activated. `stage_only` is a newer column carried on the
+      // manually-triggered check run; cast until generated types are regenerated.
+      const isStagedSubmission =
+        (hasRealCheckRun && (checkRun as { stage_only?: boolean }).stage_only === true) || false;
+      scope?.setTag("is_staged", isStagedSubmission.toString());
+
       scope?.setTag("time_zone", timeZone);
       scope?.setTag("is_not_graded", isNotGradedSubmission.toString());
       scope?.setTag("user_role", checkRun.user_roles?.role || "unknown");
@@ -1199,8 +1206,10 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               run_attempt: Number.parseInt(decoded.run_attempt),
               class_id: repoData.assignments.class_id!,
               repository_check_run_id: checkRun?.id,
-              is_not_graded: isNotGradedSubmission
-            })
+              is_not_graded: isNotGradedSubmission,
+              // `is_staged` is a newer column; cast until generated types are regenerated.
+              is_staged: isStagedSubmission
+            } as Database["public"]["Tables"]["submissions"]["Insert"])
             .select("id")
             .single();
 
@@ -1230,6 +1239,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         const checkRunUpdate: {
           status: CheckRunStatus;
           triggered_by?: null;
+          stage_only?: boolean;
         } = {
           status: {
             ...(checkRun.status as CheckRunStatus),
@@ -1239,7 +1249,15 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         if (staffTriggeredBy !== null) {
           checkRunUpdate.triggered_by = null;
         }
-        await adminSupabase.from("repository_check_runs").update(checkRunUpdate).eq("id", checkRun.id);
+        // Consume `stage_only` too, so a later real push of the same (repo, sha)
+        // does not inherit staged behavior from this check run.
+        if (isStagedSubmission) {
+          checkRunUpdate.stage_only = false;
+        }
+        await adminSupabase
+          .from("repository_check_runs")
+          .update(checkRunUpdate as Database["public"]["Tables"]["repository_check_runs"]["Update"])
+          .eq("id", checkRun.id);
       }
 
       try {

--- a/supabase/functions/autograder-trigger-grading-workflow/index.ts
+++ b/supabase/functions/autograder-trigger-grading-workflow/index.ts
@@ -23,22 +23,26 @@ async function markCheckRunRequested({
   adminSupabase,
   checkRun,
   triggeredBy,
-  requestedAt
+  requestedAt,
+  stageOnly
 }: {
   adminSupabase: SupabaseClient<Database>;
   checkRun: RepositoryCheckRunRow;
   triggeredBy: string;
   requestedAt: string;
+  stageOnly: boolean;
 }): Promise<RepositoryCheckRunRow> {
   const { data: updated, error: updateError } = await adminSupabase
     .from("repository_check_runs")
     .update({
       triggered_by: triggeredBy,
+      // `stage_only` is a newer column; cast until generated types are regenerated.
+      stage_only: stageOnly,
       status: {
         ...statusObject(checkRun.status),
         requested_at: requestedAt
       }
-    })
+    } as Database["public"]["Tables"]["repository_check_runs"]["Update"])
     .eq("id", checkRun.id)
     .select("*")
     .single();
@@ -52,12 +56,14 @@ async function upsertManualCheckRun({
   adminSupabase,
   repoData,
   commit,
-  triggeredBy
+  triggeredBy,
+  stageOnly
 }: {
   adminSupabase: SupabaseClient<Database>;
   repoData: Database["public"]["Tables"]["repositories"]["Row"];
   commit: GetCommitResponse["data"];
   triggeredBy: string;
+  stageOnly: boolean;
 }): Promise<RepositoryCheckRunRow> {
   // `commit.sha` is the canonical full lowercase sha returned by the GitHub API.
   // Always key DB lookups off it so short / mixed-case input from callers does
@@ -75,7 +81,7 @@ async function upsertManualCheckRun({
   }
   const now = new Date().toISOString();
   if (existing) {
-    return await markCheckRunRequested({ adminSupabase, checkRun: existing, triggeredBy, requestedAt: now });
+    return await markCheckRunRequested({ adminSupabase, checkRun: existing, triggeredBy, requestedAt: now, stageOnly });
   }
 
   const commitDate = commit.commit.author?.date ?? commit.commit.committer?.date ?? null;
@@ -91,6 +97,8 @@ async function upsertManualCheckRun({
       sha: canonicalSha,
       profile_id: repoData.profile_id,
       triggered_by: triggeredBy,
+      // `stage_only` is a newer column; cast until generated types are regenerated.
+      stage_only: stageOnly,
       status: {
         created_at: now,
         commit_author: commitAuthor,
@@ -98,7 +106,7 @@ async function upsertManualCheckRun({
         created_by: `manual trigger by ${triggeredBy}`,
         requested_at: now
       }
-    })
+    } as Database["public"]["Tables"]["repository_check_runs"]["Insert"])
     .select("*")
     .single();
   if (!insertError) {
@@ -119,14 +127,15 @@ async function upsertManualCheckRun({
       `Failed to recover raced repository check run insert: ${racedError?.message ?? "not found"}`
     );
   }
-  return await markCheckRunRequested({ adminSupabase, checkRun: raced, triggeredBy, requestedAt: now });
+  return await markCheckRunRequested({ adminSupabase, checkRun: raced, triggeredBy, requestedAt: now, stageOnly });
 }
 
 export async function handleRequest(
   req: Request,
   scope: Sentry.Scope
 ): Promise<{ message: string; repository_check_run_id: number }> {
-  const { repository, sha, class_id } = (await req.json()) as AutograderTriggerGradingWorkflowRequest;
+  const { repository, sha, class_id, stage_only } = (await req.json()) as AutograderTriggerGradingWorkflowRequest;
+  const stageOnly = stage_only === true;
   if (!repository || typeof repository !== "string" || !repository.includes("/")) {
     throw new SecurityError("Invalid repository");
   }
@@ -183,7 +192,8 @@ export async function handleRequest(
     adminSupabase,
     repoData,
     commit,
-    triggeredBy: enrollment.private_profile_id
+    triggeredBy: enrollment.private_profile_id,
+    stageOnly
   });
 
   await triggerWorkflow(repository, commit.sha, "grade.yml", scope);

--- a/supabase/migrations/20260604130000_regrade-late-commits-after-extension.sql
+++ b/supabase/migrations/20260604130000_regrade-late-commits-after-extension.sql
@@ -1,0 +1,610 @@
+-- Feature: Re-grade late commits after a deadline extension
+--
+-- When an instructor extends an assignment deadline, students who pushed code
+-- after the *original* deadline never got a graded submission (the autograder's
+-- deadline check rejected the push and no `submissions` row was created). This
+-- migration adds an instructor-driven workflow to surface those late commits,
+-- grade them in a "staged" (non-active, non-counting) state so a before/after
+-- score can be previewed, and then explicitly promote the chosen commit.
+--
+-- Design notes (decided with the requesting instructor):
+--   * Candidates = anyone who pushed in the (old_effective, new_effective] window,
+--     including students who already have an on-time submission.
+--   * One candidate commit per student/group: the latest push inside the window.
+--   * Promoting is always a manual, per-student instructor action. Lower scores
+--     are allowed but the UI requires an explicit per-row confirmation.
+--   * Only instructors (not graders) may enumerate/preview/apply, because this
+--     mutates real grades and notifies students.
+
+-- =====================================================================
+-- 1. Staging columns
+-- =====================================================================
+
+-- A "staged" submission is fully graded (real grader_results) but is NOT active
+-- and does NOT count toward the gradebook until an instructor promotes it.
+alter table public.submissions
+  add column if not exists is_staged boolean not null default false;
+comment on column public.submissions.is_staged is
+  'When true, this submission was created by the deadline-extension regrade flow. It is graded but never auto-activated; an instructor must explicitly promote it (which clears this flag and sets is_active).';
+
+-- Carried on the manually-triggered check run so autograder-create-submission
+-- knows to mark the resulting submission as staged (graded but not active).
+alter table public.repository_check_runs
+  add column if not exists stage_only boolean not null default false;
+comment on column public.repository_check_runs.stage_only is
+  'When true, a submission created from this check run is marked is_staged=true (deadline-extension regrade preview), instead of becoming the active submission.';
+
+-- Note: the existing partial unique indexes on submissions filter on
+-- `WHERE is_active = true`, and staged submissions are is_active=false, so no
+-- index changes are required - staged rows are naturally excluded.
+
+-- =====================================================================
+-- 2. Redefine the submissions insert hook to skip activation for staged rows
+--    (verbatim copy of the current body from
+--    20260424200000_prevent_dual_active_submissions.sql, with the two
+--    activation gates extended to also exclude is_staged submissions).
+-- =====================================================================
+CREATE OR REPLACE FUNCTION public.submissions_insert_hook_optimized()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  assigned_ordinal integer;
+  v_in_group boolean;
+  r RECORD;
+BEGIN
+  CASE TG_OP
+  WHEN 'INSERT' THEN
+    IF NEW.assignment_group_id IS NOT NULL THEN
+      INSERT INTO public.submission_ordinal_counters
+        (assignment_id, assignment_group_id, profile_id, next_ordinal, updated_at)
+      VALUES
+        (NEW.assignment_id::bigint,
+         NEW.assignment_group_id::bigint,
+         '00000000-0000-0000-0000-000000000000'::uuid,
+         2,
+         now())
+      ON CONFLICT (assignment_id, assignment_group_id, profile_id) DO UPDATE SET
+        next_ordinal = public.submission_ordinal_counters.next_ordinal + 1,
+        updated_at = now()
+      RETURNING (public.submission_ordinal_counters.next_ordinal - 1) INTO assigned_ordinal;
+
+      NEW.ordinal = assigned_ordinal;
+
+      -- Staged submissions are graded but never auto-activated; leave is_active
+      -- at its default (false) so the instructor controls promotion.
+      IF NEW.is_staged THEN
+        NEW.is_active = false;
+      ELSIF NOT NEW.is_not_graded THEN
+        NEW.is_active = true;
+        UPDATE public.submissions
+        SET is_active = false
+        WHERE assignment_id = NEW.assignment_id
+          AND assignment_group_id = NEW.assignment_group_id;
+
+        FOR r IN (
+          WITH demoted AS (
+            UPDATE public.submissions s
+            SET is_active = false
+            FROM public.assignment_groups_members agm
+            WHERE agm.assignment_id = NEW.assignment_id
+              AND agm.assignment_group_id = NEW.assignment_group_id
+              AND s.assignment_id = NEW.assignment_id
+              AND s.profile_id = agm.profile_id
+              AND s.assignment_group_id IS NULL
+              AND s.is_active = true
+            RETURNING s.profile_id
+          )
+          SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+          FROM demoted d
+          JOIN public.gradebook_column_students gcs ON gcs.student_id = d.profile_id
+          JOIN public.gradebook_columns gc
+            ON gc.id = gcs.gradebook_column_id
+           AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[NEW.assignment_id]::bigint[])
+        ) LOOP
+          PERFORM public.enqueue_gradebook_row_recalculation(
+            r.class_id, r.gradebook_id, r.student_id, r.is_private, 'group_submission_demote_individual', NULL
+          );
+        END LOOP;
+      END IF;
+    ELSE
+      IF NEW.profile_id IS NOT NULL THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.assignment_groups_members
+          WHERE assignment_id = NEW.assignment_id
+            AND profile_id = NEW.profile_id
+        ) INTO v_in_group;
+        IF v_in_group THEN
+          RAISE EXCEPTION
+            'Cannot create individual submission for profile % on assignment %: student is in an assignment group; submissions must go through the group repository.',
+            NEW.profile_id, NEW.assignment_id
+            USING ERRCODE = 'check_violation';
+        END IF;
+      END IF;
+
+      INSERT INTO public.submission_ordinal_counters
+        (assignment_id, assignment_group_id, profile_id, next_ordinal, updated_at)
+      VALUES
+        (NEW.assignment_id::bigint, 0::bigint, NEW.profile_id::uuid, 2, now())
+      ON CONFLICT (assignment_id, assignment_group_id, profile_id) DO UPDATE SET
+        next_ordinal = public.submission_ordinal_counters.next_ordinal + 1,
+        updated_at = now()
+      RETURNING (public.submission_ordinal_counters.next_ordinal - 1) INTO assigned_ordinal;
+
+      NEW.ordinal = assigned_ordinal;
+
+      IF NEW.is_staged THEN
+        NEW.is_active = false;
+      ELSIF NOT NEW.is_not_graded THEN
+        NEW.is_active = true;
+        UPDATE public.submissions
+        SET is_active = false
+        WHERE assignment_id = NEW.assignment_id
+          AND profile_id = NEW.profile_id;
+      END IF;
+    END IF;
+
+    RETURN NEW;
+  ELSE
+    RAISE EXCEPTION 'Unexpected TG_OP: "%". Should not occur!', TG_OP;
+  END CASE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.submissions_insert_hook_optimized() IS
+  'Assigns ordinals, manages is_active, rejects individual INSERT when the student is in a group, demotes straggler individual rows on new group submission and enqueues gradebook row recalc for demoted students. Staged submissions (is_staged=true) are graded but never auto-activated.';
+
+-- =====================================================================
+-- 3. Batch + candidate tables
+-- =====================================================================
+
+-- One row per "instructor extended a deadline -> review these late commits" session.
+create table if not exists public.deadline_regrade_batches (
+  id bigint generated by default as identity primary key,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  class_id bigint not null references public.classes(id) on delete cascade,
+  assignment_id bigint not null references public.assignments(id) on delete cascade,
+  created_by uuid references public.profiles(id),
+  old_due_date timestamptz not null,
+  new_due_date timestamptz not null,
+  -- open: awaiting instructor review; applied: at least one promotion done and closed;
+  -- dismissed: instructor closed without (further) action; superseded: replaced by a newer batch.
+  status text not null default 'open' check (status in ('open', 'applied', 'dismissed', 'superseded'))
+);
+create index if not exists deadline_regrade_batches_assignment_idx
+  on public.deadline_regrade_batches (assignment_id, status);
+create index if not exists deadline_regrade_batches_class_idx
+  on public.deadline_regrade_batches (class_id);
+
+-- One row per student/group candidate commit within a batch.
+create table if not exists public.deadline_regrade_candidates (
+  id bigint generated by default as identity primary key,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  batch_id bigint not null references public.deadline_regrade_batches(id) on delete cascade,
+  class_id bigint not null references public.classes(id) on delete cascade,
+  assignment_id bigint not null references public.assignments(id) on delete cascade,
+  profile_id uuid references public.profiles(id),
+  assignment_group_id bigint references public.assignment_groups(id),
+  repository_id bigint not null references public.repositories(id) on delete cascade,
+  repository text not null,
+  sha text not null,
+  commit_message text,
+  commit_date timestamptz,
+  -- Snapshot of the currently-active submission at enumeration time (for display).
+  current_submission_id bigint references public.submissions(id) on delete set null,
+  current_score numeric,
+  -- The staged (preview) submission created for this candidate, once graded.
+  staged_submission_id bigint references public.submissions(id) on delete set null,
+  staged_score numeric,
+  staged_status text not null default 'none' check (staged_status in ('none', 'grading', 'graded', 'error')),
+  staged_triggered_at timestamptz,
+  decision text not null default 'pending' check (decision in ('pending', 'applied', 'skipped'))
+);
+create index if not exists deadline_regrade_candidates_batch_idx
+  on public.deadline_regrade_candidates (batch_id);
+create unique index if not exists deadline_regrade_candidates_unique_target
+  on public.deadline_regrade_candidates (batch_id, repository_id);
+
+-- RLS: instructors read; all writes go through SECURITY DEFINER RPCs below.
+alter table public.deadline_regrade_batches enable row level security;
+alter table public.deadline_regrade_candidates enable row level security;
+
+drop policy if exists deadline_regrade_batches_instructor_select on public.deadline_regrade_batches;
+create policy deadline_regrade_batches_instructor_select
+  on public.deadline_regrade_batches for select
+  using (public.authorizeforclassinstructor(class_id));
+
+drop policy if exists deadline_regrade_candidates_instructor_select on public.deadline_regrade_candidates;
+create policy deadline_regrade_candidates_instructor_select
+  on public.deadline_regrade_candidates for select
+  using (public.authorizeforclassinstructor(class_id));
+
+-- =====================================================================
+-- 4. Enumerate candidates (creates a batch + candidate rows)
+-- =====================================================================
+create or replace function public.enumerate_deadline_regrade_candidates(
+  p_assignment_id bigint,
+  p_old_due_date timestamptz
+) returns bigint
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_class_id bigint;
+  v_new_due_date timestamptz;
+  v_creator uuid;
+  v_batch_id bigint;
+begin
+  select class_id, due_date into v_class_id, v_new_due_date
+  from public.assignments where id = p_assignment_id;
+  if v_class_id is null then
+    raise exception 'Assignment % not found', p_assignment_id;
+  end if;
+
+  if not public.authorizeforclassinstructor(v_class_id) then
+    raise exception 'Only instructors can enumerate deadline regrade candidates'
+      using errcode = 'insufficient_privilege';
+  end if;
+
+  if p_old_due_date is null or v_new_due_date is null or v_new_due_date <= p_old_due_date then
+    raise exception 'The assignment due date must be later than the supplied old due date to enumerate late commits';
+  end if;
+
+  select private_profile_id into v_creator
+  from public.user_roles
+  where user_id = auth.uid() and class_id = v_class_id
+  limit 1;
+
+  -- Supersede any prior open batch for this assignment so the dashboard only
+  -- surfaces the most recent review session.
+  update public.deadline_regrade_batches
+  set status = 'superseded', updated_at = now()
+  where assignment_id = p_assignment_id and status = 'open';
+
+  insert into public.deadline_regrade_batches
+    (class_id, assignment_id, created_by, old_due_date, new_due_date, status)
+  values (v_class_id, p_assignment_id, v_creator, p_old_due_date, v_new_due_date, 'open')
+  returning id into v_batch_id;
+
+  -- For each repository (one per student or group) compute the per-student
+  -- effective window and select the latest commit pushed inside it.
+  insert into public.deadline_regrade_candidates
+    (batch_id, class_id, assignment_id, profile_id, assignment_group_id,
+     repository_id, repository, sha, commit_message, commit_date,
+     current_submission_id, current_score, staged_status, decision)
+  select
+    v_batch_id, v_class_id, p_assignment_id, r.profile_id, r.assignment_group_id,
+    r.id, r.repository, cand.sha, cand.commit_message, cand.commit_date,
+    act.id, act.score, 'none', 'pending'
+  from public.repositories r
+  cross join lateral (
+    select public.calculate_final_due_date(p_assignment_id, r.profile_id, r.assignment_group_id) as new_eff
+  ) eff
+  cross join lateral (
+    -- old_effective = new_effective - (new_due - old_due). Assumes per-student
+    -- extensions and lab-meeting selection are unchanged by the due-date move,
+    -- which holds for the common (non-lab / within-window) case.
+    select eff.new_eff as new_eff,
+           eff.new_eff - (v_new_due_date - p_old_due_date) as old_eff
+  ) win
+  left join lateral (
+    select cr.sha, cr.commit_message,
+           coalesce((cr.status->>'commit_date')::timestamptz, cr.created_at) as commit_date
+    from public.repository_check_runs cr
+    where cr.repository_id = r.id
+      and coalesce((cr.status->>'commit_date')::timestamptz, cr.created_at) > win.old_eff
+      and coalesce((cr.status->>'commit_date')::timestamptz, cr.created_at) <= win.new_eff
+    order by coalesce((cr.status->>'commit_date')::timestamptz, cr.created_at) desc, cr.id desc
+    limit 1
+  ) cand on true
+  left join lateral (
+    select s.id, gr.score
+    from public.submissions s
+    left join public.grader_results gr
+      on gr.submission_id = s.id and gr.rerun_for_submission_id is null
+    where s.assignment_id = p_assignment_id
+      and s.is_active = true
+      and (
+        (r.assignment_group_id is not null and s.assignment_group_id = r.assignment_group_id)
+        or (r.assignment_group_id is null and s.profile_id = r.profile_id and s.assignment_group_id is null)
+      )
+    order by gr.id desc
+    limit 1
+  ) act on true
+  where r.assignment_id = p_assignment_id
+    and cand.sha is not null
+    -- skip when the candidate commit is already the active submission's commit
+    and (act.id is null or not exists (
+          select 1 from public.submissions s2 where s2.id = act.id and s2.sha = cand.sha
+        ));
+
+  return v_batch_id;
+end;
+$$;
+
+-- =====================================================================
+-- 5. Mark a candidate as grading (called right after the workflow is triggered)
+-- =====================================================================
+create or replace function public.regrade_set_candidate_grading(
+  p_candidate_id bigint
+) returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_class_id bigint;
+begin
+  select class_id into v_class_id
+  from public.deadline_regrade_candidates where id = p_candidate_id;
+  if v_class_id is null then
+    raise exception 'Regrade candidate % not found', p_candidate_id;
+  end if;
+  if not public.authorizeforclassinstructor(v_class_id) then
+    raise exception 'Only instructors can stage regrades' using errcode = 'insufficient_privilege';
+  end if;
+
+  update public.deadline_regrade_candidates
+  set staged_status = 'grading',
+      staged_triggered_at = now(),
+      updated_at = now()
+  where id = p_candidate_id and decision = 'pending';
+end;
+$$;
+
+-- =====================================================================
+-- 6. Backfill staged result when grading completes
+-- =====================================================================
+create or replace function public.regrade_backfill_staged_result()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_sub record;
+begin
+  -- Only care about primary (non-what-if) results attached to a submission.
+  if NEW.submission_id is null or NEW.rerun_for_submission_id is not null then
+    return NEW;
+  end if;
+
+  select id, assignment_id, sha, profile_id, assignment_group_id, is_staged
+  into v_sub
+  from public.submissions where id = NEW.submission_id;
+  if not found or not v_sub.is_staged then
+    return NEW;
+  end if;
+
+  update public.deadline_regrade_candidates c
+  set staged_submission_id = v_sub.id,
+      staged_score = NEW.score,
+      staged_status = 'graded',
+      updated_at = now()
+  from public.deadline_regrade_batches b
+  where c.batch_id = b.id
+    and b.status = 'open'
+    and c.assignment_id = v_sub.assignment_id
+    and c.sha = v_sub.sha
+    and c.decision = 'pending'
+    and (c.staged_submission_id is null or c.staged_submission_id = v_sub.id)
+    and (
+      (v_sub.assignment_group_id is not null and c.assignment_group_id = v_sub.assignment_group_id)
+      or (v_sub.assignment_group_id is null and c.profile_id = v_sub.profile_id)
+    );
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_regrade_backfill_staged_result on public.grader_results;
+create trigger trg_regrade_backfill_staged_result
+  after insert on public.grader_results
+  for each row execute function public.regrade_backfill_staged_result();
+
+-- =====================================================================
+-- 7. Apply (promote) a candidate's staged submission
+-- =====================================================================
+create or replace function public.apply_deadline_regrade(
+  p_candidate_id bigint
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_cand record;
+  v_staged_id bigint;
+  v_old_sub_id bigint;
+  v_old_score numeric;
+  v_creator uuid;
+  v_creator_name text;
+  r RECORD;
+begin
+  select * into v_cand from public.deadline_regrade_candidates where id = p_candidate_id;
+  if v_cand.id is null then
+    raise exception 'Regrade candidate % not found', p_candidate_id;
+  end if;
+  if not public.authorizeforclassinstructor(v_cand.class_id) then
+    raise exception 'Only instructors can apply regrades' using errcode = 'insufficient_privilege';
+  end if;
+  if v_cand.decision = 'applied' then
+    return jsonb_build_object('status', 'already_applied');
+  end if;
+  if v_cand.staged_submission_id is null then
+    raise exception 'Candidate % has no graded staged submission to promote yet', p_candidate_id;
+  end if;
+  v_staged_id := v_cand.staged_submission_id;
+
+  -- Capture the currently-active submission + autograder score (the "before").
+  select s.id, gr.score into v_old_sub_id, v_old_score
+  from public.submissions s
+  left join public.grader_results gr
+    on gr.submission_id = s.id and gr.rerun_for_submission_id is null
+  where s.assignment_id = v_cand.assignment_id
+    and s.is_active = true
+    and (
+      (v_cand.assignment_group_id is not null and s.assignment_group_id = v_cand.assignment_group_id)
+      or (v_cand.assignment_group_id is null and s.profile_id = v_cand.profile_id and s.assignment_group_id is null)
+    )
+  order by gr.id desc
+  limit 1;
+
+  -- Promote: deactivate prior active submission(s), activate + un-stage the candidate.
+  if v_cand.assignment_group_id is not null then
+    update public.submissions
+    set is_active = false
+    where assignment_id = v_cand.assignment_id
+      and assignment_group_id = v_cand.assignment_group_id
+      and id <> v_staged_id;
+  else
+    update public.submissions
+    set is_active = false
+    where assignment_id = v_cand.assignment_id
+      and profile_id = v_cand.profile_id
+      and assignment_group_id is null
+      and id <> v_staged_id;
+  end if;
+
+  update public.submissions
+  set is_active = true, is_staged = false
+  where id = v_staged_id;
+
+  update public.deadline_regrade_candidates
+  set decision = 'applied', current_submission_id = v_old_sub_id, current_score = v_old_score, updated_at = now()
+  where id = p_candidate_id;
+
+  -- Enqueue gradebook recalculation for affected student(s).
+  FOR r IN (
+    SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+    FROM public.gradebook_column_students gcs
+    JOIN public.gradebook_columns gc
+      ON gc.id = gcs.gradebook_column_id
+     AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[v_cand.assignment_id]::bigint[])
+    WHERE gcs.student_id IN (
+      SELECT v_cand.profile_id WHERE v_cand.profile_id IS NOT NULL
+      UNION
+      SELECT agm.profile_id FROM public.assignment_groups_members agm
+      WHERE v_cand.assignment_group_id IS NOT NULL
+        AND agm.assignment_group_id = v_cand.assignment_group_id
+    )
+  ) LOOP
+    PERFORM public.enqueue_gradebook_row_recalculation(
+      r.class_id, r.gradebook_id, r.student_id, r.is_private, 'deadline_extension_regrade_promote', NULL
+    );
+  END LOOP;
+
+  -- Notify the affected student(s) with the score differential + links.
+  select private_profile_id into v_creator
+  from public.user_roles where user_id = auth.uid() and class_id = v_cand.class_id limit 1;
+  select name into v_creator_name from public.profiles where id = v_creator;
+
+  insert into public.notifications (class_id, subject, body, style, user_id)
+  select
+    v_cand.class_id,
+    '{}'::jsonb,
+    jsonb_build_object(
+      'type', 'submission_regraded',
+      'action', 'promoted_after_extension',
+      'submission_id', v_staged_id,
+      'old_submission_id', v_old_sub_id,
+      'assignment_id', v_cand.assignment_id,
+      'old_score', v_old_score,
+      'new_score', v_cand.staged_score,
+      'regraded_by', v_creator,
+      'regraded_by_name', coalesce(v_creator_name, 'An instructor')
+    ),
+    'info',
+    ur.user_id
+  from public.user_roles ur
+  where ur.class_id = v_cand.class_id
+    and ur.role = 'student'
+    and ur.private_profile_id in (
+      SELECT v_cand.profile_id WHERE v_cand.profile_id IS NOT NULL
+      UNION
+      SELECT agm.profile_id FROM public.assignment_groups_members agm
+      WHERE v_cand.assignment_group_id IS NOT NULL
+        AND agm.assignment_group_id = v_cand.assignment_group_id
+    );
+
+  return jsonb_build_object(
+    'status', 'applied',
+    'old_submission_id', v_old_sub_id,
+    'new_submission_id', v_staged_id,
+    'old_score', v_old_score,
+    'new_score', v_cand.staged_score
+  );
+end;
+$$;
+
+-- =====================================================================
+-- 8. Skip a candidate / dismiss a batch
+-- =====================================================================
+create or replace function public.skip_deadline_regrade(
+  p_candidate_id bigint
+) returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_class_id bigint;
+begin
+  select class_id into v_class_id
+  from public.deadline_regrade_candidates where id = p_candidate_id;
+  if v_class_id is null then
+    raise exception 'Regrade candidate % not found', p_candidate_id;
+  end if;
+  if not public.authorizeforclassinstructor(v_class_id) then
+    raise exception 'Only instructors can skip regrades' using errcode = 'insufficient_privilege';
+  end if;
+  update public.deadline_regrade_candidates
+  set decision = 'skipped', updated_at = now()
+  where id = p_candidate_id and decision <> 'applied';
+end;
+$$;
+
+create or replace function public.dismiss_deadline_regrade_batch(
+  p_batch_id bigint,
+  p_status text default 'dismissed'
+) returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_class_id bigint;
+begin
+  if p_status not in ('dismissed', 'applied') then
+    raise exception 'Invalid batch status %', p_status;
+  end if;
+  select class_id into v_class_id
+  from public.deadline_regrade_batches where id = p_batch_id;
+  if v_class_id is null then
+    raise exception 'Regrade batch % not found', p_batch_id;
+  end if;
+  if not public.authorizeforclassinstructor(v_class_id) then
+    raise exception 'Only instructors can close regrade batches' using errcode = 'insufficient_privilege';
+  end if;
+  -- Unpromoted staged submissions are left in place: they are is_active=false
+  -- and invisible to students, and serve as an audit trail of what was previewed.
+  update public.deadline_regrade_batches
+  set status = p_status, updated_at = now()
+  where id = p_batch_id;
+end;
+$$;
+
+-- =====================================================================
+-- 9. Grants
+-- =====================================================================
+grant execute on function public.enumerate_deadline_regrade_candidates(bigint, timestamptz) to authenticated;
+grant execute on function public.regrade_set_candidate_grading(bigint) to authenticated;
+grant execute on function public.apply_deadline_regrade(bigint) to authenticated;
+grant execute on function public.skip_deadline_regrade(bigint) to authenticated;
+grant execute on function public.dismiss_deadline_regrade_batch(bigint, text) to authenticated;

--- a/tests/e2e/deadline-extension-regrade.spec.ts
+++ b/tests/e2e/deadline-extension-regrade.spec.ts
@@ -1,0 +1,266 @@
+import { Assignment, Course } from "@/utils/supabase/DatabaseTypes";
+// Pure data-layer test: import the base runner directly (no browser/page fixture).
+import { test, expect } from "@playwright/test";
+import { subDays } from "date-fns";
+import {
+  createAuthenticatedClient,
+  createClass,
+  createUserInClass,
+  getTestRunPrefix,
+  insertAssignment,
+  supabase,
+  TestingUser
+} from "@/tests/e2e/TestingUtils";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/utils/supabase/SupabaseTypes";
+
+// End-to-end coverage for the "re-grade late commits after a deadline extension"
+// feature (migration 20260604130000). Exercises the RPC lifecycle + the staging
+// trigger + the grader_results backfill trigger + notifications at the data
+// layer. One magic-link auth flow total (the instructor); each test gets a
+// fresh student + repository so tests are fully isolated.
+
+let course: Course;
+let instructor: TestingUser;
+let instructorClient: SupabaseClient<Database>;
+let assignment: Assignment;
+
+// per-test student + repo
+let student: TestingUser;
+let repoFullName: string;
+let repoId: number;
+
+const ADMIN = () => supabase as unknown as SupabaseClient<Database>;
+
+async function insertCheckRun(sha: string, message: string, daysAgo: number) {
+  const { error } = await ADMIN()
+    .from("repository_check_runs")
+    .insert({
+      class_id: course.id,
+      repository_id: repoId,
+      check_run_id: Math.floor(Math.random() * 1_000_000),
+      sha,
+      commit_message: message,
+      profile_id: student.private_profile_id,
+      status: { commit_date: subDays(new Date(), daysAgo).toISOString() }
+    } as Database["public"]["Tables"]["repository_check_runs"]["Insert"]);
+  if (error) throw new Error(`insert check run failed: ${error.message}`);
+}
+
+async function insertSubmission(sha: string, isStaged: boolean): Promise<number> {
+  const { data, error } = await ADMIN()
+    .from("submissions")
+    .insert({
+      assignment_id: assignment.id,
+      class_id: course.id,
+      profile_id: student.private_profile_id,
+      repository: repoFullName,
+      sha,
+      run_number: Math.floor(Math.random() * 1_000_000),
+      run_attempt: 1,
+      ...(isStaged ? { is_staged: true } : {})
+    } as Database["public"]["Tables"]["submissions"]["Insert"])
+    .select("id")
+    .single();
+  if (error) throw new Error(`insert submission failed: ${error.message}`);
+  return data!.id;
+}
+
+async function insertGraderResult(submissionId: number, score: number): Promise<void> {
+  const { error } = await ADMIN()
+    .from("grader_results")
+    .insert({
+      submission_id: submissionId,
+      class_id: course.id,
+      profile_id: student.private_profile_id,
+      score,
+      max_score: 100,
+      lint_output: "",
+      lint_output_format: "text",
+      lint_passed: true
+    } as Database["public"]["Tables"]["grader_results"]["Insert"]);
+  if (error) throw new Error(`insert grader_results failed: ${error.message}`);
+}
+
+async function candidatesForBatch(batchId: number) {
+  const { data, error } = await ADMIN()
+    .from("deadline_regrade_candidates")
+    .select("*")
+    .eq("batch_id", batchId);
+  if (error) throw new Error(error.message);
+  return data as unknown as Array<Record<string, unknown>>;
+}
+
+test.beforeAll(async () => {
+  const prefix = getTestRunPrefix();
+  course = await createClass({ name: `${prefix} Deadline Regrade Class` });
+  instructor = await createUserInClass({
+    role: "instructor",
+    class_id: course.id,
+    name: `${prefix} Instructor`,
+    useMagicLink: true
+  });
+  instructorClient = await createAuthenticatedClient(instructor);
+  // The "extended" deadline is now.
+  assignment = await insertAssignment({
+    due_date: new Date().toUTCString(),
+    class_id: course.id,
+    name: `${prefix} Assignment`
+  });
+});
+
+test.beforeEach(async () => {
+  // Fresh student + repo per test (no magic link needed — service role drives data).
+  const p = getTestRunPrefix(Math.random().toString(36).slice(2, 8));
+  student = await createUserInClass({ role: "student", class_id: course.id, name: `${p} Student` });
+  repoFullName = `${p}/repo`;
+  const { data: repo, error } = await ADMIN()
+    .from("repositories")
+    .insert({
+      assignment_id: assignment.id,
+      class_id: course.id,
+      repository: repoFullName,
+      profile_id: student.private_profile_id,
+      is_github_ready: true
+    } as Database["public"]["Tables"]["repositories"]["Insert"])
+    .select("id")
+    .single();
+  if (error) throw new Error(`insert repository failed: ${error.message}`);
+  repoId = repo!.id;
+});
+
+test.describe("Deadline-extension regrade", () => {
+  test("enumerate finds the in-window late commit, excludes out-of-window, and is gated to instructors", async () => {
+    const oldDue = subDays(new Date(), 2).toISOString();
+    await insertCheckRun("newcommit1", "late work", 1); // inside (old, new]
+    await insertCheckRun("oldcommit0", "old work", 5); // before old deadline -> excluded
+
+    // Non-instructor (service role -> auth.uid() null) is blocked.
+    const blocked = await ADMIN().rpc("enumerate_deadline_regrade_candidates" as never, {
+      p_assignment_id: assignment.id,
+      p_old_due_date: oldDue
+    } as never);
+    expect(blocked.error).not.toBeNull();
+
+    // Instructor enumerates -> exactly the in-window commit.
+    const { data: batchId, error } = await instructorClient.rpc("enumerate_deadline_regrade_candidates" as never, {
+      p_assignment_id: assignment.id,
+      p_old_due_date: oldDue
+    } as never);
+    expect(error).toBeNull();
+    expect(batchId).not.toBeNull();
+
+    const cands = (await candidatesForBatch(batchId as unknown as number)).filter(
+      (c) => c.profile_id === student.private_profile_id
+    );
+    expect(cands).toHaveLength(1);
+    expect(cands[0].sha).toBe("newcommit1");
+  });
+
+  test("staged grading does not activate; backfill records the score; apply promotes + notifies", async () => {
+    const oldDue = subDays(new Date(), 2).toISOString();
+
+    // Baseline on-time submission scoring 50.
+    const currentSubId = await insertSubmission("oldsha50", false);
+    await insertGraderResult(currentSubId, 50);
+
+    // A later commit inside the window.
+    await insertCheckRun("latesha80", "improved work", 1);
+
+    const { data: batchId } = await instructorClient.rpc("enumerate_deadline_regrade_candidates" as never, {
+      p_assignment_id: assignment.id,
+      p_old_due_date: oldDue
+    } as never);
+    const candidate = (await candidatesForBatch(batchId as unknown as number)).find(
+      (c) => c.profile_id === student.private_profile_id
+    )!;
+    expect(candidate.current_submission_id).toBe(currentSubId);
+    expect(Number(candidate.current_score)).toBe(50);
+
+    // Simulate the staged grading run: a staged submission + its grader_result.
+    const stagedSubId = await insertSubmission("latesha80", true);
+
+    // Staging trigger: staged must NOT be active; baseline stays active.
+    const { data: stagedRow } = await ADMIN()
+      .from("submissions")
+      .select("is_active, is_staged")
+      .eq("id", stagedSubId)
+      .single();
+    expect((stagedRow as { is_active: boolean }).is_active).toBe(false);
+    expect((stagedRow as { is_staged: boolean }).is_staged).toBe(true);
+    const { data: baselineRow } = await ADMIN()
+      .from("submissions")
+      .select("is_active")
+      .eq("id", currentSubId)
+      .single();
+    expect((baselineRow as { is_active: boolean }).is_active).toBe(true);
+
+    // grader_results insert fires the backfill trigger.
+    await insertGraderResult(stagedSubId, 80);
+    const afterBackfill = (await candidatesForBatch(batchId as unknown as number)).find(
+      (c) => c.id === candidate.id
+    )!;
+    expect(afterBackfill.staged_status).toBe("graded");
+    expect(afterBackfill.staged_submission_id).toBe(stagedSubId);
+    expect(Number(afterBackfill.staged_score)).toBe(80);
+
+    // Instructor promotes.
+    const { data: applyResult, error: applyErr } = await instructorClient.rpc("apply_deadline_regrade" as never, {
+      p_candidate_id: candidate.id
+    } as never);
+    expect(applyErr).toBeNull();
+    expect((applyResult as { status: string }).status).toBe("applied");
+
+    // Staged is now active + un-staged; old one inactive.
+    const { data: promoted } = await ADMIN()
+      .from("submissions")
+      .select("is_active, is_staged")
+      .eq("id", stagedSubId)
+      .single();
+    expect((promoted as { is_active: boolean }).is_active).toBe(true);
+    expect((promoted as { is_staged: boolean }).is_staged).toBe(false);
+    const { data: demoted } = await ADMIN()
+      .from("submissions")
+      .select("is_active")
+      .eq("id", currentSubId)
+      .single();
+    expect((demoted as { is_active: boolean }).is_active).toBe(false);
+
+    // Student got a submission_regraded notification with the differential.
+    const { data: notifs } = await ADMIN()
+      .from("notifications")
+      .select("body, user_id")
+      .eq("user_id", student.user_id);
+    const regradeNotif = (notifs ?? []).find((n) => (n.body as { type?: string }).type === "submission_regraded");
+    expect(regradeNotif).toBeTruthy();
+    const body = regradeNotif!.body as { old_score: number; new_score: number; submission_id: number };
+    expect(Number(body.old_score)).toBe(50);
+    expect(Number(body.new_score)).toBe(80);
+    expect(body.submission_id).toBe(stagedSubId);
+  });
+
+  test("skip marks the candidate skipped", async () => {
+    const oldDue = subDays(new Date(), 2).toISOString();
+    await insertCheckRun("skipsha", "late", 1);
+
+    const { data: batchId } = await instructorClient.rpc("enumerate_deadline_regrade_candidates" as never, {
+      p_assignment_id: assignment.id,
+      p_old_due_date: oldDue
+    } as never);
+    const candidateId = (await candidatesForBatch(batchId as unknown as number)).find(
+      (c) => c.profile_id === student.private_profile_id
+    )!.id as number;
+
+    const { error: skipErr } = await instructorClient.rpc("skip_deadline_regrade" as never, {
+      p_candidate_id: candidateId
+    } as never);
+    expect(skipErr).toBeNull();
+
+    const { data: skipped } = await ADMIN()
+      .from("deadline_regrade_candidates")
+      .select("decision")
+      .eq("id", candidateId)
+      .single();
+    expect((skipped as { decision: string }).decision).toBe("skipped");
+  });
+});


### PR DESCRIPTION
When an instructor extends an assignment deadline, students who pushed after the original deadline never got a graded submission. This adds an instructor-driven flow to surface those late commits, preview a before/after score, and explicitly promote chosen commits. Grade changes are never automatic.

Backend (migration 20260604130000):
- submissions.is_staged + repository_check_runs.stage_only columns; the submissions insert hook leaves staged submissions graded-but-inactive (mirrors the is_not_graded carve-out).
- deadline_regrade_batches / deadline_regrade_candidates tables (instructor RLS).
- RPCs: enumerate_deadline_regrade_candidates, regrade_set_candidate_grading, apply_deadline_regrade (promote + gradebook recalc + student notification), skip_deadline_regrade, dismiss_deadline_regrade_batch.
- grader_results trigger backfills staged scores.

Edge functions:
- autograder-trigger-grading-workflow threads stage_only onto the check run; autograder-create-submission marks the resulting submission is_staged.

Frontend:
- lib/deadlineRegrade.ts wrappers; review page (before/after table, Grade/Promote/Skip, lower-score confirm, polling); editor post-save "re-grade late commits?" dialog; dashboard banner; submission_regraded notification type.

Tests: tests/e2e/deadline-extension-regrade.spec.ts covers enumerate, instructor gating, staging trigger, backfill trigger, apply (promote + before/after + notification), and skip.

Fixes #467 