### PR TITLE
fix(chart): exempt realtime from drop-ALL securityContext so sudo works

### DIFF
--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -603,6 +603,12 @@ realtime:
     repository: supabase/realtime
     tag: "v2.76.5" # stock supabase docker-compose pin — fixes partition / metrics auth
     pullPolicy: IfNotPresent
+  # The supabase/realtime entrypoint starts as root and `sudo -u nobody`s to
+  # run migrations + the BEAM — so it needs the default capability set and
+  # privilege escalation. Under the global drop-ALL / allowPrivilegeEscalation:
+  # false context, sudo fails ("setresuid: Operation not permitted") and the
+  # pod CrashLoopBackOffs, so opt out here — same as postgres above.
+  containerSecurityContext: {}
   # BEAM clustering — pods discover peers via a headless Service.
   cluster:
     strategy: "Elixir.Cluster.Strategy.Kubernetes.DNS"


### PR DESCRIPTION
## Problem

Preview deploys (and, soon, staging) fail because **`pawtograder-realtime-0` CrashLoopBackOffs**, so `helm upgrade --wait --wait-for-jobs` blocks until the 20-minute timeout and the deploy dies with:

```
Error: UPGRADE FAILED: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
```

(observed in PR #838's preview: [run 27961019705](https://github.com/pawtograder/platform/actions/runs/27961019705/job/82747018060) — 20m exactly, realtime `CrashLoopBackOff`, everything else Running and migrations Complete.)

The realtime pod's crash log:
```
+ sudo -E -u nobody /app/bin/migrate
sudo: setresuid(-1, 1, -1): Operation not permitted
sudo: no valid sudoers sources found, quitting
```

## Root cause

The production-readiness hardening pass (#833) applied the global `containerSecurityContext` to every main container:
```yaml
allowPrivilegeEscalation: false   # sets no_new_privs → neutralizes sudo's setuid bit
capabilities: { drop: ["ALL"] }   # drops SETUID/SETGID
```
The `supabase/realtime` image's entrypoint **starts as root and `sudo -u nobody`s** to run migrations + the BEAM. Under no_new_privs + drop-ALL, sudo can't escalate → crash loop.

`postgres` hit the *identical* problem in #833 (its entrypoint starts as root, chowns PGDATA, and su's) and was given a `containerSecurityContext: {}` exemption. **realtime was simply missed.**

## Fix

Give realtime the same opt-out postgres already has, in `charts/pawtograder/values.yaml`:
```yaml
realtime:
  containerSecurityContext: {}
```

## Validation

`helm template … -f values-preview.yaml`, realtime container securityContext:
- **before (origin/staging):** `allowPrivilegeEscalation: false` + `drop: [ALL]` ← the sudo-killer
- **after:** none (only the harmless pod-level `seccompProfile` remains)

`helm lint` clean. The change touches only `realtime.containerSecurityContext`, so web and all other components keep the hardened context. End-to-end validation runs on this PR's own preview deploy.

## ⚠️ Staging is a latent failure
Staging's realtime StatefulSet spec **already carries the broken context** from #833; it's only still up because its running pod predates the rollout. The next realtime restart/reschedule will CrashLoop. This should merge before that happens.

## Related
- #842 — separate fixes for the staging runner + stuck-helm recovery (different failure modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)