### PR TITLE
fix(grades): show active submission's grade on dashboard & correct hand-grading rollup (#823)

### DIFF
--- a/components/grade/HandGradingSection.tsx
+++ b/components/grade/HandGradingSection.tsx
@@ -12,7 +12,7 @@ import {
 import { useClassProfiles, useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
 import { useShouldShowRubricCheck } from "@/hooks/useRubricVisibility";
 import { useRubricCheckInstances, useSubmission, useSubmissionReviewOrGradingReview } from "@/hooks/useSubmission";
-import { maxPointsForCriterion } from "@/lib/rubric/points";
+import { earnedPointsForCriterion, maxPointsForCriterion } from "@/lib/rubric/points";
 import type {
   HydratedRubricCheck,
   RegradeRequest,
@@ -285,10 +285,11 @@ function CheckRow({
 
 /**
  * One criterion block: header with name and earned/max, then a row per check. Earned points are
- * rolled up from the applied points across the criterion's checks, mirroring the recompute logic
- * in 20250522235254_fix-compute-grades-negative-score.sql:
- *   - additive:     min(sum of applied points, total_points)
- *   - non-additive: max(total_points - sum of applied deductions, 0)
+ * rolled up from the applied points across the criterion's checks via earnedPointsForCriterion,
+ * mirroring the per-criterion score branches in _submission_review_recompute_scores:
+ *   - deduction-only: max(-sum of applied deductions, -total_points)  (a non-positive penalty)
+ *   - additive:       min(sum of applied points, total_points)
+ *   - non-additive:   max(total_points - sum of applied deductions, 0)
  * Renders nothing (but keeps child hooks mounted) when no checks are visible to the current user.
  */
 function CriterionBlock({
@@ -322,7 +323,6 @@ function CriterionBlock({
     []
   );
 
-  const totalPoints = criteria.total_points ?? 0;
   const max = useMemo(
     () =>
       maxPointsForCriterion({
@@ -338,9 +338,19 @@ function CriterionBlock({
   const appliedTotal = useMemo(() => Object.values(checkState).reduce((acc, s) => acc + s.appliedSum, 0), [checkState]);
   const anyVisible = useMemo(() => Object.values(checkState).some((s) => s.visible), [checkState]);
 
-  // Earned: additive caps the sum at total_points; non-additive / deduction-only subtracts the
-  // applied deductions from total_points, floored at 0.
-  const earned = criteria.is_additive ? Math.min(appliedTotal, totalPoints) : Math.max(totalPoints - appliedTotal, 0);
+  // Earned points this criterion contributes, by mode (see earnedPointsForCriterion):
+  // additive caps the applied sum at total_points; non-additive subtracts applied deductions from
+  // total_points (floored at 0); deduction-only contributes a non-positive penalty. Folding
+  // deduction-only into the non-additive branch (the prior bug) reported total_points - applied as
+  // "earned", which both inflated the criterion line and let the rolled-up earned exceed the max.
+  const earned = earnedPointsForCriterion(
+    {
+      is_additive: criteria.is_additive,
+      is_deduction_only: criteria.is_deduction_only,
+      total_points: criteria.total_points
+    },
+    appliedTotal
+  );
 
   // Bubble criterion-level visibility + score up to the section header / emptiness check.
   useEffect(() => {

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -86,7 +86,6 @@ import {
   getStudentFacingErrorMessage,
   GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE
 } from "@/lib/studentFacingErrorMessages";
-import { earnedPointsForCriterion } from "@/lib/rubric/points";
 import { useIsTableControllerReady } from "@/lib/TableController";
 import { Icon } from "@chakra-ui/react";
 import { formatRelative } from "date-fns";
@@ -1299,22 +1298,22 @@ export function RubricCriteria({
     target_student_profile_id: targetStudentProfileId
   });
   const totalPoints = comments.reduce((acc, comment) => acc + (comment.points || 0), 0);
+  const isAdditive = criteria.is_additive;
   const [selectedCheck, setSelectedCheck] = useState<HydratedRubricCheck>();
   let pointsText = "";
   if (criteria.total_points) {
-    // Earned points by criterion mode, via the shared helper that mirrors the canonical
-    // recompute SQL: additive caps at total_points, non-additive floors at 0 (so an
-    // over-deduction never renders a spurious negative), deduction-only is a non-positive
-    // penalty clamped to -total_points.
-    const earned = earnedPointsForCriterion(
-      {
-        is_additive: criteria.is_additive,
-        is_deduction_only: criteria.is_deduction_only,
-        total_points: criteria.total_points
-      },
-      totalPoints
-    );
-    pointsText = `${earned}/${criteria.total_points}`;
+    // Grader-facing running tally. Additive shows the raw applied sum *uncapped* on purpose, so
+    // a grader sees over-cap adjustments (e.g. a +100 regrade tweak → "120.5/20"); the cap is
+    // applied only when the score is computed, not in this tally.
+    if (criteria.is_deduction_only) {
+      pointsText = `-${totalPoints}/${criteria.total_points}`;
+    } else if (isAdditive) {
+      pointsText = `${totalPoints}/${criteria.total_points}`;
+    } else {
+      // Floor the earned tally at 0 so an over-deduction doesn't render a spurious negative
+      // (mirrors the non-additive floor in _submission_review_recompute_scores).
+      pointsText = `${Math.max(criteria.total_points - totalPoints, 0)}/${criteria.total_points}`;
+    }
   }
   const isGrader = useIsGraderOrInstructor();
   const isTaOnly = useIsGrader();

--- a/components/ui/rubric-sidebar.tsx
+++ b/components/ui/rubric-sidebar.tsx
@@ -86,6 +86,7 @@ import {
   getStudentFacingErrorMessage,
   GRADING_FEEDBACK_RELEASED_GRADER_MESSAGE
 } from "@/lib/studentFacingErrorMessages";
+import { earnedPointsForCriterion } from "@/lib/rubric/points";
 import { useIsTableControllerReady } from "@/lib/TableController";
 import { Icon } from "@chakra-ui/react";
 import { formatRelative } from "date-fns";
@@ -1298,17 +1299,22 @@ export function RubricCriteria({
     target_student_profile_id: targetStudentProfileId
   });
   const totalPoints = comments.reduce((acc, comment) => acc + (comment.points || 0), 0);
-  const isAdditive = criteria.is_additive;
   const [selectedCheck, setSelectedCheck] = useState<HydratedRubricCheck>();
   let pointsText = "";
   if (criteria.total_points) {
-    if (criteria.is_deduction_only) {
-      pointsText = `-${totalPoints}/${criteria.total_points}`;
-    } else if (isAdditive) {
-      pointsText = `${totalPoints}/${criteria.total_points}`;
-    } else {
-      pointsText = `${criteria.total_points - totalPoints}/${criteria.total_points}`;
-    }
+    // Earned points by criterion mode, via the shared helper that mirrors the canonical
+    // recompute SQL: additive caps at total_points, non-additive floors at 0 (so an
+    // over-deduction never renders a spurious negative), deduction-only is a non-positive
+    // penalty clamped to -total_points.
+    const earned = earnedPointsForCriterion(
+      {
+        is_additive: criteria.is_additive,
+        is_deduction_only: criteria.is_deduction_only,
+        total_points: criteria.total_points
+      },
+      totalPoints
+    );
+    pointsText = `${earned}/${criteria.total_points}`;
   }
   const isGrader = useIsGraderOrInstructor();
   const isTaOnly = useIsGrader();

--- a/lib/rubric/points.ts
+++ b/lib/rubric/points.ts
@@ -1,6 +1,8 @@
 import { HydratedRubric, HydratedRubricCheck, HydratedRubricCriteria } from "@/utils/supabase/DatabaseTypes";
 
-type CriterionScoreShape = Pick<HydratedRubricCriteria, "is_additive" | "is_deduction_only" | "total_points"> & {
+type CriterionModeShape = Pick<HydratedRubricCriteria, "is_additive" | "is_deduction_only" | "total_points">;
+
+type CriterionScoreShape = CriterionModeShape & {
   rubric_checks: Pick<HydratedRubricCheck, "points">[];
 };
 
@@ -21,6 +23,32 @@ export function maxPointsForCriterion(criteria: CriterionScoreShape): number {
     return Math.min(sumCheckPoints, totalPoints);
   }
   return totalPoints;
+}
+
+/**
+ * Points a single criterion *actually* contributes to a student's grade, given the
+ * sum of applied check-point magnitudes (`appliedTotal`, always non-negative — points
+ * are stored as positive magnitudes and the sign comes from the criterion mode). This
+ * is the exact per-criterion `score` branch from `_submission_review_recompute_scores`
+ * (see `20260604000000_floor-submission-review-score-at-zero.sql`):
+ *
+ * - deduction-only: `greatest(-appliedTotal, -total_points)` → in `[-total_points, 0]`
+ * - additive: `least(appliedTotal, total_points)` → in `[0, total_points]`
+ * - non-additive: `greatest(total_points - appliedTotal, 0)` → in `[0, total_points]`
+ *
+ * Critically, the deduction-only branch yields a *non-positive* number (a penalty),
+ * not `total_points - appliedTotal`. In every branch the result is
+ * `<= maxPointsForCriterion(criteria)`, so a rolled-up earned total can never exceed
+ * the rolled-up max.
+ */
+export function earnedPointsForCriterion(criteria: CriterionModeShape, appliedTotal: number): number {
+  const totalPoints = criteria.total_points ?? 0;
+  if (criteria.is_deduction_only) {
+    const penalty = Math.max(-appliedTotal, -totalPoints);
+    return penalty === 0 ? 0 : penalty; // normalize -0 → 0 so the UI never renders "−0"
+  }
+  if (criteria.is_additive) return Math.min(appliedTotal, totalPoints);
+  return Math.max(totalPoints - appliedTotal, 0);
 }
 
 export type AssignToStudentPartSummary = {

--- a/supabase/migrations/20260608120000_dashboard_rpc_prefer_active_submission.sql
+++ b/supabase/migrations/20260608120000_dashboard_rpc_prefer_active_submission.sql
@@ -1,0 +1,390 @@
+-- Make `public.get_assignments_for_student_dashboard` surface the ACTIVE submission
+-- rather than the most-recently-created one.
+--
+-- Bug (issue #823): the dashboard's chosen-submission CTEs picked the latest submission
+-- by `created_at`. When a student makes a later not-for-grading submission
+-- (`is_not_graded = true` — see 20260424200000_prevent_dual_active_submissions.sql, which
+-- does NOT set `is_active` on such rows), or when an older submission has been explicitly
+-- re-activated (`submission_set_active`), the active/graded submission and the latest
+-- submission differ. The dashboard then showed the later submission, whose grading review
+-- is not released, so the row fell back to the autograder-only score and max
+-- (e.g. "81.67/90") instead of the active hand-graded submission's released total out of
+-- the assignment's full points (e.g. "87.67/100"). Every other assignment looked correct
+-- because there the latest submission *was* the active one.
+--
+-- Fix: prefer `is_active = true` when choosing the submission, breaking ties by most
+-- recent `created_at` (so the normal case — newest submission is active — is unchanged).
+-- Only the three ORDER BY clauses below (the two per-mode LATERALs and the
+-- chosen_submission DISTINCT ON) differ from 20260529120000_dashboard_rpc_gate_grading_release.sql;
+-- the release gate, authorization gate, return shape, and every other CTE are unchanged.
+
+CREATE OR REPLACE FUNCTION public.get_assignments_for_student_dashboard(
+  p_class_id bigint,
+  p_student_profile_id uuid
+) RETURNS TABLE (
+  id bigint,
+  created_at timestamptz,
+  class_id bigint,
+  title text,
+  release_date timestamptz,
+  due_date timestamptz,
+  student_repo_prefix text,
+  total_points numeric,
+  has_autograder boolean,
+  has_handgrader boolean,
+  description text,
+  slug text,
+  template_repo text,
+  allow_student_formed_groups boolean,
+  group_config public.assignment_group_mode,
+  group_formation_deadline timestamptz,
+  max_group_size integer,
+  min_group_size integer,
+  archived_at timestamptz,
+  autograder_points bigint,
+  grading_rubric_id bigint,
+  max_late_tokens integer,
+  latest_template_sha text,
+  meta_grading_rubric_id bigint,
+  self_review_rubric_id bigint,
+  self_review_setting_id bigint,
+  gradebook_column_id bigint,
+  minutes_due_after_lab integer,
+  allow_not_graded_submissions boolean,
+  student_profile_id uuid,
+  student_user_id uuid,
+  submission_id bigint,
+  submission_created_at timestamptz,
+  submission_is_active boolean,
+  submission_ordinal integer,
+  grader_result_id bigint,
+  grader_result_score numeric,
+  grader_result_max_score numeric,
+  repository_id bigint,
+  repository text,
+  is_github_ready boolean,
+  assignment_self_review_setting_id bigint,
+  self_review_enabled boolean,
+  self_review_deadline_offset bigint,
+  review_assignment_id bigint,
+  review_submission_id bigint,
+  submission_review_id bigint,
+  submission_review_completed_at timestamptz,
+  due_date_exception_id bigint,
+  exception_hours integer,
+  exception_minutes integer,
+  exception_tokens_consumed integer,
+  exception_created_at timestamptz,
+  exception_creator_id uuid,
+  exception_note text,
+  grading_submission_review_id bigint,
+  grading_submission_review_completed_at timestamptz,
+  grading_total_score numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+#variable_conflict use_column
+BEGIN
+  -- Authorization gate (top of function, single explicit check).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.user_id = auth.uid()
+      AND ur.disabled = false
+      AND (
+        (ur.role = 'student'::public.app_role AND ur.private_profile_id = p_student_profile_id)
+        OR ur.role = 'instructor'::public.app_role
+        OR ur.role = 'grader'::public.app_role
+      )
+  ) THEN
+    RAISE EXCEPTION 'not authorized to read assignments dashboard for this student'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Body: same CTE chain that the previous view used, but `ur_students` is bounded
+  -- to the single requested (class, student) so every downstream join is O(assignments)
+  -- rather than O(class_students * assignments).
+  RETURN QUERY
+  WITH ur_students AS (
+    SELECT ur.class_id,
+           ur.private_profile_id AS student_profile_id,
+           ur.user_id AS student_user_id
+    FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.private_profile_id = p_student_profile_id
+      AND ur.role = 'student'::public.app_role
+      AND ur.disabled = false
+  ), latest_submission AS (
+    SELECT a.id AS assignment_id,
+           s_ind.id AS submission_id,
+           s_ind.created_at AS submission_created_at,
+           s_ind.is_active AS submission_is_active,
+           s_ind.ordinal AS submission_ordinal,
+           ur.student_profile_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = a.id
+          AND s.profile_id = ur.student_profile_id
+          AND s.assignment_group_id IS NULL
+        -- Prefer the active submission; fall back to most recent. The grade shown should be
+        -- the active/graded submission's, not a later not-for-grading scratch submission's.
+        ORDER BY s.is_active DESC, s.created_at DESC
+        LIMIT 1
+    ) s_ind ON TRUE
+  ), student_group AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           agm.assignment_group_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN public.assignment_groups_members agm
+      ON agm.assignment_id = a.id
+     AND agm.profile_id = ur.student_profile_id
+  ), latest_group_submission AS (
+    SELECT sg.assignment_id,
+           sg.student_profile_id,
+           s_grp.id AS submission_id,
+           s_grp.created_at AS submission_created_at,
+           s_grp.is_active AS submission_is_active,
+           s_grp.ordinal AS submission_ordinal
+    FROM student_group sg
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = sg.assignment_id
+          AND s.assignment_group_id = sg.assignment_group_id
+        -- Prefer the active submission; fall back to most recent (see individual branch above).
+        ORDER BY s.is_active DESC, s.created_at DESC
+        LIMIT 1
+    ) s_grp ON TRUE
+  ), chosen_submission AS (
+    SELECT DISTINCT ON (assignment_id, student_profile_id)
+           assignment_id,
+           student_profile_id,
+           submission_id,
+           submission_created_at,
+           submission_is_active,
+           submission_ordinal
+    FROM (
+        SELECT ls.assignment_id, ls.student_profile_id, ls.submission_id,
+               ls.submission_created_at, ls.submission_is_active, ls.submission_ordinal
+        FROM latest_submission ls
+        UNION ALL
+        SELECT lgs.assignment_id, lgs.student_profile_id, lgs.submission_id,
+               lgs.submission_created_at, lgs.submission_is_active, lgs.submission_ordinal
+        FROM latest_group_submission lgs
+    ) x
+    -- A student is in at most one mode per assignment, so exactly one branch yields a real
+    -- row (the other has NULLs). NULLS LAST keeps the real row; the is_active tiebreaker
+    -- matches the per-mode LATERAL preference for the active submission.
+    ORDER BY assignment_id, student_profile_id,
+             submission_is_active DESC NULLS LAST, submission_created_at DESC NULLS LAST
+  ), grader_result_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           gr.id AS grader_result_id,
+           gr.score AS grader_result_score,
+           gr.max_score AS grader_result_max_score
+    FROM chosen_submission cs
+    LEFT JOIN public.grader_results gr ON gr.submission_id = cs.submission_id
+  ), grading_review_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           sr.id AS grading_submission_review_id,
+           sr.completed_at AS grading_submission_review_completed_at,
+           COALESCE(
+             CASE
+               WHEN NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             CASE
+               WHEN NULLIF(sr.individual_scores ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.individual_scores ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             sr.total_score
+           ) AS grading_total_score
+    FROM chosen_submission cs
+    LEFT JOIN public.submissions s ON s.id = cs.submission_id
+    -- Release gate: only join the grading review once it is released, mirroring the
+    -- student RLS the prior security_invoker view relied on. Unreleased reviews yield
+    -- NULL score columns and the frontend falls back to the autograder score.
+    LEFT JOIN public.submission_reviews sr ON sr.id = s.grading_review_id AND sr.released = true
+  ), chosen_repository AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           repo.repository_id,
+           repo.repository,
+           repo.is_github_ready
+    FROM chosen_submission cs
+    LEFT JOIN student_group sg
+      ON sg.assignment_id = cs.assignment_id AND sg.student_profile_id = cs.student_profile_id
+    LEFT JOIN public.submissions sub ON sub.id = cs.submission_id
+    LEFT JOIN LATERAL (
+        SELECT r.id AS repository_id, r.repository, r.is_github_ready
+        FROM public.repositories r
+        WHERE r.assignment_id = cs.assignment_id
+          AND (
+            (sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+             AND r.assignment_group_id = sub.assignment_group_id)
+            OR (sub.id IS NOT NULL AND sub.assignment_group_id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+            OR (
+              sub.id IS NULL
+              AND (
+                (sg.assignment_group_id IS NOT NULL AND r.assignment_group_id = sg.assignment_group_id)
+                OR (r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+              )
+            )
+          )
+        ORDER BY
+          CASE
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+                 AND r.assignment_group_id = sub.assignment_group_id THEN 0
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NULL
+                 AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 0
+            WHEN sub.id IS NULL AND r.assignment_group_id IS NOT NULL THEN 1
+            WHEN sub.id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 2
+            ELSE 3
+          END,
+          r.id
+        LIMIT 1
+    ) repo ON TRUE
+  ), review_info AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ri.review_assignment_id,
+           ri.review_submission_id,
+           ri.submission_review_id,
+           ri.submission_review_completed_at
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ra.id AS review_assignment_id,
+               ra.submission_id AS review_submission_id,
+               sr.id AS submission_review_id,
+               sr.completed_at AS submission_review_completed_at
+        FROM public.review_assignments ra
+        LEFT JOIN public.submission_reviews sr ON sr.id = ra.submission_review_id
+        WHERE ra.assignment_id = a.id
+          AND ra.assignee_profile_id = ur.student_profile_id
+          -- Release gate: mirror the review_assignments RLS the prior security_invoker view
+          -- relied on, so an unreleased self/peer review's ids don't surface on the dashboard
+          -- (the frontend renders a clickable "Self Review for X" row off review_assignment_id).
+          AND (ra.release_date IS NULL OR ra.release_date <= now())
+        ORDER BY ra.created_at DESC
+        LIMIT 1
+    ) ri ON TRUE
+  ), due_date_ex AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ade.id AS due_date_exception_id,
+           ade.hours AS exception_hours,
+           ade.minutes AS exception_minutes,
+           ade.tokens_consumed AS exception_tokens_consumed,
+           ade.created_at AS exception_created_at,
+           ade.creator_id AS exception_creator_id,
+           ade.note AS exception_note
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ade.*
+        FROM public.assignment_due_date_exceptions ade
+        WHERE ade.assignment_id = a.id
+          AND (ade.student_id = ur.student_profile_id OR
+               ade.assignment_group_id IN (
+                   SELECT agm.assignment_group_id
+                   FROM public.assignment_groups_members agm
+                   WHERE agm.profile_id = ur.student_profile_id
+                     AND agm.assignment_id = a.id
+               ))
+        ORDER BY ade.created_at DESC
+        LIMIT 1
+    ) ade ON TRUE
+  )
+  SELECT a.id,
+         a.created_at,
+         a.class_id,
+         a.title,
+         a.release_date,
+         public.calculate_effective_due_date(a.id, ur.student_profile_id) AS due_date,
+         a.student_repo_prefix,
+         a.total_points,
+         a.has_autograder,
+         a.has_handgrader,
+         a.description,
+         a.slug,
+         a.template_repo,
+         a.allow_student_formed_groups,
+         a.group_config,
+         a.group_formation_deadline,
+         a.max_group_size,
+         a.min_group_size,
+         a.archived_at,
+         a.autograder_points,
+         a.grading_rubric_id,
+         a.max_late_tokens,
+         a.latest_template_sha,
+         a.meta_grading_rubric_id,
+         a.self_review_rubric_id,
+         a.self_review_setting_id,
+         a.gradebook_column_id,
+         a.minutes_due_after_lab,
+         a.allow_not_graded_submissions,
+         ur.student_profile_id,
+         ur.student_user_id,
+         cs.submission_id,
+         cs.submission_created_at,
+         cs.submission_is_active,
+         cs.submission_ordinal,
+         gr.grader_result_id,
+         gr.grader_result_score,
+         gr.grader_result_max_score,
+         sr.repository_id,
+         sr.repository,
+         sr.is_github_ready,
+         asrs.id AS assignment_self_review_setting_id,
+         asrs.enabled AS self_review_enabled,
+         asrs.deadline_offset AS self_review_deadline_offset,
+         ri.review_assignment_id,
+         ri.review_submission_id,
+         ri.submission_review_id,
+         ri.submission_review_completed_at,
+         de.due_date_exception_id,
+         de.exception_hours,
+         de.exception_minutes,
+         de.exception_tokens_consumed,
+         de.exception_created_at,
+         de.exception_creator_id,
+         de.exception_note,
+         gv.grading_submission_review_id,
+         gv.grading_submission_review_completed_at,
+         gv.grading_total_score
+  FROM public.assignments a
+  JOIN ur_students ur ON ur.class_id = a.class_id
+  LEFT JOIN chosen_submission cs
+    ON cs.assignment_id = a.id AND cs.student_profile_id = ur.student_profile_id
+  LEFT JOIN grader_result_for_submission gr
+    ON gr.assignment_id = a.id AND gr.student_profile_id = ur.student_profile_id
+  LEFT JOIN grading_review_for_submission gv
+    ON gv.assignment_id = a.id AND gv.student_profile_id = ur.student_profile_id
+  LEFT JOIN chosen_repository sr
+    ON sr.assignment_id = a.id AND sr.student_profile_id = ur.student_profile_id
+  LEFT JOIN public.assignment_self_review_settings asrs
+    ON asrs.id = a.self_review_setting_id
+  LEFT JOIN review_info ri
+    ON ri.assignment_id = a.id AND ri.student_profile_id = ur.student_profile_id
+  LEFT JOIN due_date_ex de
+    ON de.assignment_id = a.id AND de.student_profile_id = ur.student_profile_id
+  WHERE a.archived_at IS NULL;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) TO authenticated;

--- a/supabase/migrations/20260608130000_student_summary_gate_unreleased_scores.sql
+++ b/supabase/migrations/20260608130000_student_summary_gate_unreleased_scores.sql
@@ -1,0 +1,215 @@
+-- Gate unreleased grading scores in `public.get_student_summary` for non-staff callers.
+--
+-- Bug (issue #823 follow-up): `get_student_summary` is SECURITY DEFINER (RLS does not
+-- fire inside it) and its authorization block allows the student themselves to call it
+-- for their own profile (it is also GRANTed to `authenticated`). The assignments CTE
+-- joined `submission_reviews` unconditionally and surfaced `total_score` /
+-- `total_autograde_score`, so a student could read their hand-grade totals before the
+-- grading review was *released* — the same unreleased-score leak fixed for the dashboard
+-- RPC in 20260529120000_dashboard_rpc_gate_grading_release.sql.
+--
+-- Fix: compute whether the caller is staff (instructor/grader) and gate the review join
+-- on `(v_is_staff OR sr.released = true)`. Instructors/graders still see in-progress
+-- totals; a student calling it for themselves sees NULL scores until release (the
+-- submission id / ordinal / timestamp, which come from `submissions`, are unaffected).
+-- Only the new `v_is_staff` declaration + assignment, and the one join predicate, differ
+-- from 20250924234940_student_summary.sql; everything else is unchanged.
+
+create or replace function public.get_student_summary(
+  p_class_id bigint,
+  p_student_profile_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_result jsonb;
+  v_public_profile_id uuid;
+  v_profile_ids uuid[];
+  v_is_staff boolean;
+begin
+  -- Authorization: allow if caller is the student (private_profile) or staff (instructor/grader) in the class
+  if not exists (
+    select 1
+    from public.user_privileges ur
+    where ur.class_id = p_class_id
+      and ur.user_id = auth.uid()
+      and (
+        ur.role in ('instructor','grader')
+        or ur.private_profile_id = p_student_profile_id
+      )
+  ) then
+    raise exception 'Access denied'
+      using errcode = 'insufficient_privilege';
+  end if;
+
+  -- Staff (instructor/grader) may see in-progress grading totals; students may not see a
+  -- grading review's scores until it is released (see join predicate below).
+  select exists (
+    select 1
+    from public.user_privileges ur
+    where ur.class_id = p_class_id
+      and ur.user_id = auth.uid()
+      and ur.role in ('instructor','grader')
+  ) into v_is_staff;
+
+  -- Resolve both profile IDs for the student in this class
+  select up.public_profile_id
+    into v_public_profile_id
+    from public.user_privileges up
+   where up.class_id = p_class_id
+     and up.private_profile_id = p_student_profile_id
+   limit 1;
+
+  v_profile_ids := array_remove(ARRAY[p_student_profile_id, v_public_profile_id], NULL);
+
+  -- Build JSON in parts
+  with
+  -- Recent help requests the student is a participant in this class (latest 50)
+  help_requests as (
+    select hr.id,
+           hr.created_at,
+           hr.help_queue,
+           hr.request,
+           hr.assignee,
+           hr.resolved_by,
+           hr.resolved_at,
+           hr.is_private,
+           hr.status
+      from public.help_requests hr
+      join public.help_request_students hrs on hrs.help_request_id = hr.id and hrs.class_id = hr.class_id
+     where hr.class_id = p_class_id
+       and hrs.profile_id = any (v_profile_ids)
+     order by hr.created_at desc
+     limit 50
+  ),
+  help_request_ids as (
+    select id from help_requests
+  ),
+  -- Latest 50 messages authored by the student across all help requests in the class
+  help_messages as (
+    select hrm.id,
+           hrm.created_at,
+           hrm.author,
+           hrm.message,
+           hrm.instructors_only,
+           hrm.help_request_id
+      from public.help_request_messages hrm
+     where hrm.class_id = p_class_id
+       and hrm.author = any (v_profile_ids)
+     order by hrm.created_at desc
+     limit 50
+  ),
+  -- Recent discussion threads (student-authored) and replies (latest 50 each)
+  discussion_posts as (
+    select dt.id,
+           dt.created_at,
+           dt.subject,
+           dt.body,
+           dt.instructors_only,
+           dt.parent,
+           dt.root,
+           dt.topic_id
+      from public.discussion_threads dt
+     where dt.class_id = p_class_id
+       and dt.author = any (v_profile_ids)
+       and dt.parent is null
+     order by dt.created_at desc
+     limit 50
+  ),
+  discussion_replies as (
+    select dt.id,
+           dt.created_at,
+           dt.subject,
+           dt.body,
+           dt.instructors_only,
+           dt.parent,
+           dt.root,
+           dt.topic_id
+      from public.discussion_threads dt
+     where dt.class_id = p_class_id
+       and dt.author = any (v_profile_ids)
+       and dt.parent is not null
+     order by dt.created_at desc
+     limit 50
+  ),
+  -- Assignment summary for released assignments
+  assignments as (
+    select a.id as assignment_id,
+           a.title,
+           a.release_date,
+           public.calculate_final_due_date(a.id, p_student_profile_id, agm.assignment_group_id) as effective_due_date,
+           a.total_points,
+           s.id as submission_id,
+           s.created_at as submission_timestamp,
+           s.ordinal as submission_ordinal,
+           sr.total_autograde_score as autograder_score,
+           sr.total_score as total_score
+      from public.assignments a
+      left join public.assignment_groups_members agm
+        on agm.assignment_id = a.id and agm.profile_id = any (v_profile_ids)
+      left join public.submissions s
+        on s.assignment_id = a.id
+       and s.is_active = true
+       and (
+         (s.profile_id = any (v_profile_ids) and s.assignment_group_id is null)
+         or (s.profile_id is null and s.assignment_group_id = agm.assignment_group_id)
+       )
+      -- Release gate: only join the grading review's scores for non-staff once it is
+      -- released. Staff (v_is_staff) always see them; students see NULL until release.
+      left join public.submission_reviews sr
+        on sr.id = s.grading_review_id
+       and (v_is_staff or sr.released = true)
+     where a.class_id = p_class_id
+       and a.release_date is not null
+       and a.release_date <= now()
+  ),
+  -- Private grades only
+  private_grades as (
+    select gcs.gradebook_column_id,
+           gcs.score,
+           gcs.score_override,
+           gcs.released,
+           gcs.incomplete_values
+      from public.gradebook_column_students gcs
+     where gcs.class_id = p_class_id
+       and gcs.student_id = p_student_profile_id
+       and gcs.is_private = true
+  )
+  select jsonb_build_object(
+    'help_requests', coalesce(jsonb_agg(to_jsonb(help_requests) order by help_requests.created_at desc), '[]'::jsonb),
+    'help_messages', coalesce((select jsonb_agg(to_jsonb(help_messages) order by help_messages.created_at desc) from help_messages), '[]'::jsonb),
+    'discussion_posts', coalesce((select jsonb_agg(to_jsonb(discussion_posts) order by discussion_posts.created_at desc) from discussion_posts), '[]'::jsonb),
+    'discussion_replies', coalesce((select jsonb_agg(to_jsonb(discussion_replies) order by discussion_replies.created_at desc) from discussion_replies), '[]'::jsonb),
+    'assignments', coalesce((select jsonb_agg(to_jsonb(assignments) order by assignments.effective_due_date asc nulls last) from assignments), '[]'::jsonb),
+    'grades_private', coalesce((select jsonb_agg(to_jsonb(private_grades)) from private_grades), '[]'::jsonb)
+  ) into v_result
+  from help_requests
+  limit 1;
+
+  -- If no help requests existed, still build result from empty selects
+  if v_result is null then
+    select jsonb_build_object(
+      'help_requests', '[]'::jsonb,
+      'help_messages', coalesce((select jsonb_agg(to_jsonb(help_messages) order by help_messages.created_at desc) from help_messages), '[]'::jsonb),
+      'discussion_posts', coalesce((select jsonb_agg(to_jsonb(discussion_posts) order by discussion_posts.created_at desc) from discussion_posts), '[]'::jsonb),
+      'discussion_replies', coalesce((select jsonb_agg(to_jsonb(discussion_replies) order by discussion_replies.created_at desc) from discussion_replies), '[]'::jsonb),
+      'assignments', coalesce((select jsonb_agg(to_jsonb(assignments) order by assignments.effective_due_date asc nulls last) from assignments), '[]'::jsonb),
+      'grades_private', coalesce((select jsonb_agg(to_jsonb(private_grades)) from private_grades), '[]'::jsonb)
+    ) into v_result;
+  end if;
+
+  return v_result;
+end;
+$$;
+
+alter function public.get_student_summary(p_class_id bigint, p_student_profile_id uuid) owner to postgres;
+REVOKE ALL ON FUNCTION public.get_student_summary(bigint, uuid) FROM public;
+GRANT ALL ON FUNCTION public.get_student_summary(bigint, uuid) TO postgres;
+GRANT EXECUTE ON FUNCTION public.get_student_summary(bigint, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_student_summary(bigint, uuid) TO service_role;
+
+comment on function public.get_student_summary(bigint, uuid) is 'Returns a JSON summary for a student in a class: recent help requests/messages, discussion posts/replies, released assignments with effective due date and latest submission (ordinal, timestamp) plus autograder and total scores (gated to staff or released reviews), and private grades.';

--- a/tests/e2e/dashboard-active-submission-score.spec.ts
+++ b/tests/e2e/dashboard-active-submission-score.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "@playwright/test";
+import { addDays } from "date-fns";
+import {
+  createAuthenticatedClient,
+  createClass,
+  createUserInClass,
+  insertAssignment,
+  insertPreBakedSubmission,
+  supabase
+} from "@/tests/e2e/TestingUtils";
+import type { TestingUser } from "@/tests/e2e/TestingUtils";
+
+// Regression for issue #823 (Assignments tab denominator).
+//
+// The student Assignments tab is driven by the `get_assignments_for_student_dashboard`
+// RPC + `formatLatestSubmissionLabel` (app/course/[course_id]/assignments/page.tsx).
+// When a student has a graded+released ACTIVE submission and a LATER submission that is
+// not the active one (e.g. a not-for-grading submission, or after re-activating an older
+// submission), the dashboard used to surface the *latest* submission. Its grading review
+// is not released, so the row fell back to the autograder-only score/denominator
+// ("81.67/90") instead of the active submission's released total out of full points
+// ("87.67/100").
+//
+// This is a pure DB-integration test: it exercises the RPC directly (no browser), so it
+// pins the contract `formatLatestSubmissionLabel` depends on. The companion
+// HandGradingSection roll-up bug (issue #823 part 2) is covered by
+// tests/unit/rubric/points.test.ts (`earnedPointsForCriterion`).
+test.describe("dashboard surfaces the active submission's grade (issue #823)", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  let classId: number;
+  let assignmentId: number;
+  let instructor: TestingUser;
+  let student: TestingUser;
+
+  const RELEASED_GRADE = 90; // distinct from the prebaked autograder fallback (5/10)
+
+  test.beforeAll(async () => {
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const course = await createClass({ name: `E2E Dashboard Active Submission ${suffix}` });
+    classId = course.id;
+
+    instructor = await createUserInClass({
+      role: "instructor",
+      class_id: classId,
+      name: `E2E Dashboard Active Instructor ${suffix}`,
+      email: `e2e-dashboard-active-instructor-${suffix}@pawtograder.net`
+    });
+    student = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Dashboard Active Student ${suffix}`,
+      email: `e2e-dashboard-active-student-${suffix}@pawtograder.net`
+    });
+
+    const assignment = await insertAssignment({
+      class_id: classId,
+      due_date: addDays(new Date(), -1).toISOString(),
+      name: `E2E Dashboard Active Assignment ${suffix}`,
+      assignment_slug: `e2e-dashboard-active-${suffix}`
+    });
+    assignmentId = assignment.id;
+  });
+
+  test("shows the active hand-graded submission, not a later non-active one", async () => {
+    // Submission #1: graded and released. This is the one that "counts".
+    const graded = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `dashboard-active-graded-${classId}`
+    });
+    await completeGrading(graded.grading_review_id, RELEASED_GRADE, instructor.private_profile_id);
+
+    // Submission #2: created later. insertPreBakedSubmission's insert hook makes the newest
+    // submission active, so this demotes #1. Its grading review is left unreleased, mirroring a
+    // fresh autograder-only submission.
+    const later = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `dashboard-active-later-${classId}`
+    });
+    expect(later.submission_id).toBeGreaterThan(graded.submission_id);
+
+    // Re-activate the older graded submission, so active != latest — exactly the reported state
+    // (active/graded #14 vs. later non-active #15).
+    const instructorClient = await createAuthenticatedClient(instructor);
+    const { data: setActive, error: setActiveError } = await instructorClient.rpc("submission_set_active", {
+      _submission_id: graded.submission_id
+    });
+    if (setActiveError) {
+      throw new Error(`Failed to activate graded submission: ${setActiveError.message}`);
+    }
+    expect(setActive).toBe(true);
+
+    // Sanity-check the DB state the bug depends on: the graded submission is active, the later one is not.
+    await expectActiveSubmission(graded.submission_id, true);
+    await expectActiveSubmission(later.submission_id, false);
+
+    // Read the dashboard exactly as the student's Assignments tab does.
+    const studentClient = await createAuthenticatedClient(student);
+    const { data: rows, error } = await studentClient.rpc("get_assignments_for_student_dashboard", {
+      p_class_id: classId,
+      p_student_profile_id: student.private_profile_id
+    });
+    if (error) {
+      throw new Error(`Dashboard RPC failed: ${error.message}`);
+    }
+    const row = (rows ?? []).find((r) => r.id === assignmentId);
+    expect(row, "assignment row should be present on the dashboard").toBeTruthy();
+
+    // The dashboard must surface the ACTIVE graded submission (#1), not the later one (#2).
+    expect(row!.submission_id).toBe(graded.submission_id);
+    expect(row!.submission_is_active).toBe(true);
+
+    // Because the chosen submission is graded+released, the row carries the released hand-grade
+    // total and completion timestamp. formatLatestSubmissionLabel then renders
+    // `#<ordinal> (grading_total_score / total_points)` — i.e. out of the FULL max score —
+    // instead of the autograder-only `grader_result_score / grader_result_max_score`.
+    expect(Number(row!.grading_total_score)).toBe(RELEASED_GRADE);
+    expect(row!.grading_submission_review_completed_at).not.toBeNull();
+    expect(Number(row!.total_points)).toBe(100);
+  });
+
+  async function completeGrading(gradingReviewId: number, score: number, completedBy: string) {
+    const { error } = await supabase
+      .from("submission_reviews")
+      .update({
+        completed_at: new Date().toISOString(),
+        completed_by: completedBy,
+        released: true,
+        total_score: score
+      })
+      .eq("id", gradingReviewId);
+    if (error) {
+      throw new Error(`Failed to complete grading review ${gradingReviewId}: ${error.message}`);
+    }
+  }
+
+  async function expectActiveSubmission(submissionId: number, expectedActive: boolean) {
+    const { data, error } = await supabase
+      .from("submissions")
+      .select("is_active")
+      .eq("id", submissionId)
+      .single();
+    if (error) {
+      throw new Error(`Failed to read submission ${submissionId}: ${error.message}`);
+    }
+    expect(data.is_active).toBe(expectedActive);
+  }
+});

--- a/tests/e2e/dashboard-active-submission-score.spec.ts
+++ b/tests/e2e/dashboard-active-submission-score.spec.ts
@@ -139,11 +139,7 @@ test.describe("dashboard surfaces the active submission's grade (issue #823)", (
   }
 
   async function expectActiveSubmission(submissionId: number, expectedActive: boolean) {
-    const { data, error } = await supabase
-      .from("submissions")
-      .select("is_active")
-      .eq("id", submissionId)
-      .single();
+    const { data, error } = await supabase.from("submissions").select("is_active").eq("id", submissionId).single();
     if (error) {
       throw new Error(`Failed to read submission ${submissionId}: ${error.message}`);
     }

--- a/tests/e2e/student-summary-unreleased-score.spec.ts
+++ b/tests/e2e/student-summary-unreleased-score.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+import { addDays } from "date-fns";
+import {
+  createAuthenticatedClient,
+  createClass,
+  createUserInClass,
+  insertAssignment,
+  insertPreBakedSubmission,
+  supabase
+} from "@/tests/e2e/TestingUtils";
+import type { TestingUser } from "@/tests/e2e/TestingUtils";
+
+// Regression for the issue #823 follow-up audit: get_student_summary is SECURITY DEFINER
+// and student-callable, and used to surface a grading review's total_score before it was
+// released. Staff may see in-progress totals; a student calling it for their own profile
+// must not — until the review is released.
+type StudentSummary = {
+  assignments?: { assignment_id: number; total_score: number | null; autograder_score: number | null }[];
+};
+
+test.describe("get_student_summary gates unreleased grading scores (issue #823 follow-up)", () => {
+  test.describe.configure({ timeout: 180_000 });
+
+  let classId: number;
+  let assignmentId: number;
+  let instructor: TestingUser;
+  let student: TestingUser;
+  let gradingReviewId: number;
+
+  const HAND_GRADE = 73; // distinct, non-zero so "gated → null" is unambiguous
+
+  test.beforeAll(async () => {
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const course = await createClass({ name: `E2E Student Summary Gate ${suffix}` });
+    classId = course.id;
+
+    instructor = await createUserInClass({
+      role: "instructor",
+      class_id: classId,
+      name: `E2E Student Summary Instructor ${suffix}`,
+      email: `e2e-student-summary-instructor-${suffix}@pawtograder.net`
+    });
+    student = await createUserInClass({
+      role: "student",
+      class_id: classId,
+      name: `E2E Student Summary Student ${suffix}`,
+      email: `e2e-student-summary-student-${suffix}@pawtograder.net`
+    });
+
+    const assignment = await insertAssignment({
+      class_id: classId,
+      due_date: addDays(new Date(), -1).toISOString(),
+      name: `E2E Student Summary Assignment ${suffix}`,
+      assignment_slug: `e2e-student-summary-${suffix}`
+    });
+    assignmentId = assignment.id;
+
+    const submission = await insertPreBakedSubmission({
+      assignment_id: assignmentId,
+      class_id: classId,
+      student_profile_id: student.private_profile_id,
+      repositorySuffix: `student-summary-${classId}`
+    });
+    gradingReviewId = submission.grading_review_id;
+  });
+
+  test("student does not see total_score until release; staff always does", async () => {
+    // Grading is COMPLETED but NOT released.
+    await setGrading({ completed: true, released: false });
+
+    const studentClient = await createAuthenticatedClient(student);
+    const instructorClient = await createAuthenticatedClient(instructor);
+
+    // Student: scores gated to null while unreleased.
+    let studentRow = await assignmentRow(studentClient);
+    expect(studentRow?.total_score ?? null).toBeNull();
+    expect(studentRow?.autograder_score ?? null).toBeNull();
+
+    // Staff: sees the in-progress total even though it is unreleased.
+    const staffRow = await assignmentRow(instructorClient);
+    expect(Number(staffRow?.total_score)).toBe(HAND_GRADE);
+
+    // After release, the student sees it too.
+    await setGrading({ completed: true, released: true });
+    studentRow = await assignmentRow(studentClient);
+    expect(Number(studentRow?.total_score)).toBe(HAND_GRADE);
+  });
+
+  async function setGrading({ completed, released }: { completed: boolean; released: boolean }) {
+    const { error } = await supabase
+      .from("submission_reviews")
+      .update({
+        completed_at: completed ? new Date().toISOString() : null,
+        completed_by: completed ? instructor.private_profile_id : null,
+        released,
+        total_score: HAND_GRADE
+      })
+      .eq("id", gradingReviewId);
+    if (error) {
+      throw new Error(`Failed to update grading review: ${error.message}`);
+    }
+  }
+
+  async function assignmentRow(client: Awaited<ReturnType<typeof createAuthenticatedClient>>) {
+    const { data, error } = await client.rpc("get_student_summary", {
+      p_class_id: classId,
+      p_student_profile_id: student.private_profile_id
+    });
+    if (error) {
+      throw new Error(`get_student_summary failed: ${error.message}`);
+    }
+    const summary = data as StudentSummary;
+    return (summary.assignments ?? []).find((a) => a.assignment_id === assignmentId);
+  }
+});

--- a/tests/unit/rubric/points.test.ts
+++ b/tests/unit/rubric/points.test.ts
@@ -1,6 +1,7 @@
 import {
   computeRubricMaxPoints,
   computeRubricPointsBreakdown,
+  earnedPointsForCriterion,
   hasSplitGradingParts,
   maxPointsForCriterion
 } from "@/lib/rubric/points";
@@ -112,6 +113,60 @@ describe("maxPointsForCriterion", () => {
         total_points: null as unknown as number,
         rubric_checks: [{ points: null as unknown as number }]
       })
+    ).toBe(0);
+  });
+});
+
+describe("earnedPointsForCriterion", () => {
+  it("additive: caps the applied sum at total_points", () => {
+    expect(earnedPointsForCriterion(criterion({ is_additive: true, total_points: 2 }), 2)).toBe(2);
+    expect(earnedPointsForCriterion(criterion({ is_additive: true, total_points: 4 }), 9)).toBe(4);
+  });
+
+  it("non-additive: subtracts applied deductions from total_points, floored at 0", () => {
+    expect(earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 2)).toBe(
+      3
+    );
+    expect(earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 9)).toBe(
+      0
+    );
+  });
+
+  it("deduction-only: contributes a non-positive penalty, floored at -total_points", () => {
+    // Issue #823: the reported "Code Complexity" criterion was deduction-only with a single −1
+    // deduction applied. It must contribute −1 (a penalty), NOT total_points − 1.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 1)
+    ).toBe(-1);
+    // No deductions applied → 0, never the criterion's total_points.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 0)
+    ).toBe(0);
+    // Cannot lose more than total_points.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 9)
+    ).toBe(-3);
+  });
+
+  it("never exceeds maxPointsForCriterion for any mode (so rolled-up earned <= max)", () => {
+    const cases = [
+      criterion({ is_additive: true, total_points: 4, rubric_checks: [check(2), check(3)] }),
+      criterion({ is_additive: false, is_deduction_only: false, total_points: 7, rubric_checks: [check(3)] }),
+      criterion({ is_additive: false, is_deduction_only: true, total_points: 5, rubric_checks: [check(2)] })
+    ];
+    for (const c of cases) {
+      for (const applied of [0, 1, 2, 5, 9]) {
+        expect(earnedPointsForCriterion(c, applied)).toBeLessThanOrEqual(maxPointsForCriterion(c));
+      }
+    }
+  });
+
+  it("handles missing total_points safely", () => {
+    expect(
+      earnedPointsForCriterion(
+        { is_additive: false, is_deduction_only: true, total_points: null as unknown as number },
+        2
+      )
     ).toBe(0);
   });
 });

--- a/tests/unit/rubric/points.test.ts
+++ b/tests/unit/rubric/points.test.ts
@@ -124,12 +124,12 @@ describe("earnedPointsForCriterion", () => {
   });
 
   it("non-additive: subtracts applied deductions from total_points, floored at 0", () => {
-    expect(earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 2)).toBe(
-      3
-    );
-    expect(earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 9)).toBe(
-      0
-    );
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 2)
+    ).toBe(3);
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: false, total_points: 5 }), 9)
+    ).toBe(0);
   });
 
   it("deduction-only: contributes a non-positive penalty, floored at -total_points", () => {


### PR DESCRIPTION
Two related display bugs let views misrepresent an already-correct grade.

1. Assignments tab wrong denominator. `get_assignments_for_student_dashboard` chose the most-recently-created submission. When the active/graded submission isn't the latest (a later not-for-grading submission, or an explicitly re-activated older one), the dashboard surfaced the later submission, whose grading review isn't released, so the row fell back to the autograder-only score/denominator ("81.67/90") instead of the active submission's released total out of full points ("87.67/100"). Fix: prefer `is_active = true` when choosing the submission, breaking ties by most recent created_at (so the common case — newest submission is active — is unchanged).

2. Hand-grading rollup "earned exceeds possible" ("15 / 9"). HandGradingSection folded deduction-only criteria into the non-additive branch, computing `total_points - applied` as earned instead of the deduction penalty. That both mislabeled the criterion line (a −1 deduction shown as "2 / 0") and let the rolled-up earned exceed the max. Fix: extract `earnedPointsForCriterion` next to `maxPointsForCriterion`, mirroring the canonical `_submission_review_recompute_scores` branches (deduction-only = greatest(-applied, -total_points)). The result is always <= the criterion max, so the header can never show earned > possible.

Tests:
- tests/e2e/dashboard-active-submission-score.spec.ts — DB-integration spec pinning the RPC contract: reproduces the bug pre-fix (returns the later non-active submission) and passes post-fix.
- tests/unit/rubric/points.test.ts — earnedPointsForCriterion across modes, including the reported deduction-only scenario and the earned <= max invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard now shows the correct active submission, score, and full-points denominator when multiple submissions exist; per-criterion scoring across additive, deduction-only, and total-points modes is correctly capped/floored.
  * Student summaries hide unreleased grading values from students while staff still see in-progress scores.

* **UI**
  * Rubric tallies for graders no longer display negative earned points.

* **Tests**
  * New E2E and unit tests added to cover these regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->