### PR TITLE
ci(staging): auto-build + deploy on push to staging

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -13,7 +13,7 @@ name: Release images
 #   - workflow_dispatch    → manual, with optional hostname/version overrides
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     tags: ["v*"]
   workflow_dispatch:
     inputs:
@@ -108,7 +108,7 @@ jobs:
     # cluster's JWT_SECRET, so a static copy drifts the moment the bundle is
     # rotated and silently breaks browser login (gateway 401). Reading it from
     # the cluster at build time guarantees build == runtime.
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging'
     steps:
       - uses: actions/checkout@v5
 
@@ -310,3 +310,62 @@ jobs:
           set -euo pipefail
           helm push pawtograder-${{ needs.meta.outputs.chart_version }}.tgz \
             oci://${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/charts
+
+  # Auto-roll the long-lived staging environment forward to the images this
+  # push just built. This is the piece that was missing: release-images used to
+  # only build+push, leaving staging on hand-tagged `staging-manual-*` images
+  # that someone had to `helm upgrade` by hand. Now every push to `staging`
+  # deploys itself.
+  #
+  # NON-DESTRUCTIVE on purpose: a plain `helm upgrade` (no uninstall, no PVC
+  # delete). The wipe-and-reinstall flow lives in scripts/redeploy-staging.sh
+  # and is never run from CI. The per-revision migrations Job runs as part of
+  # the upgrade and `--wait` blocks until it — and every Deployment — is
+  # healthy, so a failed migration or rollout turns this job red.
+  deploy-staging:
+    needs: [meta, build-web, build-edge-functions, build-migrations]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    runs-on: ubuntu-latest
+    # Serialize deploys so two staging pushes landing close together can't run
+    # overlapping `helm upgrade`s against the same release.
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_BASE64 }}
+        run: |
+          set -euo pipefail
+          [ -n "$KUBECONFIG_B64" ] || { echo "::error::KUBECONFIG_BASE64 secret is required to deploy staging"; exit 1; }
+          mkdir -p "$HOME/.kube"
+          echo "$KUBECONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: helm upgrade pawtograder (staging)
+        # helm/kubectl pick up $HOME/.kube/config (written above) by default.
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Pin all three app images to the exact tag built from this SHA
+          # (staging-<sha>) for traceability + easy rollback, overriding the
+          # defaults in values-staging.yaml.
+          helm upgrade --install pawtograder charts/pawtograder \
+            --namespace pawtograder-staging \
+            -f charts/pawtograder/examples/values-staging.yaml \
+            --set web.image.tag="$VERSION" \
+            --set edgeFunctions.image.tag="$VERSION" \
+            --set migrations.image.tag="$VERSION" \
+            --wait \
+            --timeout 15m
+
+      - name: Post-deploy status
+        if: always()
+        run: helm status pawtograder -n pawtograder-staging --kubeconfig "$HOME/.kube/config" || true

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -333,6 +333,10 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
+        with:
+          # This job handles cluster credentials; no later step needs the git
+          # token, so don't leave it persisted in .git/config.
+          persist-credentials: false
 
       - uses: azure/setup-helm@v4
         with:
@@ -364,6 +368,7 @@ jobs:
             --set edgeFunctions.image.tag="$VERSION" \
             --set migrations.image.tag="$VERSION" \
             --wait \
+            --wait-for-jobs \
             --timeout 15m
 
       - name: Post-deploy status

--- a/charts/pawtograder/dashboards/edge-functions.json
+++ b/charts/pawtograder/dashboards/edge-functions.json
@@ -18,6 +18,18 @@
         "current": { "selected": false, "text": "All", "value": "$__all" },
         "includeAll": true,
         "multi": true
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace (logs)",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values(namespace)",
+        "regex": "/pawtograder-.*/",
+        "refresh": 1,
+        "current": { "selected": true, "text": "pawtograder-staging", "value": "pawtograder-staging" },
+        "includeAll": false,
+        "multi": false
       }
     ]
   },
@@ -156,6 +168,31 @@
         }
       ],
       "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "id": 40,
+      "type": "logs",
+      "title": "Logs — $namespace / $fn",
+      "description": "Edge-function stdout from Loki, filtered to the selected function(s) via the [fn=<name>] tag stamped by the demuxer (main.ts) and wrapRequestHandler. Pick a single $fn to isolate one function.",
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 38 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "editorMode": "code",
+          "queryType": "range",
+          "expr": "{namespace=\"$namespace\", component=\"functions\"} |~ \"\\[fn=(${fn:pipe})\\]\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
     }
   ]
 }

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -174,22 +174,13 @@ edgeFunctions:
     targetCPUUtilizationPercentage: 200
   image:
     repository: ghcr.io/pawtograder/edge-functions
