### PR TITLE
feat(chart): annotations on postgres PVCs (Trident unixPermissions)

### DIFF
--- a/charts/pawtograder/templates/postgres-replica.yaml
+++ b/charts/pawtograder/templates/postgres-replica.yaml
@@ -261,6 +261,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        {{- with .Values.postgres.replica.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - {{ .Values.postgres.replica.persistence.accessMode | default "ReadWriteOnce" }}

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -299,6 +299,13 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        {{- with .Values.postgres.persistence.annotations }}
+        # Provisioner hints applied at PVC-creation time — e.g. NetApp Trident
+        # `trident.netapp.io/unixPermissions` so a non-root (uid 101) postgres
+        # can create PGDATA on a fresh root-squashed NFS volume.
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes:
           - {{ .Values.postgres.persistence.accessMode }}

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -319,6 +319,12 @@ postgres:
     storageClass: "" # e.g. "local-path" or "ceph-rbd"
     size: 50Gi
     accessMode: ReadWriteOnce
+    # Annotations stamped on the PVC (provisioner reads them at create time).
+    # On NetApp Trident + root-squashed NFS, set the volume world-writable so a
+    # non-root (uid 101) postgres can create PGDATA on the fresh mount:
+    #   annotations:
+    #     trident.netapp.io/unixPermissions: "0777"
+    annotations: {}
 
   # postgresql.conf overrides — bumped for Realtime fan-out + supavisor.
   config:
@@ -412,6 +418,8 @@ postgres:
       storageClass: ""
       size: 50Gi
       accessMode: ReadWriteOnce
+      # Same as postgres.persistence.annotations (e.g. Trident unixPermissions).
+      annotations: {}
     resources:
       requests: { cpu: "500m", memory: "2Gi" }
       limits:   { cpu: "2",    memory: "8Gi" }


### PR DESCRIPTION
## What
Adds `postgres.persistence.annotations` and `postgres.replica.persistence.annotations`, stamped onto the StatefulSet `volumeClaimTemplate` metadata.

## Why
The uid-101 Postgres fix (#863) needs the fresh NFS volume to be world-writable so a non-root process can create `PGDATA`. On NetApp Trident that's `trident.netapp.io/unixPermissions`, which is **only honored at PVC-creation time** — and our PVC is created by the StatefulSet's `volumeClaimTemplate`, which had no annotation hook. This lets us set it per-PVC from values instead of loosening the shared `netapp` StorageClass for every tenant.

```yaml
postgres:
  persistence:
    annotations:
      trident.netapp.io/unixPermissions: "0777"
```

## Behavior
Empty by default (`annotations: {}`) → no `annotations` block is rendered, so existing deploys are unchanged. Verified via `helm template`: block appears only when set (primary + replica), absent otherwise. `helm lint` clean.

Targets `docs/operations` (same base as #863) since the postgres chart work lives there, not yet on `staging`.