### PR TITLE
fix(chart): 0.3.14 — stop kong's init container needing the internet

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.13
+version: 0.3.14
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/templates/kong.yaml
+++ b/charts/pawtograder/templates/kong.yaml
@@ -140,9 +140,31 @@ spec:
             - sh
             - -c
             - |
-              set -e
-              apk add --no-cache gettext >/dev/null
-              envsubst < /template/kong.yml > /rendered/kong.yml
+              set -eu
+              # Substitute with busybox sed rather than `apk add gettext` +
+              # envsubst. The template has exactly two placeholders, so pulling
+              # a package off the internet on every pod start bought nothing —
+              # and it made pod startup depend on dl-cdn.alpinelinux.org being
+              # resolvable, which it is not on every network (Northeastern's
+              # resolver returns no answer for it). When that lookup fails the
+              # init container crash-loops, no new kong pod can start, and
+              # `helm upgrade --wait` blocks until it times out with an error
+              # that looks nothing like the cause.
+              #
+              # `|` is a safe sed delimiter here: both values are JWTs
+              # (base64url + dots), so they cannot contain `|`, `&` or `\`.
+              test -n "$SUPABASE_ANON_KEY"
+              test -n "$SUPABASE_SERVICE_KEY"
+              sed -e "s|\$SUPABASE_ANON_KEY|${SUPABASE_ANON_KEY}|g" \
+                  -e "s|\$SUPABASE_SERVICE_KEY|${SUPABASE_SERVICE_KEY}|g" \
+                  /template/kong.yml > /rendered/kong.yml
+              # Fail loudly rather than starting kong with a literal
+              # "$SUPABASE_..." string where a credential should be.
+              if grep -q '\$SUPABASE_' /rendered/kong.yml; then
+                echo "[render] ERROR: unsubstituted placeholder remains" >&2
+                grep -n '\$SUPABASE_' /rendered/kong.yml >&2
+                exit 1
+              fi
               echo "[render] /rendered/kong.yml ready ($(wc -l </rendered/kong.yml) lines)"
           env:
             - name: SUPABASE_ANON_KEY


### PR DESCRIPTION
This is the actual cause of the staging + preview deploy failures. **#897 (raising the helm client throttle) was a misdiagnosis** — it fixed a misleading error message, not the problem.

## What's happening

kong's `render-config` init container runs `apk add --no-cache gettext` on **every pod start**, just to get `envsubst`. That makes pod startup depend on resolving `dl-cdn.alpinelinux.org`:

```
WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.20/main: temporary error
ERROR: unable to select packages: gettext (no such package)
```

**Northeastern's resolver returns no answer for that name.** It resolves fine via 1.1.1.1 → Fastly, so this is filtering, not an outage. Ripley's CoreDNS forwards `.` to the node resolver, so every pod inherits it.

The init container crash-loops → the Deployment never becomes ready → `helm upgrade --wait` blocks until `--timeout` and dies with an error that looks nothing like the cause.

## Current state on ripley

| | |
|---|---|
| `pawtograder-staging` kong | `Init:Error`, **533 restarts** over 46h |
| `pawtograder-preview-pr-897` | `Init:CrashLoopBackOff` |
| `pawtograder-preview-pr-896` | `Init:CrashLoopBackOff` |

The sites still look healthy because the kong pods that started 11 days ago are still serving. **Only new pods are affected** — which is why this presented as "deploys fail" rather than "kong is down", and why it went unnoticed for ~2 days.

## Fix

`envsubst` was doing very little: the template has exactly **two** placeholders, `$SUPABASE_ANON_KEY` and `$SUPABASE_SERVICE_KEY`. Replaced with busybox `sed`, already in the image.

`|` is a safe delimiter — both values are JWTs (base64url + dots), so they can't contain `|`, `&` or `\`.

**Two guards added that didn't exist before:**
- fail if either variable is empty
- fail if any `$SUPABASE_` placeholder survives

Previously a substitution failure would have started kong with the literal string `$SUPABASE_ANON_KEY` where a credential belongs — silently, and with kong happily serving.

## Verification

Extracted the rendered ConfigMap and the generated init script from `helm template`, then **ran the script for real**:

- both keys substituted exactly once
- zero surviving placeholders
- output still parses as YAML (147 lines, unchanged)
- empty-value guard exits non-zero

## On #897

Worth deciding separately. The rate-limiter error *was* real, and raising QPS changed the failure from `client rate limiter Wait returned an error` to the honest `context deadline exceeded` — which is arguably better diagnostics. But it is not the fix and should not be merged as though it were.

## Worth noting

This removes a network dependency from a pod-start path, so it's worth having regardless of whether NU's DNS filtering is later relaxed. If other charts do the same thing, they'll have the same latent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)