### PR TITLE
chore(deployment-channels): address review feedback on #826

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -29,6 +29,14 @@ on:
         description: "Namespace whose pawtograder-jwt:ANON_KEY is baked into the web bundle"
         required: false
         default: "pawtograder-staging"
+      channel:
+        description: "Deployment channel name (A/B). Empty/stable = primary build; a name like 'team7' bakes NEXT_PUBLIC_PAWTOGRADER_CHANNEL and tags the image '<channel>-<sha>'. Set web_hostname to the channel's own host."
+        required: false
+        default: ""
+      channel_host_suffix:
+        description: "NEXT_PUBLIC_CHANNEL_HOST_SUFFIX build arg (the channel zone, e.g. 'staging.pawtograder.net') — enables per-course host redirect + cross-channel cookie scope. Empty = channel routing disabled."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -59,6 +67,8 @@ jobs:
 
       - id: v
         name: Compute version + tag list
+        env:
+          CHANNEL_INPUT: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           chart_version=$(awk '/^version:/ {print $2; exit}' charts/pawtograder/Chart.yaml)
@@ -79,6 +89,18 @@ jobs:
             version="${safe_branch}-${short_sha}"
             is_tag=false
             tags="${safe_branch}-${short_sha},${safe_branch}-latest"
+          fi
+          # A/B channel build (workflow_dispatch only): tag the image by channel
+          # so it never collides with the stable tag, and so the chart can pin
+          # channels[].web.image.tag to "<channel>-<sha>" / "<channel>-latest".
+          channel="${CHANNEL_INPUT:-}"
+          if [[ -n "$channel" && "$channel" != "stable" ]]; then
+            if [[ ! "$channel" =~ ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$ ]]; then
+              echo "::error::channel '${channel}' must be a DNS-1123 label (lowercase alphanumeric + '-', <=63 chars)"; exit 1
+            fi
+            version="${channel}-${short_sha}"
+            tags="${channel}-${short_sha},${channel}-latest"
+            is_tag=false
           fi
           echo "version=${version}"            | tee -a "$GITHUB_OUTPUT"
           echo "is_tag=${is_tag}"              | tee -a "$GITHUB_OUTPUT"
@@ -126,26 +148,44 @@ jobs:
 
       - name: Resolve hostnames + namespace
         id: hosts
