### PR TITLE
chore(seed): make seed-job failures self-documenting

### DIFF
--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -13,6 +13,16 @@
 #      / student emails get woven into the simulation (not bolted on
 #      after the fact — they ARE the first user of each role)
 #
+# Logging contract: every line is prefixed `[seed]` and timestamped so it
+# reads cleanly through `kubectl logs`. On ANY failure the script prints a
+# diagnostic snapshot (row counts for the tables the seed populates) before
+# exiting — a failed seed is almost always a *partial* seed, and knowing how
+# far it got (e.g. "1 class, 1 user, 0 everything-else" => died right after
+# the first gotrue user) is the difference between a 2-minute diagnosis and
+# re-running the whole stack to reproduce. See the 2026-06-06 preview-deploy
+# incident: a transient auth/postgres startup race killed the seed partway,
+# but the pod was gone before its logs could be read.
+#
 # Env (consumed; see Dockerfile for full list):
 #   PGHOST, PGPORT, PGUSER, PGDATABASE, PGPASSWORD
 #   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY  (used by createAdminClient)
@@ -21,6 +31,11 @@
 #   FIXED_INSTRUCTOR_EMAIL, FIXED_GRADER_EMAIL, FIXED_STUDENT_EMAIL
 
 set -euo pipefail
+
+# Timestamped, prefixed logging. log -> stdout, warn/err -> stderr.
+log()  { echo "[seed] $(date -u +%H:%M:%S) $*"; }
+warn() { echo "[seed] $(date -u +%H:%M:%S) WARN  $*" >&2; }
+err()  { echo "[seed] $(date -u +%H:%M:%S) ERROR $*" >&2; }
 
 : "${PGHOST:?PGHOST is required}"
 : "${PGUSER:?PGUSER is required}"
@@ -32,10 +47,50 @@ export PGHOST PGPORT PGUSER PGDATABASE PGPASSWORD SUPABASE_URL SUPABASE_SERVICE_
 
 SEED_TEMPLATE="${SEED_TEMPLATE:-small}"
 
-echo "[seed] target=${PGUSER}@${PGHOST}:${PGPORT:-5432}/${PGDATABASE}"
-echo "[seed] template=${SEED_TEMPLATE}"
+# -----------------------------------------------------------------------------
+# Diagnostic snapshot — how far did the seed get?
+# -----------------------------------------------------------------------------
+# Printed on every failure (via the ERR trap) and after the idempotency skip.
+# Every query is guarded so the snapshot itself can never fail the script /
+# mask the original error. A missing table (early failure, pre-migrations)
+# just prints "n/a".
+snapshot() {
+  local label="${1:-state}"
+  err "── diagnostic snapshot (${label}) ──"
+  local t
+  for t in \
+    "auth.users" \
+    "public.classes" \
+    "public.profiles" \
+    "public.user_roles" \
+    "public.assignments" \
+    "public.submissions"; do
+    local n
+    n="$(psql -tAc "SELECT count(*) FROM ${t}" 2>/dev/null)" || n="n/a (no table / no connection)"
+    err "    ${t}: ${n:-n/a}"
+  done
+  err "──────────────────────────────────"
+}
+
+# ERR trap: fires on any unhandled non-zero command (e.g. SeedDB.ts throwing,
+# a psql error under `set -e`). Prints where it died + the snapshot, then lets
+# the non-zero exit propagate.
+on_err() {
+  local rc=$?
+  err "failed (exit ${rc}) at line ${BASH_LINENO[0]:-?}: ${BASH_COMMAND}"
+  snapshot "on failure"
+}
+trap on_err ERR
+
+# fail <msg> — for the expected guard failures below. Logs, snapshots, exits 1.
+# Uses its own exit so the message is specific; the ERR trap won't double-fire
+# because we exit straight away.
+fail() { err "$*"; snapshot "on failure"; exit 1; }
+
+log "target=${PGUSER}@${PGHOST}:${PGPORT:-5432}/${PGDATABASE}"
+log "template=${SEED_TEMPLATE}"
 if [ -n "${FIXED_INSTRUCTOR_EMAIL:-}${FIXED_GRADER_EMAIL:-}${FIXED_STUDENT_EMAIL:-}" ]; then
-  echo "[seed] fixed users: instructor=${FIXED_INSTRUCTOR_EMAIL:-(faker)} grader=${FIXED_GRADER_EMAIL:-(faker)} student=${FIXED_STUDENT_EMAIL:-(faker)}"
+  log "fixed users: instructor=${FIXED_INSTRUCTOR_EMAIL:-(faker)} grader=${FIXED_GRADER_EMAIL:-(faker)} student=${FIXED_STUDENT_EMAIL:-(faker)}"
 fi
 
 # -----------------------------------------------------------------------------
