### PR TITLE
fix(ssr): sanitize avatar image src to stop SSR-stream crash on /cour…

### DIFF
--- a/app/course/[course_id]/UserMenu.tsx
+++ b/app/course/[course_id]/UserMenu.tsx
@@ -18,6 +18,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useAutomaticRealtimeConnectionStatus } from "@/hooks/useRealtimeConnectionStatus";
 import { TimeZoneContext, useTimeZone } from "@/lib/TimeZoneProvider";
 import { getTimeZoneAbbr } from "@/lib/timezoneUtils";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { createClient } from "@/utils/supabase/client";
 import { UserProfile } from "@/utils/supabase/DatabaseTypes";
 import {
@@ -296,7 +297,7 @@ const DropBoxAvatar = ({
                   onMouseEnter={() => setIsHovered(true)}
                   onMouseLeave={() => setIsHovered(false)}
                 >
-                  <Avatar.Image src={avatarLink || undefined} alt="" />
+                  <Avatar.Image src={sanitizeImageSrc(avatarLink)} alt="" />
                   <Avatar.Fallback name={profile?.name?.charAt(0) ?? "?"} />
                 </Avatar.Root>
                 {isHovered && (
@@ -734,7 +735,7 @@ function UserSettingsMenu() {
         <IconButton aria-label="Open user menu" variant="ghost" size="sm" borderRadius="full" p={0}>
           <Avatar.Root size="sm" colorPalette="gray">
             <Avatar.Fallback name={privateProfile?.data.name?.charAt(0) ?? "?"} />
-            <Avatar.Image src={privateProfile?.data.avatar_url ?? undefined} alt="" />
+            <Avatar.Image src={sanitizeImageSrc(privateProfile?.data.avatar_url)} alt="" />
           </Avatar.Root>
         </IconButton>
       </Drawer.Trigger>
@@ -748,7 +749,7 @@ function UserSettingsMenu() {
                   <HStack flex={1} minWidth={0}>
                     <Avatar.Root size="sm" colorPalette="gray">
                       <Avatar.Fallback name={privateProfile?.data.name?.charAt(0) ?? "?"} />
-                      <Avatar.Image src={privateProfile?.data.avatar_url ?? undefined} alt="" />
+                      <Avatar.Image src={sanitizeImageSrc(privateProfile?.data.avatar_url)} alt="" />
                     </Avatar.Root>
                     <VStack alignItems="flex-start" gap={0} flex={1} minWidth={0}>
                       <Text fontWeight="bold" wordBreak="break-word" lineHeight="1.2">

--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -15,6 +15,7 @@ import {
   EdgeFunctionError
 } from "@/lib/edgeFunctions";
 import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { createClient } from "@/utils/supabase/client";
 import {
   Assignment,
@@ -604,7 +605,7 @@ function GroupMember({ profile_id }: { profile_id: string }) {
   return (
     <HStack>
       <Avatar.Root size="xs">
-        <Avatar.Image src={profile?.avatar_url} alt="" />
+        <Avatar.Image src={sanitizeImageSrc(profile?.avatar_url)} alt="" />
         <Avatar.Fallback>{profile?.name?.slice(0, 2)}</Avatar.Fallback>
       </Avatar.Root>
       <Text fontSize="sm" color="fg.muted">

--- a/app/course/[course_id]/discussion/[root_id]/page.tsx
+++ b/app/course/[course_id]/discussion/[root_id]/page.tsx
@@ -23,6 +23,7 @@ import { useViewAsStudentDataMask } from "@/hooks/useViewAsStudentDataMask";
 import { useDiscussionThreadFollowStatus } from "@/hooks/useDiscussionThreadWatches";
 import useModalManager from "@/hooks/useModalManager";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { useTableControllerValueById } from "@/lib/TableController";
 import { createClient } from "@/utils/supabase/client";
 import { DiscussionThread as DiscussionThreadType, DiscussionTopic } from "@/utils/supabase/DatabaseTypes";
@@ -53,7 +54,7 @@ function ThreadHeader({ thread, topic }: { thread: DiscussionThreadType; topic: 
         <HStack align="start" gap="2" alignSelf="flex-start">
           {userProfile ? (
             <Avatar.Root size="xs">
-              <Avatar.Image src={userProfile?.avatar_url} alt="" />
+              <Avatar.Image src={sanitizeImageSrc(userProfile?.avatar_url)} alt="" />
               <Avatar.Fallback>{userProfile?.name?.charAt(0) || "?"}</Avatar.Fallback>
             </Avatar.Root>
           ) : (

--- a/app/course/[course_id]/discussion/discussion_thread.tsx
+++ b/app/course/[course_id]/discussion/discussion_thread.tsx
@@ -17,6 +17,7 @@ import useDiscussionThreadChildren, { useDiscussionThreadsController } from "@/h
 import { useDiscussionThreadLikes } from "@/hooks/useDiscussionThreadLikes";
 import { useNotifications } from "@/hooks/useNotifications";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { useIntersection } from "@/hooks/useViewportIntersection";
 import { DiscussionThread as DiscussionThreadType } from "@/utils/supabase/DatabaseTypes";
 import { Avatar, Badge, Box, Container, Flex, HStack, Icon, Link, Stack, Text } from "@chakra-ui/react";
@@ -307,7 +308,7 @@ const DiscussionThreadContent = memo(
               {authorProfile ? (
                 <Avatar.Root size="sm" variant="outline" shape="square">
                   <Avatar.Fallback name={authorProfile.name} />
-                  <Avatar.Image src={authorProfile.avatar_url} alt="" />
+                  <Avatar.Image src={sanitizeImageSrc(authorProfile.avatar_url)} alt="" />
                 </Avatar.Root>
               ) : (
                 <SkeletonCircle width="40px" height="40px" />

--- a/app/course/[course_id]/manage/course/enrollments/editUserProfileModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/editUserProfileModal.tsx
@@ -21,6 +21,7 @@ import { useForm } from "react-hook-form";
 import { useCallback, useEffect } from "react";
 import { toaster } from "@/components/ui/toaster";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { useInvalidate } from "@refinedev/core";
 
 type ProfileUpdate = Database["public"]["Tables"]["profiles"]["Update"];
@@ -162,7 +163,7 @@ export default function EditUserProfileModal({ userId, onClose }: EditUserProfil
         <HStack gap={4} align="center">
           <Avatar.Root size="lg">
             <Avatar.Fallback name={watchedName || "Username"} />
-            {watchedAvatarUrl && <Avatar.Image src={watchedAvatarUrl} alt={watchedName || "User Avatar"} />}
+            {watchedAvatarUrl && <Avatar.Image src={sanitizeImageSrc(watchedAvatarUrl)} alt={watchedName || "User Avatar"} />}
           </Avatar.Root>
           <VStack align="start" gap={1}>
             <Text fontWeight="bold" fontSize="xl">

--- a/app/course/[course_id]/manage/course/enrollments/editUserProfileModal.tsx
+++ b/app/course/[course_id]/manage/course/enrollments/editUserProfileModal.tsx
@@ -163,7 +163,9 @@ export default function EditUserProfileModal({ userId, onClose }: EditUserProfil
         <HStack gap={4} align="center">
           <Avatar.Root size="lg">
             <Avatar.Fallback name={watchedName || "Username"} />
-            {watchedAvatarUrl && <Avatar.Image src={sanitizeImageSrc(watchedAvatarUrl)} alt={watchedName || "User Avatar"} />}
+            {watchedAvatarUrl && (
+              <Avatar.Image src={sanitizeImageSrc(watchedAvatarUrl)} alt={watchedName || "User Avatar"} />
+            )}
           </Avatar.Root>
           <VStack align="start" gap={1}>
             <Text fontWeight="bold" fontSize="xl">

--- a/components/help-queue/help-request-teaser.tsx
+++ b/components/help-queue/help-request-teaser.tsx
@@ -1,5 +1,6 @@
 import { useUserProfile } from "@/hooks/useUserProfiles";
 import { getQueueTypeColor } from "@/lib/utils";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { HelpQueue } from "@/utils/supabase/DatabaseTypes";
 import { Avatar, AvatarGroup, Badge, Box, HStack, Icon, Stack, Text } from "@chakra-ui/react";
 import { formatRelative } from "date-fns";
@@ -106,7 +107,7 @@ export const HelpRequestTeaser = (props: Props) => {
     if (effectiveStudents.length === 0) {
       return (
         <Avatar.Root size="sm">
-          <Avatar.Image src={(creatorProfile?.avatar_url || undefined) as string | undefined} alt="" />
+          <Avatar.Image src={sanitizeImageSrc(creatorProfile?.avatar_url)} alt="" />
           <Avatar.Fallback>{(creatorProfile?.name || "?").charAt(0)}</Avatar.Fallback>
         </Avatar.Root>
       );
@@ -116,7 +117,7 @@ export const HelpRequestTeaser = (props: Props) => {
       const displayProfile = student1Profile || creatorProfile;
       return (
         <Avatar.Root size="sm">
-          <Avatar.Image src={(displayProfile?.avatar_url || undefined) as string | undefined} alt="" />
+          <Avatar.Image src={sanitizeImageSrc(displayProfile?.avatar_url)} alt="" />
           <Avatar.Fallback>{(displayProfile?.name || "?").charAt(0)}</Avatar.Fallback>
         </Avatar.Root>
       );
@@ -145,7 +146,7 @@ export const HelpRequestTeaser = (props: Props) => {
       <AvatarGroup size="sm">
         {avatars.map((p) => (
           <Avatar.Root key={p.id} size="sm">
-            <Avatar.Image src={p.avatar_url} alt="" />
+            <Avatar.Image src={sanitizeImageSrc(p.avatar_url)} alt="" />
             <Avatar.Fallback>{(p.name || "?").charAt(0)}</Avatar.Fallback>
           </Avatar.Root>
         ))}

--- a/components/help-queue/request-row.tsx
+++ b/components/help-queue/request-row.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { useUserProfile } from "@/hooks/useUserProfiles";
 import { HelpRequest, HelpQueue } from "@/utils/supabase/DatabaseTypes";
 import { getQueueTypeColor } from "@/lib/utils";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { BsCameraVideo, BsChatText, BsGeoAlt, BsPersonCheck, BsPersonDash } from "react-icons/bs";
 import Markdown from "@/components/ui/markdown";
 import excerpt from "@stefanprobst/remark-excerpt";
@@ -120,7 +121,7 @@ export function RequestRow({ request, href, selected, queue, students = [], vari
     if (effectiveStudents.length === 1) {
       return (
         <Avatar.Root size="sm">
-          <Avatar.Image src={(student1Profile?.avatar_url || undefined) as string | undefined} alt="" />
+          <Avatar.Image src={sanitizeImageSrc(student1Profile?.avatar_url)} alt="" />
           <Avatar.Fallback>{(student1Profile?.name || "?").charAt(0)}</Avatar.Fallback>
         </Avatar.Root>
       );
@@ -149,7 +150,7 @@ export function RequestRow({ request, href, selected, queue, students = [], vari
       <AvatarGroup size="sm">
         {avatars.map((p) => (
           <Avatar.Root key={p.id} size="sm">
-            <Avatar.Image src={p.avatar_url} alt="" />
+            <Avatar.Image src={sanitizeImageSrc(p.avatar_url)} alt="" />
             <Avatar.Fallback>{(p.name || "?").charAt(0)}</Avatar.Fallback>
           </Avatar.Root>
         ))}

--- a/components/notifications/notification-teaser.tsx
+++ b/components/notifications/notification-teaser.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Box, HStack, Skeleton, VStack, IconButton, Text } from "@chakra-ui/react";
 import { Notification } from "@/utils/supabase/DatabaseTypes";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { useNotification } from "@/hooks/useNotifications";
 import { useDiscussionThreadTeaser } from "@/hooks/useCourseController";
 import { useParams, useRouter } from "next/navigation";
@@ -308,7 +309,7 @@ function HelpRequestMessageNotificationTeaser({ notification }: { notification: 
   return (
     <HStack align="flex-start" gap="3">
       <Avatar.Root size="sm" flexShrink="0">
-        <Avatar.Image src={author.avatar_url} alt="" />
+        <Avatar.Image src={sanitizeImageSrc(author.avatar_url)} alt="" />
         <Avatar.Fallback fontSize="xs">{author.name?.charAt(0)}</Avatar.Fallback>
       </Avatar.Root>
       <VStack align="flex-start" gap="1" flex="1">
@@ -403,7 +404,7 @@ function DiscussionThreadReplyNotificationTeaser({ notification }: { notificatio
   return (
     <HStack align="flex-start" gap="3">
       <Avatar.Root size="sm" flexShrink="0">
-        <Avatar.Image src={author.avatar_url} alt="" />
+        <Avatar.Image src={sanitizeImageSrc(author.avatar_url)} alt="" />
         <Avatar.Fallback fontSize="xs">{author.name?.charAt(0)}</Avatar.Fallback>
       </Avatar.Root>
       <VStack align="flex-start" gap="1" flex="1">
@@ -503,7 +504,7 @@ function RegradeRequestNotificationTeaser({ notification }: { notification: Noti
   return (
     <HStack align="flex-start" gap="3">
       <Avatar.Root size="sm" flexShrink="0">
-        <Avatar.Image src={actor?.avatar_url} alt="" />
+        <Avatar.Image src={sanitizeImageSrc(actor?.avatar_url)} alt="" />
         <Avatar.Fallback fontSize="xs">{actor?.name?.charAt(0)}</Avatar.Fallback>
       </Avatar.Root>
       <VStack align="flex-start" gap="1" flex="1">

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -3,6 +3,7 @@
 import type { GroupProps, SlotRecipeProps } from "@chakra-ui/react";
 import { Avatar as ChakraAvatar, Group } from "@chakra-ui/react";
 import * as React from "react";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 
 type ImageProps = React.ImgHTMLAttributes<HTMLImageElement>;
 
@@ -29,7 +30,7 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(function Ava
       <AvatarFallback name={name} icon={icon}>
         {fallback}
       </AvatarFallback>
-      <ChakraAvatar.Image src={src} srcSet={srcSet} loading={loading} alt={alt ?? ""} />
+      <ChakraAvatar.Image src={sanitizeImageSrc(src)} srcSet={srcSet} loading={loading} alt={alt ?? ""} />
       {children}
     </ChakraAvatar.Root>
   );

--- a/components/ui/discussion-post-summary.tsx
+++ b/components/ui/discussion-post-summary.tsx
@@ -5,6 +5,7 @@ import { useClassProfiles, useIsReadOnly } from "@/hooks/useClassProfiles";
 import { useCourseController } from "@/hooks/useCourseController";
 import { useDiscussionThreadLikes } from "@/hooks/useDiscussionThreadLikes";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import {
   DiscussionThread as DiscussionThreadType,
   DiscussionTopic,
@@ -134,7 +135,7 @@ export function DiscussionPostSummary({
               <HStack>
                 <Avatar.Root size="sm" variant="outline" shape="square">
                   <Avatar.Fallback name={userProfile?.name} />
-                  <Avatar.Image src={userProfile?.avatar_url} alt="" />
+                  <Avatar.Image src={sanitizeImageSrc(userProfile?.avatar_url)} alt="" />
                 </Avatar.Root>
                 <Text textStyle="sm" hideBelow="sm">
                   {userProfile?.name}

--- a/components/ui/person-avatar.tsx
+++ b/components/ui/person-avatar.tsx
@@ -1,4 +1,5 @@
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { Avatar, Box } from "@chakra-ui/react";
 import { Tooltip } from "./tooltip";
 
@@ -8,7 +9,7 @@ export default function PersonName({ uid, size = "sm" }: { uid: string; size?: "
     <Tooltip content={userProfile?.name} portalled={false}>
       <Box display="inline-block">
         <Avatar.Root size={size}>
-          <Avatar.Image src={userProfile?.avatar_url} alt="" />
+          <Avatar.Image src={sanitizeImageSrc(userProfile?.avatar_url)} alt="" />
           <Avatar.Fallback>{userProfile?.name?.charAt(0)}</Avatar.Fallback>
         </Avatar.Root>
       </Box>

--- a/components/ui/person-name.tsx
+++ b/components/ui/person-name.tsx
@@ -1,5 +1,6 @@
 import { useIsGraderOrInstructor } from "@/hooks/useClassProfiles";
 import { useUserProfile } from "@/hooks/useUserProfiles";
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { Avatar, HStack, Text, TextProps, VStack } from "@chakra-ui/react";
 import { memo } from "react";
 
@@ -35,7 +36,7 @@ function PersonName({
   return (
     <HStack w="100%">
       <Avatar.Root size={size}>
-        <Avatar.Image src={userProfile?.avatar_url} alt="" />
+        <Avatar.Image src={sanitizeImageSrc(userProfile?.avatar_url)} alt="" />
         <Avatar.Fallback>{userProfile?.name?.charAt(0)}</Avatar.Fallback>
       </Avatar.Root>
       <VStack>

--- a/lib/sanitizeImageSrc.ts
+++ b/lib/sanitizeImageSrc.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalize an image `src` so that empty / `"#"` / whitespace-only / `null` /
+ * `undefined` values become `undefined` instead of reaching the DOM.
+ *
+ * Rendering `<img src="">` or `<img src="#">` (including a Chakra
+ * `<Avatar.Image>` with such a value) inside the tree of an *async server
+ * layout* corrupts Next.js's SSR stream and throws
+ * `TypeError: controller[kState].transformAlgorithm is not a function` from
+ * Node's internal webstreams, which takes down the entire route render (seen on
+ * `/course/[course_id]`). Coercing to `undefined` makes the element omit `src`
+ * entirely — and lets `Avatar` fall back to initials — which streams safely.
+ *
+ * See vercel/next.js#75995 and vercel/next.js#68319.
+ */
+export function sanitizeImageSrc(src: string | null | undefined): string | undefined {
+  if (typeof src !== "string") return undefined;
+  const trimmed = src.trim();
+  if (trimmed === "" || trimmed === "#") return undefined;
+  return src;
+}

--- a/tests/unit/sanitize-image-src.test.ts
+++ b/tests/unit/sanitize-image-src.test.ts
@@ -1,0 +1,31 @@
+import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
+
+describe("sanitizeImageSrc", () => {
+  // The whole point: an empty / "#" src reaching an <img>/<Avatar.Image> inside an
+  // async server layout corrupts Next's SSR stream (controller[kState].transformAlgorithm
+  // is not a function). These must all coerce to `undefined` so the element omits `src`.
+  it.each([
+    ["empty string", ""],
+    ["whitespace only", "   "],
+    ["hash", "#"],
+    ["hash with surrounding whitespace", "  #  "],
+    ["null", null],
+    ["undefined", undefined]
+  ])("returns undefined for %s", (_label, input) => {
+    expect(sanitizeImageSrc(input as string | null | undefined)).toBeUndefined();
+  });
+
+  it("passes through a real URL unchanged", () => {
+    const url = "https://avatars.githubusercontent.com/u/9771079?v=4";
+    expect(sanitizeImageSrc(url)).toBe(url);
+  });
+
+  it("passes through a relative path unchanged", () => {
+    expect(sanitizeImageSrc("/avatars/123.png")).toBe("/avatars/123.png");
+  });
+
+  it("does not trim a valid value (preserves the original string)", () => {
+    // Only fully-blank / "#" values are dropped; a non-blank value is returned verbatim.
+    expect(sanitizeImageSrc("data:image/png;base64,iVBORw0KGgo=")).toBe("data:image/png;base64,iVBORw0KGgo=");
+  });
+});


### PR DESCRIPTION
…se/[course_id]

Production Sentry: `TypeError: controller[kState].transformAlgorithm is not a function` during SSR streaming of `/course/[course_id]` (Vercel prefetch; prerender), with a stack entirely in Node's internal webstreams — no app frame.

Root cause is a known Next.js issue (vercel/next.js#75995, #68319): an `<img>` / Chakra `<Avatar.Image>` with `src="#"` or an empty/invalid `src`, rendered inside the tree of an *async server layout*, corrupts Next's SSR stream and throws this error from Node webstreams, taking down the whole route render. `app/course/[course_id]/layout.tsx` is exactly such an async server layout, and its avatars feed `userProfile?.avatar_url` (which can be "" / null) straight into `<Avatar.Image src=…>` with no guard. No Next release reliably fixes the framework-side symptom, so the fix is to stop emitting the bad `src`.

Add `lib/sanitizeImageSrc()` (empty / "#" / whitespace / null / undefined -> undefined, so the element omits `src` and Avatar falls back to initials) and apply it at every avatar `src` call site (19 sites across 12 files), including the shared `components/ui/avatar.tsx` wrapper. Also drops a couple of `as string | undefined` casts that were papering over the same hole.

Investigated and ruled out: the experimental `inlineCss` culprit (not enabled). A Next version bump was considered but is NOT a reliable fix per the upstream threads, so it is intentionally not part of this change.

- tsc --noEmit: 0 errors
- new unit test tests/unit/sanitize-image-src.test.ts: 9/9 pass