### PR TITLE
fix(ci): staging + preview deploys reach the cluster and self-heal stuck helm

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -423,6 +423,32 @@ jobs:
           chmod 600 "$HOME/.kube/config"
           kubectl version --client=true --output=yaml | head -20
 
+      - name: Recover stuck helm release
+        # A preview deploy that gets interrupted mid-`helm upgrade` — most
+        # commonly when `concurrency.cancel-in-progress: true` SIGKILLs the
+        # runner because a newer push to the same PR arrived, but also any
+        # runner crash/OOM — leaves the release in a `pending-*` state. Helm
+        # never clears that on its own, so every later deploy aborts instantly
+        # with "UPGRADE FAILED: another operation (install/upgrade/rollback) is
+        # in progress", permanently bricking the PR's preview until someone
+        # intervenes by hand. Uninstall the stuck release so the upgrade below
+        # recreates it cleanly. Safe for previews: `helm uninstall` does NOT
+        # delete the Postgres PVC (see the destroy job), so DB data survives,
+        # and the migration/seed jobs re-run on every deploy anyway.
+        env:
+          RELEASE: ${{ needs.meta.outputs.release }}
+          NAMESPACE: ${{ needs.meta.outputs.namespace }}
+        run: |
+          set -euo pipefail
+          status=$(helm status "$RELEASE" -n "$NAMESPACE" 2>/dev/null | sed -n 's/^STATUS: //p' || true)
+          echo "current helm release status: ${status:-<none>}"
+          case "$status" in
+            pending-install|pending-upgrade|pending-rollback)
+              echo "::warning::release '$RELEASE' is stuck in '$status' (a previous deploy was interrupted). Uninstalling so this deploy can recreate it; Postgres PVC is preserved."
+              helm uninstall "$RELEASE" -n "$NAMESPACE" --wait --timeout 10m || true
+              ;;
+          esac
+
       - name: helm upgrade --install
         env:
           RELEASE: ${{ needs.meta.outputs.release }}

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -325,7 +325,13 @@ jobs:
   deploy-staging:
     needs: [meta, build-web, build-edge-functions, build-migrations]
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
-    runs-on: ubuntu-latest
+    # MUST run on the self-hosted, in-network runner. The cluster API
+    # (talos.ripley.cloud:6443) is a private 10.201.2.x address, unreachable
+    # from GitHub-hosted runners — `helm upgrade` there fails instantly with
+    # "Kubernetes cluster unreachable: ... i/o timeout". build-web reaches the
+    # same cluster from this runner to read the anon-key secret, so it's the
+    # proven path for the helm upgrade too.
+    runs-on: pawtograder-ci
     # Serialize deploys so two staging pushes landing close together can't run
     # overlapping `helm upgrade`s against the same release.
     concurrency:
@@ -351,6 +357,36 @@ jobs:
           mkdir -p "$HOME/.kube"
           echo "$KUBECONFIG_B64" | base64 -d > "$HOME/.kube/config"
           chmod 600 "$HOME/.kube/config"
+
+      - name: Recover stuck helm release
+        # If a prior deploy was interrupted mid-`helm upgrade` (runner crash/OOM
+        # — cancel-in-progress is off here, so a cancelled run can't be the
+        # cause), the release is left in a `pending-*` state and every later
+        # upgrade aborts with "another operation (install/upgrade/rollback) is
+        # in progress". Clear it. Unlike previews we do NOT uninstall — staging
+        # is long-lived and uninstall means downtime — so roll back to the last
+        # good revision, which clears the lock and keeps staging serving.
+        run: |
+          set -euo pipefail
+          status=$(helm status pawtograder -n pawtograder-staging 2>/dev/null | sed -n 's/^STATUS: //p' || true)
+          echo "current helm release status: ${status:-<none>}"
+          case "$status" in
+            pending-install)
+              echo "::warning::staging release stuck in pending-install — uninstalling the aborted install (PVCs survive)"
+              helm uninstall pawtograder -n pawtograder-staging --wait --timeout 10m || true
+              ;;
+            pending-upgrade|pending-rollback)
+              last=$(helm history pawtograder -n pawtograder-staging -o json 2>/dev/null \
+                | jq -r '[.[] | select(.status=="deployed")] | last | .revision // empty' 2>/dev/null || true)
+              if [ -n "${last:-}" ]; then
+                echo "::warning::staging release stuck in '$status' — rolling back to last deployed revision $last to clear the lock"
+                helm rollback pawtograder "$last" -n pawtograder-staging --wait --timeout 10m || true
+              else
+                echo "::warning::staging release stuck in '$status' — rolling back to previous revision"
+                helm rollback pawtograder -n pawtograder-staging --wait --timeout 10m || true
+              fi
+              ;;
+          esac
 
       - name: helm upgrade pawtograder (staging)
         # helm/kubectl pick up $HOME/.kube/config (written above) by default.


### PR DESCRIPTION
## Problem

Two independent deploy failures, both leaving the deploy job permanently red.

### 1. Staging auto-deploy has never worked
`release-images.yml`'s `deploy-staging` job ran on `ubuntu-latest`. The cluster API (`talos.ripley.cloud:6443`) is a **private `10.201.2.x` address**, unreachable from GitHub-hosted runners. Every staging push since #817 (Jun 8) died at connect:

```
Error: Kubernetes cluster unreachable: Get "https://talos.ripley.cloud:6443/version": dial tcp 10.201.2.123:6443: i/o timeout
```

It never once succeeded — staging silently stayed frozen on the last *manual* helm revision (rev 10, Jun 5) while the build jobs went green and only the trailing deploy job went red.

### 2. Neither deploy job recovers from a stuck `pending-*` release
A deploy interrupted mid-`helm upgrade` leaves the release in `pending-upgrade`/`pending-install`, and Helm never clears it — so every later deploy aborts with:

```
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```

For previews, `concurrency.cancel-in-progress: true` SIGKILLs the runner whenever a newer push to the same PR arrives — so this is *guaranteed* to recur. It's what bricked PR #831's preview (release stuck `pending-upgrade` at rev 8; required manual intervention).

## Fix

- **`deploy-staging` → `runs-on: pawtograder-ci`** — the self-hosted, in-network runner `build-web` already uses to read the cluster's anon-key secret. Proven path to the private API.
- **Stuck-release recovery before `helm upgrade`** in both jobs:
  - **preview** (ephemeral): uninstall the stuck release; the upgrade recreates it. The Postgres PVC survives `helm uninstall`, so DB data is preserved.
  - **staging** (long-lived): roll back to the last deployed revision — clears the lock *without* taking staging down (uninstall would).

## Validation

- Root cause confirmed identical across the last 4+ staging deploy failures (Jun 8/15/15/18).
- Ran the exact staging `helm upgrade` command as `--dry-run=server` against the live cluster: renders cleanly, required secrets present.
- Recovery bash syntax-checked; the staging rollback's `jq` selector verified against live `helm history` (correctly resolves to deployed rev 10).

## Out of scope
PR #831's preview also has a **failing migration** (`20260529140000_github_org_templates.sql`, `backoffLimit` exhausted) — that's a bug in that branch's own migration, not the workflow. This PR lets the preview retry cleanly so the real migration error surfaces in the failure snapshot instead of being masked by the stuck-release lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)