### PR TITLE
fix: filter worker chunk-load noise; fix the realtime subscribe-after-close race

### DIFF
--- a/hooks/useGradebook.tsx
+++ b/hooks/useGradebook.tsx
@@ -747,7 +747,10 @@ export class GradebookCellController {
         this._data = await this._fetchGradebookForThisStudent();
       }
 
-      if (this._closed) {
+      // The class controller can be closed by a navigation while the fetch above is in flight,
+      // leaving this gradebook controller open but with nothing to subscribe to (its subscribe
+      // methods throw once closed, which would surface here as an unhandled rejection).
+      if (this._closed || this._classRealTimeController.isClosed) {
         return;
       }
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -160,13 +160,6 @@ Sentry.init({
         if (exception.value?.includes("Failed to execute 'importScripts' on 'WorkerGlobalScope'")) {
           return null;
         }
-        // Teardown race in the realtime controllers: a reconnect scheduled before a navigation
-        // fires after the ClassRealTimeController for the page being left was closed, and the
-        // throw surfaces as an unhandled rejection. The controller is already gone and the new
-        // page subscribes through its own, so there is nothing to act on.
-        if (exception.value?.includes("Cannot subscribe to channels after they have been closed")) {
-          return null;
-        }
         // Discard the stale-bundle sibling of ChunkLoadError: a deploy lands
         // mid-session, the chunk file loads (200) but the loaded webpack runtime
         // is missing the requested module factory, so `__webpack_require__` hits

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -151,6 +151,22 @@ Sentry.init({
         ) {
           return null; // Discard chunk load errors
         }
+        // The worker-side sibling of ChunkLoadError: a web worker importScripts() a Next
+        // chunk that it can't fetch — the tab dropped offline (these arrive interleaved with
+        // realtime channel_error/reconnect breadcrumbs) or a deploy landed mid-session and the
+        // old chunk is gone. Reported both as a plain onerror Error and, when the worker's
+        // ErrorEvent itself is captured, as an `ErrorEvent` whose value wraps the same text,
+        // so match on the message rather than the type.
+        if (exception.value?.includes("Failed to execute 'importScripts' on 'WorkerGlobalScope'")) {
+          return null;
+        }
+        // Teardown race in the realtime controllers: a reconnect scheduled before a navigation
+        // fires after the ClassRealTimeController for the page being left was closed, and the
+        // throw surfaces as an unhandled rejection. The controller is already gone and the new
+        // page subscribes through its own, so there is nothing to act on.
+        if (exception.value?.includes("Cannot subscribe to channels after they have been closed")) {
+          return null;
+        }
         // Discard the stale-bundle sibling of ChunkLoadError: a deploy lands
         // mid-session, the chunk file loads (200) but the loaded webpack runtime
         // is missing the requested module factory, so `__webpack_require__` hits

--- a/lib/ClassRealTimeController.ts
+++ b/lib/ClassRealTimeController.ts
@@ -123,6 +123,10 @@ export class ClassRealTimeController implements PawtograderRealTimeController {
   get profileId(): string {
     return this._profileId;
   }
+
+  get isClosed(): boolean {
+    return this._closed;
+  }
   /**
    * Start the realtime controller with enhanced features
    * Returns true when initialization is complete

--- a/lib/DiscussionThreadRealTimeController.ts
+++ b/lib/DiscussionThreadRealTimeController.ts
@@ -50,6 +50,10 @@ export class DiscussionThreadRealTimeController implements PawtograderRealTimeCo
     this._initializationPromise = this._initializeThreadChannel();
   }
 
+  get isClosed(): boolean {
+    return this._closed;
+  }
+
   /**
    * Start the realtime controller
    * Returns true when initialization is complete

--- a/lib/OfficeHoursRealTimeController.ts
+++ b/lib/OfficeHoursRealTimeController.ts
@@ -67,6 +67,10 @@ export class OfficeHoursRealTimeController implements PawtograderRealTimeControl
     this._initializationPromise = this._initializeGlobalChannels();
   }
 
+  get isClosed(): boolean {
+    return this._closed;
+  }
+
   /**
    * Start the realtime controller
    * Returns true when initialization is complete

--- a/lib/PawtograderRealTimeController.ts
+++ b/lib/PawtograderRealTimeController.ts
@@ -45,4 +45,12 @@ export interface PawtograderRealTimeController {
    * @returns Current status of all managed channels
    */
   getConnectionStatus(): ConnectionStatus;
+
+  /**
+   * Whether `close()` has been called. A closed controller has torn down its channels and
+   * cannot be revived, and its subscribe methods throw. Callers that reach a subscribe call
+   * across an `await` must re-check this: the controller can be closed by a navigation while
+   * their initial fetch is still in flight.
+   */
+  readonly isClosed: boolean;
 }

--- a/lib/TableController.ts
+++ b/lib/TableController.ts
@@ -1855,8 +1855,14 @@ export default class TableController<
           this._bumpMaxUpdatedAtFrom(r);
         }
 
-        // Set up realtime subscription if controller is provided
-        if (!this._closed && this._classRealTimeController) {
+        // Set up realtime subscription if controller is provided.
+        //
+        // `isClosed` matters as much as our own `_closed`: the initial fetch above is awaited,
+        // and a navigation during that fetch closes the class controller without closing this
+        // TableController. Subscribing then throws out of this promise executor as an unhandled
+        // rejection. A closed controller has torn down its channels and can never be revived, so
+        // there is nothing to subscribe to — skip it and leave the fetched rows in place.
+        if (!this._closed && this._classRealTimeController && !this._classRealTimeController.isClosed) {
           if (this._submissionId) {
             this._classRealtimeUnsubscribe = this._classRealTimeController.subscribeToTableForSubmission(
               table,
@@ -1885,6 +1891,11 @@ export default class TableController<
         // Subscribe to additional realtime controllers (e.g., per-thread, office hours)
         if (!this._closed && this._additionalRealTimeControllers.length > 0) {
           for (const controller of this._additionalRealTimeControllers) {
+            // Same teardown race as the class controller above: skip any that closed while the
+            // initial fetch was in flight.
+            if (controller.isClosed) {
+              continue;
+            }
             // Subscribe to table changes
             const unsubscribe = controller.subscribeToTable(table, messageHandler);
             this._additionalRealtimeUnsubscribes.push(unsubscribe);

--- a/tests/unit/table-controller-closed-realtime-controller.test.ts
+++ b/tests/unit/table-controller-closed-realtime-controller.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment node
+ *
+ * (node, not the jsdom default: this test drives a real initial fetch through supabase-js, and
+ * the fetch stub has to return a `Response`, which jsdom does not provide.)
+ *
+ * Regression test for the "Cannot subscribe to channels after they have been closed"
+ * production error (unhandled rejection, reported from onunhandledrejection).
+ *
+ * Root cause: TableController's ready promise awaits the initial fetch and then subscribes to
+ * the class realtime controller, guarding only on its OWN `_closed` flag. A navigation during
+ * that fetch closes the ClassRealTimeController — which is what the reported breadcrumbs show
+ * (channel `teardown` / `status: CLOSED` right after a route change) — while this TableController
+ * is still open, so the subscribe call threw out of the promise executor with nobody to catch it.
+ *
+ * The fix also checks the controller's `isClosed`: a closed controller has torn down its channels
+ * and cannot be revived, so there is nothing to subscribe to. The fetched rows stay in place and
+ * the ready promise resolves normally.
+ */
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+import TableController from "@/lib/TableController";
+import type { ClassRealTimeController } from "@/lib/ClassRealTimeController";
+import type { ConnectionStatus } from "@/lib/PawtograderRealTimeController";
+import type { Database } from "@/utils/supabase/SupabaseTypes";
+
+const CLOSED_ERROR = "Cannot subscribe to channels after they have been closed";
+
+/**
+ * Stands in for ClassRealTimeController: throws from its subscribe methods once closed, exactly
+ * as the real one does.
+ */
+function makeFakeRealTimeController() {
+  const fake = {
+    closed: false,
+    subscribeToTableCalls: 0,
+    get isClosed() {
+      return fake.closed;
+    },
+    subscribeToTable() {
+      if (fake.closed) throw new Error(CLOSED_ERROR);
+      fake.subscribeToTableCalls++;
+      return () => {};
+    },
+    subscribeToTableForSubmission() {
+      if (fake.closed) throw new Error(CLOSED_ERROR);
+      fake.subscribeToTableCalls++;
+      return () => {};
+    },
+    subscribeToStatus() {
+      return () => {};
+    },
+    getConnectionStatus(): ConnectionStatus {
+      return { overall: "connected", channels: [], lastUpdate: new Date() };
+    }
+  };
+  return fake;
+}
+
+/**
+ * @param closeDuringFetch when true, the controller is closed while the initial fetch is in
+ * flight — the navigation-mid-fetch race from production.
+ */
+function makeController(closeDuringFetch: boolean) {
+  const realtime = makeFakeRealTimeController();
+
+  const fetchStub = jest.fn(async () => {
+    if (closeDuringFetch) {
+      realtime.closed = true;
+    }
+    return new Response("[]", {
+      status: 200,
+      statusText: "OK",
+      headers: { "Content-Type": "application/json" }
+    });
+  });
+
+  const client = createClient<Database>("http://localhost:54321", "test-anon-key", {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { fetch: fetchStub as unknown as typeof fetch }
+  }) as SupabaseClient<Database>;
+
+  const controller = new TableController({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    query: client.from("profiles").select("*").eq("class_id", 1) as any,
+    client,
+    table: "profiles",
+    classRealTimeController: realtime as unknown as ClassRealTimeController,
+    loadEntireTable: true
+  });
+
+  return { controller, realtime };
+}
+
+describe("TableController with a class realtime controller closed mid-fetch", () => {
+  it("resolves ready instead of rejecting, and skips the subscription", async () => {
+    const { controller, realtime } = makeController(true);
+
+    await expect(controller.readyPromise).resolves.toBeUndefined();
+    expect(realtime.isClosed).toBe(true);
+    expect(realtime.subscribeToTableCalls).toBe(0);
+
+    controller.close();
+  });
+
+  it("still subscribes when the controller stays open", async () => {
+    const { controller, realtime } = makeController(false);
+
+    await expect(controller.readyPromise).resolves.toBeUndefined();
+    expect(realtime.subscribeToTableCalls).toBe(1);
+
+    controller.close();
+  });
+});


### PR DESCRIPTION
Two nuisance client-side Sentry errors. One is browser noise and gets filtered; the other turned out to be a real race in our realtime teardown, so it gets fixed at the source instead.

## Filtered: `Failed to execute 'importScripts' on 'WorkerGlobalScope'`

A web worker can't fetch a Next chunk. The reported events show the cause: breadcrumbs are full of realtime `channel_error` / `reconnect` / `network: online (wasOffline: true)` entries and a failed token refresh, i.e. the tab lost connectivity. The same signature also appears when a deploy lands mid-session and the old chunk is gone. This is the worker-side sibling of `ChunkLoadError`, which `instrumentation-client.ts` already filters.

It arrives in two shapes — a plain `Error` from the global `onerror` handler, and an `ErrorEvent` captured as an exception whose value wraps the same text — so the filter matches on the message rather than the exception type.

## Fixed: `Cannot subscribe to channels after they have been closed`

Not browser noise — our own code, and the breadcrumbs pin it down. Navigating away from `/course/635/assignments/…` tears down the `ClassRealTimeController` (channel `teardown`, `status: CLOSED`) while REST fetches for the page being left are still in flight.

Two controllers reach a subscribe call across an `await` and guard only on their **own** `_closed` flag, not the controller they are about to subscribe to:

- `TableController`'s ready promise (`lib/TableController.ts`) — awaits the initial fetch, then subscribes to the class controller and any additional controllers.
- `GradebookCellController._initialize` (`hooks/useGradebook.tsx`) — awaits its fetch, then calls `_setupRealTimeSubscriptions()`.

When the class controller closed during that fetch, the subscribe call threw out of a promise executor with nobody to catch it → unhandled rejection. Nothing was actually broken; the page it belonged to was already gone.

`isClosed` joins the `PawtograderRealTimeController` contract (all three implementations already track `_closed` internally) and both call sites now check it. A closed controller has torn down its channels and cannot be revived, so there is nothing to subscribe to — the fetched rows stay in place and the ready promise resolves.

The subscribe methods still **throw** for genuine misuse. Subscribing to a closed controller from live code is a real bug, so the filter for this message is removed rather than left as a backstop — if it reappears, it means something worth looking at.

### Not changed

The other `subscribe*` call sites (`useCourseController`, `useAssignment`, `ReviewsTable`, the submissions layout) run synchronously inside effects or constructors, where the controller can't close underneath them, so they need no guard.

## Testing

- New `tests/unit/table-controller-closed-realtime-controller.test.ts` reproduces the race: the fetch stub closes the fake controller while the initial fetch is in flight. Confirmed it fails without the fix (`Rejected to value: [Error: Cannot subscribe to channels after they have been closed]`) and passes with it, and a companion case asserts the subscription still happens when the controller stays open. It runs under `@jest-environment node` because the stub returns a real `Response`, which jsdom lacks.
- `npm test`: 529 passed, 1 skipped. The single failing suite (`llm-hint.test.ts`, `Request is not defined` under jsdom) is the pre-existing failure documented in AGENTS.md.
- `npm run lint` / `npm run format` clean; `tsc --noEmit` reports the same 8 pre-existing errors as `staging`, none in the touched files.

The `importScripts` filter itself is not unit-tested: `beforeSend` is defined inline in the `Sentry.init` call, and the file carries an explicit warning that adding imports to this entry can make the whole client-instrumentation module fail to evaluate (silently taking Sentry and PostHog init down with it). Extracting the predicate to make it testable is exactly the change that comment warns against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