@@ -44,13 +99,16 @@ fi
 ready=0
 for i in $(seq 1 60); do
   if pg_isready -q; then ready=1; break; fi
-  echo "[seed] waiting for postgres ($i/60)"
+  log "waiting for postgres ($i/60)"
   sleep 2
 done
 if [ "$ready" -ne 1 ]; then
-  echo "[seed] postgres did not become ready after 120s" >&2
-  exit 1
+  # Surface the actual pg_isready diagnostic instead of a bare timeout.
+  err "postgres did not become ready after 120s; last pg_isready:"
+  pg_isready || true
+  fail "postgres unavailable"
 fi
+log "postgres ready"
 
 # -----------------------------------------------------------------------------
 # Phase 2 — wait for supabase services to finish their own migrations
@@ -61,28 +119,43 @@ fi
 check_ready() {
   psql -tAc "$1" 2>/dev/null | grep -q 1
 }
+# Human label for each guard so a timeout names the laggard rather than just
+# reporting "not ready".
+declare -a SVC_LABELS=(
+  "auth schema (auth.identities)"
+  "storage schema (storage.buckets.public)"
+  "realtime publication (supabase_realtime)"
+  "realtime schema (realtime.messages)"
+)
+declare -a SVC_CHECKS=(
+  "SELECT 1 FROM information_schema.tables WHERE table_schema='auth' AND table_name='identities'"
+  "SELECT 1 FROM information_schema.columns WHERE table_schema='storage' AND table_name='buckets' AND column_name='public'"
+  "SELECT 1 FROM pg_publication WHERE pubname='supabase_realtime'"
+  "SELECT 1 FROM information_schema.tables WHERE table_schema='realtime' AND table_name='messages'"
+)
 ready=0
 for i in $(seq 1 90); do
   ok=true
-  check_ready "SELECT 1 FROM information_schema.tables WHERE table_schema='auth' AND table_name='identities'"                                                || ok=false
-  check_ready "SELECT 1 FROM information_schema.columns WHERE table_schema='storage' AND table_name='buckets' AND column_name='public'"                       || ok=false
-  check_ready "SELECT 1 FROM pg_publication WHERE pubname='supabase_realtime'"                                                                                || ok=false
-  check_ready "SELECT 1 FROM information_schema.tables WHERE table_schema='realtime' AND table_name='messages'"                                               || ok=false
-  if $ok; then ready=1; echo "[seed] supabase services migrated"; break; fi
-  echo "[seed] waiting for supabase services ($i/90)"
+  pending=""
+  for idx in "${!SVC_CHECKS[@]}"; do
+    if ! check_ready "${SVC_CHECKS[$idx]}"; then
+      ok=false
+      pending="${pending:+$pending, }${SVC_LABELS[$idx]}"
+    fi
+  done
+  if $ok; then ready=1; log "supabase services migrated"; break; fi
+  log "waiting for supabase services ($i/90) — pending: ${pending}"
   sleep 4
 done
 if [ "$ready" -ne 1 ]; then
-  echo "[seed] supabase services not ready after 6min" >&2
-  exit 1
+  fail "supabase services not ready after 6min — still pending: ${pending}"
 fi
 
 # Also wait for pawtograder migrations to apply public.classes etc. The
 # migrations Job is a regular install resource (not a hook), so we may
 # fire before it completes if --wait-for-jobs is misbehaving upstream.
 if ! psql -tAc "SELECT to_regclass('public.classes') IS NOT NULL" | grep -q '^t$'; then
-  echo "[seed] public.classes does not exist — pawtograder migrations have not completed" >&2
-  exit 1
+  fail "public.classes does not exist — pawtograder migrations have not completed"
 fi
 
 # -----------------------------------------------------------------------------
@@ -101,15 +174,28 @@ auth_ready() {
       .catch(() => process.exit(1));
   ' 2>/dev/null
 }
+# Verbose probe used only when the wait times out: prints the HTTP status or
+# the fetch error so we can tell "gotrue 503 / still migrating" apart from
+# "DNS/connection refused" apart from "wrong URL".
+auth_probe_verbose() {
+  node -e '
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+    const url = process.env.SUPABASE_URL + "/auth/v1/health";
+    fetch(url, { headers: { apikey: key } })
+      .then(async (r) => { console.error("    GET " + url + " -> HTTP " + r.status + " " + (await r.text()).slice(0, 200)); process.exit(0); })
+      .catch((e) => { console.error("    GET " + url + " -> " + (e && e.message ? e.message : e)); process.exit(0); });
+  ' 2>&1 || true
+}
 ready=0
 for i in $(seq 1 60); do
