### PR TITLE
fix(preview): bump edgeFunctions memory to 6Gi

### DIFF
--- a/charts/pawtograder/examples/values-preview.yaml
+++ b/charts/pawtograder/examples/values-preview.yaml
@@ -163,8 +163,8 @@ edgeFunctions:
   # invariant (mm/page_table_check.c:143) and crashed the whole node ~once
   # per day. Guaranteed QoS pins oom_score_adj near 0, breaking the loop.
   resources:
-    requests: { cpu: "2",    memory: "2Gi" }
-    limits:   { cpu: "2",    memory: "2Gi" }
+    requests: { cpu: "2",    memory: "6Gi" }
+    limits:   { cpu: "2",    memory: "6Gi" }
   # END_TO_END_SECRET / EDGE_FUNCTION_SECRET come from the chart-rendered
   # pawtograder-e2e secret (templates/secrets.yaml when secrets.create=true
   # AND edgeFunctions.e2e.enabled=true).


### PR DESCRIPTION
## Summary

Follow-up to #852. That PR made `edgeFunctions` Guaranteed QoS at 2Gi to break the kernel-side `oom_score_adj=989` trigger that was crashing Talos nodes via the `mm/page_table_check.c:143` invariant. That fix worked, but pods are still OOMKilling — they genuinely exceed 2Gi. Multiple PR previews are showing pawtograder-functions restart counts in the 4-10 range.

Bumping `edgeFunctions.resources` to 6Gi (request == limit, so Guaranteed QoS is preserved) gives headroom for:

- `worker.memoryLimitMb: 256` x ~6-8 concurrent isolates
- V8's heap-never-returned-to-OS pattern (per the chart's existing notes around `worker.lowMemoryMultiplier`)

Live patch already applied via `kubectl patch deployment` across all 7 active PR previews; this PR makes the change stick across future helm rolls.

## Scope

- Only `charts/pawtograder/examples/values-preview.yaml`.
- Base chart default (`charts/pawtograder/values.yaml`) and prod overlay are unchanged — no evidence of OOM there (prod inherits the chart-default Burstable resources block and isn't paired with the preview's Guaranteed QoS setup).

## Test plan

- [ ] CI green on this PR's own preview env (the bumped pod itself).
- [ ] After merge: confirm next preview rolls come up with `requests/limits = 6Gi` (no manual `kubectl patch` needed).
- [ ] Watch pawtograder-functions restart counts on active previews — expect to stay at 0 over an E2E run.