### PR TITLE
fix: stop long-idle tabs from crashing when a row is no longer visible

### DIFF
--- a/app/course/[course_id]/UserMenu.tsx
+++ b/app/course/[course_id]/UserMenu.tsx
@@ -388,7 +388,13 @@ const ProfileChangesMenu = () => {
    * Removes extra files in user's avatar storage bucket.
    */
   const updateProfile = async () => {
-    removeUnusedImages(privateAvatarLink ?? null, publicAvatarLink ?? null);
+    // Only clean up once both profiles are in hand: with either one missing, the
+    // "still in use" links are all we have to compare against, and passing a
+    // half-known pair would delete the other profile's avatar. See
+    // removeUnusedImages.
+    if (privateProfile?.data && publicProfile?.data) {
+      removeUnusedImages(privateAvatarLink ?? null, publicAvatarLink ?? null);
+    }
     if (publicAvatarLink && publicProfile?.data) {
       const { error } = await supabase
         .from("profiles")
@@ -548,10 +554,12 @@ const ProfileChangesMenu = () => {
                       setPrivateAvatarLink(privateProfile?.data?.avatar_url ?? null);
                       setPublicAvatarLink(publicProfile?.data?.avatar_url ?? null);
                       setName(privateProfile?.data?.name ?? "");
-                      removeUnusedImages(
-                        privateProfile?.data?.avatar_url ?? null,
-                        publicProfile?.data?.avatar_url ?? null
-                      );
+                      // As in updateProfile: without both profiles loaded, the
+                      // avatars still in use are unknown and cleanup would take
+                      // the whole directory with it.
+                      if (privateProfile?.data && publicProfile?.data) {
+                        removeUnusedImages(privateProfile.data.avatar_url, publicProfile.data.avatar_url);
+                      }
                     }}
                   >
                     Cancel

--- a/app/course/[course_id]/UserMenu.tsx
+++ b/app/course/[course_id]/UserMenu.tsx
@@ -374,12 +374,12 @@ const ProfileChangesMenu = () => {
   });
 
   useEffect(() => {
-    if (publicProfile) {
-      setPublicAvatarLink(publicProfile?.data.avatar_url);
+    if (publicProfile?.data) {
+      setPublicAvatarLink(publicProfile.data.avatar_url);
     }
-    if (privateProfile) {
-      setPrivateAvatarLink(privateProfile?.data.avatar_url);
-      setName(privateProfile?.data.name ?? "");
+    if (privateProfile?.data) {
+      setPrivateAvatarLink(privateProfile.data.avatar_url);
+      setName(privateProfile.data.name ?? "");
     }
   }, [publicProfile, privateProfile]);
 
@@ -389,7 +389,7 @@ const ProfileChangesMenu = () => {
    */
   const updateProfile = async () => {
     removeUnusedImages(privateAvatarLink ?? null, publicAvatarLink ?? null);
-    if (publicAvatarLink && publicProfile) {
+    if (publicAvatarLink && publicProfile?.data) {
       const { error } = await supabase
         .from("profiles")
         .update({ avatar_url: publicAvatarLink })
@@ -402,7 +402,7 @@ const ProfileChangesMenu = () => {
         });
       }
     }
-    if (privateAvatarLink && privateProfile) {
+    if (privateAvatarLink && privateProfile?.data) {
       const { error } = await supabase
         .from("profiles")
         .update({ avatar_url: privateAvatarLink })
@@ -416,7 +416,7 @@ const ProfileChangesMenu = () => {
       }
     }
 
-    if (privateProfile) {
+    if (privateProfile?.data) {
       const trimmedName = name?.trim() || "";
       if (trimmedName.length === 0) {
         toaster.error({
@@ -441,12 +441,12 @@ const ProfileChangesMenu = () => {
     invalidate({
       resource: "profiles",
       invalidates: ["list", "detail"],
-      id: publicProfile?.data.id
+      id: publicProfile?.data?.id
     });
     invalidate({
       resource: "profiles",
       invalidates: ["list", "detail"],
-      id: privateProfile?.data.id
+      id: privateProfile?.data?.id
     });
   };
   /**
@@ -535,7 +535,7 @@ const ProfileChangesMenu = () => {
                     </Flex>
                     <Text fontSize="sm" color="fg.muted" mt={6}>
                       Your public avatar will be used on anonymous posts along with your pseudonym, &quot;
-                      {publicProfile?.data.name}&quot;.
+                      {publicProfile?.data?.name}&quot;.
                     </Text>
                   </Flex>
                 </Flex>
@@ -545,12 +545,12 @@ const ProfileChangesMenu = () => {
                   <Button
                     variant="outline"
                     onClick={() => {
-                      setPrivateAvatarLink(privateProfile?.data.avatar_url ?? null);
-                      setPublicAvatarLink(publicProfile?.data.avatar_url ?? null);
-                      setName(privateProfile?.data.name ?? "");
+                      setPrivateAvatarLink(privateProfile?.data?.avatar_url ?? null);
+                      setPublicAvatarLink(publicProfile?.data?.avatar_url ?? null);
+                      setName(privateProfile?.data?.name ?? "");
                       removeUnusedImages(
-                        privateProfile?.data.avatar_url ?? null,
-                        publicProfile?.data.avatar_url ?? null
+                        privateProfile?.data?.avatar_url ?? null,
+                        publicProfile?.data?.avatar_url ?? null
                       );
                     }}
                   >
@@ -733,8 +733,8 @@ function UserSettingsMenu() {
       <Drawer.Trigger asChild>
         <IconButton aria-label="Open user menu" variant="ghost" size="sm" borderRadius="full" p={0}>
           <Avatar.Root size="sm" colorPalette="gray">
-            <Avatar.Fallback name={privateProfile?.data.name?.charAt(0) ?? "?"} />
-            <Avatar.Image src={sanitizeImageSrc(privateProfile?.data.avatar_url)} alt="" />
+            <Avatar.Fallback name={privateProfile?.data?.name?.charAt(0) ?? "?"} />
+            <Avatar.Image src={sanitizeImageSrc(privateProfile?.data?.avatar_url)} alt="" />
           </Avatar.Root>
         </IconButton>
       </Drawer.Trigger>
@@ -747,12 +747,12 @@ function UserSettingsMenu() {
                 <HStack justifyContent="space-between" alignItems="flex-start" width="100%" pb={2}>
                   <HStack flex={1} minWidth={0}>
                     <Avatar.Root size="sm" colorPalette="gray">
-                      <Avatar.Fallback name={privateProfile?.data.name?.charAt(0) ?? "?"} />
-                      <Avatar.Image src={sanitizeImageSrc(privateProfile?.data.avatar_url)} alt="" />
+                      <Avatar.Fallback name={privateProfile?.data?.name?.charAt(0) ?? "?"} />
+                      <Avatar.Image src={sanitizeImageSrc(privateProfile?.data?.avatar_url)} alt="" />
                     </Avatar.Root>
                     <VStack alignItems="flex-start" gap={0} flex={1} minWidth={0}>
                       <Text fontWeight="bold" wordBreak="break-word" lineHeight="1.2">
-                        {privateProfile?.data.name}
+                        {privateProfile?.data?.name}
                       </Text>
                       {gitHubUsername && (
                         <Text fontSize="sm">

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
@@ -18,8 +18,6 @@ export default function EditAssignment() {
   const form = useForm<Assignment>({
     refineCoreProps: { resource: "assignments", action: "edit", id: Number.parseInt(assignment_id as string) }
   });
-  const { data } = useOne<Assignment>({ resource: "assignments", id: assignment_id as string });
-
   const { reset, refineCore } = form;
   const queryData = refineCore.query?.data?.data;
   const { mutate: update } = useUpdate();
@@ -30,12 +28,19 @@ export default function EditAssignment() {
     }
   }, [queryData, reset]);
 
-  const { data: selfReviewSetting } = useOne<SelfReviewSettings>({
+  const selfReviewSettingId = queryData?.self_review_setting_id;
+  const { data: selfReviewSetting, isFetched: selfReviewSettingFetched } = useOne<SelfReviewSettings>({
     resource: "assignment_self_review_settings",
-    id: queryData?.self_review_setting_id
+    id: selfReviewSettingId,
+    queryOptions: { enabled: selfReviewSettingId !== undefined }
   });
   useEffect(() => {
-    if (queryData) {
+    // Wait for the settings query to settle before seeding these fields: the
+    // form renders while it is still in flight, and writing the "no settings"
+    // fallbacks (base_only, null offsets, cleared release time) in the meantime
+    // would silently disable an assignment's self review if the user saved
+    // before the real values arrived.
+    if (queryData && selfReviewSettingFetched) {
       form.setValue("eval_config", selfReviewSetting?.data?.enabled ? "use_eval" : "base_only");
       form.setValue("deadline_offset", selfReviewSetting?.data?.deadline_offset);
       form.setValue("allow_early", selfReviewSetting?.data?.allow_early);
@@ -44,6 +49,7 @@ export default function EditAssignment() {
   }, [
     queryData,
     form,
+    selfReviewSettingFetched,
     selfReviewSetting?.data?.allow_early,
     selfReviewSetting?.data?.deadline_offset,
     selfReviewSetting?.data?.enabled,
@@ -54,12 +60,14 @@ export default function EditAssignment() {
     async (values: FieldValues) => {
       try {
         const supabase = createClient();
-        if (values) {
+        // Without the id from the loaded assignment there is no row to write to;
+        // sending `id: undefined` would just make the update fail server-side.
+        if (values && selfReviewSettingId !== undefined) {
           const isEnabled = values.eval_config == "use_eval";
           update(
             {
               resource: "assignment_self_review_settings",
-              id: data?.data?.self_review_setting_id,
+              id: selfReviewSettingId,
               values: {
                 enabled: isEnabled,
                 deadline_offset: isEnabled ? values.deadline_offset : null,
@@ -139,7 +147,7 @@ export default function EditAssignment() {
         });
       }
     },
-    [form.refineCore, assignment_id, course_id, data?.data?.self_review_setting_id, update]
+    [form.refineCore, assignment_id, course_id, selfReviewSettingId, update]
   );
 
   if (form.refineCore.query?.error) {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
@@ -36,18 +36,18 @@ export default function EditAssignment() {
   });
   useEffect(() => {
     if (queryData) {
-      form.setValue("eval_config", selfReviewSetting?.data.enabled ? "use_eval" : "base_only");
-      form.setValue("deadline_offset", selfReviewSetting?.data.deadline_offset);
-      form.setValue("allow_early", selfReviewSetting?.data.allow_early);
-      form.setValue("self_review_release_at", selfReviewSetting?.data.release_at ?? null);
+      form.setValue("eval_config", selfReviewSetting?.data?.enabled ? "use_eval" : "base_only");
+      form.setValue("deadline_offset", selfReviewSetting?.data?.deadline_offset);
+      form.setValue("allow_early", selfReviewSetting?.data?.allow_early);
+      form.setValue("self_review_release_at", selfReviewSetting?.data?.release_at ?? null);
     }
   }, [
     queryData,
     form,
-    selfReviewSetting?.data.allow_early,
-    selfReviewSetting?.data.deadline_offset,
-    selfReviewSetting?.data.enabled,
-    selfReviewSetting?.data.release_at
+    selfReviewSetting?.data?.allow_early,
+    selfReviewSetting?.data?.deadline_offset,
+    selfReviewSetting?.data?.enabled,
+    selfReviewSetting?.data?.release_at
   ]);
 
   const onFinish = useCallback(
@@ -59,7 +59,7 @@ export default function EditAssignment() {
           update(
             {
               resource: "assignment_self_review_settings",
-              id: data?.data.self_review_setting_id,
+              id: data?.data?.self_review_setting_id,
               values: {
                 enabled: isEnabled,
                 deadline_offset: isEnabled ? values.deadline_offset : null,
@@ -139,7 +139,7 @@ export default function EditAssignment() {
         });
       }
     },
-    [form.refineCore, assignment_id, course_id, data?.data.self_review_setting_id, update]
+    [form.refineCore, assignment_id, course_id, data?.data?.self_review_setting_id, update]
   );
 
   if (form.refineCore.query?.error) {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/rerun-autograder/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/rerun-autograder/page.tsx
@@ -1039,7 +1039,7 @@ export default function RerunAutograderPage() {
   if (isAssignmentLoading) {
     return <Skeleton height="100px" />;
   }
-  if (!assignment?.data.autograder.grader_repo) {
+  if (!assignment?.data?.autograder?.grader_repo) {
     return <Text>Assignment not found</Text>;
   }
   return (

--- a/app/course/[course_id]/manage/course/emails/page.tsx
+++ b/app/course/[course_id]/manage/course/emails/page.tsx
@@ -325,7 +325,7 @@ function EmailsInnerPage() {
     })?.private_profile_id;
     const group = assignment && profile_id ? userGroup(profile_id) : null;
     const baseUrl = window.location.origin;
-    const course_name = course?.data.name;
+    const course_name = course?.data?.name;
     const assignment_name = assignment?.title;
     const assignment_slug = assignment?.slug;
     const assignment_group_name = group?.name;
@@ -352,7 +352,7 @@ function EmailsInnerPage() {
     }
     if (due_date) {
       // Use the user's preferred timezone from context, or fall back to course timezone
-      const displayTimeZone = timeZoneContext?.timeZone || course?.data.time_zone || "America/New_York";
+      const displayTimeZone = timeZoneContext?.timeZone || course?.data?.time_zone || "America/New_York";
       inserted_text = inserted_text.replace(
         /{due_date}/g,
         `${formatInTimeZone(due_date, displayTimeZone, "MMM d, h:mm a zzz")}`

--- a/app/course/layout.tsx
+++ b/app/course/layout.tsx
@@ -1,3 +1,4 @@
+import SessionUserRecovery from "@/components/SessionUserRecovery";
 import { AuthStateProvider } from "@/hooks/useAuthState";
 import { ClassProfileProvider } from "@/hooks/useClassProfiles";
 import { createClient } from "@/utils/supabase/server";
@@ -11,6 +12,7 @@ export default async function AuthedLayout({ children }: { children: React.React
   }
   return (
     <AuthStateProvider user={user?.user}>
+      <SessionUserRecovery userId={user.user.id} />
       <ClassProfileProvider>{children}</ClassProfileProvider>
     </AuthStateProvider>
   );

--- a/components/SessionUserRecovery.tsx
+++ b/components/SessionUserRecovery.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { installSessionUserRecovery } from "@/lib/sessionUserRecovery";
+import { createClient } from "@/utils/supabase/client";
+
+/**
+ * Watches for the tab's auth session being replaced by a different user's (e.g.
+ * a sign-in in another tab while this one sat in the background) and reloads so
+ * the page matches the session it actually holds. Renders nothing; see
+ * `lib/sessionUserRecovery.ts` for the detection + reload logic.
+ *
+ * `userId` is the user the surrounding tree was server-rendered for.
+ */
+export default function SessionUserRecovery({ userId }: { userId: string | null | undefined }) {
+  const client = useMemo(() => createClient(), []);
+  useEffect(() => {
+    return installSessionUserRecovery({ client, renderedUserId: userId });
+  }, [client, userId]);
+  return null;
+}

--- a/components/ui/provider.tsx
+++ b/components/ui/provider.tsx
@@ -5,16 +5,20 @@ import { createClient } from "@/utils/supabase/client";
 import { ChakraProvider } from "@chakra-ui/react";
 
 import { Refine } from "@refinedev/core";
-import { dataProvider, liveProvider } from "@refinedev/supabase";
+import { liveProvider } from "@refinedev/supabase";
+import { createDataProvider } from "@/lib/refineDataProvider";
 import { ColorModeProvider, type ColorModeProviderProps } from "./color-mode";
 
 const supabaseClient = createClient();
+// Built once, outside the component, so a re-render doesn't hand <Refine> a
+// freshly-allocated provider object on every pass.
+const refineDataProvider = createDataProvider(supabaseClient);
 export function Provider(props: ColorModeProviderProps) {
   // const notificationProvider = useNotificationProvider();
   return (
     <ChakraProvider value={system}>
       <Refine
-        dataProvider={dataProvider(supabaseClient)}
+        dataProvider={refineDataProvider}
         //notificationProvider={notificationProvider}
         options={{ disableTelemetry: true }}
         liveProvider={liveProvider(supabaseClient)}

--- a/components/ui/provider.tsx
+++ b/components/ui/provider.tsx
@@ -6,7 +6,7 @@ import { ChakraProvider } from "@chakra-ui/react";
 
 import { Refine } from "@refinedev/core";
 import { liveProvider } from "@refinedev/supabase";
-import { createDataProvider } from "@/lib/refineDataProvider";
+import { createDataProvider, retryUnlessMissingRow } from "@/lib/refineDataProvider";
 import { ColorModeProvider, type ColorModeProviderProps } from "./color-mode";
 
 const supabaseClient = createClient();
@@ -20,7 +20,12 @@ export function Provider(props: ColorModeProviderProps) {
       <Refine
         dataProvider={refineDataProvider}
         //notificationProvider={notificationProvider}
-        options={{ disableTelemetry: true }}
+        options={{
+          disableTelemetry: true,
+          // Refine merges this into its own query defaults (refetchOnWindowFocus
+          // off, keepPreviousData on).
+          reactQuery: { clientConfig: { defaultOptions: { queries: { retry: retryUnlessMissingRow } } } }
+        }}
         liveProvider={liveProvider(supabaseClient)}
       >
         <ColorModeProvider {...props} />

--- a/hooks/useUserProfiles.tsx
+++ b/hooks/useUserProfiles.tsx
@@ -52,7 +52,9 @@ export function useUserProfile(id: string | null | undefined):
       avatar_url: profile.avatar_url || `https://api.dicebear.com/9.x/identicon/svg?seed=${profile.id}`,
       flair: profile.flair || "",
       flair_color: profile.flair_color || "",
-      real_name: userRole?.profiles.name && profile.id !== userRole.private_profile_id ? userRole.profiles.name : "",
+      // `profiles` is a join: a `user_roles` row that arrives without it (e.g. a
+      // realtime payload carrying only the base row) must not crash the render.
+      real_name: userRole?.profiles?.name && profile.id !== userRole.private_profile_id ? userRole.profiles.name : "",
       private_profile_id: userRole?.private_profile_id,
       discussion_karma: profile.discussion_karma
     };

--- a/lib/refineDataProvider.ts
+++ b/lib/refineDataProvider.ts
@@ -45,6 +45,23 @@ export function withMissingRowErrors(base: DataProvider): DataProvider {
   };
 }
 
+/** React Query's own default: three retries before the error surfaces. */
+const DEFAULT_QUERY_RETRIES = 3;
+
+/**
+ * React Query retry policy that skips retries for the 404 above.
+ *
+ * A missing or invisible row is deterministic — refetching it three times over
+ * several seconds of backoff produces the same `200 []`, and until the retries
+ * are exhausted `useOne` stays in its loading state instead of showing the
+ * not-found/empty branch. Everything else keeps the default retry behaviour.
+ */
+export function retryUnlessMissingRow(failureCount: number, error: unknown): boolean {
+  const statusCode = (error as { statusCode?: unknown } | null | undefined)?.statusCode;
+  if (statusCode === 404) return false;
+  return failureCount < DEFAULT_QUERY_RETRIES;
+}
+
 /** The app's refine data provider: Supabase, plus the `getOne` fix above. */
 export function createDataProvider(client: Parameters<typeof supabaseDataProvider>[0]): DataProvider {
   return withMissingRowErrors(supabaseDataProvider(client));

--- a/lib/refineDataProvider.ts
+++ b/lib/refineDataProvider.ts
@@ -1,0 +1,51 @@
+import type { BaseRecord, DataProvider, GetOneParams, GetOneResponse } from "@refinedev/core";
+import { dataProvider as supabaseDataProvider } from "@refinedev/supabase";
+
+/**
+ * The `@refinedev/supabase` data provider, with `getOne` fixed to report a
+ * missing row as an error instead of as a successful empty response.
+ *
+ * Upstream implements `getOne` as an ordinary filtered select and returns
+ * `{ data: (data || [])[0] }` — no `.single()`, no error when nothing matches
+ * (see `getOne` in @refinedev/supabase). So when the row is gone, or is simply
+ * no longer *visible* to this session under RLS, PostgREST answers `200 []` and
+ * React Query is handed a **defined** response object whose `data` is
+ * `undefined`.
+ *
+ * `useOne`'s type says `data: TData` (never undefined), so callers reasonably
+ * write `result?.data.name`: the optional chain guards the *response*, not the
+ * row. `result` is defined, `result.data` is not, and the render throws
+ * `TypeError: Cannot read properties of undefined (reading 'name')`.
+ *
+ * That is the crash reported from long-idle tabs: while the tab sat in the
+ * background its stored Supabase session was replaced by another tab's (a
+ * different user signed in), so on reconnect the refetch of the *rendered*
+ * user's profile came back `200 []` under the new session's RLS and the course
+ * layout's UserMenu crashed for every route in the course.
+ *
+ * Failing the query turns that into the state every consumer already handles:
+ * `data` stays `undefined`, `?.` short-circuits, and the component falls back to
+ * its loading/empty branch. Only `getOne` is wrapped — list endpoints already
+ * return `[]` for "nothing visible", which is a legitimate result.
+ */
+export function withMissingRowErrors(base: DataProvider): DataProvider {
+  return {
+    ...base,
+    getOne: async <TData extends BaseRecord = BaseRecord>(params: GetOneParams): Promise<GetOneResponse<TData>> => {
+      const response = await base.getOne<TData>(params);
+      if (response?.data === undefined || response?.data === null) {
+        // Shaped like a refine HttpError so `useOne`'s `error` carries a status.
+        throw Object.assign(
+          new Error(`No ${params.resource} record with id ${String(params.id)} is visible to the current session.`),
+          { statusCode: 404 }
+        );
+      }
+      return response;
+    }
+  };
+}
+
+/** The app's refine data provider: Supabase, plus the `getOne` fix above. */
+export function createDataProvider(client: Parameters<typeof supabaseDataProvider>[0]): DataProvider {
+  return withMissingRowErrors(supabaseDataProvider(client));
+}

--- a/lib/sessionUserRecovery.ts
+++ b/lib/sessionUserRecovery.ts
@@ -1,0 +1,109 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Self-healing for a tab whose auth session no longer belongs to the user the
+ * page was rendered for.
+ *
+ * The Supabase browser client persists its session in shared, cross-tab storage
+ * (`sb-<ref>-auth-token` cookies, see `utils/supabase/client.ts`). Signing in as
+ * a different user in *any* tab therefore replaces the session under every other
+ * open tab — including one that has been sitting in the background for hours
+ * with a fully server-rendered page for the previous user.
+ *
+ * Nothing re-renders on that swap, so the tab keeps showing user A's course
+ * while every request it makes is now authorized as user B. Under RLS the
+ * results come back empty rather than forbidden: single-row fetches resolve to
+ * "no such row" (the crash this shipped with — see `lib/refineDataProvider.ts`),
+ * lists silently empty out, and writes fail or land under the wrong identity.
+ *
+ * The only correct state for that tab is the one the server would render for
+ * the session it actually holds, so we reload it once (guarded against loops).
+ * Because client and server share the same cookie, the reload converges: the
+ * new render matches the new session and no further mismatch fires. Mirrors
+ * `staleBundleRecovery.ts` / `corruptSessionRecovery.ts`.
+ */
+
+const RELOAD_GUARD_KEY = "pawtograder:session-user-mismatch-reloaded-at";
+// Don't reload more than once per cooldown window. If reloading doesn't resolve
+// the mismatch (say the server render disagrees with the cookie for a reason we
+// haven't anticipated), the user must not be trapped in a reload loop.
+const RELOAD_COOLDOWN_MS = 30_000;
+
+/**
+ * True when the live session belongs to a different user than the one the page
+ * was rendered for. Deliberately conservative: an absent session (signed out,
+ * or an event that carries none) is *not* a mismatch — sign-out has its own
+ * redirect path, and reloading a signed-out tab would race it.
+ */
+export function isForeignSessionUser(
+  renderedUserId: string | null | undefined,
+  sessionUserId: string | null | undefined
+): boolean {
+  if (!renderedUserId || !sessionUserId) return false;
+  return renderedUserId !== sessionUserId;
+}
+
+function hasRecentlyReloaded(): boolean {
+  try {
+    const raw = window.sessionStorage.getItem(RELOAD_GUARD_KEY);
+    if (!raw) return false;
+    const last = Number(raw);
+    if (!Number.isFinite(last)) return false;
+    return Date.now() - last < RELOAD_COOLDOWN_MS;
+  } catch {
+    // Storage can throw (private mode / blocked). Fail safe by assuming we have
+    // NOT reloaded, so a real identity swap still heals; the browser's own
+    // reload throttling backstops any loop.
+    return false;
+  }
+}
+
+function markReloaded(): void {
+  try {
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+  } catch {
+    /* ignore */
+  }
+}
+
+// `window.location.reload` is non-configurable in jsdom, so the reload action is
+// injectable to keep this testable.
+const defaultReload = () => window.location.reload();
+
+/**
+ * Reload once for a detected identity mismatch. Returns true if a reload was
+ * performed, false if suppressed by the loop guard.
+ */
+export function recoverFromForeignSession(reload: () => void = defaultReload): boolean {
+  if (typeof window === "undefined") return false;
+  if (hasRecentlyReloaded()) return false;
+  markReloaded();
+  reload();
+  return true;
+}
+
+/**
+ * Watch the auth session for the lifetime of the page and reload if it starts
+ * belonging to someone other than `renderedUserId`. No-ops on the server.
+ * Returns an uninstall function.
+ */
+export function installSessionUserRecovery({
+  client,
+  renderedUserId,
+  reload = defaultReload
+}: {
+  client: Pick<SupabaseClient, "auth">;
+  renderedUserId: string | null | undefined;
+  reload?: () => void;
+}): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  // Fires immediately with INITIAL_SESSION, which also covers the case where the
+  // swap happened before this listener was installed.
+  const { data } = client.auth.onAuthStateChange((_event, session) => {
+    if (!isForeignSessionUser(renderedUserId, session?.user?.id)) return;
+    recoverFromForeignSession(reload);
+  });
+
+  return () => data.subscription.unsubscribe();
+}

--- a/lib/sessionUserRecovery.ts
+++ b/lib/sessionUserRecovery.ts
@@ -23,11 +23,20 @@ import type { SupabaseClient } from "@supabase/supabase-js";
  * `staleBundleRecovery.ts` / `corruptSessionRecovery.ts`.
  */
 
-const RELOAD_GUARD_KEY = "pawtograder:session-user-mismatch-reloaded-at";
-// Don't reload more than once per cooldown window. If reloading doesn't resolve
-// the mismatch (say the server render disagrees with the cookie for a reason we
-// haven't anticipated), the user must not be trapped in a reload loop.
+const RELOAD_GUARD_KEY = "pawtograder:session-user-mismatch-reload-guard";
+// Don't reload more than once per cooldown window *for the same mismatch*. If
+// reloading doesn't resolve the mismatch (say the server render disagrees with
+// the cookie for a reason we haven't anticipated), the user must not be trapped
+// in a reload loop.
 const RELOAD_COOLDOWN_MS = 30_000;
+// How often to compare the live session against the render while the tab is
+// visible. Sign-in happens in a server action here (`app/actions.ts`), which
+// swaps the shared auth cookie without any browser client emitting an auth
+// event — so a tab that stays visible the whole time (a course window open
+// beside the window someone signs in from) gets no `onAuthStateChange` and no
+// visibility-triggered recovery from supabase-js either. Reading the session is
+// a local cookie parse, not a request.
+const SESSION_POLL_INTERVAL_MS = 60_000;
 
 /**
  * True when the live session belongs to a different user than the one the page
@@ -43,24 +52,46 @@ export function isForeignSessionUser(
   return renderedUserId !== sessionUserId;
 }
 
-function hasRecentlyReloaded(): boolean {
+/**
+ * The last reload we performed, recorded as the mismatch that caused it. Keyed
+ * by the pair rather than by time alone: a *different* mismatch arriving during
+ * the cooldown (A → B reloads, then B → C lands seconds later) is a new problem
+ * and must still heal, whereas the *same* pair recurring means the reload
+ * didn't converge and repeating it would loop.
+ */
+type ReloadGuard = { at: number; renderedUserId: string; sessionUserId: string };
+
+function readReloadGuard(): ReloadGuard | null {
   try {
     const raw = window.sessionStorage.getItem(RELOAD_GUARD_KEY);
-    if (!raw) return false;
-    const last = Number(raw);
-    if (!Number.isFinite(last)) return false;
-    return Date.now() - last < RELOAD_COOLDOWN_MS;
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { at, renderedUserId, sessionUserId } = parsed as Partial<ReloadGuard>;
+    if (typeof at !== "number" || !Number.isFinite(at)) return null;
+    if (typeof renderedUserId !== "string" || typeof sessionUserId !== "string") return null;
+    return { at, renderedUserId, sessionUserId };
   } catch {
-    // Storage can throw (private mode / blocked). Fail safe by assuming we have
-    // NOT reloaded, so a real identity swap still heals; the browser's own
-    // reload throttling backstops any loop.
-    return false;
+    // Storage can throw (private mode / blocked) and the value can be garbage.
+    // Fail safe by assuming we have NOT reloaded, so a real identity swap still
+    // heals; the browser's own reload throttling backstops any loop.
+    return null;
   }
 }
 
-function markReloaded(): void {
+function hasRecentlyReloadedFor(renderedUserId: string, sessionUserId: string): boolean {
+  const guard = readReloadGuard();
+  if (!guard) return false;
+  if (guard.renderedUserId !== renderedUserId || guard.sessionUserId !== sessionUserId) return false;
+  return Date.now() - guard.at < RELOAD_COOLDOWN_MS;
+}
+
+function markReloaded(renderedUserId: string, sessionUserId: string): void {
   try {
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+    window.sessionStorage.setItem(
+      RELOAD_GUARD_KEY,
+      JSON.stringify({ at: Date.now(), renderedUserId, sessionUserId } satisfies ReloadGuard)
+    );
   } catch {
     /* ignore */
   }
@@ -74,10 +105,14 @@ const defaultReload = () => window.location.reload();
  * Reload once for a detected identity mismatch. Returns true if a reload was
  * performed, false if suppressed by the loop guard.
  */
-export function recoverFromForeignSession(reload: () => void = defaultReload): boolean {
+export function recoverFromForeignSession(
+  renderedUserId: string,
+  sessionUserId: string,
+  reload: () => void = defaultReload
+): boolean {
   if (typeof window === "undefined") return false;
-  if (hasRecentlyReloaded()) return false;
-  markReloaded();
+  if (hasRecentlyReloadedFor(renderedUserId, sessionUserId)) return false;
+  markReloaded(renderedUserId, sessionUserId);
   reload();
   return true;
 }
@@ -90,20 +125,41 @@ export function recoverFromForeignSession(reload: () => void = defaultReload): b
 export function installSessionUserRecovery({
   client,
   renderedUserId,
-  reload = defaultReload
+  reload = defaultReload,
+  pollIntervalMs = SESSION_POLL_INTERVAL_MS
 }: {
   client: Pick<SupabaseClient, "auth">;
   renderedUserId: string | null | undefined;
   reload?: () => void;
+  pollIntervalMs?: number;
 }): () => void {
   if (typeof window === "undefined") return () => {};
 
-  // Fires immediately with INITIAL_SESSION, which also covers the case where the
-  // swap happened before this listener was installed.
-  const { data } = client.auth.onAuthStateChange((_event, session) => {
-    if (!isForeignSessionUser(renderedUserId, session?.user?.id)) return;
-    recoverFromForeignSession(reload);
-  });
+  const check = (sessionUserId: string | null | undefined) => {
+    if (!renderedUserId || !sessionUserId) return;
+    if (!isForeignSessionUser(renderedUserId, sessionUserId)) return;
+    recoverFromForeignSession(renderedUserId, sessionUserId, reload);
+  };
 
-  return () => data.subscription.unsubscribe();
+  // Fires immediately with INITIAL_SESSION, which also covers the case where the
+  // swap happened before this listener was installed. Covers the reported case:
+  // supabase-js re-reads storage when the tab becomes visible again and emits
+  // SIGNED_IN for the replacement session.
+  const { data } = client.auth.onAuthStateChange((_event, session) => check(session?.user?.id));
+
+  // Backstop for a tab that never goes hidden, where no auth event fires at all
+  // (see SESSION_POLL_INTERVAL_MS).
+  const poll = window.setInterval(() => {
+    if (document.visibilityState !== "visible") return;
+    void client.auth
+      .getSession()
+      .then(({ data: { session } }) => check(session?.user?.id))
+      // A failed session read tells us nothing about identity; leave the tab be.
+      .catch(() => {});
+  }, pollIntervalMs);
+
+  return () => {
+    data.subscription.unsubscribe();
+    window.clearInterval(poll);
+  };
 }

--- a/tests/unit/refine-data-provider.test.ts
+++ b/tests/unit/refine-data-provider.test.ts
@@ -1,0 +1,59 @@
+import type { DataProvider } from "@refinedev/core";
+import { withMissingRowErrors } from "@/lib/refineDataProvider";
+
+/**
+ * Minimal stand-in for the `@refinedev/supabase` provider: only `getOne` is
+ * wrapped, and only its response shape matters here.
+ */
+function baseProviderReturning(response: unknown): DataProvider {
+  return {
+    getOne: jest.fn().mockResolvedValue(response),
+    getList: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    deleteOne: jest.fn(),
+    getApiUrl: () => ""
+  } as unknown as DataProvider;
+}
+
+describe("withMissingRowErrors", () => {
+  it("rejects with a 404 when the row is not visible to the session", async () => {
+    // What @refinedev/supabase actually returns for `200 []`: a defined
+    // response whose `data` is undefined. That is what makes `result?.data.name`
+    // throw in consumers.
+    const provider = withMissingRowErrors(baseProviderReturning({ data: undefined }));
+
+    await expect(provider.getOne({ resource: "profiles", id: "profile-a" })).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it("rejects when the row comes back null", async () => {
+    const provider = withMissingRowErrors(baseProviderReturning({ data: null }));
+
+    await expect(provider.getOne({ resource: "profiles", id: "profile-a" })).rejects.toMatchObject({
+      statusCode: 404
+    });
+  });
+
+  it("names the resource and id so the failure is diagnosable", async () => {
+    const provider = withMissingRowErrors(baseProviderReturning({ data: undefined }));
+
+    await expect(provider.getOne({ resource: "profiles", id: "profile-a" })).rejects.toThrow(/profiles.*profile-a/);
+  });
+
+  it("passes a found row straight through", async () => {
+    const row = { id: "profile-a", name: "Ada" };
+    const provider = withMissingRowErrors(baseProviderReturning({ data: row }));
+
+    await expect(provider.getOne({ resource: "profiles", id: "profile-a" })).resolves.toEqual({ data: row });
+  });
+
+  it("leaves the other provider methods untouched", async () => {
+    const base = baseProviderReturning({ data: undefined });
+    const provider = withMissingRowErrors(base);
+
+    expect(provider.getList).toBe(base.getList);
+    expect(provider.update).toBe(base.update);
+  });
+});

--- a/tests/unit/refine-data-provider.test.ts
+++ b/tests/unit/refine-data-provider.test.ts
@@ -1,5 +1,5 @@
 import type { DataProvider } from "@refinedev/core";
-import { withMissingRowErrors } from "@/lib/refineDataProvider";
+import { retryUnlessMissingRow, withMissingRowErrors } from "@/lib/refineDataProvider";
 
 /**
  * Minimal stand-in for the `@refinedev/supabase` provider: only `getOne` is
@@ -55,5 +55,26 @@ describe("withMissingRowErrors", () => {
 
     expect(provider.getList).toBe(base.getList);
     expect(provider.update).toBe(base.update);
+  });
+});
+
+describe("retryUnlessMissingRow", () => {
+  it("does not retry a missing row — the answer will not change, and the wait is user-visible", () => {
+    // Without this, React Query's default retries hold `useOne` in its loading
+    // state through several seconds of backoff before the not-found UI appears.
+    expect(retryUnlessMissingRow(0, Object.assign(new Error("no such row"), { statusCode: 404 }))).toBe(false);
+  });
+
+  it("keeps the default three retries for anything that might succeed later", () => {
+    const flaky = Object.assign(new Error("network"), { statusCode: 500 });
+
+    expect(retryUnlessMissingRow(0, flaky)).toBe(true);
+    expect(retryUnlessMissingRow(2, flaky)).toBe(true);
+    expect(retryUnlessMissingRow(3, flaky)).toBe(false);
+  });
+
+  it("retries errors that carry no status", () => {
+    expect(retryUnlessMissingRow(0, new Error("boom"))).toBe(true);
+    expect(retryUnlessMissingRow(0, undefined)).toBe(true);
   });
 });

--- a/tests/unit/session-user-recovery.test.ts
+++ b/tests/unit/session-user-recovery.test.ts
@@ -29,22 +29,36 @@ describe("installSessionUserRecovery", () => {
     reloadCalls += 1;
   };
 
-  /** Stub of the Supabase auth client: hands back the emitter for the test. */
+  /**
+   * Stub of the Supabase auth client: hands back the emitter for the test, and
+   * a `setSession` that changes what `getSession` reports *without* emitting —
+   * that silence is exactly the server-action sign-in the poll exists for.
+   */
   function fakeClient() {
-    let handler: ((event: string, session: { user: { id: string } } | null) => void) | undefined;
+    type Session = { user: { id: string } } | null;
+    let handler: ((event: string, session: Session) => void) | undefined;
+    let session: Session = null;
     const unsubscribe = jest.fn();
+    const sessionFor = (userId: string | null): Session => (userId === null ? null : { user: { id: userId } });
     const client = {
       auth: {
         onAuthStateChange: (cb: typeof handler) => {
           handler = cb;
           return { data: { subscription: { unsubscribe } } };
-        }
+        },
+        getSession: async () => ({ data: { session } })
       }
     };
     return {
       client: client as never,
       unsubscribe,
-      emit: (userId: string | null) => handler?.("SIGNED_IN", userId === null ? null : { user: { id: userId } })
+      setSession: (userId: string | null) => {
+        session = sessionFor(userId);
+      },
+      emit: (userId: string | null) => {
+        session = sessionFor(userId);
+        handler?.("SIGNED_IN", session);
+      }
     };
   }
 
@@ -79,9 +93,79 @@ describe("installSessionUserRecovery", () => {
     uninstall();
   });
 
-  it("unsubscribes on uninstall", () => {
-    const { client, unsubscribe } = fakeClient();
-    installSessionUserRecovery({ client, renderedUserId: "user-a", reload })();
-    expect(unsubscribe).toHaveBeenCalled();
+  it("still recovers when a second, different user takes over during the cooldown", () => {
+    const { client, emit } = fakeClient();
+    const uninstall = installSessionUserRecovery({ client, renderedUserId: "user-a", reload });
+
+    // A → B reloads. Before the reload lands, B → C: a mismatch we have never
+    // acted on, so the loop guard must not swallow it — otherwise the tab stays
+    // rendered for B while its requests authenticate as C.
+    emit("user-b");
+    emit("user-c");
+
+    expect(reloadCalls).toBe(2);
+
+    uninstall();
+  });
+
+  it("reloads when the session is swapped with no auth event, as a server action does", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession("user-b");
+      expect(reloadCalls).toBe(0);
+
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(1);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not poll a hidden tab — supabase-js re-reads the session when it comes back", async () => {
+    jest.useFakeTimers();
+    const visibility = jest.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession("user-b");
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+
+      uninstall();
+    } finally {
+      visibility.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it("unsubscribes and stops polling on uninstall", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, unsubscribe, setSession } = fakeClient();
+      installSessionUserRecovery({ client, renderedUserId: "user-a", reload, pollIntervalMs: 1000 })();
+      expect(unsubscribe).toHaveBeenCalled();
+
+      setSession("user-b");
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/tests/unit/session-user-recovery.test.ts
+++ b/tests/unit/session-user-recovery.test.ts
@@ -1,0 +1,87 @@
+import { installSessionUserRecovery, isForeignSessionUser } from "@/lib/sessionUserRecovery";
+
+describe("isForeignSessionUser", () => {
+  it("flags a session that belongs to a different user than the render", () => {
+    // The pair from the production report: the page was rendered for the first
+    // user, the live session had been replaced by the second.
+    expect(isForeignSessionUser("fd0aad59-dd20-4dd8-85ca-5b466e14396c", "4feae240-67f4-45fc-9e07-b04e7c3d00d0")).toBe(
+      true
+    );
+  });
+
+  it("does not flag the same user (a plain token refresh keeps the id)", () => {
+    expect(isForeignSessionUser("user-a", "user-a")).toBe(false);
+  });
+
+  it("does not flag a missing session — sign-out has its own redirect path", () => {
+    expect(isForeignSessionUser("user-a", undefined)).toBe(false);
+    expect(isForeignSessionUser("user-a", null)).toBe(false);
+  });
+
+  it("does not flag a missing rendered user", () => {
+    expect(isForeignSessionUser(undefined, "user-b")).toBe(false);
+  });
+});
+
+describe("installSessionUserRecovery", () => {
+  let reloadCalls: number;
+  const reload = () => {
+    reloadCalls += 1;
+  };
+
+  /** Stub of the Supabase auth client: hands back the emitter for the test. */
+  function fakeClient() {
+    let handler: ((event: string, session: { user: { id: string } } | null) => void) | undefined;
+    const unsubscribe = jest.fn();
+    const client = {
+      auth: {
+        onAuthStateChange: (cb: typeof handler) => {
+          handler = cb;
+          return { data: { subscription: { unsubscribe } } };
+        }
+      }
+    };
+    return {
+      client: client as never,
+      unsubscribe,
+      emit: (userId: string | null) => handler?.("SIGNED_IN", userId === null ? null : { user: { id: userId } })
+    };
+  }
+
+  beforeEach(() => {
+    reloadCalls = 0;
+    window.sessionStorage.clear();
+  });
+
+  it("reloads once when the session switches to another user", () => {
+    const { client, emit } = fakeClient();
+    const uninstall = installSessionUserRecovery({ client, renderedUserId: "user-a", reload });
+
+    emit("user-b");
+    expect(reloadCalls).toBe(1);
+
+    // Loop guard: Supabase re-emits SIGNED_IN on every focus/refresh tick, and
+    // the reload itself takes a moment — none of that may reload again.
+    emit("user-b");
+    expect(reloadCalls).toBe(1);
+
+    uninstall();
+  });
+
+  it("leaves the tab alone while the session stays with the rendered user", () => {
+    const { client, emit } = fakeClient();
+    const uninstall = installSessionUserRecovery({ client, renderedUserId: "user-a", reload });
+
+    emit("user-a");
+    emit(null);
+    expect(reloadCalls).toBe(0);
+
+    uninstall();
+  });
+
+  it("unsubscribes on uninstall", () => {
+    const { client, unsubscribe } = fakeClient();
+    installSessionUserRecovery({ client, renderedUserId: "user-a", reload })();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
A tab left in the background for ~40 minutes crashed on reconnect with `TypeError: Cannot read properties of undefined (reading 'name')`, thrown from the course layout (UserMenu) and so fatal on every course route.

The @refinedev/supabase data provider implements `getOne` as a plain filtered select and returns `{ data: (data || [])[0] }`: no `.single()`, no error. When the row is gone or is no longer visible under RLS, PostgREST answers `200 []` and React Query gets a *defined* response whose `data` is `undefined`. `useOne` types `data` as non-optional, so callers write `result?.data.name` — the optional chain guards the response, not the row — and the render throws.

What made the row disappear: while the tab sat in the background its stored Supabase session was replaced by another tab's sign-in (the Sentry event's rendered user and live session user differ), so the post-reconnect refetch of the rendered user's profile came back empty under the new session's RLS.

- Wrap the provider so `getOne` rejects with a 404 instead of resolving to an empty row. `data` then stays undefined and every existing `?.` guard short-circuits into the component's loading/empty branch.
- Complete the optional chains at the `useOne` read sites that assumed `.data` was always present, and at the `user_roles` join in `useUserProfile`.
- Reload a tab once when its session starts belonging to a different user than the page was rendered for, so it stops showing (and writing) another identity's course. Mirrors staleBundleRecovery / corruptSessionRecovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of temporarily unavailable profile, course, assignment, and user data to prevent display and form errors.
  - Added clearer not-found handling when requested records are unavailable.
  - Improved recovery when a browser session belongs to a different signed-in user, including safe page reload protection.
  - Prevented errors from incomplete real-time profile updates.

- **Reliability**
  - Improved stability of data loading and authenticated course navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->