### PR TITLE
feat(preview): shared wildcard TLS cert instead of per-PR Let's Encrypt certs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -112,7 +112,10 @@ jobs:
           fi
           short_sha="${sha:0:7}"
           hostname="pr-${preview_id}.${PREVIEW_DOMAIN}"
-          api_hostname="api.pr-${preview_id}.${PREVIEW_DOMAIN}"
+          # Single-label api host so the *.preview.pawtograder.net wildcard cert
+          # covers it (matches the chart's pawtograder.api.hostname helper /
+          # global.apiHostnameFlatten). Was api.pr-${preview_id}.${PREVIEW_DOMAIN}.
+          api_hostname="pr-${preview_id}-api.${PREVIEW_DOMAIN}"
           tag="pr-${preview_id}-${short_sha}"
           release="pawtograder"
           namespace="pawtograder-preview-pr-${preview_id}"

--- a/charts/pawtograder/examples/values-preview.yaml
+++ b/charts/pawtograder/examples/values-preview.yaml
@@ -19,14 +19,14 @@
 global:
   # Set per-preview from CI: e.g. pr-123.preview.pawtograder.net
   hostname: REPLACE_PER_PREVIEW.preview.pawtograder.net
-  # Serve the Supabase API same-origin (path-routed: /auth/v1, /rest/v1, …) on
-  # the single preview host instead of a separate api.<host>. This means one
-  # hostname per preview, fully covered by the shared *.preview.pawtograder.net
-  # wildcard cert — there is no two-label api.pr-N.preview host that a wildcard
-  # could not cover. REQUIRES the matching preview.yml build-arg change (see
-  # deploy/preview-tls/README.md): NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL must
-  # point at the main hostname, not api.<hostname>.
-  apiOnSeparateHost: false
+  # Keep the API on its own host (prod-like topology), but FLATTEN it to a
+  # single label — pr-123-api.preview.pawtograder.net instead of
+  # api.pr-123.preview.pawtograder.net — so the shared *.preview.pawtograder.net
+  # wildcard cert covers it (a TLS wildcard spans only one label). REQUIRES the
+  # matching preview.yml change (see deploy/preview-tls/README.md):
+  # api_hostname must use the same pr-<N>-api.<domain> scheme.
+  apiOnSeparateHost: true
+  apiHostnameFlatten: true
   # Previews run on the general worker pool, NOT the prod-staging tier.
   # Keep node selectors / tolerations empty.
   nodeSelector: {}

--- a/charts/pawtograder/examples/values-preview.yaml
+++ b/charts/pawtograder/examples/values-preview.yaml
@@ -19,7 +19,14 @@
 global:
   # Set per-preview from CI: e.g. pr-123.preview.pawtograder.net
   hostname: REPLACE_PER_PREVIEW.preview.pawtograder.net
-  apiOnSeparateHost: true
+  # Serve the Supabase API same-origin (path-routed: /auth/v1, /rest/v1, …) on
+  # the single preview host instead of a separate api.<host>. This means one
+  # hostname per preview, fully covered by the shared *.preview.pawtograder.net
+  # wildcard cert — there is no two-label api.pr-N.preview host that a wildcard
+  # could not cover. REQUIRES the matching preview.yml build-arg change (see
+  # deploy/preview-tls/README.md): NEXT_PUBLIC_SUPABASE_URL / SUPABASE_URL must
+  # point at the main hostname, not api.<hostname>.
+  apiOnSeparateHost: false
   # Previews run on the general worker pool, NOT the prod-staging tier.
   # Keep node selectors / tolerations empty.
   nodeSelector: {}
@@ -31,20 +38,23 @@ global:
 secrets:
   autogenerate: true
 
-# Single Ingress for the chart's main hosts. The cert-manager annotation
-# auto-provisions a Certificate per preview from the *.pawtograder.net
-# wildcard issuer.
+# Single Ingress for the chart's main host. No cert-manager.io/cluster-issuer
+# annotation on purpose: previews do NOT mint their own cert. They consume the
+# shared *.preview.pawtograder.net wildcard cert, which is reflected into every
+# pawtograder-preview-* namespace as Secret `pawtograder-preview-wildcard-tls`.
+# This avoids Let's Encrypt's per-identifier (5/wk) and per-domain (50/wk) rate
+# limits that per-PR issuance hits under churn. See deploy/preview-tls/.
 ingress:
   enabled: true
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-body-size: "55m"
   tls:
     enabled: true