-    # STOPGAP: helm-branch build carrying the self-hosted edge fixes that
-    # `main-latest` lacks: (a) REDIS_URL/ioredis in _shared/Redis.ts; (b)
-    # GitHubWrapper.toPublicSupabaseUrl() (grader signed-URL host rebase, else
-    # the runner hits "ENOTFOUND pawtograder-kong"); (c) the main.ts worker
-    # lifecycle — retry retired workers, 2s CPU soft limit, and lowMemoryMultiplier
-    # early-drop; (d) **eszip bundling** — every function is pre-compiled into a
-    # vendored .eszip at image build, so each isolate loads a ready-to-run module
-    # graph instead of fetching remote deps + running the Deno transpiler per
-    # isolate. Measured: heavy autograder-create-submission dropped from ~150–250MB
-    # to ~16–20MB marginal per isolate (4 isolates: 243MB→100MB), which is what
-    # lets the 256MB cap actually hold under burst — matching supabase.com.
-    # (e) create-submission size guard — reject repos whose zipball/unzipped
-    # size exceeds MAX_SUBMISSION_ZIP_MB/UNZIPPED_MB before the in-isolate unzip,
-    # so a repo with committed build artifacts can't OOM the worker.
-    # Track helm until #741 merges, then main-latest.
-    tag: helm-d3828e1f-eszip-redisfix
+    # Tracks the latest image built from the `staging` branch by
+    # release-images.yml (the deploy-staging job pins the exact staging-<sha>
+    # at deploy time; this default is what manual `redeploy-staging.sh` runs
+    # pick up). All the self-hosted edge fixes that used to require a hand-built
+    # helm-branch image (REDIS_URL/ioredis, signed-URL host rebase, worker
+    # lifecycle limits, eszip bundling, submission size guard) are on staging.
+    tag: staging-latest
   # Worker limits inherit the chart defaults (256 MB isolate, 400s lifetime,
   # 2s/5s CPU), matching supabase.com. With eszip bundling the per-isolate
   # baseline sits ~10x below the 256MB cap, so per_request isolation is cheap
@@ -210,14 +201,13 @@ edgeFunctions:
 web:
   image:
     repository: ghcr.io/pawtograder/web
-    # STOPGAP: locally-built image that (a) bakes the CURRENT cluster anon key
-    # (`main-latest` ships a stale baked NEXT_PUBLIC_SUPABASE_ANON_KEY and 401s
-    # browser login, since NEXT_PUBLIC_* is build-time inlined) and (b) ships the
-    # shared Redis-backed Next.js cache handler (cache-handler.cjs) so
-    # revalidateTag() invalidates across all web replicas. Once release-images.yml
-    # (now reads the anon key from the cluster) produces a fresh main-latest with
-    # the cache-handler change merged, switch this back to `main-latest`.
-    tag: staging-manual-95aeb6c3-ssrcache
+    # Tracks the latest image built from the `staging` branch. release-images.yml
+    # reads the CURRENT cluster anon key at build time (so the build-time-inlined
+    # NEXT_PUBLIC_SUPABASE_ANON_KEY can't drift and 401 browser login), and the
+    # shared Redis-backed Next.js cache handler (cache-handler.cjs, so
+    # revalidateTag() invalidates across all web replicas) is on staging. The
+    # deploy-staging job pins the exact staging-<sha> at deploy time.
+    tag: staging-latest
   envFromSecrets:
     - pawtograder-github-app
     - pawtograder-discord
@@ -232,10 +222,10 @@ web:
 migrations:
   image:
     repository: ghcr.io/pawtograder/migrations
-    # STOPGAP: helm-branch build — `main-latest` is missing the helm-branch
-    # migrations (workflow_metrics_rpcs, dashboard RPCs, assessment_export_pepper,
-    # rubric visibility, etc.). Track helm until #741 merges, then main-latest.
-    tag: helm-2fe9ca9
+    # Tracks the latest image built from the `staging` branch (the deploy-staging
+    # job pins the exact staging-<sha> at deploy time). Carries all migrations
+    # through staging HEAD.
+    tag: staging-latest
   # Never set resetOnDrift here — staging data is durable, drift means
   # something's wrong and we want the deploy to fail loudly.
 

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -62,6 +62,15 @@ const ESZIP_DIR = Deno.env.get("EDGE_ESZIP_DIR") || "/home/deno/eszips";
 // Bound the retry recursion so a genuinely broken function can't loop forever.
 const MAX_RETIRED_RETRIES = 5;
 
