### PR TITLE
fix(e2e): stabilize accumulated visual-test flakiness

### DIFF
--- a/tests/e2e/VisualTestUtils.ts
+++ b/tests/e2e/VisualTestUtils.ts
@@ -106,16 +106,43 @@ export async function waitForVisualIdle(page: Page) {
 
   // Code files (components/ui/code-file.tsx) render plain text first, then re-render
   // with @wooorm/starry-night syntax highlighting once it loads asynchronously.
-  // Capturing mid-load produces per-glyph diffs across the whole code column. If any
+  // Capturing mid-load is not just a per-glyph color diff: the un-highlighted
+  // fallback collapses to one character per line (the line content has no settled
+  // width yet), which shifts the whole page and yields ~70% full-page diffs. If any
   // code file on the page is still un-highlighted, wait for it to finish before the
-  // screenshot. Bounded + non-fatal: a file with no tokenizable content still flips
-  // the flag to "true", and the catch covers pages without code files.
+  // screenshot. The timeout is generous (30s) because under the full-suite parallel
+  // load several workers import the highlighter at once and a single block can take
+  // well over 10s to tokenize — the old 10s cap let that broken state through.
+  // Bounded + non-fatal: a file with no tokenizable content still flips the flag to
+  // "true", and the catch covers pages without code files / offline highlighter loads.
   const codeFiles = page.locator("[data-syntax-highlighted]");
   if ((await codeFiles.count()) > 0) {
     await expect(page.locator('[data-syntax-highlighted="false"]'))
-      .toHaveCount(0, { timeout: 10_000 })
+      .toHaveCount(0, { timeout: 30_000 })
       .catch(() => {
         // Highlighter import can fail offline; fall through rather than block the scan.
+      });
+  }
+
+  // Monaco editor (components/ui/code-file-monaco.tsx) is the default submission code
+  // viewer. It dynamic-imports behind a skeleton, then mounts, measures, and tokenizes
+  // asynchronously, so a mid-load capture is a blank or half-laid-out pane (the manual-
+  // grading score views raced exactly this). When a Monaco editor is present, wait for
+  // its lines to render AND colorize — Monaco emits `.mtk*` token spans only once
+  // tokenization has run — before capturing. Bounded + non-fatal like the wait above.
+  const monacoEditor = page.locator(".monaco-editor");
+  if ((await monacoEditor.count()) > 0) {
+    await page
+      .waitForFunction(
+        () => {
+          const lines = Array.from(document.querySelectorAll(".monaco-editor .view-lines .view-line"));
+          return lines.length > 0 && lines.some((line) => line.querySelector('span[class*="mtk"]'));
+        },
+        undefined,
+        { timeout: 30_000, polling: 200 }
+      )
+      .catch(() => {
+        // Empty/untokenizable file or Monaco failed to load — proceed rather than block.
       });
   }
 
@@ -143,29 +170,51 @@ export async function stabilizeRubricSidebar(page: Page, rubricName: string | Re
   const rubricRegion = page.getByRole("region", { name: accessibleName }).first();
   await expect(rubricRegion).toBeVisible();
 
-  await rubricRegion.evaluate((element) => {
-    const isScrollable = (candidate: HTMLElement) => {
-      const style = window.getComputedStyle(candidate);
-      const overflowY = style.overflowY;
-      return (
-        (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
-        candidate.scrollHeight > candidate.clientHeight
-      );
-    };
+  // The sidebar's rubric checks (and any sibling rubric section stacked below, e.g. the
+  // informational "Grading Rubric" block) load asynchronously, so a single scroll-to-top
+  // computed against the current layout drifts once that content settles. Observed on
+  // WebKit as the sidebar landing at a different scroll offset run-to-run (the lower
+  // section scrolled into view in some runs but not others), producing multi-hundred-px
+  // diffs. Re-align in a short loop until the region's top sits at the target offset and
+  // stops moving, so late-loading content can no longer shift the capture.
+  const targetOffset = 8;
+  let previousTop: number | null = null;
+  for (let i = 0; i < 12; i++) {
+    const residual = await rubricRegion.evaluate((element, offset) => {
+      const isScrollable = (candidate: HTMLElement) => {
+        const style = window.getComputedStyle(candidate);
+        const overflowY = style.overflowY;
+        return (
+          (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+          candidate.scrollHeight > candidate.clientHeight
+        );
+      };
 
-    let scrollParent: HTMLElement | null = element.parentElement;
-    while (scrollParent && !isScrollable(scrollParent)) {
-      scrollParent = scrollParent.parentElement;
+      let scrollParent: HTMLElement | null = element.parentElement;
+      while (scrollParent && !isScrollable(scrollParent)) {
+        scrollParent = scrollParent.parentElement;
+      }
+
+      const container = scrollParent ?? document.scrollingElement;
+      if (!container) return 0;
+
+      const containerRect = container.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+      const delta = elementRect.top - containerRect.top - offset;
+      container.scrollTop += delta;
+      return delta;
+    }, targetOffset);
+
+    const box = await rubricRegion.boundingBox();
+    const top = box?.y ?? null;
+    // Converged once a pass needs no further scroll AND the region stopped moving
+    // between passes (i.e. content above it has finished settling).
+    if (Math.abs(residual) < 1 && previousTop !== null && top !== null && Math.abs(previousTop - top) < 1) {
+      break;
     }
-
-    const container = scrollParent ?? document.scrollingElement;
-    if (!container) return;
-
-    const containerRect = container.getBoundingClientRect();
-    const elementRect = element.getBoundingClientRect();
-    const offset = 8;
-    container.scrollTop += elementRect.top - containerRect.top - offset;
-  });
+    previousTop = top;
+    await rubricRegion.page().waitForTimeout(100);
+  }
 
   await waitForStableLocator(rubricRegion);
 }

--- a/tests/e2e/VisualTestUtils.ts
+++ b/tests/e2e/VisualTestUtils.ts
@@ -170,51 +170,29 @@ export async function stabilizeRubricSidebar(page: Page, rubricName: string | Re
   const rubricRegion = page.getByRole("region", { name: accessibleName }).first();
   await expect(rubricRegion).toBeVisible();
 
-  // The sidebar's rubric checks (and any sibling rubric section stacked below, e.g. the
-  // informational "Grading Rubric" block) load asynchronously, so a single scroll-to-top
-  // computed against the current layout drifts once that content settles. Observed on
-  // WebKit as the sidebar landing at a different scroll offset run-to-run (the lower
-  // section scrolled into view in some runs but not others), producing multi-hundred-px
-  // diffs. Re-align in a short loop until the region's top sits at the target offset and
-  // stops moving, so late-loading content can no longer shift the capture.
-  const targetOffset = 8;
-  let previousTop: number | null = null;
-  for (let i = 0; i < 12; i++) {
-    const residual = await rubricRegion.evaluate((element, offset) => {
-      const isScrollable = (candidate: HTMLElement) => {
-        const style = window.getComputedStyle(candidate);
-        const overflowY = style.overflowY;
-        return (
-          (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
-          candidate.scrollHeight > candidate.clientHeight
-        );
-      };
+  await rubricRegion.evaluate((element) => {
+    const isScrollable = (candidate: HTMLElement) => {
+      const style = window.getComputedStyle(candidate);
+      const overflowY = style.overflowY;
+      return (
+        (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+        candidate.scrollHeight > candidate.clientHeight
+      );
+    };
 
-      let scrollParent: HTMLElement | null = element.parentElement;
-      while (scrollParent && !isScrollable(scrollParent)) {
-        scrollParent = scrollParent.parentElement;
-      }
-
-      const container = scrollParent ?? document.scrollingElement;
-      if (!container) return 0;
-
-      const containerRect = container.getBoundingClientRect();
-      const elementRect = element.getBoundingClientRect();
-      const delta = elementRect.top - containerRect.top - offset;
-      container.scrollTop += delta;
-      return delta;
-    }, targetOffset);
-
-    const box = await rubricRegion.boundingBox();
-    const top = box?.y ?? null;
-    // Converged once a pass needs no further scroll AND the region stopped moving
-    // between passes (i.e. content above it has finished settling).
-    if (Math.abs(residual) < 1 && previousTop !== null && top !== null && Math.abs(previousTop - top) < 1) {
-      break;
+    let scrollParent: HTMLElement | null = element.parentElement;
+    while (scrollParent && !isScrollable(scrollParent)) {
+      scrollParent = scrollParent.parentElement;
     }
-    previousTop = top;
-    await rubricRegion.page().waitForTimeout(100);
-  }
+
+    const container = scrollParent ?? document.scrollingElement;
+    if (!container) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const offset = 8;
+    container.scrollTop += elementRect.top - containerRect.top - offset;
+  });
 
   await waitForStableLocator(rubricRegion);
 }

--- a/tests/e2e/grading.test.tsx
+++ b/tests/e2e/grading.test.tsx
@@ -416,7 +416,14 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
     // 8:06 PM applied-at timestamp diff that previously made this flaky is handled
     // by the transparent-text wrap on rubric-sidebar.tsx.
     await expect(page.getByRole("button", { name: "Draft Regrade Request" })).toBeVisible();
-    await visualScreenshot(page, "Student can request a regrade");
+    // Capture the request dialog itself, not the full page. It's a centered modal, so a
+    // full-page screenshot places it at a vertical center that shifts with total page
+    // height (run-to-run thread/scroll variance) — a placement jump, not a content diff.
+    // Scoping to the dialog crops to its own (static) box. Same approach as the resolve
+    // screenshot below.
+    await visualScreenshot(page, "Student can request a regrade", {
+      element: page.getByRole("dialog").filter({ hasText: "Request a Regrade" })
+    });
     await page.getByRole("button", { name: "Draft Regrade Request" }).click();
     await page
       .getByRole("region", { name: "Grading checks on line 4" })
@@ -529,7 +536,12 @@ test.describe("An end-to-end grading workflow self-review to grading", () => {
       await expect(appealRegion.getByText(REGRADE_RESOLUTION).first()).toBeVisible();
       await expect(appealRegion.getByText(REGRADE_ESCALATION).first()).toBeVisible();
     }
-    await visualScreenshot(page, "Students can appeal their regrade request");
+    // Capture the escalate dialog itself, not the full page. It's a centered modal whose
+    // full-page vertical position shifts with total page height run-to-run (~200px jump,
+    // ~65% full-page diff). Scoping to the dialog crops to its own (static) box.
+    await visualScreenshot(page, "Students can appeal their regrade request", {
+      element: page.getByRole("dialog").filter({ hasText: "Escalate Regrade Request" })
+    });
     await page.getByRole("button", { name: "Escalate Request" }).click();
     // Wait for the escalation to settle before axe runs — otherwise axe races
     // the closing popover / toast and reports transient focus-trap / labeling violations.

--- a/tests/e2e/manual-grading-scores.test.tsx
+++ b/tests/e2e/manual-grading-scores.test.tsx
@@ -278,7 +278,10 @@ test.describe("Manual grading score calculation", () => {
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
       // Gate on the Monaco code viewer rendering (the score heading is in the sidebar
       // and can appear first) so visualScreenshot's editor-settle wait actually applies.
-      await expect(page.getByText("public static void main(")).toBeVisible();
+      // Use the same 30s budget as that settle wait — Monaco can take >20s (the default
+      // expect timeout) to mount/tokenize under full-suite load, so a shorter gate would
+      // fail before the stabilization helps.
+      await expect(page.getByText("public static void main(")).toBeVisible({ timeout: 30_000 });
       await visualScreenshot(page, "Individual grading - student view with score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -363,7 +366,7 @@ test.describe("Manual grading score calculation", () => {
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
       // Gate on the code viewer rendering before capture (see note above).
-      await expect(page.getByText("public static void main(")).toBeVisible();
+      await expect(page.getByText("public static void main(")).toBeVisible({ timeout: 30_000 });
       await visualScreenshot(page, "Group grading shared - student view with score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -568,7 +571,7 @@ test.describe("Manual grading score calculation", () => {
       await expect(page.getByRole("heading", { name: /Overall Score/ })).not.toBeVisible();
       await expect(page.getByText("(You)")).toBeVisible();
       // Gate on the code viewer rendering before capture (see note above).
-      await expect(page.getByText("public static void main(")).toBeVisible();
+      await expect(page.getByText("public static void main(")).toBeVisible({ timeout: 30_000 });
       await visualScreenshot(page, "Group individual grading - student view with individual score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -590,7 +593,7 @@ test.describe("Manual grading score calculation", () => {
       await expect(scoresSection.getByText("Score Student B").first()).toBeVisible();
       await expect(scoresSection.getByText("Score Student C").first()).toBeVisible();
       // Gate on the code viewer rendering before capture (see note above).
-      await expect(page.getByText("public static void main(")).toBeVisible();
+      await expect(page.getByText("public static void main(")).toBeVisible({ timeout: 30_000 });
       await visualScreenshot(page, "Group individual grading - instructor view with all scores", {
         stabilizeRubric: "Grading Rubric"
       });

--- a/tests/e2e/manual-grading-scores.test.tsx
+++ b/tests/e2e/manual-grading-scores.test.tsx
@@ -276,6 +276,9 @@ test.describe("Manual grading score calculation", () => {
 
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
+      // Gate on the Monaco code viewer rendering (the score heading is in the sidebar
+      // and can appear first) so visualScreenshot's editor-settle wait actually applies.
+      await expect(page.getByText("public static void main(")).toBeVisible();
       await visualScreenshot(page, "Individual grading - student view with score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -359,6 +362,8 @@ test.describe("Manual grading score calculation", () => {
 
       const scoreHeading = page.getByRole("heading", { name: /Overall Score/ });
       await expect(scoreHeading).toBeVisible({ timeout: 15000 });
+      // Gate on the code viewer rendering before capture (see note above).
+      await expect(page.getByText("public static void main(")).toBeVisible();
       await visualScreenshot(page, "Group grading shared - student view with score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -562,6 +567,8 @@ test.describe("Manual grading score calculation", () => {
       await expect(page.getByText("Scores by student")).toBeVisible({ timeout: 15000 });
       await expect(page.getByRole("heading", { name: /Overall Score/ })).not.toBeVisible();
       await expect(page.getByText("(You)")).toBeVisible();
+      // Gate on the code viewer rendering before capture (see note above).
+      await expect(page.getByText("public static void main(")).toBeVisible();
       await visualScreenshot(page, "Group individual grading - student view with individual score", {
         stabilizeRubric: "Grading Rubric"
       });
@@ -582,6 +589,8 @@ test.describe("Manual grading score calculation", () => {
       await expect(scoresSection.getByText("Score Student A").first()).toBeVisible();
       await expect(scoresSection.getByText("Score Student B").first()).toBeVisible();
       await expect(scoresSection.getByText("Score Student C").first()).toBeVisible();
+      // Gate on the code viewer rendering before capture (see note above).
+      await expect(page.getByText("public static void main(")).toBeVisible();
       await visualScreenshot(page, "Group individual grading - instructor view with all scores", {
         stabilizeRubric: "Grading Rubric"
       });

--- a/tests/e2e/pseudonymous-grading.test.tsx
+++ b/tests/e2e/pseudonymous-grading.test.tsx
@@ -489,8 +489,43 @@ test.describe("Pseudonymous grading - graders appear as pseudonyms to students",
       page.getByRole("button", { name: "Escalate Request" }),
       "Escalate Request button is removed after escalation"
     ).toHaveCount(0);
+    // Wait for the realtime comment stream to finish rendering before the snapshot.
+    // The inline thread lazy-loads its historical comments (regrade request, grader
+    // response, escalation), which races the capture and shifts the thread height — and
+    // everything below it, including the code lines — run-to-run. Bracket oldest→newest
+    // so the whole thread has landed; .first() tolerates the just-posted comment's
+    // transient optimistic-insert + realtime-echo duplicate (same pattern as grading.test.tsx).
+    await expect(region.getByText(REGRADE_REQUEST_COMMENT).first()).toBeVisible();
+    await expect(region.getByText(GRADER_REGRADE_RESPONSE).first()).toBeVisible();
+    await expect(region.getByText(STUDENT_ESCALATION_COMMENT).first()).toBeVisible();
+    // Neutralize composer focus before capture. MessageInput re-focuses its textarea
+    // after a send (setTimeout focus in message-input.tsx), so after the comment+escalate
+    // flow the composer is left focused/expanded (its send toolbar shown) in some runs and
+    // collapsed in others — a ~20% region diff. Blur whatever holds focus so the composer
+    // is consistently collapsed.
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    // Pin the thread's scroll position. The region lives in a fixed-height scroll pane
+    // whose offset (nudged by the autoresizing composer) varies run-to-run, so an element
+    // capture otherwise shows a different vertical slice (file header vs. status badge at
+    // the top). Align the region to the top of its scroll container before capturing.
+    await region.evaluate((el) => {
+      const isScrollable = (c: HTMLElement) => {
+        const s = getComputedStyle(c);
+        return /(auto|scroll|overlay)/.test(s.overflowY) && c.scrollHeight > c.clientHeight;
+      };
+      let p: HTMLElement | null = el.parentElement;
+      while (p && !isScrollable(p)) p = p.parentElement;
+      const container = p ?? (document.scrollingElement as HTMLElement | null);
+      if (container) {
+        container.scrollTop += el.getBoundingClientRect().top - container.getBoundingClientRect().top - 8;
+      }
+    });
+    // Capture the inline thread region, not the full page. The escalation dialog is
+    // closed by now; scoping to the region (whose comments are confirmed rendered above)
+    // crops out page-level scroll/shift. Same approach as the resolve screenshot in
+    // grading.test.tsx.
     await visualScreenshot(page, "Pseudonymous grading - Student escalates regrade", {
-      stabilizeRubric: "Grading Rubric"
+      element: region
     });
     await assertStudentPageAccessible(page, "pseudonymous grading - student escalation /files");
   });


### PR DESCRIPTION
A 5x chromium+webkit soak (scripts/e2e-*.sh, same-browser exact-hash comparison) surfaced several non-deterministic Argos screenshots. Root causes and fixes (all test-only):

- Code viewer render races (the worst offenders) — the submission /files viewer captured mid-load:
  * Monaco (the default editor; manual-grading-scores' score views use it): dynamic-imports behind a skeleton, then mounts / measures / tokenizes asynchronously, so captures raced a blank / half-laid-out pane. waitForVisualIdle now waits for Monaco to render and tokenize (its `.mtk*` token spans appear only after tokenization) before capturing. manual- grading also waits for the code text before each screenshot.
  * starry-night (the classic annotation view that grading / pseudonymous-grading deliberately exercise): renders un-highlighted plain text first, which collapses to one char per line (~70% full-page diffs). The highlight wait timed out at 10s under full-suite parallel load — raised to 30s.

- Regrade modals: "request a regrade" and "appeal" captured the full page with a centered modal whose vertical position shifts with total page height (a placement jump, not a content change). Scoped each to its dialog element, matching the existing resolve-screenshot approach.

- Pseudonymous escalate: the realtime thread renders progressively, the composer re-focuses after a send (message-input.tsx), and the thread sits in a fixed-height scroll pane. Wait for the thread to render, blur the composer, pin the scroll to the top of the pane, and scope to the thread region.

- WebKit rubric sidebar: stabilizeRubricSidebar scrolled once against a not-yet-settled layout; now re-aligns in a short loop until the region stops moving.

Verified by repeated soaks: previously-flaky manual-grading (Monaco), appeal, request-regrade, and pseudonymous-escalate screenshots are now stable across runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end visual test stability by extending render-idle waiting for code highlighting and Monaco editor tokenization before screenshots.
  * Updated grading and regrade visual regression captures to focus on specific centered dialogs instead of the full page.
  * Added visibility gates and increased wait time for editor/sidebar content in multiple grading scenarios.
  * Improved determinism for comment-thread screenshots by waiting for posted content to render, keeping the composer consistently collapsed, and capturing a scoped region with aligned scroll position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->