### PR TITLE
fix(grading): scope non-submitter roster by assignment

### DIFF
--- a/supabase/migrations/20260707130000_fix_non_submitters_assignment_scope.sql
+++ b/supabase/migrations/20260707130000_fix_non_submitters_assignment_scope.sql
@@ -1,0 +1,130 @@
+-- Fix: grader roster dropped non-submitters who had submitted OTHER assignments.
+--
+-- In 20260707120000 the `submitters` CTE selected only user_role_id (not
+-- assignment_id), while `assignment_students` spans every assignment in the
+-- class. The `non_submitters` exclusion `WHERE NOT (user_role_id IN submitters)`
+-- therefore removed any student who had submitted ANY assignment, so a student
+-- with no submission for assignment X but a submission for assignment Y never
+-- appeared on X's roster (and got no "Grade anyway" button).
+--
+-- Fix: scope `submitters` by (user_role_id, assignment_id) and correlate the
+-- exclusion on both columns via NOT EXISTS (also avoids the NOT IN + NULL
+-- pitfall). Only the `submitters` and `non_submitters` CTEs change; the rest of
+-- the view is reproduced verbatim from 20260707120000.
+
+DROP VIEW IF EXISTS public.submissions_with_grades_for_assignment_nice;
+
+CREATE VIEW public.submissions_with_grades_for_assignment_nice WITH (security_invoker = 'true') AS
+ WITH assignment_students AS (
+         SELECT DISTINCT ur.id AS user_role_id,
+            ur.private_profile_id, a.class_id, a.id AS assignment_id,
+            a.due_date, a.slug AS assignment_slug,
+            ur.class_section_id, ur.lab_section_id
+           FROM public.assignments a
+             JOIN public.user_roles ur ON ((ur.class_id = a.class_id AND ur.role = 'student'::public.app_role AND ur.disabled = false))
+        ), individual_submissions AS (
+         SELECT ast.user_role_id, ast.private_profile_id, ast.class_id,
+            ast.assignment_id, s_1.id AS submission_id,
+            NULL::bigint AS assignment_group_id, ast.due_date,
+            ast.assignment_slug, ast.class_section_id, ast.lab_section_id
+           FROM assignment_students ast
+             JOIN public.submissions s_1 ON ((s_1.assignment_id = ast.assignment_id AND s_1.profile_id = ast.private_profile_id AND s_1.is_active = true AND s_1.assignment_group_id IS NULL))
+        ), group_submissions AS (
+         SELECT ast.user_role_id, ast.private_profile_id, ast.class_id,
+            ast.assignment_id, s_1.id AS submission_id,
+            agm.assignment_group_id, ast.due_date,
+            ast.assignment_slug, ast.class_section_id, ast.lab_section_id
+           FROM assignment_students ast
+             JOIN public.assignment_groups_members agm ON ((agm.assignment_id = ast.assignment_id AND agm.profile_id = ast.private_profile_id))
+             JOIN public.submissions s_1 ON ((s_1.assignment_id = ast.assignment_id AND s_1.assignment_group_id = agm.assignment_group_id AND s_1.is_active = true))
+        ), submitters AS (
+         -- Scoped by assignment: a student is a "submitter" only for the
+         -- specific assignment they submitted to, not class-wide.
+         SELECT individual_submissions.user_role_id, individual_submissions.assignment_id FROM individual_submissions
+        UNION
+         SELECT group_submissions.user_role_id, group_submissions.assignment_id FROM group_submissions
+        ), non_submitters AS (
+         -- Every enrolled student with no active submission (individual or via
+         -- their group) FOR THAT ASSIGNMENT. Carries assignment_group_id when
+         -- the student is in a group so the UI can create a group-scoped stub.
+         SELECT ast.user_role_id, ast.private_profile_id, ast.class_id,
+            ast.assignment_id, NULL::bigint AS submission_id,
+            agm.assignment_group_id, ast.due_date,
+            ast.assignment_slug, ast.class_section_id, ast.lab_section_id
+           FROM assignment_students ast
+             LEFT JOIN public.assignment_groups_members agm ON ((agm.assignment_id = ast.assignment_id AND agm.profile_id = ast.private_profile_id))
+          WHERE NOT EXISTS (
+             SELECT 1 FROM submitters su
+              WHERE su.user_role_id = ast.user_role_id
+                AND su.assignment_id = ast.assignment_id
+          )
+        ), all_submissions AS (
+         SELECT * FROM individual_submissions
+        UNION ALL
+         SELECT * FROM group_submissions
+        UNION ALL
+         SELECT * FROM non_submitters
+        ), due_date_extensions AS (
+         SELECT COALESCE(ade.student_id, ag_1.profile_id) AS effective_student_id,
+            COALESCE(ade.assignment_group_id, ag_1.assignment_group_id) AS effective_assignment_group_id,
+            ade.assignment_id,
+            sum(ade.tokens_consumed) AS tokens_consumed,
+            sum(ade.hours) AS hours
+           FROM public.assignment_due_date_exceptions ade
+             LEFT JOIN public.assignment_groups_members ag_1 ON ((ade.assignment_group_id = ag_1.assignment_group_id))
+          GROUP BY COALESCE(ade.student_id, ag_1.profile_id), COALESCE(ade.assignment_group_id, ag_1.assignment_group_id), ade.assignment_id
+        ), submissions_with_extensions AS (
+         SELECT asub.user_role_id, asub.private_profile_id, asub.class_id,
+            asub.assignment_id, asub.submission_id, asub.assignment_group_id,
+            asub.due_date, asub.assignment_slug,
+            COALESCE(dde.tokens_consumed, (0)::bigint) AS tokens_consumed,
+            COALESCE(dde.hours, (0)::bigint) AS hours,
+            asub.class_section_id, asub.lab_section_id
+           FROM all_submissions asub
+             LEFT JOIN due_date_extensions dde ON (
+               (dde.effective_student_id = asub.private_profile_id)
+               AND (dde.assignment_id = asub.assignment_id)
+               AND (
+                 (asub.assignment_group_id IS NULL AND dde.effective_assignment_group_id IS NULL)
+                 OR (asub.assignment_group_id = dde.effective_assignment_group_id)
+               )
+             )
+        )
+ SELECT swe.user_role_id AS id, swe.class_id, swe.assignment_id,
+    p.id AS student_private_profile_id, p.name, p.sortable_name,
+    s.id AS activesubmissionid, s.ordinal, s.created_at, s.released,
+    s.repository, s.sha,
+    rev.total_autograde_score AS autograder_score,
+    rev.grader, rev.meta_grader, rev.total_score, rev.tweak,
+    rev.completed_by, rev.completed_at, rev.checked_at, rev.checked_by,
+    rev.individual_scores,
+    rev.per_student_grading_totals,
+    rev.per_student_grading_shared_base,
+    graderprofile.name AS assignedgradername,
+    metagraderprofile.name AS assignedmetagradername,
+    completerprofile.name AS gradername,
+    checkgraderprofile.name AS checkername,
+    swe.assignment_group_id,
+    ag.name AS groupname,
+    mentorprofile.name AS assignment_group_mentor_name,
+    swe.tokens_consumed, swe.hours, swe.due_date,
+    (swe.due_date + ('01:00:00'::interval * (swe.hours)::double precision)) AS late_due_date,
+    ar.grader_sha, ar.grader_action_sha,
+    swe.assignment_slug, swe.class_section_id,
+    cs.name AS class_section_name,
+    swe.lab_section_id, ls.name AS lab_section_name
+   FROM submissions_with_extensions swe
+     JOIN public.profiles p ON ((p.id = swe.private_profile_id))
+     LEFT JOIN public.submissions s ON ((s.id = swe.submission_id))
+     LEFT JOIN public.submission_reviews rev ON ((rev.id = s.grading_review_id))
+     LEFT JOIN public.grader_results ar ON ((ar.submission_id = s.id))
+     LEFT JOIN public.assignment_groups ag ON ((ag.id = swe.assignment_group_id))
+     LEFT JOIN public.profiles mentorprofile ON ((mentorprofile.id = ag.mentor_profile_id))
+     LEFT JOIN public.profiles completerprofile ON ((completerprofile.id = rev.completed_by))
+     LEFT JOIN public.profiles graderprofile ON ((graderprofile.id = rev.grader))
+     LEFT JOIN public.profiles metagraderprofile ON ((metagraderprofile.id = rev.meta_grader))
+     LEFT JOIN public.profiles checkgraderprofile ON ((checkgraderprofile.id = rev.checked_by))
+     LEFT JOIN public.class_sections cs ON ((cs.id = swe.class_section_id))
+     LEFT JOIN public.lab_sections ls ON ((ls.id = swe.lab_section_id));
+
+ALTER VIEW public.submissions_with_grades_for_assignment_nice OWNER TO postgres;