-  if auth_ready; then ready=1; echo "[seed] auth HTTP API ready"; break; fi
-  echo "[seed] waiting for auth HTTP API ($i/60)"
+  if auth_ready; then ready=1; log "auth HTTP API ready"; break; fi
+  log "waiting for auth HTTP API ($i/60)"
   sleep 3
 done
 if [ "$ready" -ne 1 ]; then
-  echo "[seed] auth HTTP API ($SUPABASE_URL/auth/v1) not serving after 180s" >&2
-  exit 1
+  err "auth HTTP API ($SUPABASE_URL/auth/v1) not serving after 180s; last probe:"
+  auth_probe_verbose
+  fail "auth HTTP API unavailable"
 fi
 
 # -----------------------------------------------------------------------------
@@ -121,18 +207,31 @@ fi
 # org so re-runs across helm upgrades are no-ops.
 existing="$(psql -tAc "SELECT count(*) FROM public.classes WHERE archived=false")"
 if [ "${existing:-0}" -gt 0 ]; then
-  echo "[seed] ${existing} non-archived class(es) already present — skipping seed"
+  log "${existing} non-archived class(es) already present — skipping seed"
+  # A class with no roles/assignments is the fingerprint of a *previous*
+  # failed seed: the skip below would then mask that broken state as a green
+  # deploy. We don't change behaviour (still skip — flipping it could wipe a
+  # real class), but we log loudly so the false-green is visible at a glance.
+  roles="$(psql -tAc "SELECT count(*) FROM public.user_roles" 2>/dev/null || echo n/a)"
+  asgn="$(psql -tAc "SELECT count(*) FROM public.assignments" 2>/dev/null || echo n/a)"
+  log "existing data: user_roles=${roles} assignments=${asgn}"
+  if [ "${roles:-0}" = "0" ] || [ "${asgn:-0}" = "0" ]; then
+    warn "existing class looks PARTIAL (no roles or no assignments) — likely a"
+    warn "prior failed seed. This preview may be incompletely seeded even though"
+    warn "the deploy is green. Archive the class to force a clean re-seed."
+  fi
   exit 0
 fi
 
 # -----------------------------------------------------------------------------
 # Phase 4 — run the realistic seeder
 # -----------------------------------------------------------------------------
-echo "[seed] running scripts/SeedDB.ts --template ${SEED_TEMPLATE}"
+log "running scripts/SeedDB.ts --template ${SEED_TEMPLATE}"
 # No .env.local is created here: SeedDB.ts reads its config from the environment
 # (exported above / fed by the K8s Secret), and its
 # dotenv.config({ path: ".env.local", quiet: true }) call silently tolerates a
 # missing file — so the seeder needs no dotenv file at all.
+# A non-zero exit here trips the ERR trap, which prints the diagnostic snapshot.
 npx tsx scripts/SeedDB.ts --template "${SEED_TEMPLATE}"
 
-echo "[seed] done"
+log "done"

--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -211,27 +211,32 @@ fi
 # confirmed deterministic — direct-SQL inserts persisted while the seeder's
 # identical REST inserts vanished, and the rest pod had 0 restarts).
 #
