### PR TITLE
fix: shrink the session cookie so it stops breaking Realtime

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -96,6 +96,29 @@ export async function GET(request: Request) {
           }
         }
 
+        // Drop the provider tokens from the persisted session.
+        //
+        // @supabase/auth-js writes the WHOLE session object into the auth
+        // cookie, including provider_token and provider_refresh_token. For
+        // Azure those are Microsoft Graph tokens totalling ~3 KB, which pushes
+        // the cookie from 2 chunks to 3 and the Cookie header past 8 KB. The
+        // api host then rejects the Realtime WebSocket handshake on its
+        // request-header limit — so Realtime broke for freshly-logged-in users
+        // and silently healed about an hour later, when the first token refresh
+        // rewrote the session without them. That intermittency made it look
+        // like a Realtime fault rather than a cookie-size one.
+        //
+        // setSession() rebuilds the session from just these two tokens and
+        // re-persists it, so the provider tokens never reach the cookie. This
+        // runs after the only two readers of provider_token (the iss decode and
+        // userFetchAzureProfile above); nothing else in the codebase reads it.
+        // The GitHub reconciliation below uses data.session.user, already in
+        // hand, so it is unaffected.
+        await supabase.auth.setSession({
+          access_token: data.session.access_token,
+          refresh_token: data.session.refresh_token
+        });
+
         // Reconcile the user's existing GitHub org/team memberships on login. A user already a
         // member of the course's GitHub org (joined via another class, or added out-of-band) would
         // otherwise be stuck on the "accept your invitation" banner forever, since an invite can't

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -12,7 +12,22 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     ui_host: process.env.NEXT_PUBLIC_POSTHOG_UI_HOST,
-    defaults: "2025-05-24"
+    defaults: "2025-05-24",
+    // Keep PostHog state out of cookies entirely. Its default persistence is
+    // "localStorage+cookie", and the cookie's domain is chosen by a probe that
+    // walks up the hostname keeping the BROADEST domain the browser accepts —
+    // for pawtograder.khoury.northeastern.edu that resolves to
+    // ".northeastern.edu". So the cookie was sent to every Pawtograder host,
+    // including the api host, which never reads cookies at all.
+    //
+    // That matters because the API host has hard request-header limits: an
+    // oversized Cookie header 400s the Realtime WebSocket handshake at the
+    // ingress before it reaches Kong. localStorage costs us nothing here —
+    // there is no cross-subdomain identity requirement it cannot serve.
+    persistence: "localStorage",
+    // Belt and braces: if persistence ever goes back to a cookie mode, keep it
+    // scoped to this host rather than letting the probe pick .northeastern.edu.
+    cross_subdomain_cookie: false
   });
 } else {
   console.error("NEXT_PUBLIC_POSTHOG_KEY is not set, posthog will not be initialized");


### PR DESCRIPTION
The auth cookie reached **~8.7 KB** in Khoury production — over the ingress's 8 KB request-header limit — so the Realtime WebSocket handshake to the api host was rejected with `400` and **Realtime was broken for logged-in users**. Two independent contributors, both fixed here.

## 1. Azure provider tokens — ~4.1 KB

`@supabase/auth-js` persists the **entire session object** into the auth cookie, including `provider_token` and `provider_refresh_token`. For Azure those are Microsoft Graph tokens totalling ~3 KB, which pushes the cookie from 2 chunks to 3.

`app/auth/callback/route.ts` now re-persists via `setSession({access_token, refresh_token})` after the only two readers of `provider_token` have run (the `iss` decode and `userFetchAzureProfile`). Nothing else in the codebase reads it, and the GitHub reconciliation that follows uses `data.session.user`, already in hand.

**This also explains the intermittency.** The first token refresh — roughly an hour after login — rewrote the session without the provider tokens, and the cookie fell back under the limit on its own. So Realtime broke right after login and silently healed later, which made it look like a Realtime fault rather than a cookie-size one.

## 2. PostHog on `.northeastern.edu` — ~0.5–1.5 KB, plus everyone else's

Default persistence is `"localStorage+cookie"`, and the cookie's domain comes from a probe that walks up the hostname keeping the **broadest domain the browser accepts**. For `pawtograder.khoury.northeastern.edu` that resolves to **`.northeastern.edu`**.

Beyond our own cookie, this means *any* cookie set by *any* `*.northeastern.edu` property (Shibboleth, Canvas, GA) is in `document.cookie` on our host **and gets sent to our api host**. We don't control those and they can grow at any time.

`persistence: "localStorage"` removes our cookie; `cross_subdomain_cookie: false` guards the setting if persistence ever changes back.

## Modelled impact

Azure-SSO user with a linked GitHub identity:

| State | Cookie header |
|---|---|
| After login, today | ~9,100 B |
| After login, with both fixes | **~4,400 B** |

Under the limit with margin, and back to a single chunk in the common case.

## The real fix is structural

The api host **never reads cookies** — Kong, PostgREST and Realtime all authenticate from the `Authorization` header or the `apikey` on the wss URL. Every cookie byte sent there is pure overhead that exists only to blow header limits.

The cookie is domain-scoped to the parent zone solely so the stable and channel web hosts share a session (`utils/channels.ts`). Moving the api host out of that zone — either renaming it to a sibling (`pawtograder-api.khoury…`) or pushing the web hosts one label deeper (`app.pawtograder.khoury…`) — means the cookie can never reach it. These two changes buy headroom; they don't remove the class of bug.

## Testing

- `tsc --noEmit` clean for both files
- `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)