+        # CHANNEL / SUFFIX bake the A/B-channel routing into the bundle (see
+        # utils/channels.ts). On a channel build (workflow_dispatch with a
+        # `channel` input) the caller supplies the channel's own web_hostname and
+        # channel_host_suffix. On stable push/dispatch the suffix comes from the
+        # CHANNEL_HOST_SUFFIX repo variable (empty by default => routing disabled,
+        # so stable behaves exactly as before until an operator opts in fleet-wide
+        # by setting that variable).
         env:
           EVENT: ${{ github.event_name }}
           INPUT_WEB: ${{ inputs.web_hostname }}
           INPUT_API: ${{ inputs.api_hostname }}
           INPUT_NS: ${{ inputs.namespace }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_SUFFIX: ${{ inputs.channel_host_suffix }}
+          VAR_SUFFIX: ${{ vars.CHANNEL_HOST_SUFFIX }}
         run: |
           set -euo pipefail
           if [ "$EVENT" = "workflow_dispatch" ]; then
             web="${INPUT_WEB:-https://staging.pawtograder.net}"
             api="${INPUT_API:-https://api.staging.pawtograder.net}"
             ns="${INPUT_NS:-pawtograder-staging}"
+            channel="${INPUT_CHANNEL:-stable}"
+            suffix="${INPUT_SUFFIX:-${VAR_SUFFIX:-}}"
           else
             # push to main → staging (see job-level if condition above).
             web="https://staging.pawtograder.net"
             api="https://api.staging.pawtograder.net"
             ns="pawtograder-staging"
+            channel="stable"
+            suffix="${VAR_SUFFIX:-}"
           fi
+          # Normalize an empty channel to "stable" (the build's default).
+          [ -n "$channel" ] || channel="stable"
           echo "web=$web" >> "$GITHUB_OUTPUT"
           echo "api=$api" >> "$GITHUB_OUTPUT"
           echo "ns=$ns" >> "$GITHUB_OUTPUT"
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
 
       - name: Read anon key from cluster
         # The anon key the browser ships MUST match what the cluster's GoTrue /
@@ -186,6 +226,8 @@ jobs:
             NEXT_PUBLIC_POSTHOG_UI_HOST=${{ secrets.STAGING_POSTHOG_UI_HOST }}
             NEXT_PUBLIC_ENABLE_SIGNUPS=false
             NEXT_PUBLIC_GIT_COMMIT_SHA=${{ github.sha }}
+            NEXT_PUBLIC_PAWTOGRADER_CHANNEL=${{ steps.hosts.outputs.channel }}
+            NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=${{ steps.hosts.outputs.suffix }}
             SENTRY_RELEASE=${{ needs.meta.outputs.version }}
             SUPABASE_URL=${{ steps.hosts.outputs.api }}
           labels: |

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: ""
       channel_host_suffix:
-        description: "NEXT_PUBLIC_CHANNEL_HOST_SUFFIX build arg (the channel zone, e.g. 'staging.pawtograder.net') — enables per-course host redirect + cross-channel cookie scope. Empty = channel routing disabled."
+        description: "NEXT_PUBLIC_CHANNEL_HOST_SUFFIX build arg (the channel zone, e.g. 'staging.pawtograder.net') — enables per-course host redirect + cross-channel cookie scope. Empty falls back to the vars.CHANNEL_HOST_SUFFIX repo variable; routing is disabled only when both are empty."
         required: false
         default: ""
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,10 @@ ARG NEXT_PUBLIC_ENABLE_SIGNUPS=""
 ARG NEXT_PUBLIC_GIT_COMMIT_SHA=""
 # A/B deployment channels (see utils/channels.ts). PAWTOGRADER_CHANNEL identifies
 # the build's channel ("" => stable). CHANNEL_HOST_SUFFIX enables per-course
-# host-redirect routing in middleware; SESSION_COOKIE_DOMAIN scopes the auth
-# cookie across channel subdomains. All empty by default => routing disabled.
+# host-redirect routing in middleware and also derives the cross-channel auth
+# cookie scope (".<suffix>"). Both empty by default => routing disabled.
 ARG NEXT_PUBLIC_PAWTOGRADER_CHANNEL=""
 ARG NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=""
-ARG NEXT_PUBLIC_SESSION_COOKIE_DOMAIN=""
 ARG SENTRY_RELEASE=""
 ARG SUPABASE_URL=""
 
@@ -57,7 +56,6 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     NEXT_PUBLIC_GIT_COMMIT_SHA=$NEXT_PUBLIC_GIT_COMMIT_SHA \
     NEXT_PUBLIC_PAWTOGRADER_CHANNEL=$NEXT_PUBLIC_PAWTOGRADER_CHANNEL \
     NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=$NEXT_PUBLIC_CHANNEL_HOST_SUFFIX \
-    NEXT_PUBLIC_SESSION_COOKIE_DOMAIN=$NEXT_PUBLIC_SESSION_COOKIE_DOMAIN \
     SENTRY_RELEASE=$SENTRY_RELEASE \
     SUPABASE_URL=$SUPABASE_URL \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/charts/pawtograder/templates/_helpers.tpl
+++ b/charts/pawtograder/templates/_helpers.tpl
@@ -163,22 +163,44 @@ label, so the default two-label "api.pr-123.preview…" form is NOT coverable).
 
 {{/*
 Per-deployment-channel public host. Each channel (.Values.channels[]) is served
-on its own single-label host so a *.<zone> wildcard TLS cert covers it; the
-channel runs web + edge-functions code against the shared data plane, and the app
-redirects each course to its channel's host (classes.deployment_channel). Defaults
-to "<name>.<global.hostname>"; an entry may set `host` to override.
+on its own single-label host "<name>.<global.hostname>" so a *.<zone> wildcard
+TLS cert always covers it; the channel runs web + edge-functions code against the
+shared data plane, and the app redirects each course to its channel's host
+(classes.deployment_channel). The host pattern is fixed (no per-channel override)
+because the web middleware's hostForChannel() computes the same "<name>.<suffix>"
+to drive the redirect — the chart and the app must agree on one host per channel.
+The name is capped at 63 chars to match the DB CHECK on classes.deployment_channel
+(a longer channel could render chart resources but never be stored / pinned to).
 Usage: {{ include "pawtograder.channel.host" (dict "ctx" . "channel" $c) }}
 */}}
 {{- define "pawtograder.channel.host" -}}
 {{- $name := required "channels[].name is required" .channel.name -}}
