### PR TITLE
Fix admin SIS class creation: require GitHub org + allow admin GitHub team sync

### DIFF
--- a/app/admin/import/page.tsx
+++ b/app/admin/import/page.tsx
@@ -6,12 +6,27 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toaster } from "@/components/ui/toaster";
 import { createClient } from "@/utils/supabase/client";
-import { VStack, HStack, Text, Heading, Card, Badge, Table, Box, Flex, Grid } from "@chakra-ui/react";
+import {
+  VStack,
+  HStack,
+  Text,
+  Heading,
+  Card,
+  Badge,
+  Table,
+  Box,
+  Flex,
+  Grid,
+  NativeSelect,
+  Spinner,
+  Link
+} from "@chakra-ui/react";
 
 import { Checkbox } from "@chakra-ui/react";
 import { Download, Users, GraduationCap, BookOpen, MapPin, Clock, AlertCircle } from "lucide-react";
-import { courseImportSis, invitationCreate } from "@/lib/edgeFunctions";
+import { courseImportSis, invitationCreate, listGitHubOrgs } from "@/lib/edgeFunctions";
 import * as FunctionTypes from "@/supabase/functions/_shared/FunctionTypes.js";
+import type { GitHubOrg } from "@/supabase/functions/_shared/FunctionTypes";
 import { TermSelector } from "@/components/ui/term-selector";
 
 // Use shared types
@@ -66,6 +81,14 @@ export default function CourseImportPage() {
     Array<{ id: number; name: string | null; course_title: string | null }>
   >([]);
   const [selectedExistingClassId, setSelectedExistingClassId] = useState<number | null>(null);
+  // GitHub org selection (required when creating a brand-new class, mirroring the
+  // manual CreateClassModal). Skipped when syncing into an existing class, which
+  // already has its github_org configured.
+  const [orgs, setOrgs] = useState<GitHubOrg[] | null>(null);
+  const [orgsLoading, setOrgsLoading] = useState(false);
+  const [orgsError, setOrgsError] = useState<string | null>(null);
+  const [installUrl, setInstallUrl] = useState<string>("https://github.com/settings/installations");
+  const [selectedGithubOrg, setSelectedGithubOrg] = useState<string>("");
   const [invitationProgress, setInvitationProgress] = useState<{
     current: number;
     total: number;
@@ -328,6 +351,31 @@ export default function CourseImportPage() {
     }
   }, [semester, findExistingClassesForTerm]);
 