+// Per-request access log: one line per request tagged with the function name so
+// logs are filterable BY function in Loki/Grafana/`scripts/edge-logs.sh`
+// (`{component="functions"} |= "[fn=<name>]"`). All functions land in this one
+// pod's stdout behind the demuxer, so without this tag you can't isolate one.
+// `<name>` here is `serviceName` (the path segment) and matches the Prometheus
+// `function` label (deno_http_requests_total{function=...}) the dashboard's $fn
+// dropdown is built from. Set EDGE_ACCESS_LOG=0 to silence it (no rebuild).
+const ACCESS_LOG = (Deno.env.get("EDGE_ACCESS_LOG") ?? "1") !== "0";
+
 // Cache of loaded eszip bytes, keyed by function name. The value is a Promise
 // so concurrent first-requests for the same function share a single disk read
 // rather than each allocating their own ~40MB buffer (which under a 50-burst
@@ -126,7 +135,14 @@ Deno.serve(async (req: Request) => {
       cpuTimeHardLimitMs: CPU_HARD_MS,
       noModuleCache: false,
       importMapPath: null,
-      envVars
+      // Tell the isolate which function it's serving so its own logs can be
+      // tagged (see _shared/HandlerUtils.ts). Passed as an env var rather than a
+      // request header so the request object handed to worker.fetch() is left
+      // completely untouched — reconstructing the Request breaks functions that
+      // rely on its underlying stream resource (e.g. `metrics`). Safe because
+      // the worker is created against this function's servicePath, so it only
+      // ever serves `serviceName`.
+      envVars: [...envVars, ["EDGE_FUNCTION_NAME", serviceName] as [string, string]]
     };
     if (eszip) {
       // Pre-bundled path: load the vendored, pre-transpiled module graph from
@@ -170,7 +186,7 @@ Deno.serve(async (req: Request) => {
       // Log the real error server-side, but return a fixed generic message — the
       // raw error can carry worker/runtime internals (paths, stack frames) and
       // this gateway is public-facing (CodeQL: information exposure via stack trace).
-      console.error(`error invoking ${serviceName}:`, e);
+      console.error(`[fn=${serviceName}] error invoking ${serviceName}:`, e);
       return new Response(JSON.stringify({ msg: "internal edge function error" }), {
         status: 500,
         headers: { "content-type": "application/json" }
@@ -178,5 +194,10 @@ Deno.serve(async (req: Request) => {
     }
   };
 
-  return await callWorker();
+  const startedAt = Date.now();
+  const res = await callWorker();
+  if (ACCESS_LOG) {
+    console.log(`[fn=${serviceName}] ${req.method} ${url.pathname} -> ${res.status} ${Date.now() - startedAt}ms`);
+  }
+  return res;
 });

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Build the edge-functions image from THIS checkout and roll it out to a
+# pawtograder environment (staging or a PR preview) — without a full
+# release-images pipeline run. For fast iteration on supabase/functions/.
+#
+# It rebuilds charts/pawtograder/images/edge-functions/Dockerfile (the eszip
+# bundle + demuxer main service), pushes a unique tag to ghcr, then patches the
+# `functions` Deployment via `kubectl set image` and waits for the rollout.
+# Surgical: it touches ONLY the functions Deployment — not web/migrations/db.
+#
+# Usage:
+#   scripts/deploy-edge-functions.sh                    # -> staging
+#   scripts/deploy-edge-functions.sh --preview 815      # -> pawtograder-preview-pr-815
+#   scripts/deploy-edge-functions.sh --namespace pawtograder-staging
+#   scripts/deploy-edge-functions.sh --tag mytag --no-build   # deploy an existing tag
+#   scripts/deploy-edge-functions.sh --repo /path/to/checkout # build a different checkout
+#   scripts/deploy-edge-functions.sh -y                 # skip confirmation
+#
+# Caveat: this is a live patch of the Deployment, NOT a Helm release. The next
+# `helm upgrade` (including staging auto-deploy on push) resets the image to the
+# chart's edgeFunctions.image.tag. Use it to iterate; land real changes via the
+# branch + release-images pipeline.
+#
+# Requires: docker (logged in to ghcr, or a gh token so it can log in), kubectl,
+# git. Assumes KUBECONFIG points at the cluster.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/cluster-env.sh
+. "${SCRIPT_DIR}/lib/cluster-env.sh"
+
+REGISTRY="ghcr.io"
+IMAGE_REPO="ghcr.io/pawtograder/edge-functions"
+DEPLOYMENT="pawtograder-functions"
+CONTAINER="functions"
+
+env="" preview="" namespace="" tag="" repo="" do_build=1 auto_yes=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env)          env="$2"; shift 2 ;;
+    --preview)      preview="$2"; shift 2 ;;
+    --namespace|-n) namespace="$2"; shift 2 ;;
+    --tag)          tag="$2"; shift 2 ;;
+    --repo|-C)      repo="$2"; shift 2 ;;
+    --no-build)     do_build=0; shift ;;
+    -y|--yes)       auto_yes=1; shift ;;
+    -h|--help)      grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+require docker; require kubectl; require git
+NAMESPACE="$(resolve_namespace "$env" "$preview" "$namespace")"
+
+# Repo root to build from (the "given checkout"): --repo, else this script's repo.
+REPO_ROOT="${repo:-$(cd "$SCRIPT_DIR/.." && git rev-parse --show-toplevel)}"
+DOCKERFILE="${REPO_ROOT}/charts/pawtograder/images/edge-functions/Dockerfile"
+[ -f "$DOCKERFILE" ] || { echo "not a pawtograder checkout: ${REPO_ROOT}" >&2; exit 1; }
+
+SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo nogit)"
+DIRTY=""; git -C "$REPO_ROOT" diff --quiet 2>/dev/null || DIRTY="-dirty"
+# Default tag is unique per run. The Deployment's imagePullPolicy is
+# IfNotPresent, so a brand-new tag is what actually forces nodes to pull the
+# rebuilt image. Slug the namespace so preview tags stay readable.
+SLUG="$(printf '%s' "$NAMESPACE" | sed 's/^pawtograder-//; s/[^a-zA-Z0-9]/-/g')"
+STAMP="$(date -u +%Y%m%d%H%M%S)"
+TAG="${tag:-${SLUG}-fns-${SHA}${DIRTY}-${STAMP}}"
+IMAGE_REF="${IMAGE_REPO}:${TAG}"
+
+assert_namespace "$NAMESPACE"
+kubectl get deploy "$DEPLOYMENT" -n "$NAMESPACE" >/dev/null 2>&1 \
+  || { echo "deployment ${DEPLOYMENT} not found in ${NAMESPACE} — is the env deployed?" >&2; exit 1; }
+
+cat <<EOF
+Redeploy edge functions
+  checkout    : ${REPO_ROOT} (HEAD ${SHA}${DIRTY})
+  namespace   : ${NAMESPACE}
+  deployment  : ${DEPLOYMENT} (container ${CONTAINER})
+  image       : ${IMAGE_REF}
+  build       : $([ "$do_build" -eq 1 ] && echo yes || echo 'no (reuse existing tag)')
+EOF
+if [ "$auto_yes" -ne 1 ]; then
+  read -r -p "Proceed? [y/N] " r
+  case "$r" in [yY]|[yY][eE][sS]) ;; *) echo aborted; exit 1 ;; esac
+fi
+
+if [ "$do_build" -eq 1 ]; then
+  # Make sure we can push to ghcr. Non-interactive: if a gh token is around,
+  # use it; otherwise rely on an existing docker login and let push surface a
+  # clear error if there isn't one.
+  if command -v gh >/dev/null 2>&1; then
+    gh auth token 2>/dev/null \
+      | docker login "$REGISTRY" -u "$(gh api user --jq .login 2>/dev/null || echo x)" --password-stdin >/dev/null 2>&1 || true
+  fi
+  echo "==> docker build (eszip bundle) — this takes a few minutes…"
+  docker build \
+    -f "$DOCKERFILE" \
+    -t "$IMAGE_REF" \
+    --build-arg GIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)" \
+    --build-arg VERSION="$TAG" \
+    "$REPO_ROOT"
+  echo "==> docker push ${IMAGE_REF}"
+  docker push "$IMAGE_REF"
+fi
+
+echo "==> kubectl set image ${DEPLOYMENT} ${CONTAINER}=${IMAGE_REF}"
+kubectl set image "deploy/${DEPLOYMENT}" "${CONTAINER}=${IMAGE_REF}" -n "$NAMESPACE"
+echo "==> waiting for rollout…"
+kubectl rollout status "deploy/${DEPLOYMENT}" -n "$NAMESPACE" --timeout=5m
+
+echo
+echo "Done. ${DEPLOYMENT} in ${NAMESPACE} now runs ${IMAGE_REF}"
+echo "Note: a later 'helm upgrade' / staging auto-deploy resets this to the chart's tag."

