### PR TITLE
fix(edge-functions): mount pawtograder-sentry so SENTRY_DSN is set

### DIFF
--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -203,6 +203,10 @@ edgeFunctions:
     - pawtograder-canvas
     - pawtograder-llm
     - pawtograder-e2e
+    # Edge functions read SENTRY_DSN for server-side error reporting
+    # (_shared/HandlerUtils.ts). The secret also carries the frontend
+    # NEXT_PUBLIC_BUGSINK_* keys, which are inert in the Deno runtime.
+    - pawtograder-sentry
   e2e:
     enabled: true
     mockGitHub: true


### PR DESCRIPTION
Edge functions read `SENTRY_DSN` (_shared/HandlerUtils.ts) but `edgeFunctions.envFromSecrets` omitted `pawtograder-sentry`, so Sentry never initialized on the edge runtime. Add it so server-side edge errors report to Sentry. The DSN value lives in OpenBao (`apps/pawtograder-staging/sentry` → `SENTRY_DSN`). Applied live to staging via `kubectl set env`; this makes it survive helm deploys and covers previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated edge functions configuration to integrate server-side error reporting and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->