### PR TITLE
fix: nuisance production errors (async-worker shared handout repo + invitation duplicate key)

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1578,8 +1578,27 @@ async function waitForRepoReady(octokit: Octokit, org: string, repoName: string,
         owner: org,
         repo: repoName
       });
+      // `size` is only refreshed by a lagging GitHub background job — on a freshly generated/forked
+      // repo it can stay 0 for minutes even after the content has landed, so it is NOT a reliable
+      // readiness signal on its own (a fully-populated repo would time out here). Keep it as a fast
+      // positive, but the authoritative signal is the default-branch ref existing: it appears as
+      // soon as the initial commit is mirrored, which is exactly "content is ready to read".
       if (data && (data as { size?: number }).size && (data as { size?: number }).size! > 0) {
         return;
+      }
+      const defaultBranch = (data as { default_branch?: string }).default_branch || "main";
+      try {
+        await octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
+          owner: org,
+          repo: repoName,
+          ref: `heads/${defaultBranch}`
+        });
+        return; // default branch ref exists → the initial commit has landed
+      } catch (refErr) {
+        // 404/409 → branch not created yet; anything else is a real error.
+        if (!(refErr instanceof RequestError) || (refErr.status !== 404 && refErr.status !== 409)) {
+          throw refErr;
+        }
       }
     } catch (e) {
       if (!(e instanceof RequestError) || e.status !== 404) {

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1832,7 +1832,6 @@ export async function syncTeam(
   for (const username of removeMembers) {
     const newScope = scope?.clone();
     newScope?.setTag("username", username);
-    Sentry.captureMessage(`Removing member from team ${resolvedSlug}`, newScope);
     await octokit.request("DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}", {
       org,
       team_slug: resolvedSlug,
@@ -2542,10 +2541,11 @@ async function markUserRoleOrgConfirmedForTeam({
   team_slug: string;
 }) {
   let courseSlug: string | undefined;
-  let allowedRoles: ("instructor" | "grader" | "student")[] = [];
+  let allowedRoles: ("admin" | "instructor" | "grader" | "student")[] = [];
   if (team_slug.endsWith("-staff")) {
     courseSlug = team_slug.slice(0, -"-staff".length);
-    allowedRoles = ["instructor", "grader"];
+    // "staff" is every non-student role — admins belong on the staff team too.
+    allowedRoles = ["admin", "instructor", "grader"];
   } else if (team_slug.endsWith("-students")) {
     courseSlug = team_slug.slice(0, -"-students".length);
     allowedRoles = ["student"];

--- a/supabase/functions/_shared/InvitationUtils.ts
+++ b/supabase/functions/_shared/InvitationUtils.ts
@@ -142,13 +142,17 @@ async function processInvitation(
       .single();
 
     if (existingUser) {
-      // Check if already enrolled
+      // Check if already ACTIVELY enrolled. Only a non-disabled role counts: a user previously
+      // removed by SIS sync keeps a disabled user_roles row alongside a 'dropped' invitation, and
+      // treating that as "already enrolled" would short-circuit here and never let the dropped
+      // invitation reactivate (which is what re-enables the role via the auto-accept trigger).
       const { data: existingEnrollment } = await supabaseClient
         .from("user_roles")
         .select("role")
         .eq("user_id", existingUser.user_id)
         .eq("class_id", courseId)
-        .single();
+        .eq("disabled", false)
+        .maybeSingle();
 
       if (existingEnrollment) {
         //Set canvas_id to the sis_user_id, update class_section_id and lab_section_id if provided

--- a/supabase/functions/_shared/InvitationUtils.ts
+++ b/supabase/functions/_shared/InvitationUtils.ts
@@ -172,20 +172,25 @@ async function processInvitation(
       }
     }
 
-    // Check if invitation already exists
+    // Check if an invitation already exists (in ANY status). The unique constraint on
+    // (class_id, sis_user_id) is status-agnostic, so there is at most one row. We only let a
+    // 'dropped' invitation (removed from the SIS roster) fall through to create_invitation, which
+    // reactivates it. pending/accepted/cancelled are reported as a graceful soft error here so we
+    // never invoke the RPC just to have it raise — that RPC error would otherwise be logged to
+    // Sentry as "Error creating invitation" for what is really an expected, benign re-invite.
     const { data: existingInvitation } = await supabaseClient
       .from("invitations")
       .select("id, status, class_section_id, lab_section_id")
       .eq("class_id", courseId)
       .eq("sis_user_id", invitation.sis_user_id)
-      .eq("status", "pending")
-      .single();
+      .maybeSingle();
 
-    if (existingInvitation) {
-      //If needed, update the invitation to the new class_section_id and lab_section_id
+    if (existingInvitation && existingInvitation.status !== "dropped") {
+      // Keep an existing pending invitation's section assignments in sync with the latest request.
       if (
-        invitation.class_section_id !== existingInvitation.class_section_id ||
-        invitation.lab_section_id !== existingInvitation.lab_section_id
+        existingInvitation.status === "pending" &&
+        (invitation.class_section_id !== existingInvitation.class_section_id ||
+          invitation.lab_section_id !== existingInvitation.lab_section_id)
       ) {
         await supabaseClient
           .from("invitations")
@@ -193,11 +198,15 @@ async function processInvitation(
           .eq("id", existingInvitation.id);
       }
 
+      const reason =
+        existingInvitation.status === "pending"
+          ? "Pending invitation already exists for this user"
+          : `Invitation already exists for this user (status: ${existingInvitation.status})`;
       return {
         success: false,
         error: {
           sis_user_id: invitation.sis_user_id,
-          error: "Pending invitation already exists for this user"
+          error: reason
         }
       };
     }

--- a/supabase/functions/autograder-sync-staff-team/index.ts
+++ b/supabase/functions/autograder-sync-staff-team/index.ts
@@ -48,6 +48,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           .eq("class_id", course_id)
           .in("role", ["instructor", "grader", "admin"])
           .eq("github_org_confirmed", true)
+          .eq("disabled", false)
           .limit(1000);
         if (staffError) {
           console.error(staffError);
@@ -86,6 +87,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           .eq("class_id", course_id)
           .in("role", ["instructor", "grader", "admin"])
           .eq("github_org_confirmed", true)
+          .eq("disabled", false)
           .limit(1000);
         if (staffError) {
           console.error(staffError);

--- a/supabase/functions/autograder-sync-staff-team/index.ts
+++ b/supabase/functions/autograder-sync-staff-team/index.ts
@@ -46,7 +46,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           .from("user_roles")
           .select("github_org_confirmed, users(github_username)")
           .eq("class_id", course_id)
-          .in("role", ["instructor", "grader"])
+          .in("role", ["instructor", "grader", "admin"])
           .eq("github_org_confirmed", true)
           .limit(1000);
         if (staffError) {
@@ -84,7 +84,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           .from("user_roles")
           .select("github_org_confirmed, users(github_username)")
           .eq("class_id", course_id)
-          .in("role", ["instructor", "grader"])
+          .in("role", ["instructor", "grader", "admin"])
           .eq("github_org_confirmed", true)
           .limit(1000);
         if (staffError) {

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -871,6 +871,9 @@ export async function processEnvelope(
             .eq("class_id", envelope.class_id || 0)
             .eq("user_id", args.userId)
             .in("role", ["instructor", "grader", "admin"])
+            // Never reinvite a disabled staff member: the disable-triggered sync routes their id here,
+            // and reconcile removes them from the team — reinviting would immediately undo that.
+            .eq("disabled", false)
             .maybeSingle();
           if (error) throw error;
           if (
@@ -912,6 +915,9 @@ export async function processEnvelope(
             .eq("class_id", envelope.class_id)
             .eq("user_id", args.userId)
             .in("role", ["instructor", "grader", "admin"])
+            // Same as the pre-reconcile lookup: skip disabled staff so we don't reinvite someone the
+            // reconcile just removed.
+            .eq("disabled", false)
             .maybeSingle();
           if (
             !error &&

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -866,7 +866,7 @@ export async function processEnvelope(
             .select("invitation_date, users(github_username), classes(slug, github_org)")
             .eq("class_id", envelope.class_id || 0)
             .eq("user_id", args.userId)
-            .in("role", ["instructor", "grader"])
+            .in("role", ["instructor", "grader", "admin"])
             .single();
           if (error) throw error;
           if (
@@ -892,7 +892,7 @@ export async function processEnvelope(
               .from("user_roles")
               .select("users(github_username)")
               .eq("class_id", envelope.class_id || 0)
-              .in("role", ["instructor", "grader"])
+              .in("role", ["instructor", "grader", "admin"])
               .eq("github_org_confirmed", true)
               .limit(5000);
             if (error) throw error;
@@ -906,7 +906,7 @@ export async function processEnvelope(
             .select("invitation_date, users(github_username), classes(slug, github_org)")
             .eq("class_id", envelope.class_id)
             .eq("user_id", args.userId)
-            .in("role", ["instructor", "grader"])
+            .in("role", ["instructor", "grader", "admin"])
             .single();
           if (
             !error &&

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -49,6 +49,26 @@ function toMsLatency(enqueuedAt: string): number {
   }
 }
 
+/**
+ * Resolves the handout SHA to stamp onto a freshly-created student/group repo, scoped to the repo's
+ * own assignment. We intentionally look this up by assignment id (not `template_repo`), because
+ * multiple assignments can legitimately share a handout repo (copied assignments, multi-section
+ * courses) and a reverse lookup by repo would be ambiguous.
+ */
+async function getAssignmentTemplateSha(
+  adminSupabase: SupabaseClient<Database>,
+  assignmentId: number | null | undefined
+): Promise<string | null> {
+  if (assignmentId == null) return null;
+  const { data, error } = await adminSupabase
+    .from("assignments")
+    .select("latest_template_sha")
+    .eq("id", assignmentId)
+    .maybeSingle();
+  if (error) throw error;
+  return data?.latest_template_sha ?? null;
+}
+
 const PGMQ_ARCHIVE_MAX_ATTEMPTS = 3;
 
 /**
@@ -969,36 +989,44 @@ export async function processEnvelope(
 
         // Update repository record using the repo_id if provided (preferred method)
         try {
-          const { data: latestHandoutCommit, error: latestHandoutCommitError } = await adminSupabase
-            .from("assignments")
-            .select("latest_template_sha")
-            .eq("template_repo", templateRepo)
-            .maybeSingle();
-          if (latestHandoutCommitError) throw latestHandoutCommitError;
+          // Resolve the target repository row first, then read the handout SHA from THIS repo's own
+          // assignment. Looking the SHA up by `template_repo` is ambiguous whenever multiple assignments
+          // share a handout repo (copied assignments, multi-section courses), and the old
+          // `.maybeSingle()` there errored on >1 match — stranding the repo in an infinite requeue.
+          const repoUpdate = {
+            is_github_ready: true,
+            synced_repo_sha: headSha,
+            // Clear any prior failure now that the repo is populated and ready.
+            creation_error: null
+          };
           if (envelope.repo_id) {
             // Direct update using repo_id (more efficient and reliable)
+            const { data: repoRow, error: repoRowError } = await adminSupabase
+              .from("repositories")
+              .select("assignment_id")
+              .eq("id", envelope.repo_id)
+              .maybeSingle();
+            if (repoRowError) throw repoRowError;
+            const syncedHandoutSha = await getAssignmentTemplateSha(adminSupabase, repoRow?.assignment_id);
             const { error: updateError } = await adminSupabase
               .from("repositories")
-              .update({
-                is_github_ready: true,
-                synced_repo_sha: headSha,
-                synced_handout_sha: latestHandoutCommit?.latest_template_sha,
-                // Clear any prior failure now that the repo is populated and ready.
-                creation_error: null
-              })
+              .update({ ...repoUpdate, synced_handout_sha: syncedHandoutSha })
               .eq("id", envelope.repo_id);
             if (updateError) throw updateError;
           } else if (envelope.class_id) {
             // Fallback to old method for backward compatibility
             const fullName = `${org}/${repoName}`;
+            const { data: repoRow, error: repoRowError } = await adminSupabase
+              .from("repositories")
+              .select("assignment_id")
+              .eq("class_id", envelope.class_id)
+              .eq("repository", fullName)
+              .maybeSingle();
+            if (repoRowError) throw repoRowError;
+            const syncedHandoutSha = await getAssignmentTemplateSha(adminSupabase, repoRow?.assignment_id);
             const { error: updateError } = await adminSupabase
               .from("repositories")
-              .update({
-                is_github_ready: true,
-                synced_repo_sha: headSha,
-                synced_handout_sha: latestHandoutCommit?.latest_template_sha,
-                creation_error: null
-              })
+              .update({ ...repoUpdate, synced_handout_sha: syncedHandoutSha })
               .eq("class_id", envelope.class_id)
               .eq("repository", fullName);
             if (updateError) throw updateError;

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -861,13 +861,17 @@ export async function processEnvelope(
         if (args.userId) {
           scope.setTag("user_id", args.userId);
           //Make sure that the student has been invited to the org
+          // maybeSingle (not single): on a role DELETE the trigger enqueues this sync with the
+          // removed user_id, so the row is already gone. That must NOT throw — the class-wide
+          // reconcile below is what removes them from the team and has to run regardless. A missing
+          // row simply means "no per-user reinvite to do".
           const { data, error } = await adminSupabase
             .from("user_roles")
             .select("invitation_date, users(github_username), classes(slug, github_org)")
             .eq("class_id", envelope.class_id || 0)
             .eq("user_id", args.userId)
             .in("role", ["instructor", "grader", "admin"])
-            .single();
+            .maybeSingle();
           if (error) throw error;
           if (
             data &&
@@ -894,6 +898,7 @@ export async function processEnvelope(
               .eq("class_id", envelope.class_id || 0)
               .in("role", ["instructor", "grader", "admin"])
               .eq("github_org_confirmed", true)
+              .eq("disabled", false)
               .limit(5000);
             if (error) throw error;
             return (data || []).map((s) => s.users!.github_username!).filter(Boolean);
@@ -907,7 +912,7 @@ export async function processEnvelope(
             .eq("class_id", envelope.class_id)
             .eq("user_id", args.userId)
             .in("role", ["instructor", "grader", "admin"])
-            .single();
+            .maybeSingle();
           if (
             !error &&
             ur &&

--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -1396,10 +1396,12 @@ eventHandler.on("membership", async ({ payload }: { payload: MembershipEvent }) 
       return;
     }
 
-    // Check if the team type matches the user's role
+    // Check if the team type matches the user's role. "staff" covers every non-student role
+    // (admin/instructor/grader); admins belong on the staff team just like instructors and graders,
+    // so confirm them too rather than logging a spurious mismatch.
     const userRole = userRoleData.role;
     const isCorrectTeam =
-      (teamType === "staff" && (userRole === "instructor" || userRole === "grader")) ||
+      (teamType === "staff" && (userRole === "admin" || userRole === "instructor" || userRole === "grader")) ||
       (teamType === "student" && userRole === "student");
 
     if (isCorrectTeam) {

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -64,7 +64,7 @@ async function ensureStaffOrgMembership(userID: string, githubUsername: string, 
     .from("user_roles")
     .select("class_id, role, github_org_confirmed, classes(slug, github_org)")
     .eq("disabled", false)
-    .in("role", ["instructor", "grader"])
+    .in("role", ["instructor", "grader", "admin"])
     .eq("user_id", userID);
   if (staffError) {
     Sentry.captureException(staffError, scope);

--- a/supabase/migrations/20260728000000_create_invitation_reactivate_existing.sql
+++ b/supabase/migrations/20260728000000_create_invitation_reactivate_existing.sql
@@ -1,0 +1,138 @@
+-- Make create_invitation idempotent against the unconditional UNIQUE (class_id, sis_user_id)
+-- constraint (invitations_class_id_sis_user_id_key).
+--
+-- Previously the function only guarded against an existing *pending* invitation and then blindly
+-- INSERTed. When an invitation already existed for the same (class_id, sis_user_id) in any other
+-- status ('accepted', 'cancelled', 'dropped'), the guard passed and the INSERT violated the unique
+-- constraint — surfacing as "duplicate key value violates unique constraint
+-- invitations_class_id_sis_user_id_key" for every caller (the invitation-create edge function and the
+-- bulk CSV import RPC). Re-importing a roster or re-inviting a previously-removed student hit this.
+--
+-- Fix: when a non-pending invitation already exists, reactivate it in place (reset to 'pending' and
+-- refresh role/email/name/sections/invited_by) rather than inserting a duplicate. The existing
+-- profile pair is reused untouched, so we never orphan or duplicate profiles (#390). A 'dropped' ->
+-- 'pending' transition still fires trigger_auto_accept_invitation_on_reactivation as before. A
+-- pending invitation still raises, preserving the existing contract with callers.
+CREATE OR REPLACE FUNCTION public.create_invitation(
+  p_class_id bigint,
+  p_role public.app_role,
+  p_sis_user_id integer,
+  p_email text DEFAULT NULL,
+  p_name text DEFAULT NULL,
+  p_invited_by uuid DEFAULT auth.uid(),
+  p_class_section_id bigint DEFAULT NULL,
+  p_lab_section_id bigint DEFAULT NULL,
+  p_sis_managed boolean DEFAULT true
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_public_profile_id uuid;
+    v_private_profile_id uuid;
+    v_invitation_id bigint;
+    v_existing_id bigint;
+    v_existing_status text;
+    v_display_name text;
+    v_adjective text;
+    v_noun text;
+    v_number integer;
+    v_public_name text;
+BEGIN
+    IF NOT (public.authorizeforclassinstructor(p_class_id) OR public.authorize_for_admin()) THEN
+        RAISE EXCEPTION 'Only instructors or admins can create invitations for this class';
+    END IF;
+
+    -- Look up any existing invitation for this (class, sis_user) — the unique constraint is
+    -- unconditional, so status does not matter for conflict detection.
+    SELECT id, status INTO v_existing_id, v_existing_status
+    FROM public.invitations
+    WHERE class_id = p_class_id AND sis_user_id = p_sis_user_id
+    LIMIT 1;
+
+    IF v_existing_id IS NOT NULL THEN
+        IF v_existing_status = 'pending' THEN
+            RAISE EXCEPTION 'Invitation already exists for this user in this class';
+        END IF;
+
+        -- Reactivate the existing invitation in place, reusing its profile pair. Setting status
+        -- back to 'pending' re-invites the user; for a previously 'dropped' invitation this also
+        -- fires the auto-accept trigger when the user already has an account.
+        UPDATE public.invitations
+        SET status = 'pending',
+            role = p_role,
+            email = COALESCE(p_email, email),
+            name = COALESCE(p_name, name),
+            invited_by = COALESCE(p_invited_by, invited_by),
+            class_section_id = p_class_section_id,
+            lab_section_id = p_lab_section_id,
+            sis_managed = p_sis_managed,
+            accepted_at = NULL,
+            updated_at = NOW()
+        WHERE id = v_existing_id;
+
+        RETURN v_existing_id;
+    END IF;
+
+    v_display_name := COALESCE(p_name, split_part(p_email, '@', 1), p_sis_user_id::text);
+
+    -- If this SIS user is already enrolled in the class, reuse that enrollment's
+    -- profile pair so the invitation does not create a duplicate profile (#390).
+    SELECT ur.public_profile_id, ur.private_profile_id
+      INTO v_public_profile_id, v_private_profile_id
+    FROM public.user_roles ur
+    JOIN public.users u ON u.user_id = ur.user_id
+    WHERE u.sis_user_id = p_sis_user_id
+      AND ur.class_id = p_class_id
+    LIMIT 1;
+
+    IF v_private_profile_id IS NULL THEN
+        -- Generate a collision-resistant random name for the public profile.
+        DECLARE
+            v_attempts integer := 0;
+            v_exists boolean := true;
+        BEGIN
+            WHILE v_attempts < 20 LOOP
+                SELECT word INTO v_adjective FROM public.name_generation_words
+                WHERE is_adjective = true ORDER BY random() LIMIT 1;
+                SELECT word INTO v_noun FROM public.name_generation_words
+                WHERE is_noun = true ORDER BY random() LIMIT 1;
+                v_number := floor(random() * 1000)::integer;
+                v_public_name := COALESCE(v_adjective, 'random') || '-' || COALESCE(v_noun, 'user') || '-' || v_number;
+                SELECT EXISTS (
+                    SELECT 1 FROM public.profiles WHERE class_id = p_class_id AND name = v_public_name
+                ) INTO v_exists;
+                IF NOT v_exists THEN EXIT; END IF;
+                v_attempts := v_attempts + 1;
+            END LOOP;
+            IF v_exists THEN
+                v_public_name := v_public_name || '-' || substr(md5(random()::text || clock_timestamp()::text), 1, 6);
+            END IF;
+        END;
+
+        INSERT INTO public.profiles (name, class_id, is_private_profile)
+        VALUES (v_public_name, p_class_id, false)
+        RETURNING id INTO v_public_profile_id;
+
+        INSERT INTO public.profiles (name, class_id, is_private_profile)
+        VALUES (v_display_name, p_class_id, true)
+        RETURNING id INTO v_private_profile_id;
+    END IF;
+
+    INSERT INTO public.invitations (
+        class_id, role, sis_user_id, email, name,
+        public_profile_id, private_profile_id, invited_by,
+        class_section_id, lab_section_id, sis_managed, status,
+        created_at, updated_at
+    ) VALUES (
+        p_class_id, p_role, p_sis_user_id, p_email, p_name,
+        v_public_profile_id, v_private_profile_id, p_invited_by,
+        p_class_section_id, p_lab_section_id, p_sis_managed, 'pending',
+        NOW(), NOW()
+    ) RETURNING id INTO v_invitation_id;
+
+    RETURN v_invitation_id;
+END;
+$$;

--- a/supabase/migrations/20260728000000_create_invitation_reactivate_existing.sql
+++ b/supabase/migrations/20260728000000_create_invitation_reactivate_existing.sql
@@ -8,11 +8,19 @@
 -- invitations_class_id_sis_user_id_key" for every caller (the invitation-create edge function and the
 -- bulk CSV import RPC). Re-importing a roster or re-inviting a previously-removed student hit this.
 --
--- Fix: when a non-pending invitation already exists, reactivate it in place (reset to 'pending' and
--- refresh role/email/name/sections/invited_by) rather than inserting a duplicate. The existing
--- profile pair is reused untouched, so we never orphan or duplicate profiles (#390). A 'dropped' ->
--- 'pending' transition still fires trigger_auto_accept_invitation_on_reactivation as before. A
--- pending invitation still raises, preserving the existing contract with callers.
+-- Fix: look up any existing invitation for the pair (the constraint is status-agnostic) and, when
+-- one exists in status 'dropped' (removed from the SIS roster), reactivate it in place — reset to
+-- 'pending' reusing the existing profile pair, so we never orphan or duplicate profiles (#390) — and
+-- refresh the reused private profile's name when a corrected name is supplied. 'dropped' -> 'pending'
+-- is the transition wired to trigger_auto_accept_invitation_on_reactivation, so an existing user is
+-- actually re-enrolled. For 'pending' / 'accepted' / 'cancelled' we raise "already exists" instead of
+-- mutating: 'accepted' would un-accept an enrolled student and 'cancelled' is a deliberate instructor
+-- action, and reactivating either to 'pending' would NOT fire the (dropped-only) auto-accept trigger.
+-- A transaction-scoped advisory lock serializes concurrent calls for the same pair.
+--
+-- Callers surface "already exists" as a per-row soft error; the invitation-create edge function's
+-- pre-check also short-circuits pending/accepted/cancelled before calling this RPC, so this RAISE is
+-- primarily a race-safety net.
 CREATE OR REPLACE FUNCTION public.create_invitation(
   p_class_id bigint,
   p_role public.app_role,
@@ -35,6 +43,7 @@ DECLARE
     v_invitation_id bigint;
     v_existing_id bigint;
     v_existing_status text;
+    v_existing_private_profile_id uuid;
     v_display_name text;
     v_adjective text;
     v_noun text;
@@ -45,21 +54,34 @@ BEGIN
         RAISE EXCEPTION 'Only instructors or admins can create invitations for this class';
     END IF;
 
+    -- Serialize concurrent create_invitation calls for the same (class, sis_user) so the
+    -- lookup-then-insert/reactivate below is atomic. createInvitationsBulk fans invitations out
+    -- concurrently and duplicate SIS IDs (or simultaneous requests) could otherwise both see "no
+    -- pending row" and collide on invitations_class_id_sis_user_id_key, or both reactivate the same
+    -- row. The transaction-scoped lock is released automatically at COMMIT/ROLLBACK.
+    PERFORM pg_advisory_xact_lock(hashtext('create_invitation:' || p_class_id::text || ':' || p_sis_user_id::text));
+
     -- Look up any existing invitation for this (class, sis_user) — the unique constraint is
     -- unconditional, so status does not matter for conflict detection.
-    SELECT id, status INTO v_existing_id, v_existing_status
+    SELECT id, status, private_profile_id
+      INTO v_existing_id, v_existing_status, v_existing_private_profile_id
     FROM public.invitations
     WHERE class_id = p_class_id AND sis_user_id = p_sis_user_id
     LIMIT 1;
 
     IF v_existing_id IS NOT NULL THEN
-        IF v_existing_status = 'pending' THEN
+        -- Only a 'dropped' invitation (removed from the SIS roster) is reactivatable here, matching
+        -- the SIS-sync reactivation semantics. 'pending' already exists; 'accepted' means the user
+        -- is/was enrolled (resetting it would un-accept an enrolled student); 'cancelled' is a
+        -- deliberate instructor action. For all three we raise so the caller reports "already
+        -- exists" rather than silently mutating state. Reactivating 'dropped' -> 'pending' is the
+        -- one transition wired to trigger_auto_accept_invitation_on_reactivation, so the user is
+        -- actually re-enrolled when they already have an account.
+        IF v_existing_status <> 'dropped' THEN
             RAISE EXCEPTION 'Invitation already exists for this user in this class';
         END IF;
 
-        -- Reactivate the existing invitation in place, reusing its profile pair. Setting status
-        -- back to 'pending' re-invites the user; for a previously 'dropped' invitation this also
-        -- fires the auto-accept trigger when the user already has an account.
+        -- Reactivate the dropped invitation in place, reusing its profile pair.
         UPDATE public.invitations
         SET status = 'pending',
             role = p_role,
@@ -72,6 +94,15 @@ BEGIN
             accepted_at = NULL,
             updated_at = NOW()
         WHERE id = v_existing_id;
+
+        -- Refresh the reused private profile's display name when a (corrected) name is supplied, so
+        -- the roster/grading surfaces don't show a stale name after the user enrolls. The public
+        -- pseudonym profile is left untouched.
+        IF p_name IS NOT NULL AND v_existing_private_profile_id IS NOT NULL THEN
+            UPDATE public.profiles
+            SET name = p_name
+            WHERE id = v_existing_private_profile_id AND is_private_profile = true;
+        END IF;
 
         RETURN v_existing_id;
     END IF;

--- a/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
+++ b/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
@@ -1,0 +1,101 @@
+-- Include `admin` in GitHub staff-team reconciliation.
+--
+-- "Staff" for GitHub org/team purposes means every non-student role: admin, instructor, grader.
+-- 20260623000000_allow_admin_github_team_sync.sql already widened the authorization guard on
+-- sync_staff_github_team so an admin MAY trigger a staff-team sync, but the role-change trigger that
+-- actually ENQUEUES the sync still only matched ('instructor','grader') — so a class-scoped `admin`
+-- role was never added to (or removed from) the GitHub staff team, and the two ends disagreed.
+-- Finish that change here by teaching the trigger that admin is a staff role. (The matching edge
+-- functions that build the staff username list / write github_org_confirmed are updated alongside.)
+--
+-- Only the staff-branch role predicates change; the student branches already key off `!= 'student'`,
+-- which correctly treats admin as non-student, so they are unchanged.
+CREATE OR REPLACE FUNCTION "public"."sync_github_teams_on_role_change"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  -- Handle INSERT: new role added
+  if TG_OP = 'INSERT' then
+    if NEW.role in ('instructor', 'grader', 'admin') then
+      perform public.sync_staff_github_team(NEW.class_id, NEW.user_id);
+    elsif NEW.role = 'student' then
+      perform public.sync_student_github_team(NEW.class_id, NEW.user_id);
+      -- Also create repos for the student if github_org_confirmed is true
+      if NEW.github_org_confirmed = true then
+        perform public.create_repos_for_student(NEW.user_id, NEW.class_id);
+      end if;
+    end if;
+    return NEW;
+  end if;
+
+  -- Handle UPDATE: role changed or github_org_confirmed changed
+  if TG_OP = 'UPDATE' then
+    -- If role changed to/from staff role or between staff roles
+    if (OLD.role not in ('instructor', 'grader', 'admin') and NEW.role in ('instructor', 'grader', 'admin')) or
+       (OLD.role in ('instructor', 'grader', 'admin') and NEW.role not in ('instructor', 'grader', 'admin')) or
+       (OLD.role in ('instructor', 'grader', 'admin') and NEW.role in ('instructor', 'grader', 'admin') and OLD.role != NEW.role) then
+      perform public.sync_staff_github_team(NEW.class_id, NEW.user_id);
+    end if;
+
+    -- If role changed to/from student role
+    if (OLD.role != 'student' and NEW.role = 'student') or
+       (OLD.role = 'student' and NEW.role != 'student') then
+      perform public.sync_student_github_team(NEW.class_id, NEW.user_id);
+    end if;
+
+    -- NEW: If student role is reactivated or deactivated
+    if NEW.role = 'student' and
+       OLD.disabled != NEW.disabled then
+      perform public.sync_student_github_team(NEW.class_id, NEW.user_id);
+    end if;
+
+    -- Consolidated repo creation and permission sync logic
+    declare
+      should_create_repos boolean := false;
+      should_sync_permissions boolean := false;
+    begin
+      should_create_repos := (
+        NEW.role = 'student' and NEW.github_org_confirmed = true and (
+          -- Condition 1: Role changed to student
+          (OLD.role != 'student' and NEW.role = 'student') or
+          -- Condition 2: github_org_confirmed changed to true for existing student
+          (OLD.github_org_confirmed is distinct from NEW.github_org_confirmed) or
+          -- Condition 3: Student role was reactivated
+          (OLD.disabled = true and NEW.disabled = false)
+        )
+      );
+
+      -- Also sync existing repo permissions when github_org_confirmed changes to true
+      -- This handles the race condition where repos were created before the student joined the org
+      should_sync_permissions := (
+        NEW.role = 'student' and
+        NEW.github_org_confirmed = true and
+        (OLD.github_org_confirmed is distinct from NEW.github_org_confirmed)
+      );
+
+      if should_create_repos then
+        perform public.create_repos_for_student(NEW.user_id, NEW.class_id);
+      end if;
+
+      if should_sync_permissions then
+        perform public.sync_repo_permissions_for_student(NEW.user_id, NEW.class_id);
+      end if;
+    end;
+
+    return NEW;
+  end if;
+
+  -- Handle DELETE: role removed
+  if TG_OP = 'DELETE' then
+    if OLD.role in ('instructor', 'grader', 'admin') then
+      perform public.sync_staff_github_team(OLD.class_id, OLD.user_id);
+    elsif OLD.role = 'student' then
+      perform public.sync_student_github_team(OLD.class_id, OLD.user_id);
+    end if;
+    return OLD;
+  end if;
+
+  return null;
+end;
+$$;

--- a/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
+++ b/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
@@ -110,3 +110,70 @@ begin
   return null;
 end;
 $$;
+
+-- Let trigger-initiated syncs skip the caller re-authorization.
+--
+-- sync_staff/student_github_team re-check auth.uid() so DIRECT RPC callers must be instructor/admin.
+-- But this trigger fires AFTER the user_roles mutation has already been authorized (RLS /
+-- admin_set_user_role_disabled / the enrollment functions), and the mutation can leave the caller
+-- without the very role being checked — e.g. an admin disabling their own last admin role. The
+-- post-mutation re-auth then fails and rolls the whole operation back. Skip the re-auth when running
+-- inside a trigger (pg_trigger_depth() > 0); direct RPC calls (depth 0) are still authorized as
+-- before. This also covers the analogous self-mutation cases on the DELETE / role-change branches.
+create or replace function public.sync_staff_github_team(class_id integer, user_id uuid default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_org text;
+begin
+  if class_id is null then
+    raise warning 'sync_staff_github_team called with NULL class_id, skipping';
+    return;
+  end if;
+  if auth.uid() is not null
+     and pg_trigger_depth() = 0
+     and not (public.authorizeforclassinstructor(class_id::bigint) or public.authorize_for_admin()) then
+    raise exception 'Access denied: Only instructors or admins can sync staff GitHub team for class %', class_id;
+  end if;
+  select slug, github_org into v_slug, v_org from public.classes where id = class_id;
+  if v_slug is null or v_org is null then
+    -- Class isn't GitHub-configured; nothing to sync. Do NOT raise -- this runs
+    -- from a user_roles trigger and would otherwise block the enrollment.
+    raise warning 'Skipping staff GitHub team sync for class %: missing org/slug', class_id;
+    return;
+  end if;
+  perform public.enqueue_github_sync_staff_team(class_id::bigint, v_org, v_slug, user_id, null);
+end;
+$$;
+
+create or replace function public.sync_student_github_team(class_id integer, user_id uuid default null)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_slug text;
+  v_org text;
+begin
+  if class_id is null then
+    raise warning 'sync_student_github_team called with NULL class_id, skipping';
+    return;
+  end if;
+  if auth.uid() is not null
+     and pg_trigger_depth() = 0
+     and not (public.authorizeforclassinstructor(class_id::bigint) or public.authorize_for_admin()) then
+    raise exception 'Access denied: Only instructors or admins can sync student GitHub team for class %', class_id;
+  end if;
+  select slug, github_org into v_slug, v_org from public.classes where id = class_id;
+  if v_slug is null or v_org is null then
+    raise warning 'Skipping student GitHub team sync for class %: missing org/slug', class_id;
+    return;
+  end if;
+  perform public.enqueue_github_sync_student_team(class_id::bigint, v_org, v_slug, user_id, null);
+end;
+$$;

--- a/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
+++ b/supabase/migrations/20260728010000_include_admin_in_staff_github_team_sync.sql
@@ -8,8 +8,11 @@
 -- Finish that change here by teaching the trigger that admin is a staff role. (The matching edge
 -- functions that build the staff username list / write github_org_confirmed are updated alongside.)
 --
--- Only the staff-branch role predicates change; the student branches already key off `!= 'student'`,
--- which correctly treats admin as non-student, so they are unchanged.
+-- The staff-branch role predicates now match ('instructor','grader','admin'); the student branches
+-- already key off `!= 'student'`, which correctly treats admin as non-student, so they are unchanged.
+-- This revision also adds a staff disable/enable branch: previously only student disable/enable
+-- resynced the team, so disabling a staff member left them on the GitHub staff team. The desired-
+-- member fetchers in the edge functions gain a matching `disabled = false` filter.
 CREATE OR REPLACE FUNCTION "public"."sync_github_teams_on_role_change"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'public'
@@ -48,6 +51,14 @@ begin
     if NEW.role = 'student' and
        OLD.disabled != NEW.disabled then
       perform public.sync_student_github_team(NEW.class_id, NEW.user_id);
+    end if;
+
+    -- If a staff role is reactivated or deactivated, resync the staff team so a disabled staff
+    -- member is removed from the GitHub staff team (and a re-enabled one is re-added). Previously
+    -- only student disable/enable was handled, so disabling a staff member left them on the team.
+    if NEW.role in ('instructor', 'grader', 'admin') and
+       OLD.disabled != NEW.disabled then
+      perform public.sync_staff_github_team(NEW.class_id, NEW.user_id);
     end if;
 
     -- Consolidated repo creation and permission sync logic


### PR DESCRIPTION
Batch of fixes for recurring production/Sentry errors. Each commit is a self-contained fix.

---

## 1. `github-async-worker`: infinite requeue when assignments share a handout repo

Copying an assignment (and the `fork_from_prior_assignment` handout mode) can leave **two assignments pointing at the same handout/template repo** — a supported case for copied assignments and multi-section courses.

The `create_repo` handler resolved the handout SHA with `.eq("template_repo", templateRepo).maybeSingle()`. When two assignments share `templateRepo`, `.maybeSingle()` errors on the >1-row match, and that error is thrown inside a block whose `catch` **re-throws to requeue the job** — so the new student/group repo is stranded at `is_github_ready=false` and requeues forever.

**Fix:** every `repositories` row carries a non-null `assignment_id`, so resolve `latest_template_sha` from *this repo's own assignment* by id (new `getAssignmentTemplateSha` helper) instead of reverse-matching by repo name.

## 2. `create_invitation`: duplicate key on re-invite / roster re-import

`duplicate key value violates unique constraint "invitations_class_id_sis_user_id_key"`

`create_invitation` only guarded against an existing **`pending`** invitation, then blindly `INSERT`ed, but the constraint is unconditional (`UNIQUE (class_id, sis_user_id)`). An existing invitation in any other status slipped past the guard and violated the constraint.

**Fix** (`20260728000000_...sql` + `InvitationUtils.ts`):
- `create_invitation` looks up *any* existing invitation for the pair and reactivates it **only when it is `dropped`** (the transition wired to the auto-accept trigger, so an existing user is re-enrolled). `pending`/`accepted`/`cancelled` raise "already exists" — resetting `accepted` would un-accept an enrolled student, and reactivating `cancelled` would never fire the dropped-only auto-accept trigger. Reused profile pair is preserved (#390); the private profile's name is refreshed when a corrected name is supplied.
- A transaction-scoped `pg_advisory_xact_lock` on `(class_id, sis_user_id)` serializes concurrent calls (fresh-insert collision + reactivation race).
- The `invitation-create` edge function broadens its pre-check to any status and short-circuits pending/accepted/cancelled as a graceful soft error, so the RPC (and its Sentry-logged raise) is only reached for `dropped`/none.

## 3 & 4. `admin` role vs. the GitHub staff team

`Team type staff does not match user role admin, not updating confirmation`

"Staff" for GitHub org/team purposes means every **non-student** role (admin, instructor, grader), but almost every reconciliation path only matched `('instructor','grader')` while two paths *did* include admin — so an admin could be added to the staff team then reconciled back out / never confirmed. `20260623000000_allow_admin_github_team_sync` had already widened the auth guard but left role-inclusion half-done.

- **Commit 3** — `github-repo-webhook` membership handler now confirms `admin` on the `-staff` team (still logs a mismatch for genuinely wrong pairings, e.g. a student on the staff team).
- **Commit 4 + review follow-up** — admin is treated as staff across every reconciliation path (verified by a full audit of edge functions, SQL, and frontend): the `sync_github_teams_on_role_change` trigger (`20260728010000_...sql`), `github-user-sync` `ensureStaffOrgMembership`, `autograder-sync-staff-team` (both fetchers), `github-async-worker` `sync_staff_team`, and `GitHubWrapper.markUserRoleOrgConfirmedForTeam`. The follow-up also hardens this path: `maybeSingle` on the per-user reinvite checks so a **deleted** role can't throw and abort the class-wide reconcile; `disabled=false` on the staff desired-member fetchers; and a staff **disable/enable** resync branch in the trigger. Course-scoped `isStaff` for UI/realtime/RLS is a deliberately separate concept and is left unchanged.

## 5. `waitForRepoReady`: false "did not become ready in time" on slow repos

`Error: Repo … did not become ready in time` (from `assignment-create-solution-repo` / handout creation)

`waitForRepoReady` only considered a repo ready when `size > 0`. GitHub's `size` field is refreshed by a lagging background job, so a freshly generated/forked repo can report `size=0` for a long time **even after its content has fully landed** — the poll exhausted all 30 attempts and threw for a repo that was created correctly.

**Fix:** keep `size > 0` as a fast positive, but make the authoritative readiness signal the existence of the **default-branch ref** (`heads/{default_branch}`) — it appears as soon as the initial commit is mirrored (the same reliable check `isRepoEmpty` uses). 404/409 → keep polling; other statuses propagate.

---

## Testing

- `npm run typecheck:functions` — no new errors from the TypeScript changes (118 pre-existing errors in unrelated `scripts/`, unchanged).
- The two SQL migrations mirror the current working function bodies with only the targeted changes; not applied locally (Docker/Supabase not running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators are now included in staff GitHub team synchronization and organization confirmation workflows.
  * Re-inviting a dropped class invitation now reactivates the existing invitation instead of creating a duplicate.
  * Invitation handling now provides clearer results for existing pending, accepted, or cancelled invitations.
* **Bug Fixes**
  * Disabled staff are excluded from GitHub team synchronization and reinvitations.
  * GitHub repository readiness and assignment template synchronization are now more reliable.
  * Staff and student team updates respond more consistently to role and account-status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->