--- a/scripts/deploy-edge-functions.sh
+++ b/scripts/deploy-edge-functions.sh
@@ -49,6 +49,14 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# --no-build deploys an existing tag; without --tag the default tag is freshly
+# generated and won't exist in the registry, which would patch the Deployment to
+# an unpullable image and take functions down. Require an explicit tag.
+if [ "$do_build" -eq 0 ] && [ -z "$tag" ]; then
+  echo "--no-build requires --tag <existing-image-tag>" >&2
+  exit 2
+fi
+
 require docker; require kubectl; require git
 NAMESPACE="$(resolve_namespace "$env" "$preview" "$namespace")"
 

--- a/scripts/edge-logs.sh
+++ b/scripts/edge-logs.sh
@@ -70,15 +70,24 @@ if [ "$follow" -eq 1 ] && ! command -v logcli >/dev/null 2>&1; then
 fi
 
 # Otherwise query Loki. Open the tunnel; clean up on exit.
+# Refuse to proceed if the port is already taken — otherwise the readiness probe
+# below would "succeed" against an unrelated process and we'd query the wrong thing.
+if (exec 9<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then
+  exec 9>&- 9<&-
+  echo "local port ${localport} is already in use; pass --port <free-port>" >&2
+  exit 1
+fi
 echo "==> port-forward ${LOKI_NS}/svc/${LOKI_SVC} -> 127.0.0.1:${localport}  (query: ${LOGQL})" >&2
 kubectl port-forward -n "$LOKI_NS" "svc/${LOKI_SVC}" "${localport}:${LOKI_PORT}" >/dev/null 2>&1 &
 PF_PID=$!
 cleanup() { kill "$PF_PID" 2>/dev/null || true; }
 trap cleanup EXIT INT TERM
+up=0
 for _ in $(seq 1 50); do
-  if (exec 3<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then exec 3>&- 3<&-; up=1; break; fi
   sleep 0.2
 done
+[ "$up" = 1 ] || { echo "Loki tunnel never came up on :${localport}" >&2; exit 1; }
 
 ADDR="http://127.0.0.1:${localport}"
 

--- a/scripts/edge-logs.sh
+++ b/scripts/edge-logs.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Tail/query edge-function logs from Loki, filtered BY function name.
+#
+# All ~49 functions share one pod's stdout behind the demuxer, but each line is
+# tagged `[fn=<name>]` (by main.ts + _shared/HandlerUtils.ts), so this isolates a
+# single function across all replicas + history. Loki has no external ingress, so
+# this port-forwards svc/loki in the monitoring namespace and tears it down on exit.
+#
+# Usage (target defaults to staging):
+#   scripts/edge-logs.sh --function autograder-create-submission
+#   scripts/edge-logs.sh --preview 815 --function discord-async-worker --follow
+#   scripts/edge-logs.sh --function grade-submission --since 6h --grep error
+#   scripts/edge-logs.sh                       # all functions, last 1h
+#
+# Target: --env staging | --preview <id> | --namespace <ns>
+# Filter: --function <name>  --grep <text>  --since <dur, e.g. 30m/6h/2d>  --limit <n>
+#         --follow   (live tail)
+#
+# Requires: kubectl, jq. Uses `logcli` if installed (nicer paging/tail), else
+# curl against the Loki HTTP API (and `kubectl logs -f` for --follow).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/cluster-env.sh
+. "${SCRIPT_DIR}/lib/cluster-env.sh"
+
+LOKI_NS="monitoring"
+LOKI_SVC="loki"
+LOKI_PORT=3100
+
+env="" preview="" namespace="" function="" grep_text="" since="1h" limit=200 follow=0 localport=3100
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env)          env="$2"; shift 2 ;;
+    --preview)      preview="$2"; shift 2 ;;
+    --namespace|-n) namespace="$2"; shift 2 ;;
+    --function|-f)  function="$2"; shift 2 ;;
+    --grep)         grep_text="$2"; shift 2 ;;
+    --since)        since="$2"; shift 2 ;;
+    --limit)        limit="$2"; shift 2 ;;
+    --port)         localport="$2"; shift 2 ;;
+    --follow)       follow=1; shift ;;
+    -h|--help)      grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+require kubectl; require jq
+NAMESPACE="$(resolve_namespace "$env" "$preview" "$namespace")"
+assert_namespace "$NAMESPACE"
+
+# Build the LogQL stream selector + line filters.
+LOGQL="{namespace=\"${NAMESPACE}\", component=\"functions\"}"
+[ -n "$function" ]  && LOGQL="${LOGQL} |= \"[fn=${function}]\""
+[ -n "$grep_text" ] && LOGQL="${LOGQL} |= \"${grep_text}\""
+
+# --follow with no logcli: fall back to live pod logs (no history, but no tunnel
+# needed). grep the same tags so the UX matches.
+if [ "$follow" -eq 1 ] && ! command -v logcli >/dev/null 2>&1; then
+  echo "==> logcli not found; live-tailing pod stdout via kubectl (no history)" >&2
+  if [ -n "$function" ] || [ -n "$grep_text" ]; then
+    pat="${function:+[fn=${function}]}"
+    kubectl logs -f "deploy/pawtograder-functions" -n "$NAMESPACE" --max-log-requests=10 --prefix=false \
+      | { [ -n "$pat" ] && grep --line-buffered -F "$pat" || cat; } \
+      | { [ -n "$grep_text" ] && grep --line-buffered -F "$grep_text" || cat; }
+  else
+    kubectl logs -f "deploy/pawtograder-functions" -n "$NAMESPACE" --max-log-requests=10 --prefix=false
+  fi
+  exit 0
+fi
+
+# Otherwise query Loki. Open the tunnel; clean up on exit.
+echo "==> port-forward ${LOKI_NS}/svc/${LOKI_SVC} -> 127.0.0.1:${localport}  (query: ${LOGQL})" >&2
+kubectl port-forward -n "$LOKI_NS" "svc/${LOKI_SVC}" "${localport}:${LOKI_PORT}" >/dev/null 2>&1 &
+PF_PID=$!
+cleanup() { kill "$PF_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+for _ in $(seq 1 50); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+  sleep 0.2
+done
+
+ADDR="http://127.0.0.1:${localport}"
+
+if command -v logcli >/dev/null 2>&1; then
+  if [ "$follow" -eq 1 ]; then
+    exec logcli --addr="$ADDR" query --tail "$LOGQL"
+  fi
+  exec logcli --addr="$ADDR" query --since="$since" --limit="$limit" --forward --no-labels "$LOGQL"
+fi
+
+# curl + jq path. Loki query_range wants ns timestamps; compute start from --since.
+dur_to_secs() {
+  local v="$1" n="${1%[smhd]}" u="${1: -1}"
+  case "$u" in s) echo "$n";; m) echo $((n*60));; h) echo $((n*3600));; d) echo $((n*86400));; *) echo "$v";; esac
+}
+now_ns=$(date +%s)000000000
+start_ns=$(( now_ns - $(dur_to_secs "$since") * 1000000000 ))
+
+curl -sG "${ADDR}/loki/api/v1/query_range" \
+  --data-urlencode "query=${LOGQL}" \
+  --data "start=${start_ns}" --data "end=${now_ns}" \
+  --data "limit=${limit}" --data "direction=backward" \
+  | jq -r '
+      .data.result[]?.values[]?
+      | select((.[1] | gsub("\\s";"")) != "")          # drop blank lines
+      | ((.[0][0:10] | tonumber | todate) + "  " + .[1]) # UTC ISO ts + line
+    ' \
+  | sort \
+  | cat -s   # collapse the blank lines the functions emit between entries

