### PR TITLE
fix(chart): 0.3.6 — stop version bumps rolling postgres + fast SIGTERM (incident fix)

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.6
+version: 0.3.7
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/templates/_helpers.tpl
+++ b/charts/pawtograder/templates/_helpers.tpl
@@ -6,6 +6,24 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Version-STABLE component labels: the full componentLabels set MINUS the two
+chart-version-carrying lines (helm.sh/chart, app.kubernetes.io/version). Use on
+a StatefulSet POD TEMPLATE so a chart-only version bump does not mutate the
+template and roll the pod, while still carrying the stable common/managed labels
+(app.kubernetes.io/managed-by, global.commonLabels, name/instance/component)
+that policy/cost-allocation/admission selectors rely on.
+Usage: {{ include "pawtograder.componentStableLabels" (dict "ctx" . "component" "postgres") }}
+*/}}
+{{- define "pawtograder.componentStableLabels" -}}
+{{ include "pawtograder.selectorLabels" .ctx }}
+app.kubernetes.io/component: {{ .component }}
+app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
+{{- with .ctx.Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Fully qualified app name. Truncated to 63 chars (DNS-1123 limit).
 */}}
 {{- define "pawtograder.fullname" -}}

--- a/charts/pawtograder/templates/_helpers.tpl
+++ b/charts/pawtograder/templates/_helpers.tpl
@@ -18,7 +18,11 @@ Usage: {{ include "pawtograder.componentStableLabels" (dict "ctx" . "component" 
 {{ include "pawtograder.selectorLabels" .ctx }}
 app.kubernetes.io/component: {{ .component }}
 app.kubernetes.io/managed-by: {{ .ctx.Release.Service }}
-{{- with .ctx.Values.global.commonLabels }}
+{{- /* commonLabels last, but strip the reserved selector keys: this label set
+     goes on a StatefulSet/Deployment pod template, and the selector is immutable
+     and must equal the template labels — a commonLabels override of name/
+     instance/component would break that contract, so drop those keys. */}}
+{{- with omit (.ctx.Values.global.commonLabels | default dict) "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" }}
 {{ toYaml . }}
 {{- end }}
 {{- end -}}

--- a/charts/pawtograder/templates/backup-restore-drill.yaml
+++ b/charts/pawtograder/templates/backup-restore-drill.yaml
@@ -51,17 +51,22 @@ spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ include "pawtograder.serviceAccountName" . }}
           {{- include "pawtograder.imagePullSecrets" . | nindent 10 }}
-          # fsGroup 102 (supabase/postgres group) so the postgres user can write
-          # the ephemeral PGDATA. The image entrypoint starts as root and drops
-          # to the postgres user itself (initdb), same as the primary — so no
-          # runAsNonRoot here (mirrors postgres.podSecurityContext = {}).
+          # Per-container securityContext (NOT pod-level runAsUser): the
+          # fetch-dump init container needs root (apt installs mc), but the main
+          # container must run as uid 101 so the postgres entrypoint SKIPS its
+          # root chown — on an all_squash/anon export a squashed-root chown fails
+          # ("Operation not permitted"), and running as 101 also means PGDATA is
+          # owned by 101 (preserved by root_squash), which postgres requires.
+          # fsGroup 101 so the group matches for the ephemeral volume.
           securityContext:
-            fsGroup: 102
+            fsGroup: 101
           initContainers:
             # Fetch the newest dump. Separate container because installing `mc`
             # needs root (apt), but the postgres container must not run as root.
             - name: fetch-dump
               image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.backup.image) }}
+              securityContext:
+                runAsUser: 0
               command:
                 - bash
                 - -c
@@ -94,6 +99,11 @@ spec:
             - name: restore-drill
               image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.postgres.image) }}
               imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+              # uid 101 so the postgres entrypoint runs entirely as the postgres
+              # user (no root chown; PGDATA owned by 101 as required).
+              securityContext:
+                runAsUser: 101
+                runAsGroup: 101
               # The image entrypoint (postgres) boots a fresh cluster on the empty
               # ephemeral PGDATA, running the mounted init scripts (roles/pgsodium)
               # exactly like the primary. We background it, wait for readiness, then
@@ -104,8 +114,13 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
-                  export PGHOST=127.0.0.1 PGPORT=5432 PGUSER=supabase_admin
-                  export PGPASSWORD="$POSTGRES_PASSWORD"
+                  # Do NOT export PGHOST here: the image entrypoint's init scripts
+                  # (migrate.sh, zy-app-role.sh, …) run while postgres listens on
+                  # the UNIX SOCKET only (no TCP yet). Exporting PGHOST=127.0.0.1
+                  # makes those scripts try TCP → "connection refused" → the
+                  # entrypoint aborts init. Leave the env clean so they use the
+                  # socket (as on the primary); set connection params only AFTER
+                  # the real server is up, for our own restore commands below.
                   echo "[drill] booting throwaway postgres on ephemeral volume ($(cat /work/dump-name))"
                   docker-entrypoint.sh postgres \
                     -c config_file=/etc/postgresql/postgresql.conf \