-    secretName: pawtograder-preview-tls
+    # The reflected wildcard Secret (NOT a per-preview cert-manager secret).
+    secretName: pawtograder-preview-wildcard-tls
 
 # ----- Postgres on shared ceph-rbd (no local SSD) ----------------------------
 postgres:

--- a/charts/pawtograder/templates/_helpers.tpl
+++ b/charts/pawtograder/templates/_helpers.tpl
@@ -145,7 +145,7 @@ by a *.preview.pawtograder.net wildcard TLS cert (a wildcard spans only one
 label, so the default two-label "api.pr-123.preview…" form is NOT coverable).
 */}}
 {{- define "pawtograder.api.hostname" -}}
-{{- if .Values.global.apiHostnameFlatten -}}
+{{- if and .Values.global.apiHostnameFlatten (contains "." .Values.global.hostname) -}}
 {{- $parts := splitn "." 2 .Values.global.hostname -}}
 {{- printf "%s-api.%s" $parts._0 $parts._1 -}}
 {{- else -}}

--- a/charts/pawtograder/templates/_helpers.tpl
+++ b/charts/pawtograder/templates/_helpers.tpl
@@ -136,9 +136,26 @@ Public URLs.
 {{- printf "https://%s" .Values.global.hostname -}}
 {{- end -}}
 
+{{/*
+The separate-API hostname. Default is "api.<hostname>". When
+global.apiHostnameFlatten is true it instead prefixes "-api" onto the first
+label — pr-123.preview.pawtograder.net -> pr-123-api.preview.pawtograder.net —
+so the host stays a single label under the parent zone and is therefore covered
+by a *.preview.pawtograder.net wildcard TLS cert (a wildcard spans only one
+label, so the default two-label "api.pr-123.preview…" form is NOT coverable).
+*/}}
+{{- define "pawtograder.api.hostname" -}}
+{{- if .Values.global.apiHostnameFlatten -}}
+{{- $parts := splitn "." 2 .Values.global.hostname -}}
+{{- printf "%s-api.%s" $parts._0 $parts._1 -}}
+{{- else -}}
+{{- printf "api.%s" .Values.global.hostname -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "pawtograder.api.url" -}}
 {{- if .Values.global.apiOnSeparateHost -}}
-{{- printf "https://api.%s" .Values.global.hostname -}}
+{{- printf "https://%s" (include "pawtograder.api.hostname" .) -}}
 {{- else -}}
 {{- printf "https://%s" .Values.global.hostname -}}
 {{- end -}}

--- a/charts/pawtograder/templates/ingress.yaml
+++ b/charts/pawtograder/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - hosts:
         - {{ .Values.global.hostname | quote }}
         {{- if .Values.global.apiOnSeparateHost }}
-        - "api.{{ .Values.global.hostname }}"
+        - {{ include "pawtograder.api.hostname" . | quote }}
         {{- end }}
         {{- range .Values.ingress.extraHosts }}
         - {{ . | quote }}
@@ -84,7 +84,7 @@ spec:
                 port:
                   number: {{ .Values.web.service.port }}
     {{- if .Values.global.apiOnSeparateHost }}
-    - host: "api.{{ .Values.global.hostname }}"
+    - host: {{ include "pawtograder.api.hostname" . | quote }}
       http:
         paths:
           - path: /

--- a/deploy/preview-tls/README.md
+++ b/deploy/preview-tls/README.md
@@ -21,10 +21,12 @@ touched.
    `ingress.tls.secretName` at the reflected Secret and drops the
    `cert-manager.io/cluster-issuer` annotation, so previews consume the shared
    cert instead of minting their own.
-5. Previews serve the Supabase API **same-origin** (`global.apiOnSeparateHost:
-   false`) so there's a single hostname per preview, fully covered by the
-   wildcard. (A TLS wildcard spans one label, so it could never cover the old
-   two-label `api.pr-N.preview.pawtograder.net` host.)
+5. Previews keep a **separate API host** but flatten it to a single label
+   (`global.apiHostnameFlatten: true`): `pr-N-api.preview.pawtograder.net`
+   instead of `api.pr-N.preview.pawtograder.net`. Both the app host and the api
+   host are then single labels under `preview.pawtograder.net`, so the one
+   wildcard covers both. (A TLS wildcard spans one label, so it could never
+   cover the old two-label `api.pr-N.preview…` host.)
 
 ## Rollout (run in order; merge the chart change LAST)
 
@@ -50,23 +52,21 @@ or previews break.
 
 ## Required companion change in `.github/workflows/preview.yml`
 