--- a/scripts/lib/cluster-env.sh
+++ b/scripts/lib/cluster-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Shared helpers for the pawtograder cluster CLIs (deploy-edge-functions.sh,
+# supabase-db.sh). Source this file; it is not meant to be executed directly.
+#
+# Target selection is uniform across the tools:
+#   --env staging        (default)  -> namespace pawtograder-staging
+#   --preview <id>                   -> namespace pawtograder-preview-pr-<id>
+#   --namespace <ns>                 -> that namespace verbatim
+# The Helm release is always "pawtograder" in every pawtograder namespace.
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || { echo "missing dependency: $1" >&2; exit 1; }
+}
+
+# resolve_namespace <env> <preview_id> <explicit_ns> -> echoes the namespace.
+# Precedence: explicit --namespace > --preview > --env (default "staging").
+resolve_namespace() {
+  local env="${1:-}" preview="${2:-}" ns="${3:-}"
+  if [ -n "$ns" ];      then printf '%s\n' "$ns"; return 0; fi
+  if [ -n "$preview" ]; then printf 'pawtograder-preview-pr-%s\n' "$preview"; return 0; fi
+  case "${env:-staging}" in
+    staging) printf 'pawtograder-staging\n' ;;
+    *) echo "unknown --env '${env}' (use 'staging', or --preview <id>, or --namespace <ns>)" >&2; return 1 ;;
+  esac
+}
+
+# assert_namespace <ns> -> exit 1 with a friendly hint if it isn't reachable.
+assert_namespace() {
+  local ns="$1"
+  kubectl get ns "$ns" >/dev/null 2>&1 || {
+    echo "namespace '$ns' not found — is KUBECONFIG pointed at the right cluster?" >&2
+    echo "  current context: $(kubectl config current-context 2>/dev/null || echo '<none>')" >&2
+    exit 1
+  }
+}