-# A read/schema probe is NOT sufficient (reads work the whole time). Gate on a
-# real write round-trip instead: REST-insert a throwaway row, require REST to
-# read it back, then delete it via SQL (reliable). revoked_token_ids is a
-# self-contained leaf table (no triggers, no inbound FKs, single text PK), so a
-# throwaway insert/delete has no side effects. Nudge a schema reload each pass.
+# A read/schema probe is NOT sufficient (reads work the whole time). Nor is a
+# write to a non-RLS table: the lost writes are specifically service_role REST
+# inserts into RLS-enabled tables (profiles, user_roles) — a plain leaf table
+# without RLS persists fine through the same window and would mask the problem.
+# So probe the ACTUAL failing path: a service_role REST insert into an
+# RLS-enabled table, confirmed via a REST read-back, deleted via SQL.
+# github_circuit_breakers is the cleanest such table — RLS on with an explicit
+# service_role ALL-policy, no triggers, no FKs, simple (scope,key) text PK — so
+# a throwaway insert/delete has no side effects. Nudge a schema reload each pass.
 PROBE_TOKEN="__seed_write_probe__"
 export PROBE_TOKEN
 rest_write_probe() {
   node -e '
     const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
     const h = { apikey: key, Authorization: "Bearer " + key, "Content-Type": "application/json", Prefer: "return=minimal" };
-    const base = process.env.SUPABASE_URL + "/rest/v1/revoked_token_ids";
-    fetch(base, { method: "POST", headers: h, body: JSON.stringify({ token_id: process.env.PROBE_TOKEN }) })
+    const base = process.env.SUPABASE_URL + "/rest/v1/github_circuit_breakers";
+    const tok = process.env.PROBE_TOKEN;
+    fetch(base, { method: "POST", headers: h, body: JSON.stringify({ scope: tok, key: tok }) })
       .then((w) => { if (!w.ok) process.exit(1);
-        return fetch(base + "?token_id=eq." + encodeURIComponent(process.env.PROBE_TOKEN) + "&select=token_id", { headers: h }); })
+        return fetch(base + "?scope=eq." + encodeURIComponent(tok) + "&select=scope", { headers: h }); })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error("read HTTP " + r.status))))
       .then((rows) => process.exit(Array.isArray(rows) && rows.length >= 1 ? 0 : 1))
       .catch(() => process.exit(1));
   ' 2>/dev/null
 }
-clear_probe() { psql -tAc "DELETE FROM public.revoked_token_ids WHERE token_id='${PROBE_TOKEN}'" >/dev/null 2>&1 || true; }
+clear_probe() { psql -tAc "DELETE FROM public.github_circuit_breakers WHERE scope='${PROBE_TOKEN}'" >/dev/null 2>&1 || true; }
 clear_probe
 psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
 ready=0

--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -199,43 +199,54 @@ if [ "$ready" -ne 1 ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Phase 2c — wait for PostgREST to serve the freshly-migrated schema.
+# Phase 2c — wait until PostgREST table WRITES actually persist.
 # -----------------------------------------------------------------------------
-# SeedDB.ts does all its writes through PostgREST (the REST API behind
-# $SUPABASE_URL/rest/v1), not raw SQL. On a fresh install the migrations Job
-# creates public.* only moments before this hook fires, and PostgREST caches
-# the schema — until it reloads, requests against the just-migrated tables hit
-# a stale cache and the seeder fails partway with a confusing downstream error
-# (observed 2026-06-06: "Failed to get profile: Cannot coerce the result to a
-# single JSON object" — the user_roles read-back found 0 rows because the write
-# never landed through the cold cache; deterministic on every fresh preview).
-# Nudge a reload (NOTIFY pgrst) and poll until REST actually serves a migrated
-# table before we start seeding.
-rest_probe() {
+# SeedDB.ts writes every profile and user_role through PostgREST (the REST API
+# behind $SUPABASE_URL/rest/v1), not raw SQL. On a fresh install there is a
+# window where PostgREST returns success for a table .insert() that never lands
+# in the database — reads, RPCs and direct SQL all work in that window, ONLY
+# REST table-writes are lost. The seeder then fails partway with a confusing
+# downstream error ("Failed to get profile: Cannot coerce the result to a
+# single JSON object") when its read-back finds 0 rows (2026-06-07 incident;
+# confirmed deterministic — direct-SQL inserts persisted while the seeder's
+# identical REST inserts vanished, and the rest pod had 0 restarts).
+#
+# A read/schema probe is NOT sufficient (reads work the whole time). Gate on a
+# real write round-trip instead: REST-insert a throwaway row, require REST to
+# read it back, then delete it via SQL (reliable). revoked_token_ids is a
+# self-contained leaf table (no triggers, no inbound FKs, single text PK), so a
+# throwaway insert/delete has no side effects. Nudge a schema reload each pass.
+PROBE_TOKEN="__seed_write_probe__"
+export PROBE_TOKEN
+rest_write_probe() {
   node -e '
     const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-    const url = process.env.SUPABASE_URL + "/rest/v1/classes?select=id&limit=1";
-    fetch(url, { headers: { apikey: key, Authorization: "Bearer " + key } })
-      .then(async (r) => {
-        if (process.env.SEED_REST_VERBOSE) console.error("    GET /rest/v1/classes -> HTTP " + r.status + " " + (await r.text()).slice(0, 200));
-        process.exit(r.ok ? 0 : 1);
-      })
-      .catch((e) => { if (process.env.SEED_REST_VERBOSE) console.error("    " + (e && e.message ? e.message : e)); process.exit(1); });
+    const h = { apikey: key, Authorization: "Bearer " + key, "Content-Type": "application/json", Prefer: "return=minimal" };
+    const base = process.env.SUPABASE_URL + "/rest/v1/revoked_token_ids";
+    fetch(base, { method: "POST", headers: h, body: JSON.stringify({ token_id: process.env.PROBE_TOKEN }) })
+      .then((w) => { if (!w.ok) process.exit(1);
+        return fetch(base + "?token_id=eq." + encodeURIComponent(process.env.PROBE_TOKEN) + "&select=token_id", { headers: h }); })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error("read HTTP " + r.status))))
+      .then((rows) => process.exit(Array.isArray(rows) && rows.length >= 1 ? 0 : 1))
+      .catch(() => process.exit(1));
   ' 2>/dev/null
 }
