### PR TITLE
fix: Test Assignment preview no longer bounces to the dashboard (#883)

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/layout.tsx
@@ -20,14 +20,23 @@ export default async function AssignmentLayout({
   if (!user_id) {
     redirect("/");
   }
-  // Validate access: if not released and not grader or instructor, redirect to course page.
-  // Honor view-as so an instructor masquerading as a student gets the student release-date gate.
+  // Validate access: an unreleased assignment is off limits to students. Honor view-as so an
+  // instructor masquerading as a student gets the same release-date gate the student would.
   const role = await getEffectiveCourseIdentity(Number(course_id), user_id);
   if (!role) {
     redirect("/");
   }
 
-  if (role.role !== "instructor" && role.role !== "grader") {
+  // Staff previewing their own test-assignment submissions are exempt: the release date gates
+  // *enrolled students* out of an assignment, and staff own the assignment they are testing.
+  // Applying it to them bounced the Manage → Test Assignment submission links to the dashboard
+  // for any assignment not yet released (issue #883). The student-facing content filters
+  // (grade release, rubric visibility, hidden autograder output) still apply.
+  const isStaff = role.role === "instructor" || role.role === "grader";
+  if (!isStaff && !role.isViewingAsSelf) {
+    // Send staff masquerading as an enrolled student back to the course rather than the
+    // all-courses dashboard, so the view-as banner (and its exit button) stays in reach.
+    const blockedDestination = role.isViewingAs ? `/course/${course_id}` : "/";
     const client = await createClientWithCaching({ tags: ["assignment-release-date"] });
     const { data: assignment } = await client
       .from("assignments")
@@ -36,7 +45,7 @@ export default async function AssignmentLayout({
       .eq("class_id", Number(course_id))
       .single();
     if (!assignment) {
-      redirect("/");
+      redirect(blockedDestination);
     }
     if (
       assignment.release_date &&
@@ -45,13 +54,12 @@ export default async function AssignmentLayout({
         new TZDate(new Date(), assignment.classes.time_zone)
       )
     ) {
-      redirect("/");
+      redirect(blockedDestination);
     }
   }
 
   // Keep instructor/grader assignment pages responsive for very large classes by
   // skipping heavyweight SSR prefetch. Students retain SSR prefetch for faster first paint.
-  const isStaff = role.role === "instructor" || role.role === "grader";
   const initialData = isStaff ? undefined : await fetchAssignmentControllerData(assignmentId, false);
   return (
     <AssignmentProvider assignment_id={assignmentId} initialData={initialData}>

--- a/lib/ssrUtils.ts
+++ b/lib/ssrUtils.ts
@@ -140,6 +140,12 @@ export async function getUserRolesForCourse(course_id: number, user_id: string):
 export type EffectiveCourseIdentity = UserRoleData & {
   /** True when real staff are viewing the course as a student. */
   isViewingAs: boolean;
+  /**
+   * True when staff are previewing their *own* test-assignment work as a student, rather than
+   * masquerading as an enrolled student. These viewers keep staff-level access to the assignment
+   * itself (they own it) — only the student-facing content filters apply.
+   */
+  isViewingAsSelf: boolean;
   /** The viewer's actual role in the course (unchanged by view-as). */
   realRole: Database["public"]["Enums"]["app_role"];
   /** The target private profile id when viewing as, otherwise null. */
@@ -169,6 +175,7 @@ export async function getEffectiveCourseIdentity(
   const base: EffectiveCourseIdentity = {
     ...realRole,
     isViewingAs: false,
+    isViewingAsSelf: false,
     realRole: realRole.role,
     viewAsProfileId: null
   };
@@ -191,6 +198,7 @@ export async function getEffectiveCourseIdentity(
       public_profile_id: realRole.public_profile_id,
       private_profile_id: realRole.private_profile_id,
       isViewingAs: true,
+      isViewingAsSelf: true,
       realRole: realRole.role,
       viewAsProfileId: realRole.private_profile_id
     };
@@ -223,6 +231,7 @@ export async function getEffectiveCourseIdentity(
     public_profile_id: targetRole.public_profile_id,
     private_profile_id: targetRole.private_profile_id,
     isViewingAs: true,
+    isViewingAsSelf: false,
     realRole: realRole.role,
     viewAsProfileId: targetRole.private_profile_id
   };

--- a/tests/e2e/test-assignment-view-as-student.spec.ts
+++ b/tests/e2e/test-assignment-view-as-student.spec.ts
@@ -22,6 +22,9 @@ let course: Course;
 let instructor: TestingUser;
 let grader: TestingUser;
 let assignmentId: number;
+/** An assignment whose release date is still in the future, as it is while staff test it. */
+let unreleasedAssignmentId: number;
+let unreleasedSubmissionId: number;
 const staffSubmissions = new Map<string, number>();
 
 async function requireNoError<T>(result: { data: T; error: { message: string } | null }, context: string): Promise<T> {
@@ -207,6 +210,23 @@ test.beforeAll(async ({}, testInfo) => {
 
   staffSubmissions.set("grader", await seedStaffTestSubmission(grader, instructor.private_profile_id));
   staffSubmissions.set("instructor", await seedStaffTestSubmission(instructor, instructor.private_profile_id));
+
+  // Staff normally test an assignment before releasing it to students, so seed a second
+  // assignment whose release date is still ahead of us.
+  const unreleasedAssignment = await insertAssignment({
+    due_date: addDays(new Date(), 10).toUTCString(),
+    release_date: addDays(new Date(), 5).toUTCString(),
+    class_id: course.id,
+    name: "Test Assignment Unreleased Preview E2E"
+  });
+  unreleasedAssignmentId = unreleasedAssignment.id;
+  unreleasedSubmissionId = (
+    await insertPreBakedSubmission({
+      student_profile_id: instructor.private_profile_id,
+      assignment_id: unreleasedAssignmentId,
+      class_id: course.id
+    })
+  ).submission_id;
 });
 
 test.afterEach(async ({ logMagicLinksOnFailure }) => {
@@ -289,5 +309,32 @@ test.describe("Test Assignment student preview", () => {
 
     await banner.getByRole("button", { name: "Exit student view" }).click();
     await expect(page.getByRole("alert", { name: "Viewing as student" })).toHaveCount(0);
+  });
+
+  // Issue #883: the student release-date gate on the assignment layout also fired for staff
+  // previewing their own test submission, bouncing them to the all-courses dashboard while
+  // leaving the view-as cookie set.
+  test("instructor previews a test submission on an assignment that is not yet released", async ({ page }) => {
+    await loginAsUser(page, instructor, course);
+    await page.goto(`/course/${course.id}/manage/assignments/${unreleasedAssignmentId}/test`);
+    await expect(page.getByRole("heading", { name: "Test Assignment", exact: true })).toBeVisible();
+
+    await page.getByRole("link", { name: String(unreleasedSubmissionId), exact: true }).click();
+
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/course/${course.id}/assignments/${unreleasedAssignmentId}/submissions/${unreleasedSubmissionId}/(results|files|grade)`
+      )
+    );
+    const banner = page.getByRole("alert", { name: "Viewing as student" });
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("Test Assignment View Instructor");
+
+    // Exiting returns the same page under the instructor's own identity.
+    await banner.getByRole("button", { name: "Exit student view" }).click();
+    await expect(page.getByRole("alert", { name: "Viewing as student" })).toHaveCount(0);
+    await expect(page).toHaveURL(
+      new RegExp(`/course/${course.id}/assignments/${unreleasedAssignmentId}/submissions/${unreleasedSubmissionId}/`)
+    );
   });
 });

--- a/tests/e2e/view-as-student.spec.ts
+++ b/tests/e2e/view-as-student.spec.ts
@@ -15,6 +15,8 @@ let course: Course;
 let student: TestingUser | undefined;
 let instructor: TestingUser | undefined;
 
+let unreleasedAssignmentId: number;
+
 const STUDENT_NAME = "View As Target Student";
 const ASSIGNMENT_TITLE = "View As Target Assignment";
 
@@ -46,6 +48,16 @@ test.beforeAll(async ({}, testInfo) => {
     name: ASSIGNMENT_TITLE,
     due_date: addDays(new Date(), 7).toUTCString()
   });
+  // An assignment students cannot reach yet, to check where the release-date gate sends
+  // an instructor who is masquerading as one of them.
+  unreleasedAssignmentId = (
+    await insertAssignment({
+      class_id: course.id,
+      name: "View As Unreleased Assignment",
+      due_date: addDays(new Date(), 14).toUTCString(),
+      release_date: addDays(new Date(), 7).toUTCString()
+    })
+  ).id;
 });
 
 test.afterEach(async ({ logMagicLinksOnFailure }) => {
@@ -185,6 +197,21 @@ test.describe("Instructor view-as-student (read-only)", () => {
 
     await page.goto(`/course/${course.id}/manage/course/enrollments`);
 
+    await expect(page).toHaveURL(new RegExp(`/course/${course.id}(/)?$`));
+    await expect(page.getByRole("alert", { name: "Viewing as student" })).toBeVisible();
+  });
+
+  test("an unreleased assignment sends view-as back to the course, not the dashboard", async ({ page }) => {
+    await loginAsUser(page, instructor!, course);
+
+    await page
+      .context()
+      .addCookies([{ name: viewAsCookieName(course.id), value: student!.private_profile_id, url: BASE_URL }]);
+
+    await page.goto(`/course/${course.id}/assignments/${unreleasedAssignmentId}`);
+
+    // The student cannot see this assignment yet, so the instructor previewing as them is
+    // turned away — but within the course, where the banner's exit button is still in reach.
     await expect(page).toHaveURL(new RegExp(`/course/${course.id}(/)?$`));
     await expect(page.getByRole("alert", { name: "Viewing as student" })).toBeVisible();
   });


### PR DESCRIPTION
Fixes #883.

## What was wrong

The Test Assignment page opens a staff member's own submission in the read-only student view: clicking a row sets the per-course `view_as_<id>` cookie and reloads the submission page. `app/course/[course_id]/assignments/[assignment_id]/layout.tsx` gates students out of an assignment whose release date has not passed, and it evaluated that gate against the *effective* identity — which, during the preview, is a student. Staff testing an assignment before releasing it were redirected to `/`, the all-courses dashboard, with the view-as cookie still set. That is why the course then opened in read-only student mode. Opening the link in a new tab worked because a plain navigation never sets the cookie.

## The fix

- `getEffectiveCourseIdentity` now reports `isViewingAsSelf`, distinguishing staff previewing their own test-assignment work from staff masquerading as an enrolled student.
- The assignment layout skips the release-date gate for the self-preview. Staff own the assignment they are testing; the preview exists to show student-facing *content* rules (grade release, rubric visibility, hidden autograder output), and those are unchanged.
- When an instructor really is viewing as an enrolled student, an unreleased assignment now redirects to the course page rather than the dashboard, so the view-as banner and its exit button stay in reach.

## Testing

Validated against a freshly reset local Supabase (all migrations applied) and a production build on port 3001.

- Reproduced first: with the fix reverted, the new test fails with `Received string: "http://localhost:3001/course"` — the dashboard, exactly as reported.
- New E2E `tests/e2e/test-assignment-view-as-student.spec.ts`: instructor previews a test submission on an assignment whose release date is 5 days out, lands on the submission page with the "Viewing as student" banner, and exits back to the same page.
- New E2E `tests/e2e/view-as-student.spec.ts`: an instructor masquerading as a real student hitting an unreleased assignment lands on the course page, banner still up.
- Both view-as specs pass on chromium (9/9), along with `submission-review-completion-policy` and `student-summary-unreleased-score`. Webkit could not run locally (missing system libraries in this environment).
- `npm run lint` clean; `npm test` 527 passed with the one pre-existing `llm-hint.test.ts` failure documented in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)