--- a/scripts/supabase-db.sh
+++ b/scripts/supabase-db.sh
@@ -59,6 +59,14 @@ PW="$(kubectl get secret "$PG_SECRET" -n "$NAMESPACE" -o jsonpath='{.data.POSTGR
 [ -n "$PW" ] || { echo "could not read ${PG_SECRET}/POSTGRES_PASSWORD in ${NAMESPACE}" >&2; exit 1; }
 PW_ENC="$(jq -rn --arg v "$PW" '$v|@uri')"
 
+# Refuse to proceed if the port is already taken — otherwise the readiness probe
+# below could "succeed" against an unrelated Postgres and we'd run commands
+# (db push, psql, …) against the WRONG database.
+if (exec 9<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then
+  exec 9>&- 9<&-
+  echo "local port ${localport} is already in use; pass --port <free-port>" >&2
+  exit 1
+fi
 echo "==> port-forward ${NAMESPACE}/svc/${PG_SVC} -> 127.0.0.1:${localport}" >&2
 kubectl port-forward -n "$NAMESPACE" "svc/${PG_SVC}" "${localport}:5432" >/dev/null 2>&1 &
 PF_PID=$!

--- a/scripts/supabase-db.sh
+++ b/scripts/supabase-db.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Tunnel to a pawtograder environment's Postgres and run the supabase CLI / psql
+# against it. The cluster Postgres is not exposed publicly, so this port-forwards
+# svc/pawtograder-postgres and hands the tools an authenticated --db-url. The
+# tunnel is torn down on exit.
+#
+# Usage (target defaults to staging):
+#   scripts/supabase-db.sh db dump -f schema.sql        # npx supabase db dump …
+#   scripts/supabase-db.sh --preview 815 db dump -f -   # against a preview env
+#   scripts/supabase-db.sh --namespace pawtograder-staging migration list
+#   scripts/supabase-db.sh --psql                       # interactive psql shell
+#   scripts/supabase-db.sh --shell                      # subshell w/ $SUPABASE_DB_URL
+#   scripts/supabase-db.sh --print-url                  # print URL, keep tunnel open
+#
+# Target selection: --env staging | --preview <id> | --namespace <ns>
+# Optional: --port <local> (default 55432, to avoid clashing with a local
+# supabase on 54322). These flags must come BEFORE the supabase args; everything
+# after them (or after `--`) is passed to `npx supabase` verbatim with
+# `--db-url <tunnel>` appended.
+#
+# Connects as the supabase_admin superuser to db "postgres".
+# Requires: kubectl, jq, and npx (for supabase) or psql (for --psql).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/cluster-env.sh
+. "${SCRIPT_DIR}/lib/cluster-env.sh"
+
+PG_SVC="pawtograder-postgres"
+PG_SECRET="pawtograder-postgres"
+PG_USER="supabase_admin"
+PG_DB="postgres"
+
+env="" preview="" namespace="" localport=55432 mode=supabase
+args=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env)          env="$2"; shift 2 ;;
+    --preview)      preview="$2"; shift 2 ;;
+    --namespace|-n) namespace="$2"; shift 2 ;;
+    --port)         localport="$2"; shift 2 ;;
+    --psql)         mode=psql; shift ;;
+    --shell)        mode=shell; shift ;;
+    --print-url)    mode=url; shift ;;
+    -h|--help)      grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+    --)             shift; args+=("$@"); break ;;
+    *)              args+=("$1"); shift ;;
+  esac
+done
+
+require kubectl; require jq
+[ "$mode" = psql ] && require psql
+[ "$mode" = supabase ] && require npx
+
+NAMESPACE="$(resolve_namespace "$env" "$preview" "$namespace")"
+assert_namespace "$NAMESPACE"
+
+PW="$(kubectl get secret "$PG_SECRET" -n "$NAMESPACE" -o jsonpath='{.data.POSTGRES_PASSWORD}' 2>/dev/null | base64 -d)"
+[ -n "$PW" ] || { echo "could not read ${PG_SECRET}/POSTGRES_PASSWORD in ${NAMESPACE}" >&2; exit 1; }
+PW_ENC="$(jq -rn --arg v "$PW" '$v|@uri')"
+
+echo "==> port-forward ${NAMESPACE}/svc/${PG_SVC} -> 127.0.0.1:${localport}" >&2
+kubectl port-forward -n "$NAMESPACE" "svc/${PG_SVC}" "${localport}:5432" >/dev/null 2>&1 &
+PF_PID=$!
+cleanup() { kill "$PF_PID" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+# Wait (≤10s) for the local port to start accepting connections.
+up=0
+for _ in $(seq 1 50); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/${localport}") 2>/dev/null; then exec 3>&- 3<&-; up=1; break; fi
+  sleep 0.2
+done
+[ "$up" = 1 ] || { echo "tunnel to ${PG_SVC} never came up on :${localport}" >&2; exit 1; }
+
+DB_URL="postgresql://${PG_USER}:${PW_ENC}@127.0.0.1:${localport}/${PG_DB}"
+
+case "$mode" in
+  url)
+    echo "$DB_URL"
+    echo "tunnel open (pid ${PF_PID}); Ctrl-C to close." >&2
+    wait "$PF_PID"
+    ;;
+  psql)
+    psql "$DB_URL"
+    ;;
+  shell)
+    echo "Subshell with SUPABASE_DB_URL / PGURL set; 'exit' to close the tunnel." >&2
+    SUPABASE_DB_URL="$DB_URL" PGURL="$DB_URL" "${SHELL:-bash}" -i
+    ;;
+  supabase)
+    [ "${#args[@]}" -gt 0 ] || {
+      echo "no supabase args (e.g. 'db dump -f schema.sql'); or use --psql / --shell / --print-url" >&2
+      exit 2
+    }
+    npx supabase "${args[@]}" --db-url "$DB_URL"
+    ;;
+esac

