### PR TITLE
Deployment headaches wave 1: idempotent team sync, per-site template repos, first-login org reconcile, hide unreleased assignments

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { userFetchAzureProfile } from "@/lib/edgeFunctions";
+import { syncGitHubAccount, userFetchAzureProfile } from "@/lib/edgeFunctions";
 
 export async function GET(request: Request) {
   // The `/auth/callback` route is required for the server-side auth flow implemented
@@ -60,6 +60,31 @@ export async function GET(request: Request) {
             console.error("Error checking/updating Azure profile:", error);
             Sentry.captureException(error);
             // Continue with login even if profile check fails
+          }
+        }
+
+        // First GitHub login: reconcile the user's existing org/team memberships. A user who is
+        // already a member of the course's GitHub org (e.g. joined via another class, or added
+        // out-of-band) would otherwise be stuck on the "accept your invitation" banner forever,
+        // because they can't accept an invite that can't be sent to an existing member. Invoking
+        // github-user-sync runs the same reconciliation as the manual "Sync GitHub Account" button
+        // (it spans all of the user's enrolled orgs and flips github_org_confirmed for orgs they're
+        // already in). Gate on last_github_user_sync so we only pay the GitHub round-trips once, on
+        // first login; never block login on failure (a NULL sync timestamp is retried next login).
+        if (data.session.user.app_metadata?.provider === "github") {
+          try {
+            const { data: userData } = await supabase
+              .from("users")
+              .select("last_github_user_sync")
+              .eq("user_id", data.session.user.id)
+              .single();
+            if (!userData?.last_github_user_sync) {
+              await syncGitHubAccount(supabase);
+            }
+          } catch (error) {
+            console.error("Error reconciling GitHub org membership on first login:", error);
+            Sentry.captureException(error);
+            // Continue with login even if reconciliation fails; the manual sync path remains.
           }
         }
       } else {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -90,13 +90,15 @@ export async function GET(request: Request) {
           // forever. Reconciliation is idempotent; errors are logged, never surfaced to login.
           after(async () => {
             try {
-              const { data: unconfirmed } = await supabase
+              const { data: unconfirmed, error: fetchError } = await supabase
                 .from("user_roles")
                 .select("id")
                 .eq("user_id", userId)
                 .eq("disabled", false)
                 .eq("github_org_confirmed", false)
                 .limit(1);
+              // Supabase queries don't throw; surface the error so the catch reports it to Sentry.
+              if (fetchError) throw fetchError;
               if (unconfirmed && unconfirmed.length > 0) {
                 await syncGitHubAccount(supabase);
               }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -10,8 +10,19 @@ export async function GET(request: Request) {
   // https://supabase.com/docs/guides/auth/server-side/nextjs
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
+  // Sanitize `next` to a same-origin absolute path. `startsWith("/")` alone is not enough: a
+  // protocol-relative value like `//evil.test` (or backslash variants `/\evil.test`, `\\evil.test`
+  // that browsers/`new URL` normalize to `//`) starts with `/` yet resolves off-origin when passed
+  // to `new URL(next, redirectBase)` below, giving an open redirect. Require a leading `/` that is
+  // not followed by another `/` or a backslash, and reject any embedded backslash.
   const nextParam = searchParams.get("next") ?? "/";
-  const next = nextParam.startsWith("/") ? nextParam : "/";
+  const next =
+    nextParam.startsWith("/") &&
+    !nextParam.startsWith("//") &&
+    !nextParam.startsWith("/\\") &&
+    !nextParam.includes("\\")
+      ? nextParam
+      : "/";
   // Resolve the redirect host once: behind the load balancer, prefer X-Forwarded-Host.
   const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
   const isLocalEnv = process.env.NODE_ENV === "development";

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@/utils/supabase/server";
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { syncGitHubAccount, userFetchAzureProfile } from "@/lib/edgeFunctions";
 
@@ -63,29 +63,48 @@ export async function GET(request: Request) {
           }
         }
 
-        // First GitHub login: reconcile the user's existing org/team memberships. A user who is
-        // already a member of the course's GitHub org (e.g. joined via another class, or added
-        // out-of-band) would otherwise be stuck on the "accept your invitation" banner forever,
-        // because they can't accept an invite that can't be sent to an existing member. Invoking
-        // github-user-sync runs the same reconciliation as the manual "Sync GitHub Account" button
-        // (it spans all of the user's enrolled orgs and flips github_org_confirmed for orgs they're
-        // already in). Gate on last_github_user_sync so we only pay the GitHub round-trips once, on
-        // first login; never block login on failure (a NULL sync timestamp is retried next login).
-        if (data.session.user.app_metadata?.provider === "github") {
-          try {
-            const { data: userData } = await supabase
-              .from("users")
-              .select("last_github_user_sync")
-              .eq("user_id", data.session.user.id)
-              .single();
-            if (!userData?.last_github_user_sync) {
-              await syncGitHubAccount(supabase);
+        // Reconcile the user's existing GitHub org/team memberships on login. A user already a
+        // member of the course's GitHub org (joined via another class, or added out-of-band) would
+        // otherwise be stuck on the "accept your invitation" banner forever, since an invite can't
+        // be sent to an existing member. Invoking github-user-sync runs the same reconciliation as
+        // the manual "Sync GitHub Account" button (spans all enrolled orgs, flips
+        // github_org_confirmed for orgs they're already in).
+        //
+        // Detect a *linked* GitHub identity, not just the primary login provider: SSO/email users
+        // who later link GitHub (linkGitHubAction -> linkIdentity) come back through this callback
+        // with GitHub as a secondary identity while app_metadata.provider stays their original
+        // provider.
+        const providers = data.session.user.app_metadata?.providers;
+        const hasGitHubIdentity =
+          data.session.user.identities?.some((i) => i.provider === "github") ||
+          data.session.user.app_metadata?.provider === "github" ||
+          (Array.isArray(providers) && providers.includes("github"));
+
+        if (hasGitHubIdentity) {
+          const userId = data.session.user.id;
+          // Run in the background (after the response) so the several GitHub round-trips never delay
+          // the login redirect and can't cause auth timeouts. Gate on the presence of an
+          // unconfirmed enrollment — the banner's own condition — rather than a synced-timestamp, so
+          // a run that failed part-way (e.g. a transient GitHub error after github-user-sync already
+          // stamped last_github_user_sync) is retried on the next login instead of being skipped
+          // forever. Reconciliation is idempotent; errors are logged, never surfaced to login.
+          after(async () => {
+            try {
+              const { data: unconfirmed } = await supabase
+                .from("user_roles")
+                .select("id")
+                .eq("user_id", userId)
+                .eq("disabled", false)
+                .eq("github_org_confirmed", false)
+                .limit(1);
+              if (unconfirmed && unconfirmed.length > 0) {
+                await syncGitHubAccount(supabase);
+              }
+            } catch (error) {
+              console.error("Background GitHub org reconciliation failed:", error);
+              Sentry.captureException(error);
             }
-          } catch (error) {
-            console.error("Error reconciling GitHub org membership on first login:", error);
-            Sentry.captureException(error);
-            // Continue with login even if reconciliation fails; the manual sync path remains.
-          }
+          });
         }
       } else {
         console.log("No Azure session data returned");

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -2,6 +2,7 @@ import { createClient } from "@/utils/supabase/server";
 import { NextResponse, after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { syncGitHubAccount, userFetchAzureProfile } from "@/lib/edgeFunctions";
+import { findGithubIdentity } from "@/lib/githubIdentity";
 
 export async function GET(request: Request) {
   // The `/auth/callback` route is required for the server-side auth flow implemented
@@ -11,6 +12,27 @@ export async function GET(request: Request) {
   const code = searchParams.get("code");
   const nextParam = searchParams.get("next") ?? "/";
   const next = nextParam.startsWith("/") ? nextParam : "/";
+  // Resolve the redirect host once: behind the load balancer, prefer X-Forwarded-Host.
+  const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
+  const isLocalEnv = process.env.NODE_ENV === "development";
+  // Local dev has no load balancer, so X-Forwarded-Host doesn't apply.
+  const redirectBase = isLocalEnv ? origin : forwardedHost ? `https://${forwardedHost}` : origin;
+
+  // OAuth/link providers redirect back with `error`/`error_description` (and no `code`) when the user
+  // cancels or denies the flow. Since the course GitHub-link banner (components/github/link-account.tsx)
+  // now redirects here with `next=/course/{id}` — and its UI renders `error_description` — forward
+  // those params back to `next` so the user lands on the originating page with the actionable message.
+  // Only do this when a specific `next` page was requested; a plain login error (no `next`) still goes
+  // to the dedicated /auth/auth-code-error page below.
+  const authError = searchParams.get("error");
+  const authErrorDescription = searchParams.get("error_description");
+  if (!code && authError && next !== "/") {
+    const dest = new URL(next, redirectBase);
+    dest.searchParams.set("error", authError);
+    if (authErrorDescription) dest.searchParams.set("error_description", authErrorDescription);
+    return NextResponse.redirect(dest);
+  }
+
   if (code) {
     const supabase = await createClient();
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
@@ -76,7 +98,7 @@ export async function GET(request: Request) {
         // provider.
         const providers = data.session.user.app_metadata?.providers;
         const hasGitHubIdentity =
-          data.session.user.identities?.some((i) => i.provider === "github") ||
+          !!findGithubIdentity(data.session.user.identities) ||
           data.session.user.app_metadata?.provider === "github" ||
           (Array.isArray(providers) && providers.includes("github"));
 
@@ -90,12 +112,20 @@ export async function GET(request: Request) {
           // forever. Reconciliation is idempotent; errors are logged, never surfaced to login.
           after(async () => {
             try {
+              // Only reconcile when the user has an unconfirmed enrollment in a class that actually
+              // uses GitHub (github_org is set). Without the github_org filter, a GitHub-linked user
+              // enrolled only in non-GitHub classes keeps github_org_confirmed = false forever, so this
+              // would invoke github-user-sync on every login just for it to throw "User not in any
+              // classes" (wasted round-trip + Sentry noise). Treat NULL github_org_confirmed as
+              // unconfirmed too (the column is nullable), matching the invitation banner's own condition
+              // (resend-org-invitation.tsx hides only when github_org_confirmed is truthy).
               const { data: unconfirmed, error: fetchError } = await supabase
-                .from("user_roles")
-                .select("id")
-                .eq("user_id", userId)
-                .eq("disabled", false)
-                .eq("github_org_confirmed", false)
+                .from("classes")
+                .select("id, user_roles!inner(id)")
+                .not("github_org", "is", null)
+                .eq("user_roles.user_id", userId)
+                .eq("user_roles.disabled", false)
+                .not("user_roles.github_org_confirmed", "is", true)
                 .limit(1);
               // Supabase queries don't throw; surface the error so the catch reports it to Sentry.
               if (fetchError) throw fetchError;
@@ -112,17 +142,8 @@ export async function GET(request: Request) {
         console.log("No Azure session data returned");
       }
 
-      const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
-      const isLocalEnv = process.env.NODE_ENV === "development";
-      if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        return NextResponse.redirect(`${origin}${next}`);
-      } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
-      }
+      return NextResponse.redirect(`${redirectBase}${next}`);
     }
   }
-  return NextResponse.redirect(`${origin}/auth/auth-code-error`);
+  return NextResponse.redirect(`${redirectBase}/auth/auth-code-error`);
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -130,10 +130,17 @@ export async function GET(request: Request) {
               // classes" (wasted round-trip + Sentry noise). Treat NULL github_org_confirmed as
               // unconfirmed too (the column is nullable), matching the invitation banner's own condition
               // (resend-org-invitation.tsx hides only when github_org_confirmed is truthy).
+              //
+              // Also require a non-null `slug`: github-user-sync derives team names as
+              // `${slug}-students`/`-staff`, so a partially-configured class (github_org set, slug
+              // still NULL) would otherwise reconcile against a bogus `null-students` team. This
+              // matches the team-sync migration (20260611120001) that skips when org or slug is
+              // missing.
               const { data: unconfirmed, error: fetchError } = await supabase
                 .from("classes")
                 .select("id, user_roles!inner(id)")
                 .not("github_org", "is", null)
+                .not("slug", "is", null)
                 .eq("user_roles.user_id", userId)
                 .eq("user_roles.disabled", false)
                 .not("user_roles.github_org_confirmed", "is", true)

--- a/components/github/link-account.tsx
+++ b/components/github/link-account.tsx
@@ -109,10 +109,14 @@ export default function LinkAccount() {
           mr="0"
           colorPalette="green"
           onClick={async () => {
+            // Route through /auth/callback (not straight to the course page) so the first-login
+            // org-membership reconciliation runs for users who link GitHub from this banner; the
+            // callback then forwards to the course page via `next`.
+            const next = encodeURIComponent(`/course/${course.id}`);
             const { error } = await supabase.auth.linkIdentity({
               provider: "github",
               options: {
-                redirectTo: `${window.location.origin}/course/${course.id}`
+                redirectTo: `${window.location.origin}/auth/callback?next=${next}`
               }
             });
             if (error) {

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -16,7 +16,8 @@ import { Octokit, RequestError } from "npm:octokit";
 // helpers under test never authenticate, so set a placeholder before importing the module (dynamic
 // import so the env is set first — static imports would hoist above this).
 Deno.env.set("GITHUB_PRIVATE_KEY_STRING", Deno.env.get("GITHUB_PRIVATE_KEY_STRING") || "test-placeholder-key");
-const { assertSourceNotEmpty, isRepoEmpty, NonRetryableRepoError } = await import("./GitHubWrapper.ts");
+const { assertSourceNotEmpty, getTeamAndCreateIfNeeded, isRepoEmpty, isTeamAlreadyExistsError, NonRetryableRepoError } =
+  await import("./GitHubWrapper.ts");
 
 type Handler = (params: Record<string, unknown>) => unknown;
 
@@ -30,11 +31,18 @@ function fakeOctokit(handlers: Record<string, Handler>): Octokit {
   } as unknown as Octokit;
 }
 
-function requestError(status: number, message = "error"): RequestError {
+function requestError(status: number, message = "error", data: unknown = {}): RequestError {
   return new RequestError(message, status, {
     request: { method: "GET", url: "https://api.github.com/x", headers: {} },
     // deno-lint-ignore no-explicit-any
-    response: { status, url: "https://api.github.com/x", headers: {}, data: {} } as any
+    response: { status, url: "https://api.github.com/x", headers: {}, data } as any
+  });
+}
+
+// GitHub's 422 for a duplicate team name: structured `code: "already_exists"` on a Team resource.
+function teamAlreadyExistsError(): RequestError {
+  return requestError(422, "Validation Failed", {
+    errors: [{ resource: "Team", code: "already_exists", field: "name" }]
   });
 }
 
@@ -112,4 +120,73 @@ Deno.test("assertSourceNotEmpty: missing source (404 on repo) -> NonRetryableRep
     NonRetryableRepoError
   );
   assertEquals(err.message.includes("not found"), true);
+});
+
+// --- Idempotent team creation (getTeamAndCreateIfNeeded) ---
+
+Deno.test("isTeamAlreadyExistsError: 422 already_exists -> true", () => {
+  assertEquals(isTeamAlreadyExistsError(teamAlreadyExistsError()), true);
+});
+
+Deno.test("isTeamAlreadyExistsError: 422 with 'Name must be unique' message -> true", () => {
+  assertEquals(isTeamAlreadyExistsError(requestError(422, "Name must be unique for this org")), true);
+});
+
+Deno.test("isTeamAlreadyExistsError: unrelated 422 / 404 / non-RequestError -> false", () => {
+  assertEquals(isTeamAlreadyExistsError(requestError(422, "Some other validation error")), false);
+  assertEquals(isTeamAlreadyExistsError(requestError(404, "Not Found")), false);
+  assertEquals(isTeamAlreadyExistsError(new Error("already exists")), false);
+});
+
+Deno.test("getTeamAndCreateIfNeeded: team exists -> returns it without creating", async () => {
+  let posted = false;
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => ({ data: { id: 7, slug: "cs101-staff" } }),
+    "POST /orgs/{org}/teams": () => {
+      posted = true;
+      return { data: { id: 999 } };
+    }
+  });
+  const team = await getTeamAndCreateIfNeeded("org", "cs101-staff", octokit);
+  assertEquals(team.data.id, 7);
+  assertEquals(posted, false);
+});
+
+Deno.test("getTeamAndCreateIfNeeded: 404 then create -> returns new team", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(404, "Not Found");
+    },
+    "POST /orgs/{org}/teams": () => ({ data: { id: 42, slug: "cs101-staff" } })
+  });
+  const team = await getTeamAndCreateIfNeeded("org", "cs101-staff", octokit);
+  assertEquals(team.data.id, 42);
+});
+
+// The regression: GET 404s (race / slug mismatch) but POST then 422s because the team already
+// exists. Previously this threw; now it re-fetches the existing team instead.
+Deno.test("getTeamAndCreateIfNeeded: 404 then 422-already-exists -> re-fetches existing team", async () => {
+  let getCalls = 0;
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      getCalls++;
+      if (getCalls === 1) throw requestError(404, "Not Found");
+      return { data: { id: 55, slug: "cs101-staff" } };
+    },
+    "POST /orgs/{org}/teams": () => {
+      throw teamAlreadyExistsError();
+    }
+  });
+  const team = await getTeamAndCreateIfNeeded("org", "cs101-staff", octokit);
+  assertEquals(team.data.id, 55);
+  assertEquals(getCalls, 2);
+});
+
+Deno.test("getTeamAndCreateIfNeeded: unexpected 500 on GET rethrows", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(500, "Server Error");
+    }
+  });
+  await assertRejects(() => getTeamAndCreateIfNeeded("org", "cs101-staff", octokit), RequestError);
 });

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -256,14 +256,30 @@ Deno.test("resolveExistingTeamSlug: 404 then normalized slug in org list -> retu
   assertEquals(await resolveExistingTeamSlug("org-b", "cs101-students", octokit), "cs-101-students");
 });
 
-Deno.test("resolveExistingTeamSlug: 404 and no match -> falls back to requested slug", async () => {
+Deno.test("resolveExistingTeamSlug: 404 and no match -> falls back to requested slug, not cached", async () => {
+  // Team doesn't exist yet on the first call, then a later team-sync creates it. The no-match
+  // fallback must NOT be cached, so the retry in the same isolate picks up the real slug.
+  let teamExists = false;
   const octokit = fakeOctokit({
-    "GET /orgs/{org}/teams/{team_slug}": () => {
+    "GET /orgs/{org}/teams/{team_slug}": (p) => {
+      if (teamExists) return { data: { id: 3, slug: p.team_slug } };
       throw requestError(404, "Not Found");
     },
-    "GET /orgs/{org}/teams": () => [{ id: 3, slug: "unrelated-team", name: "unrelated-team" }]
+    "GET /orgs/{org}/teams": () => (teamExists ? [{ id: 3, slug: "cs101-staff", name: "cs101-staff" }] : [])
   });
   assertEquals(await resolveExistingTeamSlug("org-c", "cs101-staff", octokit), "cs101-staff");
+  teamExists = true;
+  assertEquals(await resolveExistingTeamSlug("org-c", "cs101-staff", octokit), "cs101-staff");
+});
+
+// Ambiguous string concatenation (org "a-b" + "-" + "c" === org "a" + "-" + "b-c") must not collide:
+// each course resolves to its own team even in a warm isolate sharing the cache.
+Deno.test("resolveExistingTeamSlug: distinct org/slug pairs don't collide in cache", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": (p) => ({ data: { id: 9, slug: `${p.org}::${p.team_slug}` } })
+  });
+  assertEquals(await resolveExistingTeamSlug("a-b", "c", octokit), "a-b::c");
+  assertEquals(await resolveExistingTeamSlug("a", "b-c", octokit), "a::b-c");
 });
 
 // A transient (non-404) error must propagate rather than trigger the team-list fallback, so callers

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -22,12 +22,15 @@ const { assertSourceNotEmpty, getTeamAndCreateIfNeeded, isRepoEmpty, isTeamAlrea
 type Handler = (params: Record<string, unknown>) => unknown;
 
 function fakeOctokit(handlers: Record<string, Handler>): Octokit {
+  const call = async (route: string, params: Record<string, unknown>) => {
+    const h = handlers[route];
+    if (!h) throw new Error(`unexpected route: ${route}`);
+    return await h(params);
+  };
   return {
-    request: async (route: string, params: Record<string, unknown>) => {
-      const h = handlers[route];
-      if (!h) throw new Error(`unexpected route: ${route}`);
-      return await h(params);
-    }
+    request: call,
+    // paginate returns the concatenated items; our list handlers return the array directly.
+    paginate: async (route: string, params: Record<string, unknown>) => await call(route, params)
   } as unknown as Octokit;
 }
 
@@ -186,6 +189,42 @@ Deno.test("getTeamAndCreateIfNeeded: unexpected 500 on GET rethrows", async () =
   const octokit = fakeOctokit({
     "GET /orgs/{org}/teams/{team_slug}": () => {
       throw requestError(500, "Server Error");
+    }
+  });
+  await assertRejects(() => getTeamAndCreateIfNeeded("org", "cs101-staff", octokit), RequestError);
+});
+
+// Out-of-band team whose GitHub-normalized slug differs from the requested name: GET by the
+// requested slug 404s, POST 422s, re-GET 404s, so we locate it in the org team list and return it
+// under its ACTUAL slug (so callers issue subsequent member calls against the right slug).
+Deno.test("getTeamAndCreateIfNeeded: 422 then slug mismatch -> resolves via org team list", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": (p) => {
+      if (p.team_slug === "cs101-staff") throw requestError(404, "Not Found");
+      return { data: { id: 88, slug: p.team_slug } };
+    },
+    "POST /orgs/{org}/teams": () => {
+      throw teamAlreadyExistsError();
+    },
+    "GET /orgs/{org}/teams": () => [{ id: 88, slug: "cs-101-staff", name: "cs101-staff" }]
+  });
+  const team = await getTeamAndCreateIfNeeded("org", "cs101-staff", octokit);
+  assertEquals(team.data.id, 88);
+  assertEquals(team.data.slug, "cs-101-staff");
+});
+
+// A transient (non-404) failure on the post-422 re-fetch must propagate, not be masked by the
+// full-team-scan fallback.
+Deno.test("getTeamAndCreateIfNeeded: 422 then non-404 on re-fetch -> rethrows", async () => {
+  let getCalls = 0;
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      getCalls++;
+      if (getCalls === 1) throw requestError(404, "Not Found");
+      throw requestError(500, "Server Error");
+    },
+    "POST /orgs/{org}/teams": () => {
+      throw teamAlreadyExistsError();
     }
   });
   await assertRejects(() => getTeamAndCreateIfNeeded("org", "cs101-staff", octokit), RequestError);

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -16,8 +16,14 @@ import { Octokit, RequestError } from "npm:octokit";
 // helpers under test never authenticate, so set a placeholder before importing the module (dynamic
 // import so the env is set first — static imports would hoist above this).
 Deno.env.set("GITHUB_PRIVATE_KEY_STRING", Deno.env.get("GITHUB_PRIVATE_KEY_STRING") || "test-placeholder-key");
