### PR TITLE
fix(preview): guaranteed QoS for edgeFunctions to break node-crash loop

### DIFF
--- a/charts/pawtograder/examples/values-preview.yaml
+++ b/charts/pawtograder/examples/values-preview.yaml
@@ -154,9 +154,17 @@ edgeFunctions:
   # supabase edge-runtime spawns per function don't garbage-collect across
   # cold-start boundaries, and a 4-worker test burst keeps several alive
   # concurrently. 2Gi gives headroom without bothering to add replicas.
+  #
+  # requests == limits → Guaranteed QoS. Previously Burstable with tiny
+  # requests on a ~720 GiB node gave oom_score_adj ≈ 989, so when several
+  # PR previews piled onto one Talos worker the kernel preferentially
+  # killed pawtograder-functions pods. Under repeated OOM-cycling the
+  # resulting page-table teardown rate tripped a Talos kernel debug
+  # invariant (mm/page_table_check.c:143) and crashed the whole node ~once
+  # per day. Guaranteed QoS pins oom_score_adj near 0, breaking the loop.
   resources:
-    requests: { cpu: "100m", memory: "256Mi" }
-    limits:   { cpu: "1",    memory: "2Gi" }
+    requests: { cpu: "2",    memory: "2Gi" }
+    limits:   { cpu: "2",    memory: "2Gi" }
   # END_TO_END_SECRET / EDGE_FUNCTION_SECRET come from the chart-rendered
   # pawtograder-e2e secret (templates/secrets.yaml when secrets.create=true
   # AND edgeFunctions.e2e.enabled=true).


### PR DESCRIPTION
## Summary
- PR-preview `pawtograder-functions` pods run as Burstable QoS with `requests: cpu=100m / mem=256Mi` (from `examples/values-preview.yaml` — overrides the chart default of `200m/512Mi`). On a ~720 GiB Talos worker that yields `oom_score_adj ≈ 989`, so the kernel preferentially kills these pods under any pressure.
- With 5-6 concurrent PR previews on one node, the resulting OOM-cycle rate (each pod restarting repeatedly with reason `OOMKilled`, restart counts climbing into the dozens) trips a Talos kernel debug invariant — `kernel BUG at mm/page_table_check.c:143` (`__page_table_check_zero+0xf3/0x100`) — and the whole node silently resets roughly once per day. Other workers don't crash only because they don't happen to host 5-6 OOM-cycling functions pods concurrently.
- Setting `requests == limits` (`cpu=2, memory=2Gi`) makes the preview pod Guaranteed QoS. kubelet then sets `oom_score_adj ≈ -997`, so the OOM killer picks these pods last instead of first, breaking the cycle.

### Where the override lived
`charts/pawtograder/examples/values-preview.yaml` (used by `.github/workflows/preview.yml` via `-f charts/pawtograder/examples/values-preview.yaml`) shrinks `edgeFunctions.resources.requests` below the chart default. The chart default at `charts/pawtograder/values.yaml` is already `200m/512Mi` requests, `2/2Gi` limits; only the preview overlay sets `100m/256Mi`. Production / staging overlays were not touched.

### What changed
Just `charts/pawtograder/examples/values-preview.yaml` — raised `edgeFunctions.resources.requests` to match `limits` (`cpu=2, memory=2Gi`). No other resource blocks touched. The V8/Deno heap behavior is separate and the chart's existing `edgeFunctions.worker.lowMemoryMultiplier: 2` plus the `beforeUnload` 50% ratios already mitigate the worst of it; this PR is purely about QoS class / `oom_score_adj`.

### Cost
2 CPU × ~6 concurrent previews = ~12 cores reserved cluster-wide while previews are live. The worker has the headroom; if this proves painful we can split into Guaranteed-memory + Burstable-CPU (`requests: { cpu: 200m, memory: 2Gi }`) — that still pins `oom_score_adj` low (per-pod kubelet calc uses memory request) without reserving full cores.

## Test plan
- [ ] Render the chart with the preview overlay and confirm the rendered `pawtograder-functions` Deployment has `requests == limits` on both cpu and memory:
  - `helm template foo charts/pawtograder -f charts/pawtograder/examples/values-preview.yaml | yq 'select(.kind=="Deployment" and .metadata.name=="pawtograder-functions") | .spec.template.spec.containers[].resources'`
- [ ] After deploy, confirm the preview pod's `status.qosClass == Guaranteed` and `/proc/<pid>/oom_score_adj` is near `-997` instead of ~989.
- [ ] Watch `talos4g` for 48h for absence of the `mm/page_table_check.c:143` BUG and absence of silent node resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the preview deployment resource settings for Edge Functions to use higher, matching CPU and memory requests and limits.
  * Improved the accompanying guidance to clarify the expected runtime behavior of these settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->