### PR TITLE
feat(build): let the web build upload source maps to Bugsink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,14 @@ RUN --mount=type=secret,id=sentry_auth_token \
         echo "       URL as SENTRY_URL, or drop the secret to skip the upload." >&2; \
         exit 1; \
       fi; \
+      if [ -z "${NEXT_PUBLIC_BUGSINK_DSN:-}" ]; then \
+        echo "ERROR: sentry_auth_token was supplied without NEXT_PUBLIC_BUGSINK_DSN." >&2; \
+        echo "       The DSN is what enables the bundler plugin that performs the" >&2; \
+        echo "       upload, so without it this build would report an upload and" >&2; \
+        echo "       send nothing. It is also what makes the app report the errors" >&2; \
+        echo "       the maps would symbolicate." >&2; \
+        exit 1; \
+      fi; \
       if [ -z "${SENTRY_UPLOAD_ID:-}" ]; then \
         echo "ERROR: sentry_auth_token was supplied without SENTRY_UPLOAD_ID. Secret" >&2; \
         echo "       contents are not part of the BuildKit cache key, so this layer" >&2; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,20 @@ ARG NEXT_PUBLIC_PAWTOGRADER_CHANNEL=""
 ARG NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=""
 ARG SENTRY_RELEASE=""
 # Source map upload target. Set SENTRY_URL to a self-hosted Bugsink base URL to
-# upload there instead of sentry.io; leave empty to skip upload entirely. The
-# auth token is NOT an ARG — it arrives as a BuildKit secret below.
+# upload there; leave empty to skip upload entirely. sentry.io is never a valid
+# target — a token without a URL is an error, not a silent upload to the SaaS
+# endpoint. The auth token is NOT an ARG — it arrives as a BuildKit secret below.
 ARG SENTRY_URL=""
 ARG SENTRY_ORG=""
 ARG SENTRY_PROJECT=""
+# Cache key for the build layer that performs the upload. BuildKit deliberately
+# leaves secret *contents* out of the cache key, and both image workflows import
+# and export layer caches, so a build of the same commit that ran before the
+# token was wired can otherwise be replayed from cache — reusing the layer and
+# skipping the upload permanently. Any non-secret value that changes when the
+# upload configuration changes works (a token fingerprint, the CI run id);
+# builds that mount sentry_auth_token are required to pass one.
+ARG SENTRY_UPLOAD_ID=""
 ARG SUPABASE_URL=""
 
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
@@ -66,6 +75,7 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     SENTRY_URL=$SENTRY_URL \
     SENTRY_ORG=$SENTRY_ORG \
     SENTRY_PROJECT=$SENTRY_PROJECT \
+    SENTRY_UPLOAD_ID=$SENTRY_UPLOAD_ID \
     SUPABASE_URL=$SUPABASE_URL \
     NEXT_TELEMETRY_DISABLED=1 \
     NEXT_OUTPUT_STANDALONE=true
@@ -85,9 +95,24 @@ RUN --mount=type=secret,id=sentry_auth_token \
     [ -n "${SENTRY_ORG:-}" ] || unset SENTRY_ORG; \
     [ -n "${SENTRY_PROJECT:-}" ] || unset SENTRY_PROJECT; \
     if [ -s /run/secrets/sentry_auth_token ]; then \
+      if [ -z "${SENTRY_URL:-}" ]; then \
+        echo "ERROR: sentry_auth_token was supplied without SENTRY_URL. The bundler" >&2; \
+        echo "       plugin treats a missing URL as sentry.io, so this would ship" >&2; \
+        echo "       private source maps to the SaaS endpoint. Pass the Bugsink base" >&2; \
+        echo "       URL as SENTRY_URL, or drop the secret to skip the upload." >&2; \
+        exit 1; \
+      fi; \
+      if [ -z "${SENTRY_UPLOAD_ID:-}" ]; then \
+        echo "ERROR: sentry_auth_token was supplied without SENTRY_UPLOAD_ID. Secret" >&2; \
+        echo "       contents are not part of the BuildKit cache key, so this layer" >&2; \
+        echo "       could be served from a cached build that skipped the upload." >&2; \
+        echo "       Pass any non-secret value that changes with the upload config" >&2; \
+        echo "       (a token fingerprint, the CI run id) as SENTRY_UPLOAD_ID." >&2; \
+        exit 1; \
+      fi; \
       SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"; \
       export SENTRY_AUTH_TOKEN; \
-      echo "sentry: uploading source maps to ${SENTRY_URL:-sentry.io} (project ${SENTRY_PROJECT:-pawtograder-web})"; \
+      echo "sentry: uploading source maps to $SENTRY_URL (project ${SENTRY_PROJECT:-pawtograder-web}, upload id $SENTRY_UPLOAD_ID)"; \
     else \
       echo "sentry: no auth token supplied, skipping source map upload"; \
     fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ ARG NEXT_PUBLIC_GIT_COMMIT_SHA=""
 ARG NEXT_PUBLIC_PAWTOGRADER_CHANNEL=""
 ARG NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=""
 ARG SENTRY_RELEASE=""