-const { assertSourceNotEmpty, getTeamAndCreateIfNeeded, isRepoEmpty, isTeamAlreadyExistsError, NonRetryableRepoError } =
-  await import("./GitHubWrapper.ts");
+const {
+  assertSourceNotEmpty,
+  getTeamAndCreateIfNeeded,
+  isRepoEmpty,
+  isTeamAlreadyExistsError,
+  NonRetryableRepoError,
+  resolveExistingTeamSlug
+} = await import("./GitHubWrapper.ts");
 
 type Handler = (params: Record<string, unknown>) => unknown;
 
@@ -228,4 +234,45 @@ Deno.test("getTeamAndCreateIfNeeded: 422 then non-404 on re-fetch -> rethrows", 
     }
   });
   await assertRejects(() => getTeamAndCreateIfNeeded("org", "cs101-staff", octokit), RequestError);
+});
+
+// --- Non-creating slug resolution (resolveExistingTeamSlug) ---
+// Uses a distinct org/slug per test since resolution is memoized per (org, requestedSlug).
+
+Deno.test("resolveExistingTeamSlug: team exists under requested slug -> returns actual slug", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": (p) => ({ data: { id: 1, slug: p.team_slug } })
+  });
+  assertEquals(await resolveExistingTeamSlug("org-a", "cs101-staff", octokit), "cs101-staff");
+});
+
+Deno.test("resolveExistingTeamSlug: 404 then normalized slug in org list -> returns normalized slug", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /orgs/{org}/teams": () => [{ id: 2, slug: "cs-101-students", name: "cs101-students" }]
+  });
+  assertEquals(await resolveExistingTeamSlug("org-b", "cs101-students", octokit), "cs-101-students");
+});
+
+Deno.test("resolveExistingTeamSlug: 404 and no match -> falls back to requested slug", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /orgs/{org}/teams": () => [{ id: 3, slug: "unrelated-team", name: "unrelated-team" }]
+  });
+  assertEquals(await resolveExistingTeamSlug("org-c", "cs101-staff", octokit), "cs101-staff");
+});
+
+// A transient (non-404) error must propagate rather than trigger the team-list fallback, so callers
+// don't silently sync against the wrong (fallback literal) slug on a blip.
+Deno.test("resolveExistingTeamSlug: non-404 error -> rethrows", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(500, "Server Error");
+    }
+  });
+  await assertRejects(() => resolveExistingTeamSlug("org-d", "cs101-staff", octokit), RequestError);
 });

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1918,32 +1918,50 @@ const teamSlugCache = new Map<string, Promise<string>>();
  * requested slug; on 404, scan the org's teams for one whose slug or name matches. Falls back to the
  * requested slug when the team can't be found, so callers behave exactly as before in the common case
  * (course slugs are already GitHub-normalized). Unlike getTeamAndCreateIfNeeded this never creates a