+clear_probe() { psql -tAc "DELETE FROM public.revoked_token_ids WHERE token_id='${PROBE_TOKEN}'" >/dev/null 2>&1 || true; }
+clear_probe
 psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
 ready=0
 for i in $(seq 1 60); do
-  if rest_probe; then ready=1; log "PostgREST serving migrated schema (public.classes)"; break; fi
+  clear_probe                         # start each attempt from a clean slate
+  if rest_write_probe; then ready=1; log "PostgREST table-writes persisting (REST write+read round-trip confirmed)"; clear_probe; break; fi
+  clear_probe                         # a "succeeded but didn't land" probe leaves nothing, but be safe
   # Re-nudge each iteration: PostgREST coalesces reload NOTIFYs, so this is cheap.
   psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
-  log "waiting for PostgREST schema cache ($i/60)"
+  log "waiting for PostgREST table-writes to persist ($i/60)"
   sleep 3
 done
 if [ "$ready" -ne 1 ]; then
-  err "PostgREST ($SUPABASE_URL/rest/v1) not serving migrated schema after 180s; last probe:"
-  SEED_REST_VERBOSE=1 rest_probe || true
-  fail "PostgREST schema cache cold — writes would silently fail"
+  err "PostgREST table-writes not durable after 180s — a REST .insert() returns OK but the row never lands (reads/RPCs/SQL all work). Seeding writes profiles/user_roles through REST and would fail partway."
+  fail "PostgREST table-writes not durable"
 fi
 
 # -----------------------------------------------------------------------------

--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -199,62 +199,6 @@ if [ "$ready" -ne 1 ]; then
 fi
 
 # -----------------------------------------------------------------------------
-# Phase 2c — wait until PostgREST table WRITES actually persist.
-# -----------------------------------------------------------------------------
-# SeedDB.ts writes every profile and user_role through PostgREST (the REST API
-# behind $SUPABASE_URL/rest/v1), not raw SQL. On a fresh install there is a
-# window where PostgREST returns success for a table .insert() that never lands
-# in the database — reads, RPCs and direct SQL all work in that window, ONLY
-# REST table-writes are lost. The seeder then fails partway with a confusing
-# downstream error ("Failed to get profile: Cannot coerce the result to a
-# single JSON object") when its read-back finds 0 rows (2026-06-07 incident;
-# confirmed deterministic — direct-SQL inserts persisted while the seeder's
-# identical REST inserts vanished, and the rest pod had 0 restarts).
-#
-# A read/schema probe is NOT sufficient (reads work the whole time). Nor is a
-# write to a non-RLS table: the lost writes are specifically service_role REST
-# inserts into RLS-enabled tables (profiles, user_roles) — a plain leaf table
-# without RLS persists fine through the same window and would mask the problem.
-# So probe the ACTUAL failing path: a service_role REST insert into an
-# RLS-enabled table, confirmed via a REST read-back, deleted via SQL.
-# github_circuit_breakers is the cleanest such table — RLS on with an explicit
-# service_role ALL-policy, no triggers, no FKs, simple (scope,key) text PK — so
-# a throwaway insert/delete has no side effects. Nudge a schema reload each pass.
-PROBE_TOKEN="__seed_write_probe__"
-export PROBE_TOKEN
-rest_write_probe() {
-  node -e '
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-    const h = { apikey: key, Authorization: "Bearer " + key, "Content-Type": "application/json", Prefer: "return=minimal" };
-    const base = process.env.SUPABASE_URL + "/rest/v1/github_circuit_breakers";
-    const tok = process.env.PROBE_TOKEN;
-    fetch(base, { method: "POST", headers: h, body: JSON.stringify({ scope: tok, key: tok }) })
-      .then((w) => { if (!w.ok) process.exit(1);
-        return fetch(base + "?scope=eq." + encodeURIComponent(tok) + "&select=scope", { headers: h }); })
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error("read HTTP " + r.status))))
-      .then((rows) => process.exit(Array.isArray(rows) && rows.length >= 1 ? 0 : 1))
-      .catch(() => process.exit(1));
-  ' 2>/dev/null
-}
-clear_probe() { psql -tAc "DELETE FROM public.github_circuit_breakers WHERE scope='${PROBE_TOKEN}'" >/dev/null 2>&1 || true; }
-clear_probe
-psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
-ready=0
-for i in $(seq 1 60); do
-  clear_probe                         # start each attempt from a clean slate
-  if rest_write_probe; then ready=1; log "PostgREST table-writes persisting (REST write+read round-trip confirmed)"; clear_probe; break; fi
-  clear_probe                         # a "succeeded but didn't land" probe leaves nothing, but be safe
-  # Re-nudge each iteration: PostgREST coalesces reload NOTIFYs, so this is cheap.
-  psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
-  log "waiting for PostgREST table-writes to persist ($i/60)"
-  sleep 3
-done
-if [ "$ready" -ne 1 ]; then
-  err "PostgREST table-writes not durable after 180s — a REST .insert() returns OK but the row never lands (reads/RPCs/SQL all work). Seeding writes profiles/user_roles through REST and would fail partway."
-  fail "PostgREST table-writes not durable"
-fi
-
-# -----------------------------------------------------------------------------
 # Phase 3 — idempotency check
 # -----------------------------------------------------------------------------
 # SeedDB.ts always creates a NEW class with the configured name. If we

