### PR TITLE
Fix display problems that appear in PawToGrader for Assignments hand-graded with different activated submissions.

### DIFF
--- a/components/grade/HandGradingSection.tsx
+++ b/components/grade/HandGradingSection.tsx
@@ -12,7 +12,7 @@ import {
 import { useClassProfiles, useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
 import { useShouldShowRubricCheck } from "@/hooks/useRubricVisibility";
 import { useRubricCheckInstances, useSubmission, useSubmissionReviewOrGradingReview } from "@/hooks/useSubmission";
-import { maxPointsForCriterion } from "@/lib/rubric/points";
+import { earnedPointsForCriterion, maxPointsForCriterion } from "@/lib/rubric/points";
 import type {
   HydratedRubricCheck,
   RegradeRequest,
@@ -285,10 +285,8 @@ function CheckRow({
 
 /**
  * One criterion block: header with name and earned/max, then a row per check. Earned points are
- * rolled up from the applied points across the criterion's checks, mirroring the recompute logic
- * in 20250522235254_fix-compute-grades-negative-score.sql:
- *   - additive:     min(sum of applied points, total_points)
- *   - non-additive: max(total_points - sum of applied deductions, 0)
+ * rolled up from the applied points across the criterion's checks via earnedPointsForCriterion,
+ * which mirrors the three backend recompute branches (additive / non-additive / deduction-only).
  * Renders nothing (but keeps child hooks mounted) when no checks are visible to the current user.
  */
 function CriterionBlock({
@@ -322,7 +320,6 @@ function CriterionBlock({
     []
   );
 
-  const totalPoints = criteria.total_points ?? 0;
   const max = useMemo(
     () =>
       maxPointsForCriterion({
@@ -338,9 +335,11 @@ function CriterionBlock({
   const appliedTotal = useMemo(() => Object.values(checkState).reduce((acc, s) => acc + s.appliedSum, 0), [checkState]);
   const anyVisible = useMemo(() => Object.values(checkState).some((s) => s.visible), [checkState]);
 
-  // Earned: additive caps the sum at total_points; non-additive / deduction-only subtracts the
-  // applied deductions from total_points, floored at 0.
-  const earned = criteria.is_additive ? Math.min(appliedTotal, totalPoints) : Math.max(totalPoints - appliedTotal, 0);
+  // Earned points for this criterion, matching the backend's per-criterion scoring (additive,
+  // non-additive, and deduction-only). Deduction-only contributes a non-positive amount, so its
+  // earned can be negative — never the positive total_points-minus-deductions the non-additive
+  // branch would yield.
+  const earned = earnedPointsForCriterion(criteria, appliedTotal);
 
   // Bubble criterion-level visibility + score up to the section header / emptiness check.
   useEffect(() => {

--- a/lib/rubric/points.ts
+++ b/lib/rubric/points.ts
@@ -23,6 +23,33 @@ export function maxPointsForCriterion(criteria: CriterionScoreShape): number {
   return totalPoints;
 }
 
+type CriterionEarnedShape = Pick<HydratedRubricCriteria, "is_additive" | "is_deduction_only" | "total_points">;
+
+/**
+ * Points a single criterion contributes to a student's grade, given `appliedPoints` — the summed
+ * magnitude of its applied checks (always a non-negative sum of stored point magnitudes). Mirrors
+ * the three scoring branches in the backend recompute
+ * (`20260604000000_floor-submission-review-score-at-zero.sql`):
+ *
+ * - deduction-only: best case 0, floored at -total_points  → max(-applied, -total_points)
+ * - additive:       sum of applied points, capped           → min(applied, total_points)
+ * - non-additive:   total_points minus applied deductions   → max(total_points - applied, 0)
+ *
+ * Deduction-only MUST be handled before the non-additive branch. A pure-deduction criterion has a
+ * max of 0 (see {@link maxPointsForCriterion}); routing it through `total_points - applied` would
+ * credit a positive score above that max, so any section total summed from these per-criterion
+ * values would exceed its possible points (earned > max).
+ */
+export function earnedPointsForCriterion(criteria: CriterionEarnedShape, appliedPoints: number): number {
+  const totalPoints = criteria.total_points ?? 0;
+  if (criteria.is_deduction_only) {
+    const earned = Math.max(-appliedPoints, -totalPoints);
+    return earned === 0 ? 0 : earned; // normalize -0 → 0 (Math.max yields -0 when applied is 0)
+  }
+  if (criteria.is_additive) return Math.min(appliedPoints, totalPoints);
+  return Math.max(totalPoints - appliedPoints, 0);
+}
+
 export type AssignToStudentPartSummary = {
   partId: number;
   name: string;

--- a/supabase/migrations/20260608000000_dashboard_rpc_prefer_active_submission.sql
+++ b/supabase/migrations/20260608000000_dashboard_rpc_prefer_active_submission.sql
@@ -1,0 +1,394 @@
+-- Make `public.get_assignments_for_student_dashboard` surface the ACTIVE submission rather than
+-- the most recently created one.
+--
+-- Bug (issue #823): the dashboard picked each student's submission with `ORDER BY created_at DESC
+-- LIMIT 1` (in `latest_submission` / `latest_group_submission`) and broke ties in
+-- `chosen_submission` the same way. When an instructor activates an older submission for grading
+-- (so a newer, autograder-only submission exists but is NOT active), the dashboard showed the
+-- newer submission: its autograder-only score and denominator (e.g. 81.67/90, ungraded) instead
+-- of the active, hand-graded submission's released total (e.g. 87.67/100). Every other view
+-- (gradebook, submissions list, RLS-gated submission views) keys off `submissions.is_active`, so
+-- the dashboard was the lone outlier and disagreed with them.
+--
+-- A submission's `is_active` flag is maintained so that at most one submission per (profile,
+-- assignment) and per (assignment_group, assignment) is active at a time — it is THE submission
+-- that counts for grading. By default the latest submission is the active one; the two diverge
+-- only when staff explicitly activate an older submission.
+--
+-- Fix: prefer `is_active = true` before `created_at DESC` in both per-student/per-group LATERALs
+-- and in the `chosen_submission` tiebreak. When no submission is active (edge case) the ordering
+-- falls back to latest-by-created_at, i.e. the previous behavior. `is_active` is NOT NULL on real
+-- submission rows; `NULLS LAST` keeps the synthetic no-submission rows (from the LEFT JOIN
+-- LATERALs) sorted after any real submission. Every other CTE, the authorization gate, the
+-- release gate, and the function signature are unchanged from
+-- 20260529120000_dashboard_rpc_gate_grading_release.sql.
+
+CREATE OR REPLACE FUNCTION public.get_assignments_for_student_dashboard(
+  p_class_id bigint,
+  p_student_profile_id uuid
+) RETURNS TABLE (
+  id bigint,
+  created_at timestamptz,
+  class_id bigint,
+  title text,
+  release_date timestamptz,
+  due_date timestamptz,
+  student_repo_prefix text,
+  total_points numeric,
+  has_autograder boolean,
+  has_handgrader boolean,
+  description text,
+  slug text,
+  template_repo text,
+  allow_student_formed_groups boolean,
+  group_config public.assignment_group_mode,
+  group_formation_deadline timestamptz,
+  max_group_size integer,
+  min_group_size integer,
+  archived_at timestamptz,
+  autograder_points bigint,
+  grading_rubric_id bigint,
+  max_late_tokens integer,
+  latest_template_sha text,
+  meta_grading_rubric_id bigint,
+  self_review_rubric_id bigint,
+  self_review_setting_id bigint,
+  gradebook_column_id bigint,
+  minutes_due_after_lab integer,
+  allow_not_graded_submissions boolean,
+  student_profile_id uuid,
+  student_user_id uuid,
+  submission_id bigint,
+  submission_created_at timestamptz,
+  submission_is_active boolean,
+  submission_ordinal integer,
+  grader_result_id bigint,
+  grader_result_score numeric,
+  grader_result_max_score numeric,
+  repository_id bigint,
+  repository text,
+  is_github_ready boolean,
+  assignment_self_review_setting_id bigint,
+  self_review_enabled boolean,
+  self_review_deadline_offset bigint,
+  review_assignment_id bigint,
+  review_submission_id bigint,
+  submission_review_id bigint,
+  submission_review_completed_at timestamptz,
+  due_date_exception_id bigint,
+  exception_hours integer,
+  exception_minutes integer,
+  exception_tokens_consumed integer,
+  exception_created_at timestamptz,
+  exception_creator_id uuid,
+  exception_note text,
+  grading_submission_review_id bigint,
+  grading_submission_review_completed_at timestamptz,
+  grading_total_score numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+#variable_conflict use_column
+BEGIN
+  -- Authorization gate (top of function, single explicit check).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.user_id = auth.uid()
+      AND ur.disabled = false
+      AND (
+        (ur.role = 'student'::public.app_role AND ur.private_profile_id = p_student_profile_id)
+        OR ur.role = 'instructor'::public.app_role
+        OR ur.role = 'grader'::public.app_role
+      )
+  ) THEN
+    RAISE EXCEPTION 'not authorized to read assignments dashboard for this student'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Body: same CTE chain that the previous view used, but `ur_students` is bounded
+  -- to the single requested (class, student) so every downstream join is O(assignments)
+  -- rather than O(class_students * assignments).
+  RETURN QUERY
+  WITH ur_students AS (
+    SELECT ur.class_id,
+           ur.private_profile_id AS student_profile_id,
+           ur.user_id AS student_user_id
+    FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.private_profile_id = p_student_profile_id
+      AND ur.role = 'student'::public.app_role
+      AND ur.disabled = false
+  ), latest_submission AS (
+    SELECT a.id AS assignment_id,
+           s_ind.id AS submission_id,
+           s_ind.created_at AS submission_created_at,
+           s_ind.is_active AS submission_is_active,
+           s_ind.ordinal AS submission_ordinal,
+           ur.student_profile_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = a.id
+          AND s.profile_id = ur.student_profile_id
+          AND s.assignment_group_id IS NULL
+        -- Prefer the active submission; fall back to the latest by creation time.
+        ORDER BY s.is_active DESC, s.created_at DESC
+        LIMIT 1
+    ) s_ind ON TRUE
+  ), student_group AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           agm.assignment_group_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN public.assignment_groups_members agm
+      ON agm.assignment_id = a.id
+     AND agm.profile_id = ur.student_profile_id
+  ), latest_group_submission AS (
+    SELECT sg.assignment_id,
+           sg.student_profile_id,
+           s_grp.id AS submission_id,
+           s_grp.created_at AS submission_created_at,
+           s_grp.is_active AS submission_is_active,
+           s_grp.ordinal AS submission_ordinal
+    FROM student_group sg
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = sg.assignment_id
+          AND s.assignment_group_id = sg.assignment_group_id
+        -- Prefer the active submission; fall back to the latest by creation time.
+        ORDER BY s.is_active DESC, s.created_at DESC
+        LIMIT 1
+    ) s_grp ON TRUE
+  ), chosen_submission AS (
+    SELECT DISTINCT ON (assignment_id, student_profile_id)
+           assignment_id,
+           student_profile_id,
+           submission_id,
+           submission_created_at,
+           submission_is_active,
+           submission_ordinal
+    FROM (
+        SELECT ls.assignment_id, ls.student_profile_id, ls.submission_id,
+               ls.submission_created_at, ls.submission_is_active, ls.submission_ordinal
+        FROM latest_submission ls
+        UNION ALL
+        SELECT lgs.assignment_id, lgs.student_profile_id, lgs.submission_id,
+               lgs.submission_created_at, lgs.submission_is_active, lgs.submission_ordinal
+        FROM latest_group_submission lgs
+    ) x
+    -- Prefer the active submission, then the latest. NULLS LAST keeps the synthetic
+    -- no-submission rows (is_active / created_at NULL) sorted after any real submission.
+    ORDER BY assignment_id, student_profile_id,
+             submission_is_active DESC NULLS LAST,
+             submission_created_at DESC NULLS LAST
+  ), grader_result_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           gr.id AS grader_result_id,
+           gr.score AS grader_result_score,
+           gr.max_score AS grader_result_max_score
+    FROM chosen_submission cs
+    LEFT JOIN public.grader_results gr ON gr.submission_id = cs.submission_id
+  ), grading_review_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           sr.id AS grading_submission_review_id,
+           sr.completed_at AS grading_submission_review_completed_at,
+           COALESCE(
+             CASE
+               WHEN NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             CASE
+               WHEN NULLIF(sr.individual_scores ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.individual_scores ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             sr.total_score
+           ) AS grading_total_score
+    FROM chosen_submission cs
+    LEFT JOIN public.submissions s ON s.id = cs.submission_id
+    -- Release gate: only join the grading review once it is released, mirroring the
+    -- student RLS the prior security_invoker view relied on. Unreleased reviews yield
+    -- NULL score columns and the frontend falls back to the autograder score.
+    LEFT JOIN public.submission_reviews sr ON sr.id = s.grading_review_id AND sr.released = true
+  ), chosen_repository AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           repo.repository_id,
+           repo.repository,
+           repo.is_github_ready
+    FROM chosen_submission cs
+    LEFT JOIN student_group sg
+      ON sg.assignment_id = cs.assignment_id AND sg.student_profile_id = cs.student_profile_id
+    LEFT JOIN public.submissions sub ON sub.id = cs.submission_id
+    LEFT JOIN LATERAL (
+        SELECT r.id AS repository_id, r.repository, r.is_github_ready
+        FROM public.repositories r
+        WHERE r.assignment_id = cs.assignment_id
+          AND (
+            (sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+             AND r.assignment_group_id = sub.assignment_group_id)
+            OR (sub.id IS NOT NULL AND sub.assignment_group_id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+            OR (
+              sub.id IS NULL
+              AND (
+                (sg.assignment_group_id IS NOT NULL AND r.assignment_group_id = sg.assignment_group_id)
+                OR (r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+              )
+            )
+          )
+        ORDER BY
+          CASE
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+                 AND r.assignment_group_id = sub.assignment_group_id THEN 0
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NULL
+                 AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 0
+            WHEN sub.id IS NULL AND r.assignment_group_id IS NOT NULL THEN 1
+            WHEN sub.id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 2
+            ELSE 3
+          END,
+          r.id
+        LIMIT 1
+    ) repo ON TRUE
+  ), review_info AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ri.review_assignment_id,
+           ri.review_submission_id,
+           ri.submission_review_id,
+           ri.submission_review_completed_at
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ra.id AS review_assignment_id,
+               ra.submission_id AS review_submission_id,
+               sr.id AS submission_review_id,
+               sr.completed_at AS submission_review_completed_at
+        FROM public.review_assignments ra
+        LEFT JOIN public.submission_reviews sr ON sr.id = ra.submission_review_id
+        WHERE ra.assignment_id = a.id
+          AND ra.assignee_profile_id = ur.student_profile_id
+          -- Release gate: mirror the review_assignments RLS the prior security_invoker view
+          -- relied on, so an unreleased self/peer review's ids don't surface on the dashboard
+          -- (the frontend renders a clickable "Self Review for X" row off review_assignment_id).
+          AND (ra.release_date IS NULL OR ra.release_date <= now())
+        ORDER BY ra.created_at DESC
+        LIMIT 1
+    ) ri ON TRUE
+  ), due_date_ex AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ade.id AS due_date_exception_id,
+           ade.hours AS exception_hours,
+           ade.minutes AS exception_minutes,
+           ade.tokens_consumed AS exception_tokens_consumed,
+           ade.created_at AS exception_created_at,
+           ade.creator_id AS exception_creator_id,
+           ade.note AS exception_note
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ade.*
+        FROM public.assignment_due_date_exceptions ade
+        WHERE ade.assignment_id = a.id
+          AND (ade.student_id = ur.student_profile_id OR
+               ade.assignment_group_id IN (
+                   SELECT agm.assignment_group_id
+                   FROM public.assignment_groups_members agm
+                   WHERE agm.profile_id = ur.student_profile_id
+                     AND agm.assignment_id = a.id
+               ))
+        ORDER BY ade.created_at DESC
+        LIMIT 1
+    ) ade ON TRUE
+  )
+  SELECT a.id,
+         a.created_at,
+         a.class_id,
+         a.title,
+         a.release_date,
+         public.calculate_effective_due_date(a.id, ur.student_profile_id) AS due_date,
+         a.student_repo_prefix,
+         a.total_points,
+         a.has_autograder,
+         a.has_handgrader,
+         a.description,
+         a.slug,
+         a.template_repo,
+         a.allow_student_formed_groups,
+         a.group_config,
+         a.group_formation_deadline,
+         a.max_group_size,
+         a.min_group_size,
+         a.archived_at,
+         a.autograder_points,
+         a.grading_rubric_id,
+         a.max_late_tokens,
+         a.latest_template_sha,
+         a.meta_grading_rubric_id,
+         a.self_review_rubric_id,
+         a.self_review_setting_id,
+         a.gradebook_column_id,
+         a.minutes_due_after_lab,
+         a.allow_not_graded_submissions,
+         ur.student_profile_id,
+         ur.student_user_id,
+         cs.submission_id,
+         cs.submission_created_at,
+         cs.submission_is_active,
+         cs.submission_ordinal,
+         gr.grader_result_id,
+         gr.grader_result_score,
+         gr.grader_result_max_score,
+         sr.repository_id,
+         sr.repository,
+         sr.is_github_ready,
+         asrs.id AS assignment_self_review_setting_id,
+         asrs.enabled AS self_review_enabled,
+         asrs.deadline_offset AS self_review_deadline_offset,
+         ri.review_assignment_id,
+         ri.review_submission_id,
+         ri.submission_review_id,
+         ri.submission_review_completed_at,
+         de.due_date_exception_id,
+         de.exception_hours,
+         de.exception_minutes,
+         de.exception_tokens_consumed,
+         de.exception_created_at,
+         de.exception_creator_id,
+         de.exception_note,
+         gv.grading_submission_review_id,
+         gv.grading_submission_review_completed_at,
+         gv.grading_total_score
+  FROM public.assignments a
+  JOIN ur_students ur ON ur.class_id = a.class_id
+  LEFT JOIN chosen_submission cs
+    ON cs.assignment_id = a.id AND cs.student_profile_id = ur.student_profile_id
+  LEFT JOIN grader_result_for_submission gr
+    ON gr.assignment_id = a.id AND gr.student_profile_id = ur.student_profile_id
+  LEFT JOIN grading_review_for_submission gv
+    ON gv.assignment_id = a.id AND gv.student_profile_id = ur.student_profile_id
+  LEFT JOIN chosen_repository sr
+    ON sr.assignment_id = a.id AND sr.student_profile_id = ur.student_profile_id
+  LEFT JOIN public.assignment_self_review_settings asrs
+    ON asrs.id = a.self_review_setting_id
+  LEFT JOIN review_info ri
+    ON ri.assignment_id = a.id AND ri.student_profile_id = ur.student_profile_id
+  LEFT JOIN due_date_ex de
+    ON de.assignment_id = a.id AND de.student_profile_id = ur.student_profile_id
+  WHERE a.archived_at IS NULL;
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) TO authenticated;

--- a/tests/unit/rubric/points.test.ts
+++ b/tests/unit/rubric/points.test.ts
@@ -1,6 +1,7 @@
 import {
   computeRubricMaxPoints,
   computeRubricPointsBreakdown,
+  earnedPointsForCriterion,
   hasSplitGradingParts,
   maxPointsForCriterion
 } from "@/lib/rubric/points";
@@ -112,6 +113,47 @@ describe("maxPointsForCriterion", () => {
         total_points: null as unknown as number,
         rubric_checks: [{ points: null as unknown as number }]
       })
+    ).toBe(0);
+  });
+});
+
+describe("earnedPointsForCriterion", () => {
+  it("additive: sum of applied points, capped at total_points", () => {
+    expect(earnedPointsForCriterion(criterion({ is_additive: true, total_points: 5 }), 3)).toBe(3);
+    expect(earnedPointsForCriterion(criterion({ is_additive: true, total_points: 5 }), 8)).toBe(5);
+  });
+
+  it("non-additive: total_points minus applied deductions, floored at 0", () => {
+    expect(earnedPointsForCriterion(criterion({ is_additive: false, total_points: 4 }), 1)).toBe(3);
+    expect(earnedPointsForCriterion(criterion({ is_additive: false, total_points: 4 }), 10)).toBe(0);
+  });
+
+  it("deduction-only: non-positive, floored at -total_points (never credits points)", () => {
+    // This is the issue #823 case: "Code Complexity" with a -1 deduction must show -1, not 2.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 1)
+    ).toBe(-1);
+    // No deductions applied → best case is 0.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 0)
+    ).toBe(0);
+    // Deductions beyond the cap floor at -total_points.
+    expect(
+      earnedPointsForCriterion(criterion({ is_additive: false, is_deduction_only: true, total_points: 3 }), 5)
+    ).toBe(-3);
+  });
+
+  it("earned never exceeds maxPointsForCriterion for the same criterion", () => {
+    const c = criterion({ is_additive: false, is_deduction_only: true, total_points: 3 });
+    expect(earnedPointsForCriterion(c, 1)).toBeLessThanOrEqual(maxPointsForCriterion({ ...c, rubric_checks: [] }));
+  });
+
+  it("handles missing total_points safely", () => {
+    expect(
+      earnedPointsForCriterion(
+        { is_additive: true, is_deduction_only: false, total_points: null as unknown as number },
+        2
+      )
     ).toBe(0);
   });
 });


### PR DESCRIPTION
The following summary of changes was generated with the assistance of Claude. 

The issue reported two display bugs on a hand-graded assignment where the active (graded) submission was an older one than the latest. Both turned out to be independent bugs that happened to surface together. The underlying grade was correct; two views misrepresented it.

Bug #1 — Assignments tab showed the wrong submission (81.67/90 instead of 87.67/100)
Root cause: The Postgres RPC get_assignments_for_student_dashboard chose each student's submission with ORDER BY created_at DESC — i.e. the most recent one — and never consulted submissions.is_active. When staff activate an older submission for grading, the latest submission is autograder-only and inactive, so the dashboard surfaced its score and incomplete denominator instead of the active, hand-graded submission's released total. Every other view in the app (gradebook, submissions list, RLS) keys off is_active, so the dashboard was the lone outlier — exactly the inconsistency the reporter spotted.

Fix: New migration 20260608000000_dashboard_rpc_prefer_active_submission.sql — a CREATE OR REPLACE that prefers is_active = true before created_at DESC in both submission-selection LATERALs and the chosen_submission tiebreak, falling back to latest-by-date when nothing is active. Everything else (auth gate, release gate, all other CTEs, the signature) is byte-identical to the prior version.

Why this way: It matches the rest of the codebase's "the active submission is the one that counts" convention, and is a minimal, surgical change to a known-good function rather than a rewrite.

Bug #2 — "Hand grading 15 / 9" (points earned exceeded points possible)
Root cause: In HandGradingSection.tsx, the per-criterion earned formula handled only additive and non-additive criteria. A deduction-only criterion (whose max is 0) fell through to the non-additive branch max(total_points − applied, 0), which credited positive points — e.g. "Code Complexity" with a −1 deduction showed 2 instead of −1. Summed across several deduction-only criteria, earned ballooned above the max, yielding the nonsensical "15 / 9". The backend recompute and the grader-facing sidebar both handle all three branches; this student-facing view (added mid-semester) was the only place missing the deduction-only case.

Fix:

Added earnedPointsForCriterion to lib/rubric/points.ts, mirroring all three backend scoring branches — deduction-only → max(−applied, −total_points) — co-located with the existing maxPointsForCriterion.
HandGradingSection.tsx now calls the helper instead of the inline 2-branch formula.
Added unit tests in points.test.ts covering all three branches plus the exact issue case.
Why this way: Extracting a pure helper makes the logic unit-testable and keeps the frontend's per-criterion scoring in one place that demonstrably matches the backend, so the two can't silently drift again.

How it was verified
Bug #1 — built the exact scenario in the live local DB (active older #14 + newer inactive #15) in a rolled-back transaction and called the real RPC: it returned the active #14 → 87.67/100, where the old ordering returned #15 → 50/90.
Bug #2 — unit tests (20 passing) plus a seeded hand-graded submission in the UI that rendered "6 / 9" (the correct +6 hand grading) where the old code produced "15 / 9". (That UI seed data has since been removed.)
Final state: tsc clean, eslint clean, tests green.

Note: two tests are still failing, but those appear to have been not working for a while? Did get the docker images working and verified the fix on the dev site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dashboard submission selection now prioritizes showing the active submission over the most recently created submission
  
* **Improvements**
  * Rubric scoring computation now uses consistent calculation logic across all criterion scoring modes, improving consistency in grade calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->