+# Source map upload target. Set SENTRY_URL to a self-hosted Bugsink base URL to
+# upload there instead of sentry.io; leave empty to skip upload entirely. The
+# auth token is NOT an ARG — it arrives as a BuildKit secret below.
+ARG SENTRY_URL=""
+ARG SENTRY_ORG=""
+ARG SENTRY_PROJECT=""
 ARG SUPABASE_URL=""
 
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
@@ -57,6 +63,9 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     NEXT_PUBLIC_PAWTOGRADER_CHANNEL=$NEXT_PUBLIC_PAWTOGRADER_CHANNEL \
     NEXT_PUBLIC_CHANNEL_HOST_SUFFIX=$NEXT_PUBLIC_CHANNEL_HOST_SUFFIX \
     SENTRY_RELEASE=$SENTRY_RELEASE \
+    SENTRY_URL=$SENTRY_URL \
+    SENTRY_ORG=$SENTRY_ORG \
+    SENTRY_PROJECT=$SENTRY_PROJECT \
     SUPABASE_URL=$SUPABASE_URL \
     NEXT_TELEMETRY_DISABLED=1 \
     NEXT_OUTPUT_STANDALONE=true
@@ -65,7 +74,24 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
 RUN test -n "$NEXT_PUBLIC_PAWTOGRADER_WEB_URL" \
     || (echo "ERROR: NEXT_PUBLIC_PAWTOGRADER_WEB_URL build arg is required" && exit 1)
 
-RUN NODE_OPTIONS=--max-old-space-size=8000 npm run build
+# The Sentry auth token is a BuildKit secret, not an ARG, so it never lands in
+# an image layer or `docker history`. The mount is optional: without a token the
+# bundler plugin still emits and injects debug IDs, it just skips the upload.
+# Empty ARGs are unset rather than exported as "" — the plugin only falls back to
+# sentry.io when SENTRY_URL is nullish, and "" would be treated as a real URL.
+RUN --mount=type=secret,id=sentry_auth_token \
+    set -eu; \
+    [ -n "${SENTRY_URL:-}" ] || unset SENTRY_URL; \
+    [ -n "${SENTRY_ORG:-}" ] || unset SENTRY_ORG; \
+    [ -n "${SENTRY_PROJECT:-}" ] || unset SENTRY_PROJECT; \
+    if [ -s /run/secrets/sentry_auth_token ]; then \
+      SENTRY_AUTH_TOKEN="$(cat /run/secrets/sentry_auth_token)"; \
+      export SENTRY_AUTH_TOKEN; \
+      echo "sentry: uploading source maps to ${SENTRY_URL:-sentry.io} (project ${SENTRY_PROJECT:-pawtograder-web})"; \
+    else \
+      echo "sentry: no auth token supplied, skipping source map upload"; \
+    fi; \
+    NODE_OPTIONS=--max-old-space-size=8000 npm run build
 
 FROM node:22-bookworm-slim AS runner
 WORKDIR /app

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -353,6 +353,7 @@ the build is given somewhere to send them:
 ```sh
 docker build \
   --build-arg NEXT_PUBLIC_PAWTOGRADER_WEB_URL=https://staging.pawtograder.net \
+  --build-arg NEXT_PUBLIC_BUGSINK_DSN=$BUGSINK_DSN \
   --build-arg SENTRY_URL=https://bugsink.example.edu \
   --build-arg SENTRY_PROJECT=pawtograder-web \
   --build-arg SENTRY_UPLOAD_ID=$(date +%s) \
@@ -362,6 +363,11 @@ docker build \
 
 - **`sentry_auth_token`** is a BuildKit secret, never a build-arg, so it stays out
   of the image layers and `docker history`. Create it in the Bugsink UI.
+- **`NEXT_PUBLIC_BUGSINK_DSN`** is what enables the bundler plugin that does the
+  upload, so it is required here even though it is otherwise about runtime error
+  reporting. Without it there are no reported errors to symbolicate, so a token
+  without a DSN is a misconfiguration and fails the build rather than reporting an
+  upload that never happens.
 - **`SENTRY_URL`** — your Bugsink base URL. Required whenever the token is
   present: the bundler plugin reads a missing URL as sentry.io, so the build
   fails rather than shipping your source maps to a third party.

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -344,6 +344,40 @@ docker build \
   -t ghcr.io/pawtograder/web:$VERSION .
 ```
 