--- a/charts/pawtograder/images/seeder/run-seed.sh
+++ b/charts/pawtograder/images/seeder/run-seed.sh
@@ -199,6 +199,46 @@ if [ "$ready" -ne 1 ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Phase 2c — wait for PostgREST to serve the freshly-migrated schema.
+# -----------------------------------------------------------------------------
+# SeedDB.ts does all its writes through PostgREST (the REST API behind
+# $SUPABASE_URL/rest/v1), not raw SQL. On a fresh install the migrations Job
+# creates public.* only moments before this hook fires, and PostgREST caches
+# the schema — until it reloads, requests against the just-migrated tables hit
+# a stale cache and the seeder fails partway with a confusing downstream error
+# (observed 2026-06-06: "Failed to get profile: Cannot coerce the result to a
+# single JSON object" — the user_roles read-back found 0 rows because the write
+# never landed through the cold cache; deterministic on every fresh preview).
+# Nudge a reload (NOTIFY pgrst) and poll until REST actually serves a migrated
+# table before we start seeding.
+rest_probe() {
+  node -e '
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+    const url = process.env.SUPABASE_URL + "/rest/v1/classes?select=id&limit=1";
+    fetch(url, { headers: { apikey: key, Authorization: "Bearer " + key } })
+      .then(async (r) => {
+        if (process.env.SEED_REST_VERBOSE) console.error("    GET /rest/v1/classes -> HTTP " + r.status + " " + (await r.text()).slice(0, 200));
+        process.exit(r.ok ? 0 : 1);
+      })
+      .catch((e) => { if (process.env.SEED_REST_VERBOSE) console.error("    " + (e && e.message ? e.message : e)); process.exit(1); });
+  ' 2>/dev/null
+}
+psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
+ready=0
+for i in $(seq 1 60); do
+  if rest_probe; then ready=1; log "PostgREST serving migrated schema (public.classes)"; break; fi
+  # Re-nudge each iteration: PostgREST coalesces reload NOTIFYs, so this is cheap.
+  psql -tAc "NOTIFY pgrst, 'reload schema'" >/dev/null 2>&1 || true
+  log "waiting for PostgREST schema cache ($i/60)"
+  sleep 3
+done
+if [ "$ready" -ne 1 ]; then
+  err "PostgREST ($SUPABASE_URL/rest/v1) not serving migrated schema after 180s; last probe:"
+  SEED_REST_VERBOSE=1 rest_probe || true
+  fail "PostgREST schema cache cold — writes would silently fail"
+fi
+
+# -----------------------------------------------------------------------------
 # Phase 3 — idempotency check
 # -----------------------------------------------------------------------------
 # SeedDB.ts always creates a NEW class with the configured name. If we

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -51,18 +51,6 @@ spec:
             - "config_file=/etc/postgresql/postgresql.conf"
             - "-c"
             - "hba_file=/etc/postgresql/pg_hba.conf"
-            # DEBUG (chore/seed-logging, REVERT before merge): log every
-            # statement with the role (%u), application (%a) and transaction id
-            # (%x) so we can see exactly what happens to the seeder's
-            # profiles/user_roles REST inserts on a fresh install — which role
-            # runs them, whether they're wrapped in a transaction, and whether
-            # that transaction commits or rolls back.
-            - "-c"
-            - "log_statement=all"
-            - "-c"
-            - "log_min_error_statement=error"
-            - "-c"
-            - "log_line_prefix=%m [%p] u=%u db=%d app=%a xid=%x "
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgres.database | quote }}

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -51,6 +51,18 @@ spec:
             - "config_file=/etc/postgresql/postgresql.conf"
             - "-c"
             - "hba_file=/etc/postgresql/pg_hba.conf"