--- a/supabase/functions/_shared/HandlerUtils.ts
+++ b/supabase/functions/_shared/HandlerUtils.ts
@@ -19,6 +19,32 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
 };
 
+// --- Per-function log tagging -------------------------------------------------
+// All ~49 functions share one pod's stdout behind the demuxer (main.ts), so logs
+// aren't filterable BY function unless each line carries the function name. The
+// demuxer passes the name to each worker as the EDGE_FUNCTION_NAME env var; here
+// we prefix this isolate's console output with `[fn=<name>]` so
+// `{component="functions"} |= "[fn=<name>]"` works in Loki/Grafana/
+// `scripts/edge-logs.sh`. Done once per isolate and safe: the edge-runtime
+// creates each worker against a single function's servicePath, so the isolate
+// only ever serves that one function — the name is constant for its lifetime.
+// Exported so the few functions that don't use wrapRequestHandler can call it
+// at entry too.
+let fnLogContextInstalled = false;
+export function installFunctionLogContext(): string | null {
+  const fn = Deno.env.get("EDGE_FUNCTION_NAME") ?? null;
+  if (fnLogContextInstalled || !fn) return fn;
+  fnLogContextInstalled = true;
+  const prefix = `[fn=${fn}]`;
+  const c = console as unknown as Record<string, (...a: unknown[]) => void>;
+  for (const m of ["log", "info", "warn", "error", "debug"]) {
+    const orig = c[m]?.bind(console);
+    if (!orig) continue;
+    c[m] = (...args: unknown[]) => orig(prefix, ...args);
+  }
+  return fn;
+}
+
 /**
  * Add comprehensive database operation tags to Sentry scope
  */