+### Source map upload (optional)
+
+Every web bundle carries injected debug IDs, but a stack trace in Bugsink stays
+minified until the matching source maps are uploaded. That upload is off unless
+the build is given somewhere to send them:
+
+```sh
+docker build \
+  --build-arg NEXT_PUBLIC_PAWTOGRADER_WEB_URL=https://staging.pawtograder.net \
+  --build-arg SENTRY_URL=https://bugsink.example.edu \
+  --build-arg SENTRY_PROJECT=pawtograder-web \
+  --build-arg SENTRY_UPLOAD_ID=$(date +%s) \
+  --secret id=sentry_auth_token,env=BUGSINK_AUTH_TOKEN \
+  -t ghcr.io/pawtograder/web:$VERSION .
+```
+
+- **`sentry_auth_token`** is a BuildKit secret, never a build-arg, so it stays out
+  of the image layers and `docker history`. Create it in the Bugsink UI.
+- **`SENTRY_URL`** — your Bugsink base URL. Required whenever the token is
+  present: the bundler plugin reads a missing URL as sentry.io, so the build
+  fails rather than shipping your source maps to a third party.
+- **`SENTRY_PROJECT`** — Bugsink ≥ 2.2.0 rejects an upload naming a project slug
+  it does not have. `SENTRY_ORG` is accepted but ignored (Bugsink is single-org).
+- **`SENTRY_UPLOAD_ID`** — cache key for the layer that performs the upload.
+  BuildKit deliberately leaves secret *contents* out of the build cache, so
+  without a value that changes per build, a layer built before the token existed
+  can be replayed afterwards and upload nothing. Any changing non-secret value
+  works; in CI use the run id plus the run attempt, since re-running a run keeps
+  the same run id. The build refuses a token without one.
+
+Pass none of these and the build behaves exactly as it did before: maps are
+generated, debug IDs are injected, and the upload step is skipped with
+`sentry: no auth token supplied, skipping source map upload` in the log.
+
 ## Deployment skinning / branding
 
 Self-hosted deployments can re-brand the app — service name, tagline, logos, and

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,8 +13,13 @@ const disableSentryComponentAnnotation =
   process.env.SENTRY_DISABLE_COMPONENT_ANNOTATION === "1" || useFastSentryBuildProfile;
 const disableSentryRouteManifestInjection =
   process.env.SENTRY_DISABLE_ROUTE_MANIFEST_INJECTION === "1" || useFastSentryBuildProfile;
-const disableSentryReleaseCreate = process.env.SENTRY_DISABLE_RELEASE_CREATE === "1";
-const disableSentryReleaseFinalize = process.env.SENTRY_DISABLE_RELEASE_FINALIZE === "1";
+// SENTRY_URL is only set when the build points at a self-hosted Bugsink rather
+// than sentry.io. Bugsink implements the source map upload endpoints that
+// sentry-cli uses (chunk-upload, artifactbundle/assemble) but not the release
+// API, so create/finalize 404 there — default them off when talking to Bugsink.
+const usingBugsink = !!process.env.SENTRY_URL;
+const disableSentryReleaseCreate = process.env.SENTRY_DISABLE_RELEASE_CREATE === "1" || usingBugsink;
+const disableSentryReleaseFinalize = process.env.SENTRY_DISABLE_RELEASE_FINALIZE === "1" || usingBugsink;
 const disableSentrySourcemaps = process.env.SENTRY_DISABLE_SOURCEMAPS === "1";
 const useSentryRunAfterProductionCompileHook = process.env.SENTRY_USE_RUN_AFTER_PRODUCTION_COMPILE === "1";
 
