### PR TITLE
Fix Monaco editor model leak in submission grading view

### DIFF
--- a/components/ui/code-file-monaco.tsx
+++ b/components/ui/code-file-monaco.tsx
@@ -7,7 +7,7 @@ import { RubricCheck, RubricCriteria, SubmissionFile, SubmissionFileComment } fr
 import { Badge, Box, Button, Flex, HStack, Icon, Text } from "@chakra-ui/react";
 import { useColorMode } from "@/components/ui/color-mode";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, forwardRef } from "react";
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState, forwardRef } from "react";
 import { FaComments, FaEyeSlash, FaTimes } from "react-icons/fa";
 import { Skeleton } from "./skeleton";
 import { toaster } from "./toaster";
@@ -47,6 +47,10 @@ const Editor = dynamic(() => import("@monaco-editor/react").then((mod) => mod.de
 
 export type { RubricCheckSubOption, RubricCheckDataWithOptions, CodeFileHandle, CodeFileProps };
 export { isRubricCheckDataWithOptions };
+
+// Monotonic counter used to give every editor mount a unique model-URI authority (see instanceIdRef).
+// Module-scoped so it is shared across all panes in the (single, client-only) bundle.
+let paneInstanceSeq = 0;
 
 // Map file extensions to Monaco language IDs
 function getMonacoLanguage(fileName: string): string {
@@ -394,7 +398,19 @@ const CodeFileMonaco = forwardRef<CodeFileHandle, CodeFileProps>(
     // file. In split view two panes mount at once, so they must not request the same URI — otherwise
     // the second pane throws "Cannot add model because it already exists!". Scope every model URI to
     // this instance via a unique authority; `uri.path` is unchanged, so filename lookups still work.
-    const instanceId = useId().replace(/[^a-zA-Z0-9]/g, "");
+    //
+    // This is a *per-mount* id, deliberately NOT useId(): useId is stable for a given position in the
+    // React tree, so when this editor remounts at the same position — and it remounts constantly (the
+    // page swaps in a loading skeleton on every file switch, and React keeps the outgoing page mounted
+    // during route transitions) — the old and new mounts would share an authority. The new mount would
+    // then adopt the previous mount's models via getModel(), tangling which instance owns and disposes
+    // them and leaking models into monaco's global (singleton) registry. A fresh id per mount gives
+    // every instance a private model namespace it alone creates and tears down on unmount.
+    const instanceIdRef = useRef<string>("");
+    if (!instanceIdRef.current) {
+      instanceIdRef.current = `${paneInstanceSeq++}`;
+    }
+    const instanceId = instanceIdRef.current;
 
     const [expanded, setExpanded] = useState<number[]>([]);
     // Flips true once the (dynamically imported) Monaco editor has mounted. Effects that draw view
@@ -780,6 +796,14 @@ const CodeFileMonaco = forwardRef<CodeFileHandle, CodeFileProps>(
         monacoRef.current = monaco;
         setEditorReady(true);
 
+        // @monaco-editor/react creates its own throwaway model from the (empty) `value` prop and
+        // attaches it before onMount fires. We immediately replace it with our own per-file models
+        // below, which orphans that throwaway. The library only disposes `editor.getModel()` on
+        // unmount — by then that's *our* model, not its original — so the throwaway leaks one model
+        // per mount. Monaco is a singleton, so these accumulate across the whole SPA session until a
+        // full reload. Capture it now and dispose it once we've swapped in our model.
+        const libraryInitialModel = editor.getModel();
+
         // Create models for every submission file (not just the displayed one) so cross-file
         // go-to-definition can target them. Scoped to this editor instance so split panes don't
         // collide on the global model registry.
@@ -798,6 +822,12 @@ const CodeFileMonaco = forwardRef<CodeFileHandle, CodeFileProps>(
           if (model) {
             editor.setModel(model);
           }
+        }
+
+        // Dispose the library's throwaway model now that ours is attached. Guard against the case
+        // where we never swapped (no currentFile) and it's still the editor's active model.
+        if (libraryInitialModel && libraryInitialModel !== editor.getModel() && !libraryInitialModel.isDisposed()) {
+          libraryInitialModel.dispose();
         }
 
         // Clean up old providers
@@ -1062,8 +1092,23 @@ const CodeFileMonaco = forwardRef<CodeFileHandle, CodeFileProps>(
           clearTimeout(highlightTimeoutRef.current);
           highlightTimeoutRef.current = null;
         }
-        models.forEach((model) => model.dispose());
+        models.forEach((model) => {
+          if (!model.isDisposed()) model.dispose();
+        });
         models.clear();
+        // Safety net: dispose any straggler models scoped to this mount's authority that never made it
+        // into modelsRef (e.g. an interrupted mount, or a model created but not yet tracked). Each
+        // mount owns a unique authority, so this only ever touches our own models — and every undisposed
+        // model keeps a listener on monaco's global services, which is exactly the leak we're fixing.
+        const monaco = monacoRef.current;
+        if (monaco) {
+          const authority = `pane-${instanceId}`;
+          for (const model of monaco.editor.getModels()) {
+            if (!model.isDisposed() && model.uri.authority === authority) {
+              model.dispose();
+            }
+          }
+        }
         decorations.clear();
         viewZones.clear();
         setViewZoneNodes(new Map());
@@ -1079,7 +1124,8 @@ const CodeFileMonaco = forwardRef<CodeFileHandle, CodeFileProps>(
         baseOpenCodeEditorRef.current = null;
         overrideOpenCodeEditorRef.current = null;
       };
-    }, []);
+      // instanceId is a stable per-mount constant, so this still only runs cleanup on unmount.
+    }, [instanceId]);
 
     // Handle editor before mount (worker setup)
     const handleEditorWillMount = useCallback(() => {

--- a/tests/e2e/grading-monaco-model-leak.spec.ts
+++ b/tests/e2e/grading-monaco-model-leak.spec.ts
@@ -1,0 +1,164 @@
+import { Assignment, Course, RubricCheck, RubricPart } from "@/utils/supabase/DatabaseTypes";
+import { test, expect } from "../global-setup";
+import { addDays } from "date-fns";
+import dotenv from "dotenv";
+import {
+  createClass,
+  createUsersInClass,
+  insertAssignment,
+  insertPreBakedSubmission,
+  loginAsUser,
+  supabase,
+  TestingUser
+} from "./TestingUtils";
+
+dotenv.config({ path: ".env.local", quiet: true });
+
+// Regression test for the production "[NNN] potential listener LEAK detected, having 200 listeners
+// already" warning that surfaced after the submission view migrated to the Monaco grading editor
+// (#565). Monaco is a process-wide singleton: every text model it creates registers a listener on a
+// shared service, and that listener only goes away when the model is disposed. The grading page tears
+// the editor down and rebuilds it on every file switch, so any model that escapes disposal accumulates
+// across the whole SPA session until the count crosses Monaco's leak threshold.
+//
+// Two escapes were fixed in code-file-monaco.tsx: (1) the editor used a useId()-derived model-URI
+// authority, which is stable per tree position, so a remount at the same position could adopt the
+// previous mount's models instead of cleanly owning its own; (2) @monaco-editor/react auto-creates a
+// throwaway model and attaches it before onMount, and we replaced it without ever disposing it.
+//
+// Rather than drive the count all the way to 200, this test switches files many times and asserts the
+// number of *live* Monaco models stays bounded — with either bug it grows roughly one model per switch.
+
+const FILES: { name: string; contents: string }[] = [
+  { name: "alpha.py", contents: "# ALPHA_MARKER\nclass Alpha:\n    def run(self):\n        return 1\n" },
+  { name: "bravo.py", contents: "# BRAVO_MARKER\nclass Bravo:\n    def run(self):\n        return 2\n" },
+  { name: "charlie.ts", contents: "// CHARLIE_MARKER\nexport class Charlie {\n  run(): number {\n    return 3;\n  }\n}\n" },
+  { name: "delta.ts", contents: "// DELTA_MARKER\nexport class Delta {\n  run(): number {\n    return 4;\n  }\n}\n" }
+];
+
+// A unique token present only in each file, used to confirm the editor has actually swapped to it
+// (i.e. the new mount finished and created its models) before we trigger the next switch.
+const TOKEN_BY_NAME: Record<string, string> = {
+  "alpha.py": "ALPHA_MARKER",
+  "bravo.py": "BRAVO_MARKER",
+  "charlie.ts": "CHARLIE_MARKER",
+  "delta.ts": "DELTA_MARKER"
+};
+
+let course: Course;
+let instructor: TestingUser | undefined;
+let student: TestingUser | undefined;
+let assignment: (Assignment & { rubricParts: RubricPart[]; rubricChecks: RubricCheck[] }) | undefined;
+let submission_id: number | undefined;
+const fileIdByName = new Map<string, number>();
+
+test.beforeAll(async () => {
+  course = await createClass();
+  [student, instructor] = await createUsersInClass([
+    {
+      name: "Leak Student",
+      email: "leak-student@pawtograder.net",
+      role: "student",
+      class_id: course.id,
+      useMagicLink: true
+    },
+    {
+      name: "Leak Instructor",
+      email: "leak-instructor@pawtograder.net",
+      role: "instructor",
+      class_id: course.id,
+      useMagicLink: true
+    }
+  ]);
+  assignment = await insertAssignment({
+    due_date: addDays(new Date(), 1).toUTCString(),
+    class_id: course.id,
+    name: "Monaco Leak Assignment"
+  });
+  const res = await insertPreBakedSubmission({
+    student_profile_id: student!.private_profile_id,
+    assignment_id: assignment!.id,
+    class_id: course.id,
+    files: FILES
+  });
+  submission_id = res.submission_id;
+
+  const { data: fileRows, error: filesError } = await supabase
+    .from("submission_files")
+    .select("id, name")
+    .eq("submission_id", submission_id!);
+  if (filesError) throw new Error(`Failed to load submission files: ${filesError.message}`);
+  for (const row of fileRows ?? []) {
+    fileIdByName.set(row.name, row.id);
+  }
+});
+
+test.afterEach(async ({ logMagicLinksOnFailure }) => {
+  await logMagicLinksOnFailure([student, instructor]);
+});
+
+test.describe("Monaco grading viewer model leak", () => {
+  test.setTimeout(180_000);
+
+  test("switching files repeatedly does not accumulate Monaco models", async ({ page }) => {
+    await loginAsUser(page, instructor!, course);
+
+    const firstFile = "alpha.py";
+    const firstId = fileIdByName.get(firstFile);
+    expect(firstId, `file id for ${firstFile}`).toBeDefined();
+    await page.goto(
+      `/course/${course.id}/assignments/${assignment!.id}/submissions/${submission_id}/files?file_id=${firstId}`,
+      // This route keeps long-lived realtime/websocket connections open, so the "load" event is
+      // unreliable; wait for the DOM instead and then for the editor itself below.
+      { waitUntil: "domcontentloaded" }
+    );
+
+    const editor = page.locator(".monaco-editor").first();
+    await expect(editor).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator(".view-line", { hasText: TOKEN_BY_NAME[firstFile] }).first()).toBeVisible({
+      timeout: 30_000
+    });
+
+    // Monaco is loaded from the CDN by @monaco-editor/loader, which assigns the global `monaco`. Confirm
+    // we can read the live model registry before relying on it for the assertion.
+    const modelCount = () =>
+      page.evaluate(() => {
+        const m = (window as unknown as { monaco?: { editor: { getModels(): unknown[] } } }).monaco;
+        return m ? m.editor.getModels().length : -1;
+      });
+
+    const baseline = await modelCount();
+    expect(baseline, "window.monaco should be exposed so we can count models").toBeGreaterThan(0);
+
+    // Switch through the files in the navigator many times. Each switch unmounts and remounts the editor
+    // (the page swaps in a loading skeleton mid-switch), so a per-mount model leak compounds here.
+    const order = ["bravo.py", "charlie.ts", "delta.ts", "alpha.py"];
+    const ROUNDS = 4; // 16 switches total
+    for (let round = 0; round < ROUNDS; round++) {
+      for (const name of order) {
+        const id = fileIdByName.get(name);
+        expect(id, `file id for ${name}`).toBeDefined();
+        await page.locator(`[data-file-navigator] [data-file-id="${id}"]`).first().click();
+        // Wait for the editor to actually show this file — proves the new mount finished and created
+        // its models, so the count we read at the end reflects settled state, not a mid-switch blip.
+        await expect(page.locator(".view-line", { hasText: TOKEN_BY_NAME[name] }).first()).toBeVisible({
+          timeout: 15_000
+        });
+      }
+    }
+
+    // Let any in-flight switch settle, then count. With the leak, the registry would hold roughly
+    // `baseline + number_of_switches` models; fixed, it stays around one mount's worth.
+    await page.waitForTimeout(500);
+    const finalCount = await modelCount();
+
+    // Generous bound: one mounted pane creates one model per file. Allow up to ~2x the file count for a
+    // transient overlap during a switch — far below the ~baseline+16 a per-switch leak would produce.
+    const upperBound = FILES.length * 2;
+    expect(
+      finalCount,
+      `live Monaco models after ${ROUNDS * order.length} switches (baseline ${baseline}); a value near ` +
+        `baseline + switches indicates the model leak has regressed`
+    ).toBeLessThanOrEqual(upperBound);
+  });
+});

--- a/tests/e2e/grading-monaco-model-leak.spec.ts
+++ b/tests/e2e/grading-monaco-model-leak.spec.ts
@@ -152,9 +152,7 @@ test.describe("Monaco grading viewer model leak", () => {
     await page.waitForTimeout(500);
     const finalCount = await modelCount();
 
-    // Generous bound: one mounted pane creates one model per file. Allow up to ~2x the file count for a
-    // transient overlap during a switch — far below the ~baseline+16 a per-switch leak would produce.
-    const upperBound = FILES.length * 2;
+    const upperBound = baseline + FILES.length * 2;
     expect(
       finalCount,
       `live Monaco models after ${ROUNDS * order.length} switches (baseline ${baseline}); a value near ` +

--- a/tests/e2e/grading-monaco-model-leak.spec.ts
+++ b/tests/e2e/grading-monaco-model-leak.spec.ts
@@ -32,7 +32,10 @@ dotenv.config({ path: ".env.local", quiet: true });
 const FILES: { name: string; contents: string }[] = [
   { name: "alpha.py", contents: "# ALPHA_MARKER\nclass Alpha:\n    def run(self):\n        return 1\n" },
   { name: "bravo.py", contents: "# BRAVO_MARKER\nclass Bravo:\n    def run(self):\n        return 2\n" },
-  { name: "charlie.ts", contents: "// CHARLIE_MARKER\nexport class Charlie {\n  run(): number {\n    return 3;\n  }\n}\n" },
+  {
+    name: "charlie.ts",
+    contents: "// CHARLIE_MARKER\nexport class Charlie {\n  run(): number {\n    return 3;\n  }\n}\n"
+  },
   { name: "delta.ts", contents: "// DELTA_MARKER\nexport class Delta {\n  run(): number {\n    return 4;\n  }\n}\n" }
 ];
 


### PR DESCRIPTION
The submission grading viewer (#565) accumulated Monaco text models until the editor's leak detector fired in prod ("[NNN] potential listener LEAK detected, having 200 listeners"). Monaco is a process-wide singleton, so every undisposed model keeps a listener on a shared service and they pile up across the whole SPA session — and the page rebuilds the editor on every file switch, so per-mount leaks compound quickly.

Two escapes in code-file-monaco.tsx:

1. The model-URI authority came from useId(), which is stable per React tree position. On remount at the same position (every file switch, plus React keeping the outgoing page mounted during route transitions) the new mount could adopt the previous mount's models via getModel() instead of cleanly owning its own. Use a per-mount counter id instead.

2. @monaco-editor/react auto-creates a throwaway model and attaches it before onMount; we replace it with editor.setModel(ours). On unmount the library only disposes editor.getModel() (our model by then), never its original, so the throwaway leaks one model per mount. Capture and dispose it in onMount.

Also adds a defensive unmount sweep that disposes any model scoped to this mount's authority, catching orphans from interrupted mounts.

Adds an e2e regression test that switches files 16x and asserts the live model count stays bounded: buggy build grows baseline 5 -> 21 (~1/switch), fixed stays <= 8. Cross-file go-to-definition (Java/Python/TS) still passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in the in-browser code editor so switching between files no longer causes unbounded model growth and improves performance over long sessions.

* **Tests**
  * Added an end-to-end regression test that repeatedly switches files and asserts the editor's model count remains bounded to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->