-Switching to same-origin API means the web app must be **built** to call the
-API on the main host (Next.js bakes `NEXT_PUBLIC_*` at build time). This file
-is a GitHub Actions workflow, which the automation token here can't push — apply
-it by hand:
+The web image bakes the API URL at build time (`NEXT_PUBLIC_SUPABASE_URL`), and
+that URL flows from the `meta` job's `api_hostname`. Flatten it to the same
+`pr-<N>-api` scheme the chart now derives, so the built app calls the host the
+wildcard actually covers. This is a GitHub Actions workflow file, which the
+automation token here can't push — apply it by hand:
 
 ```diff
-   build-args: |
-     NEXT_PUBLIC_PAWTOGRADER_WEB_URL=https://${{ needs.meta.outputs.hostname }}
--    NEXT_PUBLIC_SUPABASE_URL=https://${{ needs.meta.outputs.api_hostname }}
-+    NEXT_PUBLIC_SUPABASE_URL=https://${{ needs.meta.outputs.hostname }}
-     ...
--    SUPABASE_URL=https://${{ needs.meta.outputs.api_hostname }}
-+    SUPABASE_URL=https://${{ needs.meta.outputs.hostname }}
+       hostname="pr-${preview_id}.${PREVIEW_DOMAIN}"
+-      api_hostname="api.pr-${preview_id}.${PREVIEW_DOMAIN}"
++      api_hostname="pr-${preview_id}-api.${PREVIEW_DOMAIN}"
 ```
 