-{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" $name) -}}
-{{- fail (printf "invalid channels[].name %q: must be a DNS-1123 label (lowercase alphanumeric and '-', starting/ending alphanumeric) — it becomes a resource name and host label" $name) -}}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$" $name) -}}
+{{- fail (printf "invalid channels[].name %q: must be a DNS-1123 label, <=63 chars (lowercase alphanumeric and '-', starting/ending alphanumeric) — it becomes a resource name and host label" $name) -}}
 {{- end -}}
-{{- $host := default (printf "%s.%s" $name .ctx.Values.global.hostname) .channel.host -}}
-{{- if not (regexMatch "^[a-z0-9]([-.a-z0-9]*[a-z0-9])?$" $host) -}}
-{{- fail (printf "invalid channel host %q for channel %q: must be a DNS hostname" $host $name) -}}
+{{- printf "%s.%s" $name .ctx.Values.global.hostname -}}
 {{- end -}}
-{{- $host -}}
+
+{{/*
+Shared Supabase API path routes (auth / rest / realtime / storage / functions →
+Kong) for an Ingress host. Used by the primary host, its TLS-SAN extraHosts, and
+every deployment-channel host, so the five proxied prefixes (and their port
+handling) can't drift between the three Ingresses. Caller decides whether to emit
+them (the primary host omits these when global.apiOnSeparateHost).
+Usage: {{ include "pawtograder.ingress.apiPaths" $ | trim | nindent 10 }}
+*/}}
+{{- define "pawtograder.ingress.apiPaths" -}}
+{{- $kong := include "pawtograder.kong.host" . -}}
+{{- $port := .Values.kong.service.port -}}
+{{- range $p := (list "auth" "rest" "realtime" "storage" "functions") }}
+- path: /{{ $p }}/v1
+  pathType: Prefix
+  backend:
+    service:
+      name: {{ $kong }}
+      port:
+        number: {{ $port }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/pawtograder/templates/edge-functions-channels.yaml
+++ b/charts/pawtograder/templates/edge-functions-channels.yaml
@@ -9,9 +9,24 @@ channel host's /functions/v1 traffic to the matching functions-<name> Service
 {{- if .Values.edgeFunctions.enabled }}
 {{- range $c := .Values.channels }}
 {{- if $c.edgeFunctions }}
-{{- $image := mergeOverwrite (deepCopy $.Values.edgeFunctions.image) ($c.edgeFunctions.image | default dict) }}
+{{- /* A channel's functions are reached only via its web host's /functions/v1
+   (Kong routes that host — see kong-config.yaml; the Ingress is created by the
+   web block in ingress-channels.yaml). An edgeFunctions-only channel renders a
+   Deployment/Service with no Ingress, so it's unreachable from outside the
+   cluster — fail fast instead of shipping a silent dead end. */ -}}
+{{- if not $c.web }}
+{{- fail (printf "channel %q: an edgeFunctions block requires a web block — without it the channel host has no Ingress and /functions/v1 is unreachable from outside the cluster" $c.name) }}
+{{- end }}
+{{- /* Require the channel's own image tag (see web-channels.yaml). */ -}}
+{{- if not (and $c.edgeFunctions.image $c.edgeFunctions.image.tag) }}
+{{- fail (printf "channel %q: channels[].edgeFunctions.image.tag is required when an edgeFunctions block is present (a channel without its own tag would run the stable functions image)" $c.name) }}
+{{- end }}
+{{- $image := mergeOverwrite (deepCopy $.Values.edgeFunctions.image) $c.edgeFunctions.image }}
+{{- /* hasKey, not `default 1`, so replicas: 0 can idle the channel (Sprig
+   `default` treats 0 as empty). */ -}}
+{{- $replicas := ternary $c.edgeFunctions.replicas 1 (hasKey $c.edgeFunctions "replicas") }}
 ---
-{{ include "pawtograder.edgeFunctions.workload" (dict "ctx" $ "component" (printf "functions-%s" $c.name) "image" $image "replicas" (default 1 $c.edgeFunctions.replicas) "autoscaling" false) }}
+{{ include "pawtograder.edgeFunctions.workload" (dict "ctx" $ "component" (printf "functions-%s" $c.name) "image" $image "replicas" $replicas "autoscaling" false) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pawtograder/templates/ingress-channels.yaml
+++ b/charts/pawtograder/templates/ingress-channels.yaml
@@ -3,28 +3,25 @@ Per-deployment-channel Ingress. Each channel with a `web` block gets its own
 single-label host (<name>.<global.hostname>) serving that channel's web
 deployment at /, with the Supabase API paths proxied to the shared Kong (which
 routes /functions/v1 to the channel's functions by host — see
-templates/kong-config.yaml; auth/rest/realtime/storage stay shared). TLS uses the
-*.<zone> wildcard secret (channelWildcardTlsSecret), so adding channels needs no
-per-host ACME issuance.
+templates/kong-config.yaml; auth/rest/realtime/storage stay shared). The host is
+always a single label under <global.hostname>, so the *.<zone> wildcard secret
+(channelWildcardTlsSecret) always covers it and adding channels needs no per-host
+ACME issuance; channels[].tls.secretName is an optional override for a dedicated
+per-channel cert.
 */ -}}
 {{- if and .Values.ingress.enabled .Values.web.enabled }}
 {{- range $c := .Values.channels }}
 {{- if $c.web }}
 {{- $host := include "pawtograder.channel.host" (dict "ctx" $ "channel" $c) }}
-{{- /* Resolve the channel ingress TLS secret:
-   - channels[].tls.secretName, if set, wins (per-channel cert; any host).
-   - otherwise the host must be under the *.<global.hostname> wildcard zone so
-     channelWildcardTlsSecret can cover it (the default <name>.<hostname> host
-     always is); an overridden host outside the zone fails fast rather than
-     serving a mismatched cert. */ -}}
+{{- /* Channel ingress TLS secret: channels[].tls.secretName wins if set
+   (dedicated per-channel cert); otherwise the reflected *.<zone> wildcard
+   (channelWildcardTlsSecret), which always covers the single-label host. */ -}}
 {{- $tlsSecret := "" }}
 {{- if $.Values.ingress.tls.enabled }}
 {{- if and $c.tls $c.tls.secretName }}
 {{- $tlsSecret = $c.tls.secretName }}
-{{- else if hasSuffix (printf ".%s" $.Values.global.hostname) $host }}
-{{- $tlsSecret = required "channelWildcardTlsSecret is required for channels under the wildcard zone with ingress.tls.enabled (a reflected *.<zone> cert), or set channels[].tls.secretName" $.Values.channelWildcardTlsSecret }}
 {{- else }}
-{{- fail (printf "channel %q host %q is outside the wildcard zone *.%s, so channelWildcardTlsSecret can't cover it; set channels[].tls.secretName for a per-channel cert" $c.name $host $.Values.global.hostname) }}
+{{- $tlsSecret = required "channelWildcardTlsSecret is required for channels with ingress.tls.enabled (a reflected *.<zone> cert), or set channels[].tls.secretName for a per-channel cert" $.Values.channelWildcardTlsSecret }}
 {{- end }}
 {{- end }}
 {{- $component := printf "web-%s" $c.name }}
@@ -42,7 +39,12 @@ metadata:
     # overflow nginx's default proxy buffers (502 "upstream sent too big header").
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
-    {{- with $.Values.ingress.annotations }}
+    {{- /* Inherit the primary ingress annotations EXCEPT cert-manager's issuer
+       hints: this host's TLS uses a pre-provisioned reflected wildcard secret, so
+       an issuer annotation here would make cert-manager's ingress-shim issue a
+       competing single-SAN cert into that same secret — overwriting the shared
+       wildcard and breaking TLS for the stable host and every other channel. */ -}}
+    {{- with omit $.Values.ingress.annotations "cert-manager.io/cluster-issuer" "cert-manager.io/issuer" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
@@ -61,41 +63,7 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - path: /auth/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /rest/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /realtime/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /storage/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /functions/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
+          {{- include "pawtograder.ingress.apiPaths" $ | trim | nindent 10 }}
           - path: /
             pathType: Prefix
             backend:

--- a/charts/pawtograder/templates/ingress.yaml
+++ b/charts/pawtograder/templates/ingress.yaml
@@ -40,41 +40,7 @@ spec:
       http:
         paths:
           {{- if not .Values.global.apiOnSeparateHost }}
-          - path: /auth/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" . }}
-                port:
-                  number: {{ .Values.kong.service.port }}
-          - path: /rest/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" . }}
-                port:
-                  number: {{ .Values.kong.service.port }}
-          - path: /realtime/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" . }}
-                port:
-                  number: {{ .Values.kong.service.port }}
-          - path: /storage/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" . }}
-                port:
-                  number: {{ .Values.kong.service.port }}
-          - path: /functions/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" . }}
-                port:
-                  number: {{ .Values.kong.service.port }}
+          {{- include "pawtograder.ingress.apiPaths" . | trim | nindent 10 }}
           {{- end }}
           - path: /
             pathType: Prefix
@@ -106,41 +72,7 @@ spec:
       http:
         paths:
           {{- if not $.Values.global.apiOnSeparateHost }}
-          - path: /auth/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /rest/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /realtime/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /storage/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
-          - path: /functions/v1
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "pawtograder.kong.host" $ }}
-                port:
-                  number: {{ $.Values.kong.service.port }}
+          {{- include "pawtograder.ingress.apiPaths" $ | trim | nindent 10 }}
           {{- end }}
           - path: /
             pathType: Prefix

--- a/charts/pawtograder/templates/web-channels.yaml
+++ b/charts/pawtograder/templates/web-channels.yaml
@@ -9,9 +9,18 @@ channel's host based on classes.deployment_channel.
 {{- if .Values.web.enabled }}
 {{- range $c := .Values.channels }}
 {{- if $c.web }}
-{{- $image := mergeOverwrite (deepCopy $.Values.web.image) ($c.web.image | default dict) }}
+{{- /* Require the channel's own image tag: without it mergeOverwrite falls back
+   to the stable repository+tag, so the channel host would serve byte-identical
+   stable code (the intended A/B split silently produces zero difference). */ -}}
+{{- if not (and $c.web.image $c.web.image.tag) }}
+{{- fail (printf "channel %q: channels[].web.image.tag is required when a web block is present (a channel without its own tag would run the stable image, not a canary build)" $c.name) }}
+{{- end }}
+{{- $image := mergeOverwrite (deepCopy $.Values.web.image) $c.web.image }}
+{{- /* hasKey, not `default 1`: Sprig `default` treats 0 as empty, which would
+   render replicas: 0 as 1 and make a channel impossible to idle to zero. */ -}}
+{{- $replicas := ternary $c.web.replicas 1 (hasKey $c.web "replicas") }}
 ---
-{{ include "pawtograder.web.workload" (dict "ctx" $ "component" (printf "web-%s" $c.name) "image" $image "replicas" (default 1 $c.web.replicas)) }}
+{{ include "pawtograder.web.workload" (dict "ctx" $ "component" (printf "web-%s" $c.name) "image" $image "replicas" $replicas) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -48,30 +48,35 @@ global:
 # Extra, concurrent web + edge-functions deployments running DIFFERENT image
 # tags against the SAME data plane (Postgres/auth/storage) as the stable
 # release. Each channel is served on its own single-label host
-# (<name>.<global.hostname>, override with `host`); the app redirects each
-# course to its channel's host based on the classes.deployment_channel column,
-# so one user can use stable + canary courses in the same session. Kong routes a
-# channel host's /functions/v1 to that channel's functions; everything else is
-# shared. Default empty = stable only, no extra objects rendered.
+# (<name>.<global.hostname>, a fixed pattern — the web middleware computes the
+# same host to drive its redirect, so there's no per-channel host override); the
+# app redirects each course to its channel's host based on the
+# classes.deployment_channel column, so one user can use stable + canary courses
+# in the same session. Kong routes a channel host's /functions/v1 to that
+# channel's functions; everything else is shared. Default empty = stable only,
+# no extra objects rendered.
 #
-# Channel image build args matter: the web image for a channel must be built
-# with NEXT_PUBLIC_PAWTOGRADER_CHANNEL=<name> and its own host as
-# NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_PAWTOGRADER_WEB_URL (NEXT_PUBLIC_* bake
-# at build time). Channel code must be schema-compatible with the shared DB
-# (expand/contract migrations only).
+# Channel image build args matter: the web image for a channel MUST be built with
+# NEXT_PUBLIC_PAWTOGRADER_CHANNEL=<name>, NEXT_PUBLIC_CHANNEL_HOST_SUFFIX set to
+# the zone, and its own channel host as NEXT_PUBLIC_PAWTOGRADER_WEB_URL (so
+# password-reset / signup-confirm / OAuth callbacks land on the channel host, not
+# stable), with the shared NEXT_PUBLIC_SUPABASE_URL — all NEXT_PUBLIC_* bake at
+# build time (see .github/workflows/release-images.yml `channel` input). Channel
+# code must be schema-compatible with the shared DB (expand/contract migrations
+# only). A web/edgeFunctions block without its own image.tag, and an edgeFunctions
+# block without a web block, both fail the render (see *-channels.yaml).
 channels: []
 #  - name: team7
-#    # host: team7.staging.pawtograder.net   # optional; default <name>.<global.hostname>
 #    # tls:
-#    #   secretName: team7-tls   # optional per-channel cert; required if `host` is
-#    #                           # outside the *.<global.hostname> wildcard zone
+#    #   secretName: team7-tls   # optional override for a dedicated per-channel
+#    #                           # cert; default is the *.<zone> wildcard below
 #    web:
 #      image:
-#        tag: "team7-<sha>"      # repository/pullPolicy default from web.image
-#      replicas: 1
+#        tag: "team7-<sha>"      # REQUIRED; repository/pullPolicy default from web.image
+#      replicas: 1               # 0 idles the channel (kept distinct from absent)
 #    edgeFunctions:
 #      image:
-#        tag: "team7-<sha>"      # repository/pullPolicy default from edgeFunctions.image
+#        tag: "team7-<sha>"      # REQUIRED; repository/pullPolicy default from edgeFunctions.image
 #      replicas: 1
 
 # Reflected *.<zone> wildcard TLS secret used by every channel Ingress (e.g.

--- a/tests/unit/channels.test.ts
+++ b/tests/unit/channels.test.ts
@@ -1,0 +1,100 @@
+import {
+  channelHostSuffix,
+  currentChannel,
+  hostForChannel,
+  sessionCookieOptions,
+  STABLE_CHANNEL
+} from "@/utils/channels";
+
+/**
+ * A/B deployment-channel routing primitives (utils/channels.ts) are the single
+ * source of truth the web middleware and the Helm chart must agree on:
+ *  - hostForChannel() must produce exactly "<channel>.<suffix>" (the chart pins
+ *    every channel to that fixed host; there is no per-channel host override).
+ *  - sessionCookieOptions() must DERIVE the cross-channel cookie domain from the
+ *    suffix, so the redirect and the cookie scope can never be half-configured.
+ * These read process.env at call time, so we mutate it per test.
+ */
+describe("utils/channels", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PUBLIC_PAWTOGRADER_CHANNEL;
+    delete process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe("currentChannel", () => {
+    it("defaults to stable when unset", () => {
+      expect(currentChannel()).toBe(STABLE_CHANNEL);
+      expect(STABLE_CHANNEL).toBe("stable");
+    });
+
+    it("reflects the baked channel", () => {
+      process.env.NEXT_PUBLIC_PAWTOGRADER_CHANNEL = "team7";
+      expect(currentChannel()).toBe("team7");
+    });
+  });
+
+  describe("channelHostSuffix", () => {
+    it("is undefined when routing is disabled", () => {
+      expect(channelHostSuffix()).toBeUndefined();
+    });
+
+    it("treats an empty string as disabled (not a zero-length zone)", () => {
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "";
+      expect(channelHostSuffix()).toBeUndefined();
+    });
+
+    it("returns the configured suffix", () => {
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "staging.pawtograder.net";
+      expect(channelHostSuffix()).toBe("staging.pawtograder.net");
+    });
+  });
+
+  describe("hostForChannel", () => {
+    it("returns undefined when routing is disabled (no extra work / no redirect)", () => {
+      expect(hostForChannel("team7")).toBeUndefined();
+      expect(hostForChannel(STABLE_CHANNEL)).toBeUndefined();
+    });
+
+    it("serves stable on the bare suffix host", () => {
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "staging.pawtograder.net";
+      expect(hostForChannel(STABLE_CHANNEL)).toBe("staging.pawtograder.net");
+    });
+
+    it("serves a channel on the fixed <channel>.<suffix> host the chart renders", () => {
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "staging.pawtograder.net";
+      // Must match charts/.../_helpers.tpl pawtograder.channel.host exactly.
+      expect(hostForChannel("team7")).toBe("team7.staging.pawtograder.net");
+    });
+  });
+
+  describe("sessionCookieOptions", () => {
+    it("is a no-op (host-only cookies) when routing is disabled", () => {
+      expect(sessionCookieOptions()).toEqual({});
+    });
+
+    it("derives the parent-zone cookie domain from the suffix when routing is enabled", () => {
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "staging.pawtograder.net";
+      expect(sessionCookieOptions()).toEqual({
+        cookieOptions: { domain: ".staging.pawtograder.net" }
+      });
+    });
+
+    it("scopes the cookie to the same zone the channel hosts live under", () => {
+      // The derived domain must be a parent of both the stable host and every
+      // <channel>.<suffix> host, or a cross-host redirect drops the session.
+      process.env.NEXT_PUBLIC_CHANNEL_HOST_SUFFIX = "staging.pawtograder.net";
+      const opts = sessionCookieOptions() as { cookieOptions: { domain: string } };
+      const channelHost = hostForChannel("team7")!;
+      const stableHost = hostForChannel(STABLE_CHANNEL)!;
+      expect(channelHost.endsWith(opts.cookieOptions.domain.slice(1))).toBe(true);
+      expect(stableHost.endsWith(opts.cookieOptions.domain.slice(1))).toBe(true);
+    });
+  });
+});

--- a/utils/channels.ts
+++ b/utils/channels.ts
@@ -28,11 +28,31 @@ export function channelHostSuffix(): string | undefined {
 
 /**
  * Public host serving a given channel: the suffix itself for "stable", else
- * "<channel>.<suffix>" — matching the chart's pawtograder.channel.host default.
+ * "<channel>.<suffix>" — matching the chart's pawtograder.channel.host. The
+ * chart pins every channel to this exact pattern (no per-channel host override),
+ * so this is the single source of truth the redirect and the Ingress agree on.
  * Returns undefined when channel routing is disabled.
  */
 export function hostForChannel(channel: string): string | undefined {
   const suffix = channelHostSuffix();
   if (!suffix) return undefined;
   return channel === STABLE_CHANNEL ? suffix : `${channel}.${suffix}`;
+}
+
+/**
+ * Supabase SSR `cookieOptions` for cross-channel-host sessions, derived from the
+ * channel host suffix (NOT a second env var). When channel routing is enabled,
+ * scope the auth cookies to the parent zone (".<suffix>") so a session survives
+ * a redirect between a channel host (<channel>.<suffix>) and the stable host
+ * (<suffix>). Deriving it from the suffix means the redirect and the cookie
+ * scope can never be half-configured — set the suffix and both turn on together.
+ *
+ * Returns `{}` when routing is disabled (local / supabase.com / single-channel)
+ * so clients keep host-only cookies, behavior unchanged. Spread into the
+ * createServerClient/createBrowserClient options: `...sessionCookieOptions()`.
+ */
+export function sessionCookieOptions(): { cookieOptions: { domain: string } } | Record<string, never> {
+  const suffix = channelHostSuffix();
+  if (!suffix) return {};
+  return { cookieOptions: { domain: `.${suffix}` } };
 }

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -2,6 +2,7 @@ import { createBrowserClient } from "@supabase/ssr";
 import { createClient as supabaseCreateClient } from "@supabase/supabase-js";
 import { Database } from "./SupabaseTypes";
 import { assert } from "../utils";
+import { sessionCookieOptions } from "../channels";
 
 export const createClient = () => {
   const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -13,11 +14,9 @@ export const createClient = () => {
     realtime: {
       worker: true
     },
-    // See utils/supabase/middleware.ts: scope auth cookies to the parent domain
-    // for cross-channel-host sessions when NEXT_PUBLIC_SESSION_COOKIE_DOMAIN is set.
-    ...(process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN
-      ? { cookieOptions: { domain: process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN } }
-      : {})
+    // Scope auth cookies to the parent zone for cross-channel-host sessions.
+    // Derived from the channel host suffix; see utils/channels.ts.
+    ...sessionCookieOptions()
   });
 };
 

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,7 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
-import { channelHostSuffix, currentChannel, hostForChannel, STABLE_CHANNEL } from "@/utils/channels";
+import {
+  channelHostSuffix,
+  currentChannel,
+  hostForChannel,
+  sessionCookieOptions,
+  STABLE_CHANNEL
+} from "@/utils/channels";
 export const updateSession = async (request: NextRequest) => {
   try {
     // Create a new Headers object to inject validated user ID
@@ -18,13 +24,11 @@ export const updateSession = async (request: NextRequest) => {
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
-        // Cross-subdomain session: when set (e.g. ".staging.pawtograder.net"),
-        // scope the auth cookies to the parent domain so a session survives a
-        // redirect between deployment-channel hosts (<channel>.<base>). Unset on
-        // local/supabase.com/single-channel installs => host-only cookies, unchanged.
-        ...(process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN
-          ? { cookieOptions: { domain: process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN } }
-          : {}),
+        // Cross-subdomain session: scope the auth cookies to the parent zone so a
+        // session survives a redirect between deployment-channel hosts. Derived
+        // from the channel host suffix; a no-op on local/supabase.com/single-channel
+        // installs (host-only cookies, unchanged). See utils/channels.ts.
+        ...sessionCookieOptions(),
         cookies: {
           getAll() {
             return request.cookies.getAll();
@@ -79,21 +83,39 @@ export const updateSession = async (request: NextRequest) => {
     // supabase.com, single-channel staging/prod) do ZERO extra work — no DB
     // lookup. Only /course/<id> is course-scoped, so that's the only path where
     // a channel can be resolved.
-    if (channelHostSuffix() && claims?.data?.claims) {
+    // Only GET navigations are safe to bounce cross-host: a 307/308 redirect
+    // replays method + body, so a Server Action POST would be re-issued to the
+    // channel host where Next.js's same-origin Origin check rejects it (a failed
+    // or duplicated mutation instead of a clean re-route). A page load that
+    // lands on the wrong host is always a GET, so gating on GET loses nothing.
+    if (channelHostSuffix() && claims?.data?.claims && request.method === "GET") {
       const courseMatch = request.nextUrl.pathname.match(/^\/course\/(\d+)(?:\/|$)/);
       if (courseMatch) {
         const courseId = Number(courseMatch[1]);
-        const { data: cls } = await supabase
+        const { data: cls, error: clsError } = await supabase
           .from("classes")
           .select("deployment_channel")
           .eq("id", courseId)
           .maybeSingle();
-        const courseChannel = cls?.deployment_channel || STABLE_CHANNEL;
-        if (courseChannel !== currentChannel()) {
-          const targetHost = hostForChannel(courseChannel);
-          if (targetHost && targetHost !== request.nextUrl.host) {
-            const target = new URL(`${request.nextUrl.pathname}${request.nextUrl.search}`, `https://${targetHost}`);
-            return NextResponse.redirect(target);
+        // Fail CLOSED: on a transient read error (statement timeout, pool
+        // exhaustion, RLS/role hiccup) we don't know the course's channel, so
+        // stay on the current host rather than falling back to "stable" — that
+        // fallback would bounce a canary user off the canary host mid-session
+        // (and back once the DB recovers), a visible flap. Log it so the glitch
+        // isn't silent.
+        if (clsError) {
+          Sentry.captureException(clsError, {
+            tags: { feature: "deployment-channels" },
+            extra: { courseId, currentChannel: currentChannel() }
+          });
+        } else {
+          const courseChannel = cls?.deployment_channel || STABLE_CHANNEL;
+          if (courseChannel !== currentChannel()) {
+            const targetHost = hostForChannel(courseChannel);
+            if (targetHost && targetHost !== request.nextUrl.host) {
+              const target = new URL(`${request.nextUrl.pathname}${request.nextUrl.search}`, `https://${targetHost}`);
+              return NextResponse.redirect(target);
+            }
           }
         }
       }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import { Database } from "./SupabaseTypes";
+import { sessionCookieOptions } from "../channels";
 
 export const createClient = async () => {
   const cookieStore = await cookies();
@@ -9,11 +10,9 @@ export const createClient = async () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      // See utils/supabase/middleware.ts: scope auth cookies to the parent domain
-      // for cross-channel-host sessions when NEXT_PUBLIC_SESSION_COOKIE_DOMAIN is set.
-      ...(process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN
-        ? { cookieOptions: { domain: process.env.NEXT_PUBLIC_SESSION_COOKIE_DOMAIN } }
-        : {}),
+      // Scope auth cookies to the parent zone for cross-channel-host sessions.
+      // Derived from the channel host suffix; see utils/channels.ts.
+      ...sessionCookieOptions(),
       cookies: {
         getAll() {
           return cookieStore.getAll();


### PR DESCRIPTION
Follow-up cleanup for the merged A/B deployment-channels PR (#826), working through the review threads. Decisions confirmed with @jon-bell up front: **drop the per-channel `host` override**, **derive the cookie domain from the suffix**, and **wire the CI build-args here** (not a separate PR).

## Correctness — web middleware (`utils/supabase/middleware.ts`)
- **Fail closed on the channel lookup.** The `classes.deployment_channel` read previously discarded its error and fell back to `stable`, so a transient DB glitch (statement timeout, pool exhaustion, RLS hiccup) bounced a canary user off the canary host mid-session — and back once the DB recovered. Now we capture the error, **stay on the current host**, and report it to Sentry instead of flapping silently.
- **GET-only cross-host redirect.** `NextResponse.redirect` defaults to 307, which replays method + body; a Server Action POST landing on the wrong host was being replayed cross-origin and rejected by Next's same-origin check. Page loads that need re-routing are always GET, so gating on GET loses nothing.

## Cookie scope (the cross-host-session footgun)
- Cross-host redirect and the shared auth cookie were gated on **two independent** env vars; set one without the other and sessions silently broke. Now the cookie domain is **derived from `NEXT_PUBLIC_CHANNEL_HOST_SUFFIX`** (`.<suffix>`) via a single `sessionCookieOptions()` helper in `utils/channels.ts`, replacing the duplicated spread in middleware/client/server. Setting the suffix turns the redirect **and** the cookie scope on together. Drops the now-unused `NEXT_PUBLIC_SESSION_COOKIE_DOMAIN` build arg.

## Chart
- **Dropped `channels[].host`.** The host is always `<name>.<global.hostname>` — the same value `hostForChannel()` computes — so the chart and the app can no longer diverge to a host with no Ingress. Consequence: every channel host is now single-label under the wildcard zone, making the off-zone / multi-label TLS guards dead code, so they're removed (`channels[].tls.secretName` kept as an optional per-channel cert escape hatch).
- **cert-manager fight fixed.** Channel Ingresses now strip `cert-manager.io/cluster-issuer`/`issuer` from the inherited annotations, so ingress-shim can't issue a competing single-SAN cert into the shared reflected wildcard secret and break TLS for the stable host + every channel.
- **`required` image tags** on `web`/`edgeFunctions` channel blocks (a block without its own tag silently ran the *stable* image → zero A/B difference); **`fail`** when `edgeFunctions` is set without `web` (unreachable — no Ingress); **`hasKey` for replicas** so `replicas: 0` idles a channel instead of rendering as `1`.
- Capped the channel-name regex at **63 chars** to match the DB CHECK.
- Extracted the 5-prefix Kong API-path block into `pawtograder.ingress.apiPaths`, now used by the primary host, its `extraHosts`, and channel hosts (was a third verbatim copy).

## CI (`release-images.yml`)
- The Dockerfile's new `NEXT_PUBLIC_*` channel args were baking as `""` because **no workflow passed them** — the feature was inert on every built image. CI now passes `NEXT_PUBLIC_PAWTOGRADER_CHANNEL` + `NEXT_PUBLIC_CHANNEL_HOST_SUFFIX`.
- Added `workflow_dispatch` `channel` + `channel_host_suffix` inputs to build channel images (tagged `<channel>-<sha>` / `<channel>-latest`).
- The stable suffix comes from a **`CHANNEL_HOST_SUFFIX` repo variable**, empty by default — so stable behavior is byte-for-byte unchanged until an operator opts in fleet-wide by setting it (avoids forcing a per-course DB lookup on every staging course load as a side effect of this PR).

## Tests
- `tests/unit/channels.test.ts` (11 cases) covers host derivation and the derived cookie domain, asserting `hostForChannel()` matches the chart's host pattern.

## Validation
- `helm lint` clean; rendered with `apiOnSeparateHost: false` + extraHosts + a channel to confirm `apiPaths` output is identical and the new guards fire (missing tag, edgeFunctions-without-web, >63-char name all `fail`; `replicas: 0` renders as `0`).
- `tsc --noEmit` clean for changed files; `prettier --check` clean; `jest tests/unit/channels.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added A/B channel image builds and channel-aware routing with fixed `<channel>.<hostname>` hostnames
  * Updated channel deployments so web apps receive channel routing config at build time

* **Bug Fixes**
  * Improved cross-channel auth by scoping session cookies based on the channel host suffix
  * Hardened Helm rendering with fail-fast validations for channel web, edge functions, TLS, and image tags

* **Tests**
  * Added/expanded unit tests to cover channel routing and cookie scoping behavior

* **Documentation**
  * Updated channel configuration guidance to match the new hostname and deployment behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->