### PR TITLE
fix(auth): include /auth/v1 prefix in API_EXTERNAL_URL (broken password-reset links)

### DIFF
--- a/charts/pawtograder/templates/auth.yaml
+++ b/charts/pawtograder/templates/auth.yaml
@@ -73,8 +73,14 @@ spec:
             - name: GOTRUE_METRICS_PORT
               value: "9100"
             {{- end }}
+            # MUST include the `/auth/v1` gateway prefix: GoTrue builds email
+            # links (recovery/confirmation) and the OAuth callback as
+            # `{API_EXTERNAL_URL}/verify` / `/callback`, and Kong only routes
+            # `/auth/v1/*` to GoTrue. Without the prefix, password-reset links
+            # point at `…/verify` → 404. (The JWT `iss` is pinned separately by
+            # GOTRUE_JWT_ISSUER below, so this doesn't affect token validation.)
             - name: API_EXTERNAL_URL
-              value: {{ include "pawtograder.api.url" . }}
+              value: {{ include "pawtograder.api.url" . }}/auth/v1
             - name: GOTRUE_SITE_URL
               value: {{ include "pawtograder.web.url" . }}
             - name: GOTRUE_URI_ALLOW_LIST


### PR DESCRIPTION
## Problem
Staging password-reset emails contained links like
`https://api.staging.pawtograder.net/verify?token=pkce_…&type=recovery&redirect_to=…`
which **404** — Kong only routes `/auth/v1/*` to GoTrue, so `/verify` has no route.

## Root cause
`API_EXTERNAL_URL` was set to the bare api host (`https://api.<env>.pawtograder.net`).
GoTrue builds email links and the OAuth callback as `{API_EXTERNAL_URL}/verify` /
`/callback`, so they landed at `…/verify` instead of `…/auth/v1/verify`.

## Fix
Append `/auth/v1` to `API_EXTERNAL_URL` so links resolve to `/auth/v1/verify`
(verified: `/verify` → 404, `/auth/v1/verify` → 400/routes). Token validation is
unaffected — the JWT `iss` is pinned separately via `GOTRUE_JWT_ISSUER`
(already `{api.url}/auth/v1`).

Applied live to `pawtograder-staging` via `kubectl set env` for immediate relief;
this commit makes it permanent and covers preview envs too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken password reset links and OAuth callback routing by updating authentication service configuration to properly integrate with API gateway paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->