+            # DEBUG (chore/seed-logging, REVERT before merge): log every
+            # statement with the role (%u), application (%a) and transaction id
+            # (%x) so we can see exactly what happens to the seeder's
+            # profiles/user_roles REST inserts on a fresh install — which role
+            # runs them, whether they're wrapped in a transaction, and whether
+            # that transaction commits or rolls back.
+            - "-c"
+            - "log_statement=all"
+            - "-c"
+            - "log_min_error_statement=error"
+            - "-c"
+            - "log_line_prefix=%m [%p] u=%u db=%d app=%a xid=%x "
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgres.database | quote }}

--- a/scripts/SeedDB.ts
+++ b/scripts/SeedDB.ts
@@ -691,7 +691,13 @@ async function main() {
 
     await runSeeding(config);
   } catch (error) {
-    console.error("❌ Seeding failed:", error);
+    // Log with a greppable `[seed]` prefix and ALWAYS include the stack — when
+    // this runs as a k8s post-install hook the pod is often gone before its
+    // logs can be read, so the one log line we do get needs to carry the full
+    // trace, not just the message. (See the 2026-06-06 preview-deploy seed
+    // failure, where a transient error left no actionable trace.)
+    const detail = error instanceof Error ? (error.stack ?? `${error.name}: ${error.message}`) : String(error);
+    console.error(`[seed] ❌ Seeding failed: ${detail}`);
     process.exit(1);
   }
 }

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -885,11 +885,23 @@ export async function createUserInClass({
   let publicProfileData: { id: string }, privateProfileData: { id: string };
 
   if (existingRole.length > 0 && !roleCheckError) {
-    // User already enrolled in class, get existing profile data
+    // User already enrolled in class, get existing profile data. This also
+    // covers the real demo class: the create_user_ensure_profiles_and_demo
+    // trigger provisions a profile + role for the is_demo class when the auth
+    // user is created, so the role already exists here and we just reuse it.
     publicProfileData = { id: existingRole[0].public_profile_id };
     privateProfileData = { id: existingRole[0].private_profile_id };
-  } else if (class_id !== 1) {
-    // User not enrolled or new class, create profiles and enrollment
+  } else {
+    // Not enrolled (and the trigger didn't provision us — e.g. a normal,
+    // non-is_demo class). Create profiles + enrollment ourselves.
+    //
+    // NOTE: this used to be `else if (class_id !== 1)`, which assumed class 1
+    // is always the trigger-provisioned demo class and skipped provisioning
+    // for it. On a fresh database the seeder's own (non-demo) class gets id 1,
+    // so that skip left every seeded user with no profile/role and the
+    // read-back below failed with "Failed to get profile". The existingRole
+    // check above already handles the genuine demo-class case, so gating on
+    // class_id is both wrong and unnecessary.
     const { data: newPublicProfileDataList, error: publicProfileError } = await (
       rateLimitManager ?? DEFAULT_RATE_LIMIT_MANAGER
     ).trackAndLimit("profiles", () =>

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -933,7 +933,7 @@ export async function createUserInClass({
     publicProfileData = newPublicProfileData;
     privateProfileData = newPrivateProfileData;
 
-    await supabase.from("user_roles").insert({
+    const { error: roleInsertError } = await supabase.from("user_roles").insert({
       user_id: userId,
       class_id: class_id,
       private_profile_id: privateProfileData.id,
@@ -942,6 +942,13 @@ export async function createUserInClass({
       class_section_id: section_id,
       lab_section_id: lab_section_id
     });
+    // Check the insert: an unchecked failure here (e.g. a cold PostgREST
+    // schema cache on a fresh stack) makes the .single() read-back below find
+    // 0 rows and throw the misleading "Failed to get profile" instead of the
+    // real cause. Fail loudly at the actual point of failure.
+    if (roleInsertError) {
+      throw new Error(`Failed to create ${role} user_role in class ${class_id}: ${roleInsertError.message}`);
+    }
   } else if (section_id || lab_section_id) {
     await (rateLimitManager ?? DEFAULT_RATE_LIMIT_MANAGER).trackAndLimit("user_roles", () =>
       supabase

--- a/tests/e2e/TestingUtils.ts
+++ b/tests/e2e/TestingUtils.ts
@@ -891,6 +891,20 @@ export async function createUserInClass({
     // user is created, so the role already exists here and we just reuse it.
     publicProfileData = { id: existingRole[0].public_profile_id };
     privateProfileData = { id: existingRole[0].private_profile_id };
+    // Apply any requested section assignment to the pre-existing role.
+    if (section_id || lab_section_id) {
+      await (rateLimitManager ?? DEFAULT_RATE_LIMIT_MANAGER).trackAndLimit("user_roles", () =>
+        supabase
+          .from("user_roles")
+          .update({
+            class_section_id: section_id,
+            lab_section_id: lab_section_id
+          })
+          .eq("user_id", userId)
+          .eq("class_id", class_id)
+          .select("id")
+      );
+    }
   } else {
     // Not enrolled (and the trigger didn't provision us — e.g. a normal,
     // non-is_demo class). Create profiles + enrollment ourselves.
@@ -961,18 +975,6 @@ export async function createUserInClass({
     if (roleInsertError) {
       throw new Error(`Failed to create ${role} user_role in class ${class_id}: ${roleInsertError.message}`);
     }
-  } else if (section_id || lab_section_id) {
-    await (rateLimitManager ?? DEFAULT_RATE_LIMIT_MANAGER).trackAndLimit("user_roles", () =>
-      supabase
-        .from("user_roles")
-        .update({
-          class_section_id: section_id,
-          lab_section_id: lab_section_id
-        })
-        .eq("user_id", userId)
-        .eq("class_id", class_id)
-        .select("id")
-    );
   }
   const { data: profileData, error: profileError } = await supabase
     .from("user_roles")


### PR DESCRIPTION
## Why

The preview-deploy **seed job** is a Helm post-install hook. When it fails, the pod is usually gone before its logs can be read — so a *transient* failure leaves no actionable trace. On 2026-06-06 a transient auth/postgres startup race killed the seed partway; the only way to find out *where* it died was to hand-query the preview DB (it had created the class + first gotrue user, then nothing else). Worse, the leftover orphan class then trips the idempotency skip-check on retry, so the next deploy goes **green with a half-seeded DB**.

This PR makes the seed path self-documenting. **No behaviour change** — same waits, same skip semantics, same exit codes — purely observability.

## `run-seed.sh`

- Timestamped, `[seed]`-prefixed `log`/`warn`/`err` helpers.
- An `ERR` trap + `fail()` that print a **diagnostic snapshot** on *any* failure — row counts for `auth.users`, `public.classes`, `profiles`, `user_roles`, `assignments`, `submissions` (each query guarded so the snapshot can't fail the script). "1 class, 1 user, 0 everything-else" instantly tells you it died right after the first user.
- The supabase-services and auth-HTTP waits now **name the laggard** instead of a bare "not ready", and print the real `pg_isready` / gotrue `/auth/v1/health` response on the final timeout instead of swallowing it (`2>/dev/null`).
- On the idempotency skip, log the existing-data counts and **`WARN` loudly when the existing class looks partial** (no roles / no assignments) — the fingerprint of a prior failed seed masquerading as a green deploy.

## `SeedDB.ts`

- The failure path logs the **full stack trace** with a greppable `[seed]` prefix (the message alone isn't enough when you only get one log line from a vanishing pod).

## Testing

- `bash -n run-seed.sh` clean.
- Verified the live seed path end-to-end against a preview stack: full seed completes (`[seed] done`, ~3.4k rows); the snapshot/partial-seed warnings render as intended on the failure/skip paths.

## Follow-ups (not in this PR — observability only)

The transient failure itself has root causes worth separate fixes: auth (gotrue) crash-loops on fresh installs because it boots before the `pawtograder-postgres` Service DNS resolves; the seed Job has `backoffLimit: 0` so one transient failure = red with no retry; and the idempotency check treats a *partial* class as "already seeded."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Seeding now records UTC, standardized "[seed]" logs, captures diagnostic snapshots on errors, and provides detailed timeout diagnostics for database and service readiness (including REST durability checks).
  * Readiness checks report per-iteration progress and warn on likely partial prior runs when existing data is detected.

* **Chores**
  * Centralized, greppable seeding logs and unified failure handling.

* **Tests**
  * Test utilities now fail fast with descriptive enrollment-insert errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->