### PR TITLE
chore(staging): add standing canary deployment channel

### DIFF
--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -48,6 +48,34 @@ ingress:
     enabled: true
     secretName: pawtograder-staging-tls
 
+# ----- A/B deployment channel: canary lane ----------------------------------
+# Standing canary channel served at canary.staging.pawtograder.net (its own web
+# + edge-functions build) against the SAME staging data plane. Courses opt in
+# via classes.deployment_channel='canary'; the stable web middleware then
+# redirects those courses here and shares the session cookie across the two
+# hosts. That redirect is baked into the stable image at build time from the
+# CHANNEL_HOST_SUFFIX Actions variable (set on the repo) — without it, stable
+# ignores channels and this lane is simply unreachable via redirect.
+#
+# Pin to a known-good canary tag, NOT canary-latest: the staging auto-deploy
+# (release-images.yml deploy-staging) runs `helm upgrade --wait`, which blocks
+# on these channel pods too, so a broken canary image would turn an ordinary
+# staging deploy red. Roll the canary forward by bumping this pin in a PR.
+channels:
+  - name: canary
+    web:
+      image:
+        tag: canary-055b7e2
+      replicas: 1
+    edgeFunctions:
+      image:
+        tag: canary-055b7e2
+      replicas: 1
+
+# Reflected *.staging.pawtograder.net wildcard cert (cert-manager Certificate
+# `staging-wildcard` in this namespace) — covers every channel host.
+channelWildcardTlsSecret: staging-wildcard-tls
+
 # Secrets come from ExternalSecrets synced out of OpenBao
 # (kv/apps/pawtograder-staging/*). Bootstrap with:
 #   scripts/setup-openbao-edge-functions.sh --bundle <name>


### PR DESCRIPTION
Persists the canary A/B lane in `values-staging.yaml` so it survives the `deploy-staging` auto-upgrade (renders from this file; a one-off `--set` channel gets dropped on every staging push — which is what broke the last test).

**What merging does** (via `release-images.yml` on push to `staging`): builds `staging-<sha>` **with the channel-routing suffix baked** (the `CHANNEL_HOST_SUFFIX` repo var is now set), then `deploy-staging` `helm upgrade -f values-staging.yaml` deploys stable-with-routing **and** the canary channel together. Reroute (course pinned to `canary` → `canary.staging.pawtograder.net`) and cross-host SSO then work end to end.

- Channel pinned to a **known-good** canary tag (`canary-055b7e2`), not `canary-latest`, because the staging deploy `--wait`s on these pods — a broken canary image would otherwise redden normal staging deploys. Bump the pin to roll the canary forward.
- **Heads-up:** the stable image rebuild changes the session-cookie domain to `.staging.pawtograder.net`, so everyone on staging re-logs-in once after this deploy.

Do not merge until the `canary-055b7e2` build is green (image must exist + be healthy or the auto-deploy `--wait` fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)