@@ -185,8 +190,12 @@ const hasSentryDsn = !!process.env.NEXT_PUBLIC_BUGSINK_DSN;
 
 const sentryConfig = {
   tunnelRoute: true,
-  org: "pawtograder",
-  project: "pawtograder-web",
+  // Overridable so a build can target a Bugsink project slug. Bugsink is
+  // single-org and ignores `org` entirely, but since 2.2.0 it rejects an upload
+  // whose `project` does not match an existing project slug.
+  // `||` not `??`: the Dockerfile passes these through as ARGs that default to "".
+  org: process.env.SENTRY_ORG || "pawtograder",
+  project: process.env.SENTRY_PROJECT || "pawtograder-web",
   // Keep Sentry enabled in CI while reducing build-time-only instrumentation overhead.
   routeManifestInjection: disableSentryRouteManifestInjection ? false : true,
   reactComponentAnnotation: {
@@ -200,7 +209,10 @@ const sentryConfig = {
     create: !disableSentryReleaseCreate,
     finalize: !disableSentryReleaseFinalize
   },
-  silent: !isCi,
+  // Quiet for local dev, but never while actually uploading source maps: the
+  // build runs inside Docker where CI is unset, and the upload report is the
+  // only evidence the upload happened at all.
+  silent: !isCi && !process.env.SENTRY_AUTH_TOKEN,
   disableLogger: true
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -216,4 +216,19 @@ const sentryConfig = {
   disableLogger: true
 };
 
-export default hasSentryDsn && !disableSentryBundlingPlugin ? withSentryConfig(nextConfig, sentryConfig) : nextConfig;
+const sentryPluginEnabled = hasSentryDsn && !disableSentryBundlingPlugin;
+
+// The only symbolication target is the self-hosted Bugsink named by SENTRY_URL;
+// there is no sentry.io account. The bundler plugin normalizes a nullish URL to
+// https://sentry.io, so a token without a URL would upload private source maps
+// to a third party. Fail the build instead. The Dockerfile checks this too, to
+// fail before spending a build, but the guard belongs here as well because the
+// upload runs for any `npm run build`, not just the containerized one.
+if (sentryPluginEnabled && !disableSentrySourcemaps && !!process.env.SENTRY_AUTH_TOKEN && !process.env.SENTRY_URL) {
+  throw new Error(
+    "SENTRY_AUTH_TOKEN is set but SENTRY_URL is empty: refusing to upload source maps to sentry.io. " +
+      "Set SENTRY_URL to the Bugsink base URL, or unset SENTRY_AUTH_TOKEN to skip the upload."
+  );
+}
+
+export default sentryPluginEnabled ? withSentryConfig(nextConfig, sentryConfig) : nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -218,17 +218,32 @@ const sentryConfig = {
 
 const sentryPluginEnabled = hasSentryDsn && !disableSentryBundlingPlugin;
 
-// The only symbolication target is the self-hosted Bugsink named by SENTRY_URL;
-// there is no sentry.io account. The bundler plugin normalizes a nullish URL to
-// https://sentry.io, so a token without a URL would upload private source maps
-// to a third party. Fail the build instead. The Dockerfile checks this too, to
-// fail before spending a build, but the guard belongs here as well because the
-// upload runs for any `npm run build`, not just the containerized one.
-if (sentryPluginEnabled && !disableSentrySourcemaps && !!process.env.SENTRY_AUTH_TOKEN && !process.env.SENTRY_URL) {
-  throw new Error(
-    "SENTRY_AUTH_TOKEN is set but SENTRY_URL is empty: refusing to upload source maps to sentry.io. " +
-      "Set SENTRY_URL to the Bugsink base URL, or unset SENTRY_AUTH_TOKEN to skip the upload."
-  );
+// An auth token means this build intends to upload source maps, so anything that
+// would quietly turn the upload into a no-op is an error. A build that reports
+// "uploading" and then ships minified stack traces is the exact failure this
+// change exists to remove. The Dockerfile pre-checks the same conditions to fail
+// before spending a build, but the guards belong here too: the upload runs for
+// any `npm run build`, not only the containerized one.
+if (process.env.SENTRY_AUTH_TOKEN && !disableSentrySourcemaps) {
+  // The only symbolication target is the self-hosted Bugsink named by SENTRY_URL;
+  // there is no sentry.io account. The bundler plugin normalizes a nullish URL to
+  // https://sentry.io, so a token without a URL hands private maps to a third party.
+  if (!process.env.SENTRY_URL) {
+    throw new Error(
+      "SENTRY_AUTH_TOKEN is set but SENTRY_URL is empty: refusing to upload source maps to sentry.io. " +
+        "Set SENTRY_URL to the Bugsink base URL, or unset SENTRY_AUTH_TOKEN to skip the upload."
+    );
+  }
+  // `withSentryConfig` is what installs the uploader, and the DSN is what turns it
+  // on. Without the DSN nothing uploads — and nothing reports errors either, so
+  // there would be no minified trace to symbolicate in the first place.
+  if (!sentryPluginEnabled) {
+    throw new Error(
+      "SENTRY_AUTH_TOKEN is set but the Sentry bundler plugin is disabled " +
+        `(${hasSentryDsn ? "NEXT_DISABLE_SENTRY=1" : "NEXT_PUBLIC_BUGSINK_DSN is empty"}), so no source maps ` +
+        "would be uploaded. Pass the DSN the app reports errors to, or unset SENTRY_AUTH_TOKEN to skip the upload."
+    );
+  }
 }
 
 export default sentryPluginEnabled ? withSentryConfig(nextConfig, sentryConfig) : nextConfig;


### PR DESCRIPTION
Khoury prod bundles already carry injected Sentry debug IDs — I pulled a live chunk to check:

```
$ curl .../\_next/static/chunks/webpack-8d5d180d599d4a3e.js | grep -o 'sentry-dbid-[a-f0-9-]*'
sentry-dbid-3f80ac8f-605e-4ba6-9a24-98063c9109b0
```

…but the maps themselves were never uploaded, so every Bugsink stack trace is minified. `@sentry/bundler-plugin-core` reads `SENTRY_AUTH_TOKEN` and `SENTRY_URL` from the environment; neither was ever set, so it warned once into a silenced logger and skipped the upload. The maps are not served publicly either (`.js.map` → 404), so there was no leak — just no symbolication.

This is the platform half. The prod-charts half passes the values in.

## What changed

**Dockerfile** — the token arrives as a BuildKit secret, not an `ARG`, so it never lands in an image layer or `docker history`. `SENTRY_URL`/`ORG`/`PROJECT` are plain build args. Empty args are `unset` rather than exported as `""`: the plugin only falls back to sentry.io when `SENTRY_URL` is *nullish*, so `""` would be treated as a real base URL and break the upload.

**next.config.ts** — three things Bugsink forces, each verified against [its source](https://github.com/bugsink/bugsink/blob/main/bugsink/urls.py):

- `org`/`project` become env-overridable. Bugsink is single-org and ignores the org slug, but since 2.2.0 `get_artifact_bundle_projects` rejects an upload whose project slug it does not have, so a hardcoded `pawtograder-web` cannot serve every target.
- release create/finalize default off when `SENTRY_URL` is set. Bugsink routes `chunk-upload` and `artifactbundle/assemble` but not the release API — confirmed against the live instance:
  ```
  GET /api/0/organizations/x/releases/  →  404 Unimplemented API endpoint
  ```
- the plugin is no longer silent while uploading. `silent: !isCi` was hiding the upload report, because `CI` is unset *inside* the Docker build — and that report is the only evidence the upload happened.

## Blast radius

None without a token. The build logs `sentry: no auth token supplied, skipping source map upload` and proceeds exactly as before, which is what staging and preview will keep doing until they are wired up too.

## Checked

- `docker buildx build --check` clean; the `--max-old-space-size=8000` anchor that prod-charts `sed`s is untouched
- `tsc --noEmit` introduces no new errors (43 pre-existing, all in `tests/`)
- shell logic of the new `RUN` simulated across all three states (no config / empty secret file / fully configured) — exits 0 in each, and `set -eu` never trips on the unset token

Not yet verified end-to-end: that needs a real Bugsink auth token, which only exists behind Jon's login. See the prod-charts PR for that step.