### PR TITLE
fix(chart): postgres standby init must not run as root / chown to 999

### DIFF
--- a/charts/pawtograder/templates/postgres-replica.yaml
+++ b/charts/pawtograder/templates/postgres-replica.yaml
@@ -80,12 +80,15 @@ spec:
         - name: pg-basebackup
           image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.postgres.image) }}
           imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
-          # Run as root so we can fix ownership/perms to what postgres requires
-          # (data dir must be 0700, owned by uid 999). The main container's
-          # entrypoint also chowns, but we set it here so pg_basebackup's own
-          # write succeeds under fsGroup.
-          securityContext:
-            runAsUser: 0
+          # Inherit the pod-level securityContext (pawtograder.podSecurityContext)
+          # so pg_basebackup runs as the SAME user the postgres container will —
+          # the supabase/postgres user (uid 101), NOT root. That matters on
+          # root-squashed NFS (e.g. NetApp): a root process is squashed to the
+          # anon uid and can neither chown nor own PGDATA, so a root init here
+          # made the standby unstartable. pg_basebackup writes PGDATA as its own
+          # uid, so no post-hoc chown is needed; we only chmod 700 (the running
+          # user owns the dir). On non-squashing storage the default pod context
+          # (root) still works — the main container entrypoint chowns as before.
           command:
             - bash
             - -c
@@ -130,7 +133,11 @@ spec:
                 # refuses read connections and never becomes Ready.
                 echo "hot_standby = on"
               } >> "$PGDATA/postgresql.auto.conf"
-              chown -R 999:999 "$PGDATA"
+              # No chown: pg_basebackup already wrote PGDATA as the running user
+              # (the postgres uid), which is what the server requires. The former
+              # recursive chown to 999:999 here was both the wrong uid (supabase
+              # postgres is 101) and impossible under NFS root_squash. Postgres
+              # only requires the dir be mode 0700, which its owner can set.
               chmod 700 "$PGDATA"
               echo "[bootstrap] standby prepared"
           env:

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: {{ include "pawtograder.serviceAccountName" . }}
       {{- include "pawtograder.imagePullSecrets" . | nindent 6 }}
       {{- include "pawtograder.priorityClassName" (dict "ctx" . "component" .Values.postgres) | nindent 6 }}
-      {{- /* fsGroup 999 + seccomp; see postgres.podSecurityContext in values */}}
+      {{- /* fsGroup 102 (supabase/postgres group) + seccomp; see postgres.podSecurityContext in values */}}
       {{- include "pawtograder.podSecurityContext" (dict "ctx" . "component" .Values.postgres) | nindent 6 }}
       # Long grace so a busy postgres can checkpoint + flush WAL instead of
       # being SIGKILLed 30s into a drain and paying a recovery replay on the

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -292,9 +292,11 @@ postgres:
   # The supabase/postgres entrypoint starts as root, chowns PGDATA, and
   # su's to postgres — it needs the default capability set, so the global
   # drop-ALL containerSecurityContext is opted out here. fsGroup keeps the
-  # PVC group-writable for uid 999.
+  # PVC group-writable for the supabase/postgres group (gid 102). (An overlay
+  # that runs the pod as uid 101 — e.g. for root-squashed NFS — should set
+  # runAsUser/runAsGroup here too; see examples/values-prod.yaml.)
   podSecurityContext:
-    fsGroup: 999
+    fsGroup: 102
     seccompProfile:
       type: RuntimeDefault
   containerSecurityContext: {}


### PR DESCRIPTION
## What
The replica `pg-basebackup` init container (`charts/pawtograder/templates/postgres-replica.yaml`) hard-coded `securityContext.runAsUser: 0` and a recursive `chown -R 999:999 "$PGDATA"`. This PR removes both.

## Why
Two independent bugs, same line:

1. **Wrong uid.** `supabase/postgres` runs as **uid 101 / gid 102**, not 999. The chown targeted a nonexistent user; it only appeared to work because the *main* container's entrypoint re-chowns PGDATA to the real postgres user on startup, masking it.
2. **Breaks on root-squashed NFS.** On NetApp NFS with `root_squash`, a root process is squashed to the anon uid (65534) and can neither `chown` nor own PGDATA — so the standby's init crashed and the pod never started. This is the same failure class as the primary in #599. The primary is fixed by running its pod as uid 101, but a `runAsNonRoot` pod securityContext is *incompatible* with this init container's `runAsUser: 0`, so the replica re-broke it.

## Fix
- Drop the explicit `runAsUser: 0` → the init inherits the pod-level `pawtograder.podSecurityContext`, so it runs as the **same** user as the postgres container (uid 101 under the prod overlay).
- Drop the `chown` → `pg_basebackup` already writes PGDATA as its own uid; the server only needs the dir at mode `0700`, which `chmod 700` still sets.

## Compatibility
- **Non-squashing storage (default):** the default pod context is unchanged (root), the init runs as root exactly as before, and the main entrypoint chowns — no behavior change.
- **Root-squashed NFS + Option A overlay (pod runs as 101):** the init now runs as 101, matching the primary, and the standby comes up.

## Validation
- `helm lint` clean; `helm template` with `postgres.replica.enabled=true` + `walg.enabled=true` + `podSecurityContext.runAsUser=101` renders the init container with **no** `runAsUser: 0` and **no** chown; pod securityContext = 101/102/runAsNonRoot.
- The uid-101-on-NFS mechanism this depends on was validated end-to-end on a Talos cluster: `supabase/postgres` as uid 101 on NFSv4.1 with **numeric-id passthrough** (`-v4-numeric-ids` analog) + `root_squash` + `unixPermissions 0777` → `initdb` succeeds, files owned 101:102 server-side, pod `Ready`.

Targets `docs/operations` (base of #858) since the replica template is introduced there, not yet on `staging`.