@@ -122,6 +137,8 @@ spec:
                   pg_isready -q -h 127.0.0.1 -U supabase_admin -d postgres \
                     || { echo "[drill] FATAL: instance never became ready"; exit 1; }
 
+                  # Server is up on TCP now — safe to point our restore at it.
+                  export PGHOST=127.0.0.1 PGPORT=5432 PGUSER=supabase_admin PGPASSWORD="$POSTGRES_PASSWORD"
                   SCRATCH="restore_drill"
                   psql -d postgres -c "CREATE DATABASE \"$SCRATCH\";"
                   # Triggers off for the whole restore (defense in depth: no audit/

--- a/charts/pawtograder/templates/postgres-replica.yaml
+++ b/charts/pawtograder/templates/postgres-replica.yaml
@@ -64,8 +64,10 @@ spec:
       {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres-replica") | nindent 6 }}
   template:
     metadata:
+      # Version-STABLE labels only — see postgres-statefulset.yaml: componentLabels
+      # carry the chart version, which would roll the standby on every chart bump.
       labels:
-        {{- include "pawtograder.componentLabels" (dict "ctx" . "component" "postgres-replica") | nindent 8 }}
+        {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres-replica") | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/postgres-config.yaml") . | sha256sum }}
     spec:

--- a/charts/pawtograder/templates/postgres-replica.yaml
+++ b/charts/pawtograder/templates/postgres-replica.yaml
@@ -64,12 +64,16 @@ spec:
       {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres-replica") | nindent 6 }}
   template:
     metadata:
-      # Version-STABLE labels only — see postgres-statefulset.yaml: componentLabels
-      # carry the chart version, which would roll the standby on every chart bump.
+      # Version-STABLE labels — see postgres-statefulset.yaml: drops only the
+      # chart/version labels (which would roll the standby on every chart bump)
+      # while keeping the stable common/managed labels.
       labels:
-        {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres-replica") | nindent 8 }}
+        {{- include "pawtograder.componentStableLabels" (dict "ctx" . "component" "postgres-replica") | nindent 8 }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/postgres-config.yaml") . | sha256sum }}
+        # Hash CONFIG content only, not the chart-version labels (helm.sh/chart,
+        # app.kubernetes.io/version) — otherwise a chart-only bump rolls the
+        # standby even with no real config change. Mirrors postgres-statefulset.yaml.
+        checksum/config: {{ regexReplaceAll "(?m)^.*(helm\\.sh/chart|app\\.kubernetes\\.io/version):.*$" (include (print $.Template.BasePath "/postgres-config.yaml") .) "" | sha256sum }}
     spec:
       serviceAccountName: {{ include "pawtograder.serviceAccountName" . }}
       {{- include "pawtograder.imagePullSecrets" . | nindent 6 }}

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -30,8 +30,16 @@ spec:
       {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres") | nindent 6 }}
   template:
     metadata:
+      # Version-STABLE labels only (selector labels, not componentLabels): the
+      # full labels carry helm.sh/chart + app.kubernetes.io/version, which change
+      # on every chart bump. Since a StatefulSet rolls its pods whenever the pod
+      # template changes, using componentLabels here rolled the PRIMARY on every
+      # version bump (even with no real config change) — a needless restart that,
+      # combined with the sidecars' slow SIGTERM, took the DB down for ~10 min.
+      # With selector labels + the version-independent checksum/config annotation,
+      # the template changes only when the actual postgres config does.
       labels:
-        {{- include "pawtograder.componentLabels" (dict "ctx" . "component" "postgres") | nindent 8 }}
+        {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres") | nindent 8 }}
       annotations:
         # Hash only the CONFIG content, not the chart-version-carrying metadata
         # labels (helm.sh/chart, app.kubernetes.io/version) that
@@ -175,19 +183,29 @@ spec:
               export PGDATA=/var/lib/postgresql/data/pgdata
               INTERVAL=$(( {{ .Values.postgres.walg.baseBackup.intervalHours | default 24 }} * 3600 ))
               KEEP={{ .Values.postgres.walg.baseBackup.keepBackups | default 8 }}
+              # Exit promptly on SIGTERM. Every long op runs as a backgrounded
+              # child that we `wait` on, and the trap kills it and exits. Without
+              # this, bash defers the signal until the foreground `sleep ${INTERVAL}`
+              # (up to intervalHours) returns — so on a pod roll postgres shuts
+              # down cleanly but this sidecar pins the pod in Terminating until the
+              # 600s grace SIGKILL, stalling the StatefulSet's replacement primary
+              # (and cascading DB_HOST=nxdomain crashes in dependents).
+              CHILD=""
+              trap 'echo "[base-backup] SIGTERM — exiting"; [ -n "$CHILD" ] && kill "$CHILD" 2>/dev/null; exit 0' TERM INT
+              run() { "$@" & CHILD=$!; wait "$CHILD"; }
               echo "[base-backup] first run in {{ .Values.postgres.walg.baseBackup.initialDelaySeconds | default 120 }}s, then every ${INTERVAL}s (keep ${KEEP})"
-              sleep {{ .Values.postgres.walg.baseBackup.initialDelaySeconds | default 120 }}
+              run sleep {{ .Values.postgres.walg.baseBackup.initialDelaySeconds | default 120 }}
               while true; do
                 echo "[base-backup] $(date -u +%FT%TZ) wal-g backup-push"
-                if wal-g backup-push "$PGDATA"; then
+                if run wal-g backup-push "$PGDATA"; then
                   # Retention: keep the newest ${KEEP} full backups; --confirm
                   # actually deletes (dry-run without it). Non-fatal if it fails
                   # — a failed prune must not stop future backups.
-                  wal-g delete retain FULL "${KEEP}" --confirm || echo "[base-backup] WARN: retention prune failed"
+                  run wal-g delete retain FULL "${KEEP}" --confirm || echo "[base-backup] WARN: retention prune failed"
                 else
                   echo "[base-backup] ERROR: backup-push failed; will retry next cycle"
                 fi
-                sleep "${INTERVAL}"
+                run sleep "${INTERVAL}"
               done
           env:
             # Connect over TCP to the postgres container in the same pod. Per

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -30,16 +30,17 @@ spec:
       {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres") | nindent 6 }}
   template:
     metadata:
-      # Version-STABLE labels only (selector labels, not componentLabels): the
-      # full labels carry helm.sh/chart + app.kubernetes.io/version, which change
-      # on every chart bump. Since a StatefulSet rolls its pods whenever the pod
-      # template changes, using componentLabels here rolled the PRIMARY on every
-      # version bump (even with no real config change) — a needless restart that,
-      # combined with the sidecars' slow SIGTERM, took the DB down for ~10 min.
-      # With selector labels + the version-independent checksum/config annotation,
-      # the template changes only when the actual postgres config does.
+      # Version-STABLE labels: full componentLabels MINUS helm.sh/chart +
+      # app.kubernetes.io/version (which change on every chart bump). A
+      # StatefulSet rolls its pods whenever the template changes, so the full
+      # componentLabels rolled the PRIMARY on every version bump (no real config
+      # change) — a needless restart that, with the sidecars' slow SIGTERM, took
+      # the DB down ~10 min. componentStableLabels keeps the stable common/managed
+      # labels (managed-by, global.commonLabels — needed by policy/cost/admission
+      # selectors) but drops only the version labels; with the version-independent
+      # checksum/config, the template changes only when the postgres config does.
       labels:
-        {{- include "pawtograder.componentSelectorLabels" (dict "ctx" . "component" "postgres") | nindent 8 }}
+        {{- include "pawtograder.componentStableLabels" (dict "ctx" . "component" "postgres") | nindent 8 }}
       annotations:
         # Hash only the CONFIG content, not the chart-version-carrying metadata
         # labels (helm.sh/chart, app.kubernetes.io/version) that
@@ -192,7 +193,9 @@ spec:
               # (and cascading DB_HOST=nxdomain crashes in dependents).
               CHILD=""
               trap 'echo "[base-backup] SIGTERM — exiting"; [ -n "$CHILD" ] && kill "$CHILD" 2>/dev/null; exit 0' TERM INT
-              run() { "$@" & CHILD=$!; wait "$CHILD"; }
+              # Clear CHILD once the child reaps, so a SIGTERM landing between
+              # `run` calls can't kill an exited/reused PID.
+              run() { "$@" & CHILD=$!; wait "$CHILD"; local rc=$?; CHILD=""; return $rc; }
               echo "[base-backup] first run in {{ .Values.postgres.walg.baseBackup.initialDelaySeconds | default 120 }}s, then every ${INTERVAL}s (keep ${KEEP})"
               run sleep {{ .Values.postgres.walg.baseBackup.initialDelaySeconds | default 120 }}
               while true; do


### PR DESCRIPTION
Root-cause fix for today's ~10-min primary outage during the 0.3.5 deploy.

**A** — postgres + replica pod templates now use version-stable selector labels (not componentLabels, which carry helm.sh/chart + version), so a chart bump no longer rolls the primary. Combined with the version-independent checksum/config annotation, the template changes only on a real config change.

**B** — base-backup sidecar now exits promptly on SIGTERM (backgrounded children + trap) instead of pinning the pod for the 600s grace.

⚠️ The deploy that applies this still rolls postgres once (the label change), on the current pod with the OLD sidecar — that one roll may hang; force-delete the cleanly-shut-down pod to speed it. After 0.3.6, version bumps don't roll postgres and rolls don't hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved backup/restore drill reliability with safer restore sequencing and corrected container permissions.
  * Backup workflows now terminate promptly on shutdown signals.
* **Bug Fixes**
  * Reduced unnecessary PostgreSQL rollouts by using chart-version-stable pod labels.
  * Improved rollout triggering accuracy by refining how the config checksum is computed.
* **Chores**
  * Updated the Helm chart version to **0.3.8**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->