@@ -202,7 +228,9 @@ export async function wrapRequestHandler(
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }
+  const functionName = installFunctionLogContext();
   const scope = new Sentry.Scope();
+  if (functionName) scope.setTag("function", functionName);
   scope.setTag("URL", req.url);
   scope.setTag("Method", req.method);
   try {


### PR DESCRIPTION
release-images only built+pushed images on `main`/tags, so the long-lived staging environment was left on hand-tagged `staging-manual-*` / `helm-*` images that had to be `helm upgrade`d by hand — and had drifted ~2 days behind the staging branch.

- Trigger release-images on push to `staging` (and let build-web run for it, not just main/dispatch) → produces `staging-<sha>` + `staging-latest`.
- New `deploy-staging` job: non-destructive `helm upgrade --install` of the pawtograder-staging release, pinning web/edge/migrations to the exact `staging-<sha>` just built. `--wait` blocks on the per-revision migrations Job + every Deployment, so a bad migration/rollout fails the job. The wipe-and-reinstall flow stays in scripts/redeploy-staging.sh, never CI.
- values-staging.yaml: drop the stale STOPGAP image pins (the helm-branch work they tracked, #741, has merged) in favour of `staging-latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated staging environment deployment via CI/CD on code pushes
  * Enhanced edge function logging with per-function filtering and request/response tracking
  * New CLI utilities for quick edge function redeployment and log inspection

* **Chores**
  * Updated Grafana dashboard with staging environment log filtering
  * Improved logging context for better observability across edge functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->