+  // Load the installed GitHub orgs once so the admin can pick one when creating a
+  // brand-new class. (Syncing into an existing class doesn't need it.)
+  useEffect(() => {
+    let cancelled = false;
+    setOrgsLoading(true);
+    setOrgsError(null);
+    listGitHubOrgs(supabase)
+      .then(({ orgs: fetched, installUrl: url }) => {
+        if (cancelled) return;
+        setOrgs(fetched);
+        if (url) setInstallUrl(url);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setOrgs([]);
+        setOrgsError(error instanceof Error ? error.message : "Failed to load GitHub organizations");
+      })
+      .finally(() => {
+        if (!cancelled) setOrgsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
+
   // Find existing sections by CRN
   const findExistingSections = useCallback(
     async (classId: number, crns: number[]) => {
@@ -527,6 +575,12 @@ export default function CourseImportPage() {
         summary.classCreated = false; // Not creating, just syncing
         summary.classId = classId;
       } else {
+        // A new class must be tied to a GitHub org so handout/staff/student team
+        // and repo sync works. Enforce here (and disable the button) rather than
+        // silently creating a class with a NULL github_org.
+        if (!selectedGithubOrg) {
+          throw new Error("Please select a GitHub organization. Install the GitHub App if your org is not listed.");
+        }
         // Extract year and term from semester code (e.g., 202610 -> Fall 2026)
         let year = Math.floor(semester / 100);
         const termCode = semester % 100;
@@ -551,6 +605,7 @@ export default function CourseImportPage() {
           p_course_title: importData.courseInfo.title,
           p_start_date: importData.courseInfo.startDate,
           p_end_date: importData.courseInfo.endDate,
+          p_github_org_name: selectedGithubOrg,
           p_github_template_prefix: `${termMap[termCode]}${lastTwoDigits}`
         });
 
@@ -702,7 +757,15 @@ export default function CourseImportPage() {
       setIsCreating(false);
       setInvitationProgress(null); // Make sure to clear progress on error
     }
-  }, [importData, selectedSections, selectedExistingClassId, supabase, processBatchedInvitations, semester]);
+  }, [
+    importData,
+    selectedSections,
+    selectedExistingClassId,
+    selectedGithubOrg,
+    supabase,
+    processBatchedInvitations,
+    semester
+  ]);
 
   const toggleSection = (crn: number) => {
     const newSelected = new Set(selectedSections);
@@ -1388,6 +1451,46 @@ export default function CourseImportPage() {
             </Card.Header>
             <Card.Body>
               <VStack gap={4}>
+                {/* GitHub org picker -- only needed when creating a new class. */}
+                {!selectedExistingClassId && (
+                  <VStack align="start" w="full" gap={1}>
+                    <Label htmlFor="github_org_name">GitHub Organization *</Label>
+                    {orgsLoading ? (
+                      <HStack color="fg.muted" fontSize="sm">
+                        <Spinner size="sm" /> <Text>Loading organizations…</Text>
+                      </HStack>
+                    ) : (
+                      <NativeSelect.Root>
+                        <NativeSelect.Field
+                          id="github_org_name"
+                          value={selectedGithubOrg}
+                          onChange={(e) => setSelectedGithubOrg(e.target.value)}
+                        >
+                          <option value="">Select an organization…</option>
+                          {(orgs ?? []).map((org) => (
+                            <option key={org.installationId} value={org.login}>
+                              {org.login}
+                            </option>
+                          ))}
+                        </NativeSelect.Field>
+                        <NativeSelect.Indicator />
+                      </NativeSelect.Root>
+                    )}
+                    <Text fontSize="xs" color="fg.muted">
+                      {orgsError ? (
+                        <Text as="span" color="fg.error">
+                          {orgsError}.{" "}
+                        </Text>
+                      ) : null}
+                      Don&apos;t see your org?{" "}
+                      <Link href={installUrl} target="_blank" rel="noopener noreferrer" colorPalette="blue">
+                        Install the GitHub App
+                      </Link>{" "}
+                      then reload this page.
+                    </Text>
+                  </VStack>
+                )}
+
                 {(() => {
                   const analysis = getCreationAnalysis();
                   if (!analysis) return null;
@@ -1539,7 +1642,11 @@ export default function CourseImportPage() {
                 <Button
                   onClick={handleCreateClass}
                   loading={isCreating}
-                  disabled={selectedSections.size === 0 || !!invitationProgress}
+                  disabled={
+                    selectedSections.size === 0 ||
+                    !!invitationProgress ||
+                    (!selectedExistingClassId && !selectedGithubOrg)
+                  }
                   size="lg"
                   colorScheme="blue"
                 >

--- a/supabase/migrations/20260623000000_allow_admin_github_team_sync.sql
+++ b/supabase/migrations/20260623000000_allow_admin_github_team_sync.sql
@@ -1,0 +1,79 @@
+-- Allow platform admins (not just class instructors) to trigger GitHub team sync.
+--
+-- create_invitation() permits BOTH class instructors and platform admins
+-- (authorizeforclassinstructor OR authorize_for_admin). But invitation acceptance
+-- runs the auto_accept_invitation_if_user_exists trigger, which inserts/updates a
+-- user_roles row, which in turn fires sync_github_teams_on_role_change ->
+-- sync_student_github_team / sync_staff_github_team. Those two functions only
+-- accepted class instructors:
+--
+--   if auth.uid() is not null and not authorizeforclassinstructor(class_id) then
+--     raise exception 'Access denied: Only instructors can sync ... for class %';
+--
+-- So when a platform admin (who is NOT an instructor of the class) created
+-- invitations -- e.g. the "Create class from SIS" / SIS import flow -- and any
+-- invited user already had an account, the trigger raised:
+--
+--   Access denied: Only instructors can sync student GitHub team for class <id>
+--
+-- which rolled the enrollment (and the whole invitation insert) back. This widens
+-- the authorization check to match create_invitation: a request authorized as
+-- either a class instructor OR a platform admin is allowed to sync. The bodies
+-- are otherwise unchanged from 20260611120001 (still tolerate a NULL org/slug by
+-- skipping the sync instead of raising).
+
+create or replace function public.sync_staff_github_team(class_id integer, user_id uuid default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_org text;
+begin
+  if class_id is null then
+    raise warning 'sync_staff_github_team called with NULL class_id, skipping';
+    return;
+  end if;
+  if auth.uid() is not null
+     and not (public.authorizeforclassinstructor(class_id::bigint) or public.authorize_for_admin()) then
+    raise exception 'Access denied: Only instructors or admins can sync staff GitHub team for class %', class_id;
+  end if;
+  select slug, github_org into v_slug, v_org from public.classes where id = class_id;
+  if v_slug is null or v_org is null then
+    -- Class isn't GitHub-configured; nothing to sync. Do NOT raise -- this runs
+    -- from a user_roles trigger and would otherwise block the enrollment.
+    raise warning 'Skipping staff GitHub team sync for class %: missing org/slug', class_id;
+    return;
+  end if;
+  perform public.enqueue_github_sync_staff_team(class_id::bigint, v_org, v_slug, user_id, null);
+end;
+$$;
+
+create or replace function public.sync_student_github_team(class_id integer, user_id uuid default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_org text;
+begin
+  if class_id is null then
+    raise warning 'sync_student_github_team called with NULL class_id, skipping';
+    return;
+  end if;
+  if auth.uid() is not null
+     and not (public.authorizeforclassinstructor(class_id::bigint) or public.authorize_for_admin()) then
+    raise exception 'Access denied: Only instructors or admins can sync student GitHub team for class %', class_id;
+  end if;
+  select slug, github_org into v_slug, v_org from public.classes where id = class_id;
+  if v_slug is null or v_org is null then
+    raise warning 'Skipping student GitHub team sync for class %: missing org/slug', class_id;
+    return;
+  end if;
+  perform public.enqueue_github_sync_student_team(class_id::bigint, v_org, v_slug, user_id, null);
+end;
+$$;


### PR DESCRIPTION
## Problem

Two related issues in the admin **Create class from SIS** flow (`/admin/import`):

1. **No GitHub org selection.** The manual `CreateClassModal` forces the admin to pick an installed GitHub org (and template prefix), but the SIS import page never loaded or required one — it called `admin_create_class` without `p_github_org_name`, so SIS-created classes ended up with a **NULL `github_org`**. Handout/team/repo sync then has no org to target.

2. **`Error creating invitation: Access denied: Only instructors can sync student GitHub team for class 631`.** `create_invitation()` authorizes **class instructors OR platform admins**. But accepting an invitation runs `auto_accept_invitation_if_user_exists` → inserts/updates `user_roles` → fires `sync_github_teams_on_role_change` → `sync_student_github_team` / `sync_staff_github_team`. Those two functions only accepted **instructors**, so when a platform admin (not an instructor of the class) ran SIS import and an invited user already had an account, the trigger raised and rolled the enrollment back.

## Fix

- **Frontend (`app/admin/import/page.tsx`)**: load installed GitHub orgs via `listGitHubOrgs`, render a required org picker (with an *Install the GitHub App* link) when creating a **new** class, pass `p_github_org_name` to `admin_create_class`, and disable the create button until an org is chosen. Syncing into an existing class is unchanged (it already has an org).
- **Migration (`20260623000000_allow_admin_github_team_sync.sql`)**: widen the auth check in `sync_student_github_team` / `sync_staff_github_team` to `authorizeforclassinstructor(...) OR authorize_for_admin()`, matching `create_invitation`. Bodies are otherwise unchanged from `20260611120001` (still skip sync when org/slug is NULL rather than raising).

## Note on the companion `column invitations.expires_at does not exist` error

That error is **already fixed in source** by #777, which dropped the `expires_at` column and removed it from the `invitation-create` edge function's `SELECT`. A fresh DB built from current migrations has zero references to `invitations.expires_at` (verified locally). The affected environment is running a **pre-#777 edge function**; the edge-function redeploy triggered by merging this change heals it.

## Testing

- New migration applies cleanly against local Supabase; confirmed the rewritten functions carry the `... OR public.authorize_for_admin()` check.
- `tsc --noEmit` and `prettier --check` pass on the changed frontend file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub organization selection when creating new classes in SIS import workflow, with helpful installation guidance and error handling
  * Class instructors can now trigger GitHub team synchronization directly; this capability was previously limited to platform administrators only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->