### PR TITLE
ci(e2e): exclude flaky analytics+vector from supabase start

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,12 @@ jobs:
             reset_supabase
             for attempt in $(seq 1 5); do
               echo "=== supabase start attempt ${attempt}/5 ==="
-              if npx supabase start; then
+              # Exclude analytics (Logflare) + vector: the tests do not use the
+              # logs UI, and these two containers are flaky to bring up healthy on
+              # CI runners — they intermittently report "unhealthy" and fail the
+              # whole start (and thus every retry). Skipping them keeps the schema,
+              # auth, storage, realtime, and edge-runtime services the suite needs.
+              if npx supabase start -x analytics,vector; then
                 echo 0 > "${RUN_TMP}/supabase-start.exitcode"
                 exit 0
               fi


### PR DESCRIPTION
## Problem
`e2e-local` (E2E Tests) intermittently fails before any test runs, because `supabase start` can't bring up the **analytics (Logflare)** and **vector** containers healthy on the self-hosted runner:

```
supabase_analytics_... container is not ready: unhealthy
supabase_vector_...    container is not ready: unhealthy
```

This aborts the whole start — and every one of the 5 retries hits the same unhealthy containers, so the job exits 1 with no `playwright-report`. It's flaky/environmental (the same branch passes and fails across runs) and hits every open PR (e.g. [#850 run](https://github.com/pawtograder/platform/actions/runs/28274385808/job/83778101224)).

## Fix
Start the local stack with `npx supabase start -x analytics,vector`. The E2E suite doesn't use the logs/analytics UI; excluding those two containers keeps everything the tests need (Postgres, auth, storage, realtime, edge runtime) and removes the flakiest dependency. Local dev is unchanged (this only affects the CI start command).

## Provenance
This is commit `316716a4`, cherry-picked out of the still-open PR #789 (LTI 1.3) where it currently lives — landing it standalone on `staging` unblocks E2E for **all** open PRs now, instead of waiting on that large PR to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the end-to-end test startup flow so local services begin with fewer components, making setup leaner and more reliable.
  * Kept the existing retry and pass/fail behavior unchanged while reducing unnecessary startup overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->