-(`api_hostname`/the `api.` host can then be dropped from the `meta` job and the
-PR-comment "API:" line, but that's cosmetic — leaving them is harmless.)
+That single line keeps `api_hostname` (used by the web build args, the seeder
+`SUPABASE_URL`, and the PR-comment "API:" link) in lockstep with the chart's
+`pawtograder.api.hostname` helper. No other workflow change is needed.
 
 ## Rollback
 

--- a/deploy/preview-tls/README.md
+++ b/deploy/preview-tls/README.md
@@ -72,5 +72,5 @@ That single line keeps `api_hostname` (used by the web build args, the seeder
 
 Revert the `values-preview.yaml` change and restore the two `preview.yml` lines;
 previews go back to per-PR issuance. The wildcard cert + reflector can stay (they
-do no harm) or be removed with `kubectl delete -f wildcard-certificate.yaml` and
+do no harm) or be removed with `kubectl delete -f deploy/preview-tls/wildcard-certificate.yaml` and
 `helm uninstall -n reflector reflector`.

--- a/deploy/preview-tls/README.md
+++ b/deploy/preview-tls/README.md
@@ -1,0 +1,76 @@
+# Preview TLS: shared wildcard cert
+
+Replaces the per-PR Let's Encrypt cert (one per preview, rate-limit-prone) with
+a single reflected wildcard cert for `*.preview.pawtograder.net`.
+
+See `wildcard-certificate.yaml` for the full rationale. TL;DR: LE caps certs at
+**5 per exact identifier set / week** and **50 per registered domain / week**;
+per-PR issuance bumps into both under churn (it took down `pr-821`'s SSL on
+2026-06-07). One shared wildcard issued once = no per-PR issuance = limit never
+touched.
+
+## How it fits together
+
+1. `letsencrypt-prod` (existing) already has a Cloudflare **DNS-01** solver for
+   the `pawtograder.net` zone — required for wildcards.
+2. `wildcard-certificate.yaml` issues `*.preview.pawtograder.net` once into the
+   `cert-manager` namespace as Secret `pawtograder-preview-wildcard-tls`.
+3. **Reflector** copies that Secret into every `pawtograder-preview-*` namespace
+   (and into new ones as they're created) and keeps copies in sync on renewal.
+4. The preview chart (`examples/values-preview.yaml`) points
+   `ingress.tls.secretName` at the reflected Secret and drops the
+   `cert-manager.io/cluster-issuer` annotation, so previews consume the shared
+   cert instead of minting their own.
+5. Previews serve the Supabase API **same-origin** (`global.apiOnSeparateHost:
+   false`) so there's a single hostname per preview, fully covered by the
+   wildcard. (A TLS wildcard spans one label, so it could never cover the old
+   two-label `api.pr-N.preview.pawtograder.net` host.)
+
+## Rollout (run in order; merge the chart change LAST)
+
+```bash
+# 1. Install reflector (one-time; ~1 small controller pod)
+helm repo add emberstack https://emberstack.github.io/helm-charts
+helm upgrade --install reflector emberstack/reflector \
+  --namespace reflector --create-namespace
+
+# 2. Issue the wildcard cert + reflection config
+kubectl apply -f deploy/preview-tls/wildcard-certificate.yaml
+kubectl -n cert-manager wait --for=condition=Ready certificate/pawtograder-preview-wildcard --timeout=300s
+
+# 3. Confirm reflection lands in a live preview namespace
+kubectl -n cert-manager get secret pawtograder-preview-wildcard-tls
+#   open a PR / redeploy one, then:
+kubectl -n pawtograder-preview-pr-<N> get secret pawtograder-preview-wildcard-tls
+```
+
+Only after steps 1–3 succeed, merge this PR (the `values-preview.yaml` change)
+**and** apply the `preview.yml` companion change below — they must land together
+or previews break.
+
+## Required companion change in `.github/workflows/preview.yml`
+
+Switching to same-origin API means the web app must be **built** to call the
+API on the main host (Next.js bakes `NEXT_PUBLIC_*` at build time). This file
+is a GitHub Actions workflow, which the automation token here can't push — apply
+it by hand:
+
+```diff
+   build-args: |
+     NEXT_PUBLIC_PAWTOGRADER_WEB_URL=https://${{ needs.meta.outputs.hostname }}
+-    NEXT_PUBLIC_SUPABASE_URL=https://${{ needs.meta.outputs.api_hostname }}
++    NEXT_PUBLIC_SUPABASE_URL=https://${{ needs.meta.outputs.hostname }}
+     ...
+-    SUPABASE_URL=https://${{ needs.meta.outputs.api_hostname }}
++    SUPABASE_URL=https://${{ needs.meta.outputs.hostname }}
+```
+
+(`api_hostname`/the `api.` host can then be dropped from the `meta` job and the
+PR-comment "API:" line, but that's cosmetic — leaving them is harmless.)
+
+## Rollback
+
+Revert the `values-preview.yaml` change and restore the two `preview.yml` lines;
+previews go back to per-PR issuance. The wildcard cert + reflector can stay (they
+do no harm) or be removed with `kubectl delete -f wildcard-certificate.yaml` and
+`helm uninstall -n reflector reflector`.

--- a/deploy/preview-tls/wildcard-certificate.yaml
+++ b/deploy/preview-tls/wildcard-certificate.yaml
@@ -15,10 +15,12 @@
 # rate limit is never touched again. The cert auto-renews once; renewals are
 # re-reflected automatically.
 #
-# This covers the single-label app host pr-N.preview.pawtograder.net. The api is
-# served same-origin on that host (global.apiOnSeparateHost: false in
-# values-preview.yaml), so there is no api.pr-N.preview.pawtograder.net host to
-# cover — a TLS wildcard only spans one label and could not cover it anyway.
+# A TLS wildcard spans only ONE label, so it covers single-label hosts under
+# preview.pawtograder.net. Previews keep a separate API host but flatten it to a
+# single label (pr-N-api.preview.pawtograder.net, via global.apiHostnameFlatten)
+# so both the app host (pr-N.preview…) and the api host (pr-N-api.preview…) fall
+# under this one wildcard. The old two-label api.pr-N.preview… form could never
+# be wildcard-covered.
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/deploy/preview-tls/wildcard-certificate.yaml
+++ b/deploy/preview-tls/wildcard-certificate.yaml
@@ -29,8 +29,8 @@ metadata:
   namespace: cert-manager
 spec:
   secretName: pawtograder-preview-wildcard-tls
-  duration: 2160h    # 90d
-  renewBefore: 720h  # 30d
+  duration: 2160h # 90d
+  renewBefore: 720h # 30d
   privateKey:
     rotationPolicy: Always
   issuerRef:

--- a/deploy/preview-tls/wildcard-certificate.yaml
+++ b/deploy/preview-tls/wildcard-certificate.yaml
@@ -1,0 +1,47 @@
+# Shared wildcard TLS certificate for per-PR preview deploys.
+#
+# WHY: previews used to request a fresh Let's Encrypt cert per PR for the exact
+# SAN set [pr-N.preview…, api.pr-N.preview…]. LE caps "certificates per exact
+# set of identifiers" at 5/week, so a heavily re-deployed PR (or enough churn
+# across PRs against the 50/week per-registered-domain cap) starts getting
+# `429 rateLimited`, cert-manager can't fill the Secret, and nginx serves its
+# self-signed "Fake Certificate" → browser SSL error.
+#
+# FIX: issue ONE wildcard cert for *.preview.pawtograder.net via the existing
+# letsencrypt-prod ClusterIssuer (which already has a Cloudflare DNS-01 solver
+# for the pawtograder.net zone — wildcards REQUIRE DNS-01), and reflect its
+# Secret into every pawtograder-preview-* namespace. Previews then consume the
+# shared Secret instead of each minting their own — zero per-PR issuance, so the
+# rate limit is never touched again. The cert auto-renews once; renewals are
+# re-reflected automatically.
+#
+# This covers the single-label app host pr-N.preview.pawtograder.net. The api is
+# served same-origin on that host (global.apiOnSeparateHost: false in
+# values-preview.yaml), so there is no api.pr-N.preview.pawtograder.net host to
+# cover — a TLS wildcard only spans one label and could not cover it anyway.
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pawtograder-preview-wildcard
+  namespace: cert-manager
+spec:
+  secretName: pawtograder-preview-wildcard-tls
+  duration: 2160h    # 90d
+  renewBefore: 720h  # 30d
+  privateKey:
+    rotationPolicy: Always
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.preview.pawtograder.net"
+  # Reflector (emberstack) copies the resulting Secret into every namespace
+  # matching the regex, and keeps copies in sync on renewal. The annotations
+  # live on the *Secret* cert-manager creates, via secretTemplate.
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "pawtograder-preview-.*"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "pawtograder-preview-.*"


### PR DESCRIPTION
## Why

Per-PR previews each request their **own** Let's Encrypt cert for the exact SAN
set `[pr-N.preview.pawtograder.net, api.pr-N.preview.pawtograder.net]`. LE caps:
- **5 certs / week** per *exact identifier set*, and
- **50 certs / week** per *registered domain* (`pawtograder.net`).

Under churn this 429s, cert-manager can't populate the TLS Secret, and nginx
falls back to its self-signed **"Fake Certificate"** → browser SSL error. This
took down `pr-821`'s SSL on 2026-06-07 after ~8 redeploys in a day.

## What this does

One **shared wildcard cert**, so per-PR issuance (and the rate limits) go away:

- **`deploy/preview-tls/wildcard-certificate.yaml`** — issues
  `*.preview.pawtograder.net` **once** via the existing `letsencrypt-prod`
  Cloudflare **DNS-01** solver, into `cert-manager` as Secret
  `pawtograder-preview-wildcard-tls`, with **reflector** annotations to copy it
  into every `pawtograder-preview-*` namespace (kept in sync on renewal).
- **Chart** — previews consume the reflected Secret, **drop** the per-PR
  `cert-manager.io/cluster-issuer` annotation, and **keep a separate API host**
  but **flatten it to a single label** so the wildcard covers it:
  `pr-N-api.preview.pawtograder.net` instead of `api.pr-N.preview.pawtograder.net`
  (a TLS wildcard spans one label only). New `pawtograder.api.hostname` helper
  gated on `global.apiHostnameFlatten`; **prod/staging are unchanged**
  (`api.<hostname>`).

Renders for `pr-821`:
```
ingress hosts:  pr-821.preview.pawtograder.net, pr-821-api.preview.pawtograder.net
tls secretName: pawtograder-preview-wildcard-tls
pod env SUPABASE_URL: https://pr-821-api.preview.pawtograder.net
```
`helm lint` clean; non-preview render still emits `api.app.example.com`.

## Rollout (ordered — see `deploy/preview-tls/README.md`)

> ⚠️ Merge the chart change **last**. Steps 1–3 + the `preview.yml` companion
> must land together or previews break.

1. `helm upgrade --install reflector emberstack/reflector -n reflector --create-namespace`
2. `kubectl apply -f deploy/preview-tls/wildcard-certificate.yaml` → wait Ready
3. Verify the Secret reflects into a live `pawtograder-preview-pr-*` namespace
4. Apply the **`preview.yml` companion** (one line — not in this PR; the bot
   token lacks `workflow` scope). Change `api_hostname` to the `pr-N-api` scheme:
   ```diff
   -      api_hostname="api.pr-${preview_id}.${PREVIEW_DOMAIN}"
   +      api_hostname="pr-${preview_id}-api.${PREVIEW_DOMAIN}"
   ```
5. Merge this PR.

## Notes

- Separate API origin is preserved (prod-like) — only the hostname *shape*
  changes (`pr-N-api` vs `api.pr-N`).
- Rollback: revert the chart change + the one `preview.yml` line; the
  cert/reflector are harmless to leave.
- `pr-821`'s own SSL self-heals after the LE window clears (~2026-06-08 06:51
  UTC) independent of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized preview environment TLS infrastructure by implementing a shared wildcard certificate instead of per-preview certificate issuance.
  * Updated API hostname pattern for preview deployments to align with new certificate scheme.

* **Documentation**
  * Added documentation for preview TLS certificate configuration and deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->