### PR DESCRIPTION
## Problem

After #855 shipped "grade students without a submission," the **Grade anyway** buttons didn't appear for almost anyone in prod. The grader roster only showed students who had *never submitted a single assignment all term*.

## Root cause

The `submissions_with_grades_for_assignment_nice` view builds a `submitters` CTE from **only `user_role_id`**, while `assignment_students` spans **every assignment in the class** (the per-assignment filter is applied later, in the outer `WHERE`). The `non_submitters` exclusion `WHERE NOT (user_role_id IN submitters)` therefore removed any student who had submitted *any* assignment.

So a student with no submission for assignment X but a submission for assignment Y was excluded from X's non-submitters — and since they also had no submission row for X, they appeared nowhere on X's roster, hence no button.

Verified on prod: an assignment with 9 enrolled students returned only the 6 who submitted *that* assignment; the 3 non-submitters all had submissions to *other* assignments in the class.

## Fix

- Scope `submitters` by `(user_role_id, assignment_id)`.
- Correlate the `non_submitters` exclusion on **both** columns via `NOT EXISTS` (also avoids the `NOT IN` + NULL pitfall).

The view definition is otherwise reproduced verbatim from the #855 migration. Pure `CREATE VIEW` redefinition — no data risk.

## Testing

- Locally reproduced the 6/9 → 9/9 fix on the affected class/assignment.
- Non-submitters now surface with a null `activesubmissionid`, so the **Grade anyway** button renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assignment rosters so students are only excluded when they have submitted that specific assignment.
  * Improved grading and review views to correctly scope submitter/non-submitter matching per assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->