- * team, so it's safe on read/permission paths that must not materialize an unwanted team. Cached per
- * (org, requestedSlug) so repeated per-repo permission syncs don't refetch.
+ * team, so it's safe on read/permission paths that must not materialize an unwanted team.
+ *
+ * Only a *genuine* resolution (the team was found) is cached, keyed per (org, requestedSlug) so
+ * repeated per-repo permission syncs don't refetch. A no-match fallback is NOT cached: the team may
+ * simply not exist yet, and a later team-sync could create it within the same warm isolate — caching
+ * the miss would keep every retry hitting the wrong slug until cold start.
  */
 export async function resolveExistingTeamSlug(org: string, team_slug: string, octokit: Octokit): Promise<string> {
-  const cacheKey = org + "-" + team_slug;
-  if (!teamSlugCache.has(cacheKey)) {
-    teamSlugCache.set(
-      cacheKey,
-      (async () => {
-        try {
-          const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
-          return team.data.slug ?? team_slug;
-        } catch (e) {
-          if (!(e instanceof RequestError && e.status === 404)) {
-            throw e;
-          }
-          const teams = await octokit.paginate("GET /orgs/{org}/teams", { org, per_page: 100 });
-          return teams.find((t) => t.slug === team_slug || t.name === team_slug)?.slug ?? team_slug;
-        }
-      })().catch((err) => {
-        teamSlugCache.delete(cacheKey);
-        throw err;
-      })
-    );
+  // JSON tuple, not `org + "-" + team_slug`: string concat is ambiguous (org "a-b"/slug "c" would
+  // collide with org "a"/slug "b-c") and could reuse one course's resolved slug for another.
+  const cacheKey = JSON.stringify([org, team_slug]);
+  const cached = teamSlugCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
-  return teamSlugCache.get(cacheKey)!;
+  const pending = (async () => {
+    let slug = team_slug;
+    let resolved = false;
+    try {
+      const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
+      slug = team.data.slug ?? team_slug;
+      resolved = true;
+    } catch (e) {
+      if (!(e instanceof RequestError && e.status === 404)) {
+        throw e;
+      }
+      const teams = await octokit.paginate("GET /orgs/{org}/teams", { org, per_page: 100 });
+      const match = teams.find((t) => t.slug === team_slug || t.name === team_slug);
+      if (match?.slug) {
+        slug = match.slug;
+        resolved = true;
+      }
+    }
+    // Don't retain a no-match fallback so a retry re-checks once the team exists.
+    if (!resolved) {
+      teamSlugCache.delete(cacheKey);
+    }
+    return slug;
+  })().catch((err) => {
+    teamSlugCache.delete(cacheKey);
+    throw err;
+  });
+  teamSlugCache.set(cacheKey, pending);
+  return pending;
 }
 
 export async function reinviteToOrgTeam(org: string, team_slug: string, githubUsername: string, scope?: Sentry.Scope) {

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1910,6 +1910,42 @@ export async function getTeamAndCreateIfNeeded(org: string, team_slug: string, o
   }
 }
 
+const teamSlugCache = new Map<string, Promise<string>>();
+
+/**
+ * Resolve a team's actual GitHub slug, tolerating the case where GitHub normalized the team's slug
+ * differently from the `${courseSlug}-…` name we derive (e.g. a team created out-of-band). GET by the
+ * requested slug; on 404, scan the org's teams for one whose slug or name matches. Falls back to the
+ * requested slug when the team can't be found, so callers behave exactly as before in the common case
+ * (course slugs are already GitHub-normalized). Unlike getTeamAndCreateIfNeeded this never creates a
+ * team, so it's safe on read/permission paths that must not materialize an unwanted team. Cached per
+ * (org, requestedSlug) so repeated per-repo permission syncs don't refetch.
+ */
+export async function resolveExistingTeamSlug(org: string, team_slug: string, octokit: Octokit): Promise<string> {
+  const cacheKey = org + "-" + team_slug;
+  if (!teamSlugCache.has(cacheKey)) {
+    teamSlugCache.set(
+      cacheKey,
+      (async () => {
+        try {
+          const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
+          return team.data.slug ?? team_slug;
+        } catch (e) {
+          if (!(e instanceof RequestError && e.status === 404)) {
+            throw e;
+          }
+          const teams = await octokit.paginate("GET /orgs/{org}/teams", { org, per_page: 100 });
+          return teams.find((t) => t.slug === team_slug || t.name === team_slug)?.slug ?? team_slug;
+        }
+      })().catch((err) => {
+        teamSlugCache.delete(cacheKey);
+        throw err;
+      })
+    );
+  }
+  return teamSlugCache.get(cacheKey)!;
+}
+
 export async function reinviteToOrgTeam(org: string, team_slug: string, githubUsername: string, scope?: Sentry.Scope) {
   scope?.setTag("github_operation", "reinvite_to_team");
   scope?.setTag("org", org);
@@ -2263,7 +2299,10 @@ export async function syncRepoPermissions(
   if (!octokit) {
     throw new Error("No octokit found for organization " + org);
   }
-  const team_slug = `${courseSlug}-staff`;
+  // Resolve to the team's real GitHub slug: if the team was created out-of-band and GitHub
+  // normalized its slug differently from `${courseSlug}-staff`, the literal would 404 on the
+  // members/repo-access endpoints below, silently leaving repos without staff access.
+  const team_slug = await resolveExistingTeamSlug(org, `${courseSlug}-staff`, octokit);
   if (!staffTeamCache.has(org + "-" + courseSlug)) {
     staffTeamCache.set(
       org + "-" + courseSlug,
@@ -2320,8 +2359,9 @@ export async function syncRepoPermissions(
       permission: "maintain"
     });
   }
-  // Optionally grant the students team read access (mode 2 handout repos).
-  const studentsTeamSlug = `${courseSlug}-students`;
+  // Optionally grant the students team read access (mode 2 handout repos). Resolve the real slug for
+  // the same reason as the staff team above, so grant/revoke hit the correct team endpoint.
+  const studentsTeamSlug = await resolveExistingTeamSlug(org, `${courseSlug}-students`, octokit);
   if (options.studentTeamPermission) {
     const hasStudentsTeam = teamsWithAccess.some(
       (t) => t.slug === studentsTeamSlug && t.permission === options.studentTeamPermission

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1817,7 +1817,9 @@ export async function syncTeam(
     });
     members = data;
   } catch (e) {
-    if (e instanceof RequestError && e.message.includes("Not Found")) {
+    // Match on the 404 status, not the message text (GitHub rewords "Not Found"), consistent with
+    // getTeamAndCreateIfNeeded's status-based checks.
+    if (e instanceof RequestError && e.status === 404) {
       console.log(`Team ${resolvedSlug} not found`);
       console.log(e);
       //This seems to happen when there are no members in the team?
@@ -1959,7 +1961,9 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
       message: `Found ${teamMembers.length} members in team ${resolvedSlug}`,
       level: "info"
     });
-    isUserInTeam = teamMembers.some((member) => member.login === githubUsername);
+    // GitHub logins are case-insensitive; compare lowercased (as syncTeam does) so a casing
+    // difference between the members endpoint and githubUsername doesn't miss an existing member.
+    isUserInTeam = teamMembers.some((member) => member.login.toLowerCase() === githubUsername.toLowerCase());
   } catch (error) {
     console.log(`Error checking team membership: ${error}`);
     // Continue with invitation if we can't check membership

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1939,7 +1939,10 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
     level: "info"
   });
 
-  // Check if user is already in the team
+  // Check if user is already in the team. Keep ONLY the membership *check* inside this try, so a
+  // failure to read team members degrades to "proceed with invitation" — but the confirmation write
+  // below is deliberately outside it (see next block).
+  let isUserInTeam = false;
   try {
     scope?.addBreadcrumb({
       category: "github",
@@ -1956,36 +1959,33 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
       message: `Found ${teamMembers.length} members in team ${resolvedSlug}`,
       level: "info"
     });
-
-    const isUserInTeam = teamMembers.some((member) => member.login === githubUsername);
-    if (isUserInTeam) {
-      scope?.addBreadcrumb({
-        category: "github",
-        message: `User ${githubUsername} is already in team ${resolvedSlug}`,
-        level: "info"
-      });
-      // Guarantee our side reflects reality regardless of the caller: a user already in the team
-      // must have github_org_confirmed set, or the "accept your invitation" banner never clears.
-      // Isolate this write so a transient DB error is reported accurately and doesn't fall through
-      // to the invite flow (which would misattribute it as a membership-check failure and send a
-      // redundant invite to a user already in the team).
-      try {
-        await markUserRoleOrgConfirmedForTeam({ github_username: githubUsername, org, team_slug });
-      } catch (confirmErr) {
-        console.log(`Error marking org-confirmed for ${githubUsername} in team ${team_slug}: ${confirmErr}`);
-        Sentry.captureException(confirmErr, scope);
-      }
-      return false;
-    }
-    scope?.addBreadcrumb({
-      category: "github",
-      message: `User ${githubUsername} is not in team ${team_slug}, proceeding with invitation`,
-      level: "info"
-    });
+    isUserInTeam = teamMembers.some((member) => member.login === githubUsername);
   } catch (error) {
     console.log(`Error checking team membership: ${error}`);
     // Continue with invitation if we can't check membership
   }
+
+  if (isUserInTeam) {
+    scope?.addBreadcrumb({
+      category: "github",
+      message: `User ${githubUsername} is already in team ${resolvedSlug}; marking org-confirmed`,
+      level: "info"
+    });
+    // Guarantee our side reflects reality regardless of the caller: a user already in the team must
+    // have github_org_confirmed set, or the "accept your invitation" banner never clears. Let a
+    // failure here PROPAGATE rather than returning false: reporting a successful reconciliation when
+    // the confirmation write didn't stick would let the async team sync (whose intended-member query
+    // filters on github_org_confirmed = true) drop this already-present user from the team. Because
+    // this runs outside the membership-check try above, the throw isn't misattributed as a
+    // membership-check failure and doesn't fall through to the (redundant) invite flow.
+    await markUserRoleOrgConfirmedForTeam({ github_username: githubUsername, org, team_slug });
+    return false;
+  }
+  scope?.addBreadcrumb({
+    category: "github",
+    message: `User ${githubUsername} is not in team ${resolvedSlug}, proceeding with invitation`,
+    level: "info"
+  });
 
   // Proactively check whether the user is already an active member of the org.
   // GitHub's POST /orgs/{org}/invitations endpoint only works for non-members; for users that are

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1803,18 +1803,22 @@ export async function syncTeam(
     return;
   }
   const team = await getTeamAndCreateIfNeeded(org, team_slug, octokit);
-  console.log(`Using team ${team_slug} with id ${team.data.id}`);
+  // Use the team's ACTUAL slug for every subsequent team endpoint: if the team was resolved
+  // out-of-band, GitHub's normalized slug can differ from the requested name, and the member
+  // endpoints would 404 on the requested slug.
+  const resolvedSlug = team.data.slug ?? team_slug;
+  console.log(`Using team ${resolvedSlug} with id ${team.data.id}`);
   let members: Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["response"]["data"][] = [];
   try {
     const data = await octokit.paginate("GET /orgs/{org}/teams/{team_slug}/members", {
       org,
-      team_slug,
+      team_slug: resolvedSlug,
       per_page: 100
     });
     members = data;
   } catch (e) {
     if (e instanceof RequestError && e.message.includes("Not Found")) {
-      console.log(`Team ${team_slug} not found`);
+      console.log(`Team ${resolvedSlug} not found`);
       console.log(e);
       //This seems to happen when there are no members in the team?
       members = [];
@@ -1826,15 +1830,15 @@ export async function syncTeam(
   const existingMembers = members.map((m) => m.login.toLowerCase());
   const newMembers = githubUsernames.filter((u) => u && !existingMembers.includes(u));
   const removeMembers = existingMembers.filter((u) => u && !githubUsernames.includes(u));
-  console.log(`Class team: ${team_slug} intended members: ${githubUsernames.join(", ")}`);
-  console.log(`Existing members in team ${team_slug}: ${members.map((m) => m.login).join(", ")}`);
+  console.log(`Class team: ${resolvedSlug} intended members: ${githubUsernames.join(", ")}`);
+  console.log(`Existing members in team ${resolvedSlug}: ${members.map((m) => m.login).join(", ")}`);
   console.log(`New members to add: ${newMembers.join(", ")}`);
   console.log(`Members to remove: ${removeMembers.join(", ")}`);
   for (const username of newMembers) {
     try {
       await octokit.request("PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", {
         org,
-        team_slug,
+        team_slug: resolvedSlug,
         username,
         role: "member"
       });
@@ -1850,10 +1854,10 @@ export async function syncTeam(
   for (const username of removeMembers) {
     const newScope = scope?.clone();
     newScope?.setTag("username", username);
-    Sentry.captureMessage(`Removing member from team ${team_slug}`, newScope);
+    Sentry.captureMessage(`Removing member from team ${resolvedSlug}`, newScope);
     await octokit.request("DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}", {
       org,
-      team_slug,
+      team_slug: resolvedSlug,
       username
     });
   }
@@ -1887,7 +1891,12 @@ export async function getTeamAndCreateIfNeeded(org: string, team_slug: string, o
     console.log(`Team ${team_slug} already exists, resolving existing team`);
     try {
       return await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
-    } catch {
+    } catch (refetchErr) {
+      // Only treat a 404 as a slug-normalization mismatch worth a full team scan. A transient
+      // error (5xx, rate limit, network) must propagate rather than be masked by the fallback.
+      if (!(refetchErr instanceof RequestError && refetchErr.status === 404)) {
+        throw refetchErr;
+      }
       // GitHub may have normalized the slug differently from the name — find it by name/slug.
       const teams = await octokit.paginate("GET /orgs/{org}/teams", { org, per_page: 100 });
       const match = teams.find((t) => t.slug === team_slug || t.name === team_slug);
@@ -1915,6 +1924,10 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
     throw new Error("No octokit found for organization " + org);
   }
   const team = await getTeamAndCreateIfNeeded(org, team_slug, octokit);
+  // Use the team's ACTUAL slug for GitHub team endpoints (see syncTeam). Keep the requested
+  // team_slug for markUserRoleOrgConfirmedForTeam, which derives the class slug from our naming
+  // convention (`{classSlug}-staff|-students`), not GitHub's normalization.
+  const resolvedSlug = team.data.slug ?? team_slug;
   const user = await octokit.request("GET /users/{username}", {
     username: githubUsername
   });
@@ -1922,7 +1935,7 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
   const teamID = team.data.id;
   scope?.addBreadcrumb({
     category: "github",
-    message: `Team ${team_slug} has id ${teamID}`,
+    message: `Team ${resolvedSlug} has id ${teamID}`,
     level: "info"
   });
 
@@ -1930,17 +1943,17 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
   try {
     scope?.addBreadcrumb({
       category: "github",
-      message: `Checking if user ${githubUsername} is already in team ${team_slug}...`,
+      message: `Checking if user ${githubUsername} is already in team ${resolvedSlug}...`,
       level: "info"
     });
     const teamMembers = await octokit.paginate("GET /orgs/{org}/teams/{team_slug}/members", {
       org,
-      team_slug,
+      team_slug: resolvedSlug,
       per_page: 100 // Optimize for large teams
     });
     scope?.addBreadcrumb({
       category: "github",
-      message: `Found ${teamMembers.length} members in team ${team_slug}`,
+      message: `Found ${teamMembers.length} members in team ${resolvedSlug}`,
       level: "info"
     });
 
@@ -1948,12 +1961,20 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
     if (isUserInTeam) {
       scope?.addBreadcrumb({
         category: "github",
-        message: `User ${githubUsername} is already in team ${team_slug}`,
+        message: `User ${githubUsername} is already in team ${resolvedSlug}`,
         level: "info"
       });
       // Guarantee our side reflects reality regardless of the caller: a user already in the team
       // must have github_org_confirmed set, or the "accept your invitation" banner never clears.
-      await markUserRoleOrgConfirmedForTeam({ github_username: githubUsername, org, team_slug });
+      // Isolate this write so a transient DB error is reported accurately and doesn't fall through
+      // to the invite flow (which would misattribute it as a membership-check failure and send a
+      // redundant invite to a user already in the team).
+      try {
+        await markUserRoleOrgConfirmedForTeam({ github_username: githubUsername, org, team_slug });
+      } catch (confirmErr) {
+        console.log(`Error marking org-confirmed for ${githubUsername} in team ${team_slug}: ${confirmErr}`);
+        Sentry.captureException(confirmErr, scope);
+      }
       return false;
     }
     scope?.addBreadcrumb({
@@ -2007,12 +2028,12 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
   if (isAlreadyActiveOrgMember) {
     scope?.addBreadcrumb({
       category: "github",
-      message: `User ${githubUsername} is already in org ${org}; adding directly to team ${team_slug}`,
+      message: `User ${githubUsername} is already in org ${org}; adding directly to team ${resolvedSlug}`,
       level: "info"
     });
     await octokit.request("PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", {
       org,
-      team_slug,
+      team_slug: resolvedSlug,
       username: githubUsername,
       role: "member"
     });

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1094,6 +1094,28 @@ function isRepoNameAlreadyExistsError(e: unknown): boolean {
 }
 
 /**
+ * True when a `POST /orgs/{org}/teams` failed because a team with that name already exists.
+ * GitHub returns 422 with `errors: [{ resource: "Team", code: "already_exists", field: "name" }]`;
+ * the human message varies ("already exists", "Name must be unique for this org"), so check the
+ * structured `code` first and fall back to the message. This lets team creation be idempotent under
+ * concurrent syncs (two workers both 404 on GET, both POST, one 422s) and when a same-named team was
+ * created out-of-band.
+ */
+export function isTeamAlreadyExistsError(e: unknown): boolean {
+  if (!(e instanceof RequestError) || e.status !== 422) return false;
+  const errors = (e.response?.data as { errors?: unknown } | undefined)?.errors;
+  if (Array.isArray(errors)) {
+    for (const err of errors) {
+      if (err && typeof err === "object" && (err as { code?: string }).code === "already_exists") {
+        return true;
+      }
+    }
+  }
+  const msg = (e.message ?? "").toLowerCase();
+  return msg.includes("already exists") || msg.includes("name must be unique");
+}
+
+/**
  * Shared post-create finalization: enable squash merge + template flag, enable Actions, resolve the
  * default branch's head SHA, and apply the branch-protection ruleset. Run identically for freshly
  * created, repaired, and adopted pre-existing repos so the paths never drift. Returns the head SHA.
@@ -1780,27 +1802,8 @@ export async function syncTeam(
     console.warn("No octokit found for organization " + org);
     return;
   }
-  let team_id: number;
-  try {
-    const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", {
-      org,
-      team_slug
-    });
-    team_id = team.data.id;
-    console.log(`Found team ${team_slug} with id ${team_id}`);
-  } catch (e) {
-    if (e instanceof RequestError && e.message.includes("Not Found")) {
-      // Team doesn't exist, create it
-      const newTeam = await octokit.request("POST /orgs/{org}/teams", {
-        org,
-        name: team_slug
-      });
-      team_id = newTeam.data.id;
-      console.log(`Created team ${team_slug} with id ${team_id}`);
-    } else {
-      throw e;
-    }
-  }
+  const team = await getTeamAndCreateIfNeeded(org, team_slug, octokit);
+  console.log(`Using team ${team_slug} with id ${team.data.id}`);
   let members: Endpoints["GET /orgs/{org}/teams/{team_slug}/members"]["response"]["data"][] = [];
   try {
     const data = await octokit.paginate("GET /orgs/{org}/teams/{team_slug}/members", {
@@ -1855,24 +1858,44 @@ export async function syncTeam(
     });
   }
 }
-async function getTeamAndCreateIfNeeded(org: string, team_slug: string, octokit: Octokit) {
+/**
+ * Idempotently resolve a team by slug, creating it if it doesn't exist yet. Tolerates the race /
+ * pre-existing cases where `GET` 404s but `POST` then 422s ("already_exists"): on that 422 we
+ * re-fetch by slug, and if the existing team's slug differs from the requested name we locate it in
+ * the org's team list. Callers use `.data.id` / `.data.slug`.
+ */
+export async function getTeamAndCreateIfNeeded(org: string, team_slug: string, octokit: Octokit) {
+  // Fast path: the team already exists under this slug.
   try {
-    const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", {
-      org,
-      team_slug
-    });
-    return team;
+    return await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
   } catch (e) {
-    console.log(`Team ${team_slug} not found, creating it`);
-    if (e instanceof RequestError && e.message.includes("Not Found")) {
-      // Team doesn't exist, create it
-      const newTeam = await octokit.request("POST /orgs/{org}/teams", {
-        org,
-        name: team_slug
-      });
-      return newTeam;
+    if (!(e instanceof RequestError && e.status === 404)) {
+      throw e;
     }
-    throw e;
+  }
+
+  // Not found by slug — create it.
+  console.log(`Team ${team_slug} not found, creating it`);
+  try {
+    return await octokit.request("POST /orgs/{org}/teams", { org, name: team_slug });
+  } catch (e) {
+    if (!isTeamAlreadyExistsError(e)) {
+      throw e;
+    }
+    // A team with this name already exists (concurrent create won, or created out-of-band).
+    // Re-fetch by slug; the created slug usually matches the requested name.
+    console.log(`Team ${team_slug} already exists, resolving existing team`);
+    try {
+      return await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
+    } catch {
+      // GitHub may have normalized the slug differently from the name — find it by name/slug.
+      const teams = await octokit.paginate("GET /orgs/{org}/teams", { org, per_page: 100 });
+      const match = teams.find((t) => t.slug === team_slug || t.name === team_slug);
+      if (!match) {
+        throw e;
+      }
+      return await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug: match.slug });
+    }
   }
 }
 
@@ -1928,6 +1951,9 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
         message: `User ${githubUsername} is already in team ${team_slug}`,
         level: "info"
       });
+      // Guarantee our side reflects reality regardless of the caller: a user already in the team
+      // must have github_org_confirmed set, or the "accept your invitation" banner never clears.
+      await markUserRoleOrgConfirmedForTeam({ github_username: githubUsername, org, team_slug });
       return false;
     }
     scope?.addBreadcrumb({

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2099,13 +2099,13 @@ export async function reinviteToOrgTeam(org: string, team_slug: string, githubUs
     if (structurallyAlreadyMember || textuallyAlreadyMember) {
       scope?.addBreadcrumb({
         category: "github",
-        message: `User ${githubUsername} appears to already be in org ${org}; adding to team ${team_slug}`,
+        message: `User ${githubUsername} appears to already be in org ${org}; adding to team ${resolvedSlug}`,
         level: "info"
       });
-      //Add them to the team directly...
+      //Add them to the team directly (use the team's actual slug, not the requested class slug)...
       await octokit.request("PUT /orgs/{org}/teams/{team_slug}/memberships/{username}", {
         org,
-        team_slug,
+        team_slug: resolvedSlug,
         username: githubUsername,
         role: "member"
       });

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -853,22 +853,40 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   if (!user) {
     throw new SecurityError("User not found");
   }
-  const { data: classData, error: classError } = await supabase
+  const { data: classRows, error: classError } = await supabase
     .from("classes")
     .select("github_org, user_roles!inner(user_id, disabled)")
     .eq("user_roles.user_id", user.id)
     .eq("user_roles.disabled", false)
-    .not("github_org", "is", "null")
-    .limit(1)
-    .single();
+    .not("github_org", "is", "null");
   if (classError) {
     Sentry.captureException(classError, scope);
     throw new UserVisibleError("Error fetching class");
   }
-  if (!classData) {
+  const orgs = [...new Set((classRows ?? []).map((c) => c.github_org).filter((o): o is string => Boolean(o)))];
+  if (orgs.length === 0) {
     throw new UserVisibleError("User not in any classes");
   }
-  return await syncGitHubUser(user.id, classData.github_org!, false, scope);
+
+  // syncGitHubUser reconciles ALL of the user's enrolled orgs/teams internally (see
+  // ensureAllReposExist + ensureStaffOrgMembership), so a single successful call covers every org.
+  // The org argument only selects which org's GitHub App installation resolves the login from the
+  // github_user_id — so try each until one succeeds, ensuring one mis-installed org doesn't block
+  // reconciliation of the rest.
+  let lastError: unknown;
+  for (const org of orgs) {
+    try {
+      return await syncGitHubUser(user.id, org, false, scope);
+    } catch (e) {
+      lastError = e;
+      scope?.addBreadcrumb({
+        category: "github",
+        level: "warning",
+        message: `GitHub sync via org ${org} failed, trying next org if any: ${e}`
+      });
+    }
+  }
+  throw lastError instanceof Error ? lastError : new UserVisibleError("Error syncing GitHub account");
 }
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -884,11 +884,20 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   // github_user_id — so try each until one succeeds, ensuring one mis-installed org doesn't block
   // reconciliation of the rest.
   let lastError: unknown;
-  for (const org of orgs) {
+  for (let i = 0; i < orgs.length; i++) {
+    const org = orgs[i];
+    // The first attempt respects the throttle decision (hasUnconfirmedEnrollment). RETRIES force
+    // past it: syncGitHubUser stamps last_github_user_sync before reconciling, so a first attempt
+    // that throws mid-reconcile would leave a retry hitting the 24h recent-sync gate — which returns
+    // a benign "synced recently" response that would mask the real failure and report a repair that
+    // never happened. Forcing retries makes them actually run (and surface a real error if they too
+    // fail).
+    const force = i === 0 ? hasUnconfirmedEnrollment : true;
     try {
-      return await syncGitHubUser(user.id, org, hasUnconfirmedEnrollment, scope);
+      return await syncGitHubUser(user.id, org, force, scope);
     } catch (e) {
       lastError = e;
+      Sentry.captureException(e, scope);
       scope?.addBreadcrumb({
         category: "github",
         level: "warning",

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -128,17 +128,20 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   const errorMessages: string[] = [];
 
   for (const c of classes) {
-    if (c!.classes.github_org) {
+    // Require both org and slug: the student team name is derived as `${slug}-students`, so a class
+    // with github_org set but slug still NULL would reconcile against a bogus `null-students` team.
+    // Mirrors the staff loop above and the team-sync migration (20260611120001).
+    if (c!.classes.github_org && c!.classes.slug) {
       Sentry.addBreadcrumb({
         category: "github",
-        message: `Reinviting user ${githubUsername} to org ${c!.classes.github_org}, team ${c!.classes.slug! + "-students"}`,
+        message: `Reinviting user ${githubUsername} to org ${c!.classes.github_org}, team ${c!.classes.slug + "-students"}`,
         level: "info"
       });
       // Reconcile each enrolled org independently: a failure in one org (broken installation,
       // transient GitHub/DB error) must not abort reconciliation of the user's other orgs. Record
       // and continue rather than throwing out of the whole sync.
       try {
-        const resp = await reinviteToOrgTeam(c!.classes.github_org, c!.classes.slug! + "-students", githubUsername);
+        const resp = await reinviteToOrgTeam(c!.classes.github_org, c!.classes.slug + "-students", githubUsername);
         madeChanges = madeChanges || resp;
         if (!resp) {
           await adminSupabase

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -882,8 +882,11 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   // throttled with github_org_confirmed = false — the "accept your invitation" banner stuck for 24h.
   // Deciding force server-side from github_org_confirmed (not a client flag) keeps the throttle's
   // anti-spam guarantee for already-reconciled users while letting a stuck user retry each login.
+  // Treat NULL github_org_confirmed as unconfirmed too (the column is nullable): the invitation
+  // banner shows whenever github_org_confirmed is falsy, so `!== true` keeps this force decision
+  // aligned with the banner instead of skipping NULL rows that still show the stuck banner.
   const hasUnconfirmedEnrollment = (classRows ?? []).some((c) =>
-    (c.user_roles ?? []).some((r) => r.github_org_confirmed === false)
+    (c.user_roles ?? []).some((r) => r.github_org_confirmed !== true)
   );
 
   // syncGitHubUser reconciles ALL of the user's enrolled orgs/teams internally (see
@@ -900,7 +903,7 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
     // a benign "synced recently" response that would mask the real failure and report a repair that
     // never happened. Forcing retries makes them actually run (and surface a real error if they too
     // fail).
-    const force = i === 0 ? hasUnconfirmedEnrollment : true;
+    const force = i > 0 || hasUnconfirmedEnrollment;
     try {
       return await syncGitHubUser(user.id, org, force, scope);
     } catch (e) {

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -855,7 +855,7 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   }
   const { data: classRows, error: classError } = await supabase
     .from("classes")
-    .select("github_org, user_roles!inner(user_id, disabled)")
+    .select("github_org, user_roles!inner(user_id, disabled, github_org_confirmed)")
     .eq("user_roles.user_id", user.id)
     .eq("user_roles.disabled", false)
     .not("github_org", "is", "null");
@@ -868,6 +868,16 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
     throw new UserVisibleError("User not in any classes");
   }
 
+  // Force past syncGitHubUser's 24h recent-sync throttle when the user still has an unconfirmed
+  // org enrollment. syncGitHubUser stamps last_github_user_sync before reconciling, so a run that
+  // failed part-way (e.g. a transient error in ensureAllReposExist) would otherwise leave the user
+  // throttled with github_org_confirmed = false — the "accept your invitation" banner stuck for 24h.
+  // Deciding force server-side from github_org_confirmed (not a client flag) keeps the throttle's
+  // anti-spam guarantee for already-reconciled users while letting a stuck user retry each login.
+  const hasUnconfirmedEnrollment = (classRows ?? []).some((c) =>
+    (c.user_roles ?? []).some((r) => r.github_org_confirmed === false)
+  );
+
   // syncGitHubUser reconciles ALL of the user's enrolled orgs/teams internally (see
   // ensureAllReposExist + ensureStaffOrgMembership), so a single successful call covers every org.
   // The org argument only selects which org's GitHub App installation resolves the login from the
@@ -876,7 +886,7 @@ async function handleStudentGitHubSync(req: Request, scope: Sentry.Scope) {
   let lastError: unknown;
   for (const org of orgs) {
     try {
-      return await syncGitHubUser(user.id, org, false, scope);
+      return await syncGitHubUser(user.id, org, hasUnconfirmedEnrollment, scope);
     } catch (e) {
       lastError = e;
       scope?.addBreadcrumb({

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -185,14 +185,25 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   const assignments = allAssignments.filter(
     (a) =>
       a.template_repo?.includes("/") &&
+      // Skip assignments in classes that aren't GitHub-ready (no org, or slug still NULL): the repo
+      // name is built from `${slug}-...` and the row from `${github_org}/...`, so a partially
+      // configured class would produce bogus `null-*` repos. Mirrors the invite-loop guard above.
+      a.classes?.github_org &&
+      a.classes?.slug &&
       ((a.release_date && new TZDate(a.release_date, a.classes.time_zone!) < TZDate.tz(a.classes.time_zone!)) ||
         a.classes.user_roles.some((r) => r.role === "instructor" || r.role === "grader"))
   );
 
   //For each group repo, sync the permissions
   const createdAsGroupRepos = await Promise.all(
-    classes.flatMap((c) =>
-      c!.profiles!.assignment_groups_members!.flatMap(async (groupMembership) => {
+    classes.flatMap((c) => {
+      // Skip classes that aren't GitHub-ready (no org, or slug still NULL): repo names/rows below are
+      // built from `${slug}-...` / `${github_org}/...`, so a partially configured class would create
+      // bogus `null-*` repositories. Mirrors the invite-loop guard above.
+      if (!c!.classes.github_org || !c!.classes.slug) {
+        return [];
+      }
+      return c!.profiles!.assignment_groups_members!.flatMap(async (groupMembership) => {
         const group = groupMembership.assignment_groups;
         const assignment = groupMembership.assignments;
         if (!assignment.template_repo?.includes("/")) {
@@ -298,8 +309,8 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
           Sentry.captureException(e, scope);
           errorMessages.push(`Error syncing repo permissions for ${repoName}`);
         }
-      })
-    )
+      });
+    })
   );
 
   const requests = assignments!

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -125,6 +125,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   }
 
   let madeChanges = false;
+  const errorMessages: string[] = [];
 
   for (const c of classes) {
     if (c!.classes.github_org) {
@@ -133,14 +134,22 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         message: `Reinviting user ${githubUsername} to org ${c!.classes.github_org}, team ${c!.classes.slug! + "-students"}`,
         level: "info"
       });
-      const resp = await reinviteToOrgTeam(c!.classes.github_org, c!.classes.slug! + "-students", githubUsername);
-      madeChanges = madeChanges || resp;
-      if (!resp) {
-        await adminSupabase
-          .from("user_roles")
-          .update({ github_org_confirmed: true })
-          .eq("user_id", userID)
-          .eq("class_id", c!.class_id);
+      // Reconcile each enrolled org independently: a failure in one org (broken installation,
+      // transient GitHub/DB error) must not abort reconciliation of the user's other orgs. Record
+      // and continue rather than throwing out of the whole sync.
+      try {
+        const resp = await reinviteToOrgTeam(c!.classes.github_org, c!.classes.slug! + "-students", githubUsername);
+        madeChanges = madeChanges || resp;
+        if (!resp) {
+          await adminSupabase
+            .from("user_roles")
+            .update({ github_org_confirmed: true })
+            .eq("user_id", userID)
+            .eq("class_id", c!.class_id);
+        }
+      } catch (e) {
+        Sentry.captureException(e, scope);
+        errorMessages.push(`Error reconciling org membership for ${c!.classes.github_org}/${c!.classes.slug}-students`);
       }
     }
   }
@@ -177,7 +186,6 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         a.classes.user_roles.some((r) => r.role === "instructor" || r.role === "grader"))
   );
 
-  const errorMessages: string[] = [];
   //For each group repo, sync the permissions
   const createdAsGroupRepos = await Promise.all(
     classes.flatMap((c) =>

--- a/supabase/migrations/20260715120000_global_default_template_repos.sql
+++ b/supabase/migrations/20260715120000_global_default_template_repos.sql
@@ -15,16 +15,47 @@
 -- config in 20260528120000_lti_1_3_integration.sql:
 --     ALTER DATABASE postgres SET app.settings.default_handout_template_repo  = 'my-org/handout';
 --     ALTER DATABASE postgres SET app.settings.default_solution_template_repo = 'my-org/grader';
--- (new connections pick it up; run `SELECT pg_reload_conf();` is not required for a DATABASE-level
--- SET, but existing sessions must reconnect.)
+-- (existing sessions must reconnect to pick up a DATABASE-level SET).
 --
--- current_setting(..., true) returns NULL when the GUC is unset, so a deployment that never sets it
--- behaves exactly as before (falls through to the pawtograder/* constant). The TS constants in
--- supabase/functions/_shared/GitHubSyncHelpers.ts remain the last-resort literal and are unchanged;
--- resolve_class_template_repos stays the source of truth.
+-- The resolution + the "owner/repo" validation (previously duplicated per call site) are centralized
+-- in one STABLE helper, public.resolve_effective_template_repo, so the GUC name, the format check,
+-- and the hardcoded constant live in a single place. The helper validates the GUC value the same
+-- way admin-supplied overrides are validated (set_class_template_overrides / admin_upsert_github_org):
+-- a deployment typo (missing slash, stray whitespace) is ignored and falls through to the constant
+-- rather than silently propagating an invalid repo string into the repo-creation edge functions.
 --
--- Only the final COALESCE fallback of each resolver changes below; all guards/security/return
--- shapes are reproduced verbatim from 20260529140000.
+-- The TS constants in supabase/functions/_shared/GitHubSyncHelpers.ts remain the last-resort literal
+-- and are unchanged; resolve_class_template_repos stays the source of truth.
+
+----------------------------------------------------------------------------------------
+-- Shared resolver: override -> org default -> validated GUC -> constant
+----------------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.resolve_effective_template_repo(
+    p_override text,
+    p_org_default text,
+    p_guc_name text,
+    p_constant text
+) RETURNS text
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+    SELECT COALESCE(
+        p_override,
+        p_org_default,
+        -- Only honor the GUC when it's a well-formed "owner/repo"; otherwise ignore it so a
+        -- deployment typo can't propagate an invalid repo string (matches the override validation).
+        CASE
+            WHEN current_setting(p_guc_name, true) ~ '^[^/[:space:]]+/[^/[:space:]]+$'
+            THEN current_setting(p_guc_name, true)
+        END,
+        p_constant
+    );
+$$;
+
+COMMENT ON FUNCTION public.resolve_effective_template_repo(text, text, text, text) IS
+    'Resolve a template repo: per-class/admin override -> org default -> validated app.settings GUC -> hardcoded constant.';
 
 ----------------------------------------------------------------------------------------
 -- resolve_class_template_repos: the hot path used by the edge functions when creating repos.
@@ -46,18 +77,12 @@ BEGIN
 
     RETURN QUERY
     SELECT
-        COALESCE(
-            c.handout_template_repo,
-            go.default_handout_template_repo,
-            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
-            'pawtograder/template-assignment-handout'
-        ),
-        COALESCE(
-            c.solution_template_repo,
-            go.default_solution_template_repo,
-            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
-            'pawtograder/template-assignment-grader'
-        )
+        public.resolve_effective_template_repo(
+            c.handout_template_repo, go.default_handout_template_repo,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            c.solution_template_repo, go.default_solution_template_repo,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader')
     FROM public.classes c
     LEFT JOIN public.github_orgs go ON go.org_name = c.github_org
     WHERE c.id = p_class_id;
@@ -96,16 +121,12 @@ BEGIN
     )
     SELECT
         o.org_name,
-        COALESCE(
-            go.default_handout_template_repo,
-            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
-            'pawtograder/template-assignment-handout'
-        ),
-        COALESCE(
-            go.default_solution_template_repo,
-            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
-            'pawtograder/template-assignment-grader'
-        ),
+        public.resolve_effective_template_repo(
+            NULL, go.default_handout_template_repo,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            NULL, go.default_solution_template_repo,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         (SELECT COUNT(*) FROM public.classes c WHERE c.github_org = o.org_name)::bigint,
         (go.org_name IS NOT NULL) AS is_configured,
         go.created_at,
@@ -156,30 +177,22 @@ BEGIN
         updated_by
     ) VALUES (
         trim(p_org_name),
-        COALESCE(
-            NULLIF(trim(p_handout), ''),
-            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
-            'pawtograder/template-assignment-handout'
-        ),
-        COALESCE(
-            NULLIF(trim(p_solution), ''),
-            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
-            'pawtograder/template-assignment-grader'
-        ),
+        public.resolve_effective_template_repo(
+            NULLIF(trim(p_handout), ''), NULL,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            NULLIF(trim(p_solution), ''), NULL,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         auth.uid(),
         auth.uid()
     )
     ON CONFLICT (org_name) DO UPDATE SET
-        default_handout_template_repo = COALESCE(
-            NULLIF(trim(p_handout), ''),
-            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
-            'pawtograder/template-assignment-handout'
-        ),
-        default_solution_template_repo = COALESCE(
-            NULLIF(trim(p_solution), ''),
-            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
-            'pawtograder/template-assignment-grader'
-        ),
+        default_handout_template_repo = public.resolve_effective_template_repo(
+            NULLIF(trim(p_handout), ''), NULL,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        default_solution_template_repo = public.resolve_effective_template_repo(
+            NULLIF(trim(p_solution), ''), NULL,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         updated_by = auth.uid(),
         updated_at = now();
 END;
@@ -217,21 +230,23 @@ BEGIN
         COALESCE(c.archived, false),
         c.handout_template_repo,
         c.solution_template_repo,
-        COALESCE(
-            c.handout_template_repo,
-            go.default_handout_template_repo,
-            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
-            'pawtograder/template-assignment-handout'
-        ),
-        COALESCE(
-            c.solution_template_repo,
-            go.default_solution_template_repo,
-            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
-            'pawtograder/template-assignment-grader'
-        )
+        public.resolve_effective_template_repo(
+            c.handout_template_repo, go.default_handout_template_repo,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            c.solution_template_repo, go.default_solution_template_repo,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader')
     FROM public.classes c
     LEFT JOIN public.github_orgs go ON go.org_name = c.github_org
     WHERE c.github_org = p_org_name
     ORDER BY c.name;
 END;
 $$;
+
+----------------------------------------------------------------------------------------
+-- Grants: the helper is called from within SECURITY DEFINER functions (so it runs with the
+-- definer's rights there), but grant execute explicitly for directness/consistency.
+----------------------------------------------------------------------------------------
+
+REVOKE EXECUTE ON FUNCTION public.resolve_effective_template_repo(text, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.resolve_effective_template_repo(text, text, text, text) TO authenticated, service_role;

--- a/supabase/migrations/20260715120000_global_default_template_repos.sql
+++ b/supabase/migrations/20260715120000_global_default_template_repos.sql
@@ -244,9 +244,15 @@ END;
 $$;
 
 ----------------------------------------------------------------------------------------
--- Grants: the helper is called from within SECURITY DEFINER functions (so it runs with the
--- definer's rights there), but grant execute explicitly for directness/consistency.
+-- Grants: DO NOT expose this helper as a PostgREST RPC. It returns current_setting(p_guc_name)
+-- for a caller-supplied GUC name, so granting it to `authenticated` would let any signed-in user
+-- read arbitrary GUC-stored settings — including secrets like app.settings.lti_cron_secret that
+-- happen to match the owner/repo shape. The SECURITY DEFINER resolver/admin functions above call it
+-- as the function owner, so no role grant is needed for internal use. Revoke the default PUBLIC
+-- EXECUTE so it is not reachable via the API.
 ----------------------------------------------------------------------------------------
 
-REVOKE EXECUTE ON FUNCTION public.resolve_effective_template_repo(text, text, text, text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.resolve_effective_template_repo(text, text, text, text) TO authenticated, service_role;
+-- Revoke from the API roles explicitly (not just PUBLIC): CREATE OR REPLACE preserves prior ACLs,
+-- so this guarantees the owner-only end state even if an earlier revision granted these roles.
+REVOKE ALL ON FUNCTION public.resolve_effective_template_repo(text, text, text, text)
+    FROM PUBLIC, anon, authenticated, service_role;

--- a/supabase/migrations/20260715120000_global_default_template_repos.sql
+++ b/supabase/migrations/20260715120000_global_default_template_repos.sql
@@ -1,0 +1,237 @@
+-- Per-deployment (site-wide) default handout/solution template repos.
+--
+-- Background: 20260529140000_github_org_templates.sql introduced a three-tier resolution for the
+-- handout/solution template repos: per-class override -> per-GitHub-org default -> hardcoded
+-- constant ('pawtograder/template-assignment-handout' / '-grader'). On a fresh deployment that runs
+-- its own GitHub org, neither a per-class override nor a github_orgs row exists yet, so every class
+-- falls all the way through to the pawtograder/* constants baked into the migration. Changing that
+-- default meant editing a migration.
+--
+-- This migration inserts a new "site default" tier, read from a Postgres GUC, BETWEEN the org
+-- default and the hardcoded constant:
+--     class override -> org default -> app.settings.default_*_template_repo (GUC) -> constant
+--
+-- The GUC is the "env var to the Postgres pod" equivalent, set per-deployment exactly like the LTI
+-- config in 20260528120000_lti_1_3_integration.sql:
+--     ALTER DATABASE postgres SET app.settings.default_handout_template_repo  = 'my-org/handout';
+--     ALTER DATABASE postgres SET app.settings.default_solution_template_repo = 'my-org/grader';
+-- (new connections pick it up; run `SELECT pg_reload_conf();` is not required for a DATABASE-level
+-- SET, but existing sessions must reconnect.)
+--
+-- current_setting(..., true) returns NULL when the GUC is unset, so a deployment that never sets it
+-- behaves exactly as before (falls through to the pawtograder/* constant). The TS constants in
+-- supabase/functions/_shared/GitHubSyncHelpers.ts remain the last-resort literal and are unchanged;
+-- resolve_class_template_repos stays the source of truth.
+--
+-- Only the final COALESCE fallback of each resolver changes below; all guards/security/return
+-- shapes are reproduced verbatim from 20260529140000.
+
+----------------------------------------------------------------------------------------
+-- resolve_class_template_repos: the hot path used by the edge functions when creating repos.
+-- The GUC tier only matters here when a class has no per-class override AND no github_orgs row,
+-- i.e. the fresh-deployment case.
+----------------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.resolve_class_template_repos(p_class_id bigint)
+RETURNS TABLE (handout_template_repo text, solution_template_repo text)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT (auth.role() = 'service_role' OR public.authorizeforclassinstructor(p_class_id)) THEN
+        RAISE EXCEPTION 'Access denied: instructor role required for class %', p_class_id;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        COALESCE(
+            c.handout_template_repo,
+            go.default_handout_template_repo,
+            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
+            'pawtograder/template-assignment-handout'
+        ),
+        COALESCE(
+            c.solution_template_repo,
+            go.default_solution_template_repo,
+            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
+            'pawtograder/template-assignment-grader'
+        )
+    FROM public.classes c
+    LEFT JOIN public.github_orgs go ON go.org_name = c.github_org
+    WHERE c.id = p_class_id;
+END;
+$$;
+
+----------------------------------------------------------------------------------------
+-- admin_get_github_orgs: reports each org's effective default; the GUC tier applies to orgs
+-- that don't yet have a github_orgs row (is_configured = false).
+----------------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_get_github_orgs()
+RETURNS TABLE (
+    org_name text,
+    default_handout_template_repo text,
+    default_solution_template_repo text,
+    course_count bigint,
+    is_configured boolean,
+    created_at timestamptz,
+    updated_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT public.authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    RETURN QUERY
+    WITH orgs AS (
+        SELECT go.org_name FROM public.github_orgs go
+        UNION
+        SELECT DISTINCT c.github_org AS org_name FROM public.classes c WHERE c.github_org IS NOT NULL
+    )
+    SELECT
+        o.org_name,
+        COALESCE(
+            go.default_handout_template_repo,
+            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
+            'pawtograder/template-assignment-handout'
+        ),
+        COALESCE(
+            go.default_solution_template_repo,
+            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
+            'pawtograder/template-assignment-grader'
+        ),
+        (SELECT COUNT(*) FROM public.classes c WHERE c.github_org = o.org_name)::bigint,
+        (go.org_name IS NOT NULL) AS is_configured,
+        go.created_at,
+        go.updated_at
+    FROM orgs o
+    LEFT JOIN public.github_orgs go ON go.org_name = o.org_name
+    ORDER BY o.org_name;
+END;
+$$;
+
+----------------------------------------------------------------------------------------
+-- admin_upsert_github_org: when the admin leaves a default blank, materialize the site default
+-- (GUC) rather than the hardcoded constant, so a fresh org inherits the deployment's default.
+----------------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_upsert_github_org(
+    p_org_name text,
+    p_handout text DEFAULT NULL,
+    p_solution text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT public.authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    IF p_org_name IS NULL OR trim(p_org_name) = '' THEN
+        RAISE EXCEPTION 'Org name is required';
+    END IF;
+
+    -- A non-empty default must be exactly "owner/repo" (NULL/empty falls back to site default -> constant).
+    IF NULLIF(trim(p_handout), '') IS NOT NULL AND trim(p_handout) !~ '^[^/[:space:]]+/[^/[:space:]]+$' THEN
+        RAISE EXCEPTION 'Invalid handout template repo "%": expected "owner/repo"', p_handout;
+    END IF;
+    IF NULLIF(trim(p_solution), '') IS NOT NULL AND trim(p_solution) !~ '^[^/[:space:]]+/[^/[:space:]]+$' THEN
+        RAISE EXCEPTION 'Invalid solution template repo "%": expected "owner/repo"', p_solution;
+    END IF;
+
+    INSERT INTO public.github_orgs (
+        org_name,
+        default_handout_template_repo,
+        default_solution_template_repo,
+        created_by,
+        updated_by
+    ) VALUES (
+        trim(p_org_name),
+        COALESCE(
+            NULLIF(trim(p_handout), ''),
+            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
+            'pawtograder/template-assignment-handout'
+        ),
+        COALESCE(
+            NULLIF(trim(p_solution), ''),
+            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
+            'pawtograder/template-assignment-grader'
+        ),
+        auth.uid(),
+        auth.uid()
+    )
+    ON CONFLICT (org_name) DO UPDATE SET
+        default_handout_template_repo = COALESCE(
+            NULLIF(trim(p_handout), ''),
+            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
+            'pawtograder/template-assignment-handout'
+        ),
+        default_solution_template_repo = COALESCE(
+            NULLIF(trim(p_solution), ''),
+            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
+            'pawtograder/template-assignment-grader'
+        ),
+        updated_by = auth.uid(),
+        updated_at = now();
+END;
+$$;
+
+----------------------------------------------------------------------------------------
+-- admin_get_org_courses: effective (resolved) templates per course, mirroring the resolver.
+----------------------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.admin_get_org_courses(p_org_name text)
+RETURNS TABLE (
+    id bigint,
+    name text,
+    term integer,
+    archived boolean,
+    handout_template_repo text,
+    solution_template_repo text,
+    effective_handout_template_repo text,
+    effective_solution_template_repo text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT public.authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        c.id,
+        c.name,
+        c.term,
+        COALESCE(c.archived, false),
+        c.handout_template_repo,
+        c.solution_template_repo,
+        COALESCE(
+            c.handout_template_repo,
+            go.default_handout_template_repo,
+            NULLIF(current_setting('app.settings.default_handout_template_repo', true), ''),
+            'pawtograder/template-assignment-handout'
+        ),
+        COALESCE(
+            c.solution_template_repo,
+            go.default_solution_template_repo,
+            NULLIF(current_setting('app.settings.default_solution_template_repo', true), ''),
+            'pawtograder/template-assignment-grader'
+        )
+    FROM public.classes c
+    LEFT JOIN public.github_orgs go ON go.org_name = c.github_org
+    WHERE c.github_org = p_org_name
+    ORDER BY c.name;
+END;
+$$;

--- a/supabase/migrations/20260715120100_hide_unreleased_assignments_from_student_dashboard.sql
+++ b/supabase/migrations/20260715120100_hide_unreleased_assignments_from_student_dashboard.sql
@@ -1,0 +1,389 @@
+-- Hide not-yet-released assignments from the student assignments dashboard.
+--
+-- Bug: public.get_assignments_for_student_dashboard is SECURITY DEFINER, so the assignments RLS
+-- ("read assignments in own class regardless of release date") does not gate it. The RPC returned
+-- every non-archived assignment for the class, so a student's "Assignments" tab
+-- (app/course/[course_id]/assignments/page.tsx) listed assignments whose release_date is still in
+-- the future — even though the individual assignment page already redirects students away from an
+-- unreleased assignment (app/course/[course_id]/assignments/[assignment_id]/layout.tsx).
+--
+-- Fix: add a release gate to the final WHERE, mirroring the gate this same function already applies
+-- to review_assignments (`ra.release_date IS NULL OR ra.release_date <= now()`, added in
+-- 20260529120000). A NULL release_date means "always released" (matches the individual-assignment
+-- redirect, which only redirects when release_date is set AND in the future).
+--
+-- The gate applies to every caller of this student-dashboard RPC — real students and staff using
+-- view-as-student / gradebook what-if — which is intentional: this RPC represents the student's
+-- view. Instructor/grader management surfaces load assignments through other queries (the
+-- assignments TableController's `.from("assignments").select("*")`), which are unaffected, so staff
+-- still see unreleased assignments in their management views.
+--
+-- Everything below is copied verbatim from 20260529120000_dashboard_rpc_gate_grading_release.sql
+-- except the final WHERE clause.
+
+CREATE OR REPLACE FUNCTION public.get_assignments_for_student_dashboard(
+  p_class_id bigint,
+  p_student_profile_id uuid
+) RETURNS TABLE (
+  id bigint,
+  created_at timestamptz,
+  class_id bigint,
+  title text,
+  release_date timestamptz,
+  due_date timestamptz,
+  student_repo_prefix text,
+  total_points numeric,
+  has_autograder boolean,
+  has_handgrader boolean,
+  description text,
+  slug text,
+  template_repo text,
+  allow_student_formed_groups boolean,
+  group_config public.assignment_group_mode,
+  group_formation_deadline timestamptz,
+  max_group_size integer,
+  min_group_size integer,
+  archived_at timestamptz,
+  autograder_points bigint,
+  grading_rubric_id bigint,
+  max_late_tokens integer,
+  latest_template_sha text,
+  meta_grading_rubric_id bigint,
+  self_review_rubric_id bigint,
+  self_review_setting_id bigint,
+  gradebook_column_id bigint,
+  minutes_due_after_lab integer,
+  allow_not_graded_submissions boolean,
+  student_profile_id uuid,
+  student_user_id uuid,
+  submission_id bigint,
+  submission_created_at timestamptz,
+  submission_is_active boolean,
+  submission_ordinal integer,
+  grader_result_id bigint,
+  grader_result_score numeric,
+  grader_result_max_score numeric,
+  repository_id bigint,
+  repository text,
+  is_github_ready boolean,
+  assignment_self_review_setting_id bigint,
+  self_review_enabled boolean,
+  self_review_deadline_offset bigint,
+  review_assignment_id bigint,
+  review_submission_id bigint,
+  submission_review_id bigint,
+  submission_review_completed_at timestamptz,
+  due_date_exception_id bigint,
+  exception_hours integer,
+  exception_minutes integer,
+  exception_tokens_consumed integer,
+  exception_created_at timestamptz,
+  exception_creator_id uuid,
+  exception_note text,
+  grading_submission_review_id bigint,
+  grading_submission_review_completed_at timestamptz,
+  grading_total_score numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+#variable_conflict use_column
+BEGIN
+  -- Authorization gate (top of function, single explicit check).
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.user_id = auth.uid()
+      AND ur.disabled = false
+      AND (
+        (ur.role = 'student'::public.app_role AND ur.private_profile_id = p_student_profile_id)
+        OR ur.role = 'instructor'::public.app_role
+        OR ur.role = 'grader'::public.app_role
+      )
+  ) THEN
+    RAISE EXCEPTION 'not authorized to read assignments dashboard for this student'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Body: same CTE chain that the previous view used, but `ur_students` is bounded
+  -- to the single requested (class, student) so every downstream join is O(assignments)
+  -- rather than O(class_students * assignments).
+  RETURN QUERY
+  WITH ur_students AS (
+    SELECT ur.class_id,
+           ur.private_profile_id AS student_profile_id,
+           ur.user_id AS student_user_id
+    FROM public.user_roles ur
+    WHERE ur.class_id = p_class_id
+      AND ur.private_profile_id = p_student_profile_id
+      AND ur.role = 'student'::public.app_role
+      AND ur.disabled = false
+  ), latest_submission AS (
+    SELECT a.id AS assignment_id,
+           s_ind.id AS submission_id,
+           s_ind.created_at AS submission_created_at,
+           s_ind.is_active AS submission_is_active,
+           s_ind.ordinal AS submission_ordinal,
+           ur.student_profile_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = a.id
+          AND s.profile_id = ur.student_profile_id
+          AND s.assignment_group_id IS NULL
+        ORDER BY s.created_at DESC
+        LIMIT 1
+    ) s_ind ON TRUE
+  ), student_group AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           agm.assignment_group_id
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN public.assignment_groups_members agm
+      ON agm.assignment_id = a.id
+     AND agm.profile_id = ur.student_profile_id
+  ), latest_group_submission AS (
+    SELECT sg.assignment_id,
+           sg.student_profile_id,
+           s_grp.id AS submission_id,
+           s_grp.created_at AS submission_created_at,
+           s_grp.is_active AS submission_is_active,
+           s_grp.ordinal AS submission_ordinal
+    FROM student_group sg
+    LEFT JOIN LATERAL (
+        SELECT s.id, s.created_at, s.is_active, s.ordinal
+        FROM public.submissions s
+        WHERE s.assignment_id = sg.assignment_id
+          AND s.assignment_group_id = sg.assignment_group_id
+        ORDER BY s.created_at DESC
+        LIMIT 1
+    ) s_grp ON TRUE
+  ), chosen_submission AS (
+    SELECT DISTINCT ON (assignment_id, student_profile_id)
+           assignment_id,
+           student_profile_id,
+           submission_id,
+           submission_created_at,
+           submission_is_active,
+           submission_ordinal
+    FROM (
+        SELECT ls.assignment_id, ls.student_profile_id, ls.submission_id,
+               ls.submission_created_at, ls.submission_is_active, ls.submission_ordinal
+        FROM latest_submission ls
+        UNION ALL
+        SELECT lgs.assignment_id, lgs.student_profile_id, lgs.submission_id,
+               lgs.submission_created_at, lgs.submission_is_active, lgs.submission_ordinal
+        FROM latest_group_submission lgs
+    ) x
+    ORDER BY assignment_id, student_profile_id, submission_created_at DESC NULLS LAST
+  ), grader_result_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           gr.id AS grader_result_id,
+           gr.score AS grader_result_score,
+           gr.max_score AS grader_result_max_score
+    FROM chosen_submission cs
+    LEFT JOIN public.grader_results gr ON gr.submission_id = cs.submission_id
+  ), grading_review_for_submission AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           sr.id AS grading_submission_review_id,
+           sr.completed_at AS grading_submission_review_completed_at,
+           COALESCE(
+             CASE
+               WHEN NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.per_student_grading_totals ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             CASE
+               WHEN NULLIF(sr.individual_scores ->> cs.student_profile_id::text, '') ~ '^[+-]?[0-9]+(\.[0-9]+)?$'
+               THEN (NULLIF(sr.individual_scores ->> cs.student_profile_id::text, ''))::numeric
+               ELSE NULL
+             END,
+             sr.total_score
+           ) AS grading_total_score
+    FROM chosen_submission cs
+    LEFT JOIN public.submissions s ON s.id = cs.submission_id
+    -- Release gate: only join the grading review once it is released, mirroring the
+    -- student RLS the prior security_invoker view relied on. Unreleased reviews yield
+    -- NULL score columns and the frontend falls back to the autograder score.
+    LEFT JOIN public.submission_reviews sr ON sr.id = s.grading_review_id AND sr.released = true
+  ), chosen_repository AS (
+    SELECT cs.assignment_id,
+           cs.student_profile_id,
+           repo.repository_id,
+           repo.repository,
+           repo.is_github_ready
+    FROM chosen_submission cs
+    LEFT JOIN student_group sg
+      ON sg.assignment_id = cs.assignment_id AND sg.student_profile_id = cs.student_profile_id
+    LEFT JOIN public.submissions sub ON sub.id = cs.submission_id
+    LEFT JOIN LATERAL (
+        SELECT r.id AS repository_id, r.repository, r.is_github_ready
+        FROM public.repositories r
+        WHERE r.assignment_id = cs.assignment_id
+          AND (
+            (sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+             AND r.assignment_group_id = sub.assignment_group_id)
+            OR (sub.id IS NOT NULL AND sub.assignment_group_id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+            OR (
+              sub.id IS NULL
+              AND (
+                (sg.assignment_group_id IS NOT NULL AND r.assignment_group_id = sg.assignment_group_id)
+                OR (r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL)
+              )
+            )
+          )
+        ORDER BY
+          CASE
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NOT NULL
+                 AND r.assignment_group_id = sub.assignment_group_id THEN 0
+            WHEN sub.id IS NOT NULL AND sub.assignment_group_id IS NULL
+                 AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 0
+            WHEN sub.id IS NULL AND r.assignment_group_id IS NOT NULL THEN 1
+            WHEN sub.id IS NULL AND r.profile_id = cs.student_profile_id AND r.assignment_group_id IS NULL THEN 2
+            ELSE 3
+          END,
+          r.id
+        LIMIT 1
+    ) repo ON TRUE
+  ), review_info AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ri.review_assignment_id,
+           ri.review_submission_id,
+           ri.submission_review_id,
+           ri.submission_review_completed_at
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ra.id AS review_assignment_id,
+               ra.submission_id AS review_submission_id,
+               sr.id AS submission_review_id,
+               sr.completed_at AS submission_review_completed_at
+        FROM public.review_assignments ra
+        LEFT JOIN public.submission_reviews sr ON sr.id = ra.submission_review_id
+        WHERE ra.assignment_id = a.id
+          AND ra.assignee_profile_id = ur.student_profile_id
+          -- Release gate: mirror the review_assignments RLS the prior security_invoker view
+          -- relied on, so an unreleased self/peer review's ids don't surface on the dashboard
+          -- (the frontend renders a clickable "Self Review for X" row off review_assignment_id).
+          AND (ra.release_date IS NULL OR ra.release_date <= now())
+        ORDER BY ra.created_at DESC
+        LIMIT 1
+    ) ri ON TRUE
+  ), due_date_ex AS (
+    SELECT a.id AS assignment_id,
+           ur.student_profile_id,
+           ade.id AS due_date_exception_id,
+           ade.hours AS exception_hours,
+           ade.minutes AS exception_minutes,
+           ade.tokens_consumed AS exception_tokens_consumed,
+           ade.created_at AS exception_created_at,
+           ade.creator_id AS exception_creator_id,
+           ade.note AS exception_note
+    FROM public.assignments a
+    JOIN ur_students ur ON ur.class_id = a.class_id
+    LEFT JOIN LATERAL (
+        SELECT ade.*
+        FROM public.assignment_due_date_exceptions ade
+        WHERE ade.assignment_id = a.id
+          AND (ade.student_id = ur.student_profile_id OR
+               ade.assignment_group_id IN (
+                   SELECT agm.assignment_group_id
+                   FROM public.assignment_groups_members agm
+                   WHERE agm.profile_id = ur.student_profile_id
+                     AND agm.assignment_id = a.id
+               ))
+        ORDER BY ade.created_at DESC
+        LIMIT 1
+    ) ade ON TRUE
+  )
+  SELECT a.id,
+         a.created_at,
+         a.class_id,
+         a.title,
+         a.release_date,
+         public.calculate_effective_due_date(a.id, ur.student_profile_id) AS due_date,
+         a.student_repo_prefix,
+         a.total_points,
+         a.has_autograder,
+         a.has_handgrader,
+         a.description,
+         a.slug,
+         a.template_repo,
+         a.allow_student_formed_groups,
+         a.group_config,
+         a.group_formation_deadline,
+         a.max_group_size,
+         a.min_group_size,
+         a.archived_at,
+         a.autograder_points,
+         a.grading_rubric_id,
+         a.max_late_tokens,
+         a.latest_template_sha,
+         a.meta_grading_rubric_id,
+         a.self_review_rubric_id,
+         a.self_review_setting_id,
+         a.gradebook_column_id,
+         a.minutes_due_after_lab,
+         a.allow_not_graded_submissions,
+         ur.student_profile_id,
+         ur.student_user_id,
+         cs.submission_id,
+         cs.submission_created_at,
+         cs.submission_is_active,
+         cs.submission_ordinal,
+         gr.grader_result_id,
+         gr.grader_result_score,
+         gr.grader_result_max_score,
+         sr.repository_id,
+         sr.repository,
+         sr.is_github_ready,
+         asrs.id AS assignment_self_review_setting_id,
+         asrs.enabled AS self_review_enabled,
+         asrs.deadline_offset AS self_review_deadline_offset,
+         ri.review_assignment_id,
+         ri.review_submission_id,
+         ri.submission_review_id,
+         ri.submission_review_completed_at,
+         de.due_date_exception_id,
+         de.exception_hours,
+         de.exception_minutes,
+         de.exception_tokens_consumed,
+         de.exception_created_at,
+         de.exception_creator_id,
+         de.exception_note,
+         gv.grading_submission_review_id,
+         gv.grading_submission_review_completed_at,
+         gv.grading_total_score
+  FROM public.assignments a
+  JOIN ur_students ur ON ur.class_id = a.class_id
+  LEFT JOIN chosen_submission cs
+    ON cs.assignment_id = a.id AND cs.student_profile_id = ur.student_profile_id
+  LEFT JOIN grader_result_for_submission gr
+    ON gr.assignment_id = a.id AND gr.student_profile_id = ur.student_profile_id
+  LEFT JOIN grading_review_for_submission gv
+    ON gv.assignment_id = a.id AND gv.student_profile_id = ur.student_profile_id
+  LEFT JOIN chosen_repository sr
+    ON sr.assignment_id = a.id AND sr.student_profile_id = ur.student_profile_id
+  LEFT JOIN public.assignment_self_review_settings asrs
+    ON asrs.id = a.self_review_setting_id
+  LEFT JOIN review_info ri
+    ON ri.assignment_id = a.id AND ri.student_profile_id = ur.student_profile_id
+  LEFT JOIN due_date_ex de
+    ON de.assignment_id = a.id AND de.student_profile_id = ur.student_profile_id
+  -- Release gate: hide assignments not yet released from the student dashboard. A NULL
+  -- release_date is treated as released, matching the individual-assignment page redirect.
+  WHERE a.archived_at IS NULL
+    AND (a.release_date IS NULL OR a.release_date <= now());
+END
+$$;
+
+REVOKE ALL ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_assignments_for_student_dashboard(bigint, uuid) TO authenticated;

--- a/supabase/migrations/20260715120100_hide_unreleased_assignments_from_student_dashboard.sql
+++ b/supabase/migrations/20260715120100_hide_unreleased_assignments_from_student_dashboard.sql
@@ -18,8 +18,11 @@
 -- assignments TableController's `.from("assignments").select("*")`), which are unaffected, so staff
 -- still see unreleased assignments in their management views.
 --
--- Everything below is copied verbatim from 20260529120000_dashboard_rpc_gate_grading_release.sql
--- except the final WHERE clause.
+-- Everything below is copied verbatim from the latest definition
+-- (20260608120000_dashboard_rpc_prefer_active_submission.sql — which prefers the ACTIVE submission
+-- via the `is_active DESC` ordering in the two per-mode LATERALs and the chosen_submission
+-- DISTINCT ON) except the final WHERE clause. Basing on that version preserves the
+-- active-submission preference; only the release gate is new.
 
 CREATE OR REPLACE FUNCTION public.get_assignments_for_student_dashboard(
   p_class_id bigint,
@@ -135,7 +138,9 @@ BEGIN
         WHERE s.assignment_id = a.id
           AND s.profile_id = ur.student_profile_id
           AND s.assignment_group_id IS NULL
-        ORDER BY s.created_at DESC
+        -- Prefer the active submission; fall back to most recent. The grade shown should be
+        -- the active/graded submission's, not a later not-for-grading scratch submission's.
+        ORDER BY s.is_active DESC, s.created_at DESC
         LIMIT 1
     ) s_ind ON TRUE
   ), student_group AS (
@@ -160,7 +165,8 @@ BEGIN
         FROM public.submissions s
         WHERE s.assignment_id = sg.assignment_id
           AND s.assignment_group_id = sg.assignment_group_id
-        ORDER BY s.created_at DESC
+        -- Prefer the active submission; fall back to most recent (see individual branch above).
+        ORDER BY s.is_active DESC, s.created_at DESC
         LIMIT 1
     ) s_grp ON TRUE
   ), chosen_submission AS (
@@ -180,7 +186,11 @@ BEGIN
                lgs.submission_created_at, lgs.submission_is_active, lgs.submission_ordinal
         FROM latest_group_submission lgs
     ) x
-    ORDER BY assignment_id, student_profile_id, submission_created_at DESC NULLS LAST
+    -- A student is in at most one mode per assignment, so exactly one branch yields a real
+    -- row (the other has NULLs). NULLS LAST keeps the real row; the is_active tiebreaker
+    -- matches the per-mode LATERAL preference for the active submission.
+    ORDER BY assignment_id, student_profile_id,
+             submission_is_active DESC NULLS LAST, submission_created_at DESC NULLS LAST
   ), grader_result_for_submission AS (
     SELECT cs.assignment_id,
            cs.student_profile_id,


### PR DESCRIPTION
## Context

First wave of fixes for deployment/onboarding pain points on fresh Pawtograder sites, plus a student-visibility bug. Four independent changes.

## 1. Idempotent GitHub team sync (`fix(github)`)
`syncTeam` / `getTeamAndCreateIfNeeded` did a GET-by-slug then blindly `POST /orgs/{org}/teams`, throwing on GitHub's **422 "already_exists"** when the team already existed (concurrent create race, or slug normalized from a differing name).
- On 422, re-fetch the existing team by slug, falling back to locating it in the org's team list.
- New `isTeamAlreadyExistsError` (structured 422 `code` detection) mirroring `isRepoNameAlreadyExistsError`.
- Collapsed the duplicate buggy create-block in `syncTeam` to reuse the one helper.
- **7 new unit tests** incl. the `404 → 422-already-exists → re-fetch` regression.

## 2. Per-site default template repos via Postgres GUC (`feat(github)`)
Handout/solution defaults were hardcoded in a migration. Adds a **site-default tier** read from `app.settings.default_*_template_repo`, between the per-org default and the constant:
`class override → org default → GUC → constant`.
Set per deployment (the "env var to the postgres pod" idea), mirroring the existing LTI GUC pattern:
```sql
ALTER DATABASE postgres SET app.settings.default_handout_template_repo  = 'my-org/handout';
ALTER DATABASE postgres SET app.settings.default_solution_template_repo = 'my-org/grader';
```
Unset = identical to today. Updates the four resolvers in a new migration.

## 3. Reconcile org membership on first GitHub login (`fix(github)`)
A user already a member of the course org was stuck forever on the "accept your invitation" banner (you can't invite an existing member).
- The auth callback now invokes `github-user-sync` on **first** GitHub login (gated on `last_github_user_sync`; wrapped so it never blocks login).
- `syncGitHubUser` already reconciles all of a user's enrolled orgs internally; `handleStudentGitHubSync` no longer hinges on one arbitrary org.
- `reinviteToOrgTeam`'s "already in team" path now sets `github_org_confirmed`, so the banner clears regardless of caller.

## 4. Hide unreleased assignments from students (`fix(assignments)`)
`get_assignments_for_student_dashboard` is SECURITY DEFINER, so the assignments RLS didn't gate it and the student **Assignments tab listed future-release assignments**. Adds a release gate to the final `WHERE` (NULL release_date = released), mirroring the gate this function already applies to `review_assignments`. Instructor management surfaces use other queries and are unaffected.

## Verification
- `next lint && prettier --check .` → pass
- Deno edge-function type-check: no new errors vs. base (only pre-existing octokit/ruleset typing)
- Deno unit tests: **14 passed** (7 new)
- Fresh local Supabase: all migrations apply; verified end-to-end that the student RPC hides future / shows past & NULL release dates, and that template resolution honors override → GUC → constant precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitHub linking now routes through the standard auth callback and returns users to the intended course after org membership reconciliation.
  - Template repository selection now uses consistent tiered defaults with validated configuration fallbacks.

- **Bug Fixes**
  - Student dashboard assignments are now hidden until release (including proper handling of `NULL` release dates).
  - Auth callback now safely sanitizes redirects and forwards certain OAuth/link errors to the intended destination.
  - GitHub team sync is more idempotent and resilient to slug normalization, races, and already-in-team confirmations.
  - GitHub org reconciliation continues per enrollment/org even if one reconciliation fails.

- **Chores**
  - Updated RPC execute permissions for the student dashboard function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->