### PR TITLE
fix: NVDA read sweep answering the survey it reads (#913); cross-tab sign-out (#911)

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,3 +1,4 @@
+import SessionUserRecovery from "@/components/SessionUserRecovery";
 import { createClient } from "@/utils/supabase/server";
 import { Link, Box, Flex, VStack, HStack, Heading, Text } from "@chakra-ui/react";
 import { TimeZoneProvider } from "@/lib/TimeZoneProvider";
@@ -52,6 +53,11 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <TimeZoneProvider courseTimeZone={ADMIN_DISPLAY_TIME_ZONE}>
+      {/* Same self-healing the course layout installs: without it, an admin tab
+          whose session was signed out or swapped in another tab keeps showing
+          this dashboard — the most sensitive surface in the app — until someone
+          reloads by hand (issue #911). */}
+      <SessionUserRecovery userId={user.id} />
       <Box minH="100vh" bg="bg.canvas">
         <Box as="header" bg="bg" shadow="sm" borderBottom="1px" borderColor="border.muted">
           <Box maxW="7xl" mx="auto" px={{ base: 4, sm: 6, lg: 8 }}>

--- a/lib/sessionUserRecovery.ts
+++ b/lib/sessionUserRecovery.ts
@@ -161,17 +161,33 @@ function hasReloadedForSignOut(renderedUserId: string): boolean {
   try {
     return window.sessionStorage.getItem(SIGNED_OUT_RELOAD_GUARD_KEY) === renderedUserId;
   } catch {
-    // Same failure posture as readReloadGuard: assume we have NOT reloaded, so a
-    // real sign-out still heals. The browser's own reload throttling backstops.
-    return false;
+    // Unlike readReloadGuard, "assume we have NOT reloaded" is NOT safe here.
+    // That guard is paired with a converging reload; this one is not, so a tab
+    // that cannot read the marker would reload on every poll forever. Reporting
+    // "already reloaded" instead means an unreadable store suppresses the
+    // recovery rather than looping it — see markReloadedForSignOut.
+    return true;
   }
 }
 
-function markReloadedForSignOut(renderedUserId: string): void {
+/**
+ * Record the reload, and say whether the record will survive it.
+ *
+ * False means the marker could not be persisted, and the caller must NOT reload:
+ * with no marker the next poll sees the same absent session and reloads again,
+ * once a minute, forever. The one-reload bound is only a bound if it can be
+ * remembered, so where it cannot, the safe failure is to leave the tab alone —
+ * stale content the user can still navigate away from, rather than a page that
+ * reloads out from under them. Private mode and blocked-storage profiles pay
+ * that cost; the mismatch guard next door is unaffected, since its reload
+ * converges and cannot loop.
+ */
+function markReloadedForSignOut(renderedUserId: string): boolean {
   try {
     window.sessionStorage.setItem(SIGNED_OUT_RELOAD_GUARD_KEY, renderedUserId);
+    return window.sessionStorage.getItem(SIGNED_OUT_RELOAD_GUARD_KEY) === renderedUserId;
   } catch {
-    /* ignore */
+    return false;
   }
 }
 
@@ -216,7 +232,9 @@ export function recoverFromForeignSession(
 export function recoverFromSignedOutSession(renderedUserId: string, reload: () => void = defaultReload): boolean {
   if (typeof window === "undefined") return false;
   if (hasReloadedForSignOut(renderedUserId)) return false;
-  markReloadedForSignOut(renderedUserId);
+  // Mark BEFORE reloading, and only reload if the mark stuck: an unrecorded
+  // reload is an unbounded one (see markReloadedForSignOut).
+  if (!markReloadedForSignOut(renderedUserId)) return false;
   reload();
   return true;
 }
@@ -268,7 +286,7 @@ export function installSessionUserRecovery({
   // anyway — INITIAL_SESSION arrives with none on any page that legitimately has
   // no session yet, and treating that as a sign-out would reload the sign-in
   // page. A poll tick, by contrast, is a positive statement about *now*.
-  const poll = window.setInterval(() => {
+  const checkNow = () => {
     if (document.visibilityState !== "visible") return;
     void client.auth
       .getSession()
@@ -287,10 +305,23 @@ export function installSessionUserRecovery({
       // A failed session read tells us nothing — neither about identity nor
       // about whether the user is still signed in. Leave the tab be.
       .catch(() => {});
-  }, pollIntervalMs);
+  };
+
+  const poll = window.setInterval(checkNow, pollIntervalMs);
+
+  // The moment the tab comes back is the moment its staleness starts to matter,
+  // and it is exactly when the poll has been skipping (hidden tabs are not
+  // polled). Without this, a tab that was hidden when another tab signed out
+  // shows its rendered, authenticated page for up to a full interval after the
+  // user looks at it again — the window in which someone reads private data on
+  // a machine that has been signed out. supabase-js does not close it either:
+  // its own visibility recovery emits nothing when the cookie is simply gone.
+  const onVisible = () => checkNow();
+  document.addEventListener("visibilitychange", onVisible);
 
   return () => {
     data.subscription.unsubscribe();
     window.clearInterval(poll);
+    document.removeEventListener("visibilitychange", onVisible);
   };
 }

--- a/lib/sessionUserRecovery.ts
+++ b/lib/sessionUserRecovery.ts
@@ -21,9 +21,29 @@ import type { SupabaseClient } from "@supabase/supabase-js";
  * Because client and server share the same cookie, the reload converges: the
  * new render matches the new session and no further mismatch fires. Mirrors
  * `staleBundleRecovery.ts` / `corruptSessionRecovery.ts`.
+ *
+ * SIGNING OUT elsewhere is the same failure with the session removed rather than
+ * replaced, and it is the worse half: `signOutAction` clears the shared cookie
+ * for every tab and redirects only the tab it was invoked from, so every other
+ * open tab keeps its rendered, authenticated page — and whatever private data is
+ * already on screen — until someone navigates or reloads it by hand. On a shared
+ * or lab machine that is the whole point of signing out defeated (issue #911).
+ *
+ * That case cannot be detected as permissively as a mismatch, because a null
+ * session is ambiguous: genuinely signed out, or a token refresh that failed.
+ * Three things keep it safe — only a *clean* read counts
+ * (`isConfirmedAbsentSession`), only the poll acts on it (never an auth event,
+ * whose null sessions are routine), and it is bounded to one reload per tab so an
+ * environment where the reload cannot converge costs one reload rather than a
+ * loop.
  */
 
 const RELOAD_GUARD_KEY = "pawtograder:session-user-mismatch-reload-guard";
+// Separate from RELOAD_GUARD_KEY because the two guards answer different
+// questions. The mismatch guard is keyed by the (rendered, session) PAIR and
+// expires, so a new mismatch still heals; the signed-out guard has no second
+// user to key on and must NOT expire — see hasReloadedForSignOut.
+const SIGNED_OUT_RELOAD_GUARD_KEY = "pawtograder:session-signed-out-reload-guard";
 // Don't reload more than once per cooldown window *for the same mismatch*. If
 // reloading doesn't resolve the mismatch (say the server render disagrees with
 // the cookie for a reason we haven't anticipated), the user must not be trapped
@@ -40,9 +60,9 @@ const SESSION_POLL_INTERVAL_MS = 60_000;
 
 /**
  * True when the live session belongs to a different user than the one the page
- * was rendered for. Deliberately conservative: an absent session (signed out,
- * or an event that carries none) is *not* a mismatch — sign-out has its own
- * redirect path, and reloading a signed-out tab would race it.
+ * was rendered for. Deliberately conservative: an absent session is *not* a
+ * mismatch — that case is handled separately by isConfirmedAbsentSession, which
+ * can afford to be strict about it in a way this predicate cannot.
  */
 export function isForeignSessionUser(
   renderedUserId: string | null | undefined,
@@ -50,6 +70,26 @@ export function isForeignSessionUser(
 ): boolean {
   if (!renderedUserId || !sessionUserId) return false;
   return renderedUserId !== sessionUserId;
+}
+
+/**
+ * True when the session is absent and we can BELIEVE that it is absent.
+ *
+ * `getSession()` returns a null session for two very different reasons: the user
+ * is genuinely signed out (the case this recovers), or an access token needed
+ * refreshing and the refresh failed (a network blip). Acting on an
+ * undiscriminated null would throw people off a working page whenever their
+ * connection wobbles, which is why #902 left this alone.
+ *
+ * The discriminator is the error channel: supabase-js reports a failed refresh
+ * as an error alongside the null session, whereas a real sign-out is a clean
+ * read that simply finds nothing. So an error — of any kind, including a
+ * rejected promise, which the caller treats the same way — means "we do not
+ * know", never "signed out".
+ */
+export function isConfirmedAbsentSession(sessionUserId: string | null | undefined, error: unknown = null): boolean {
+  if (error) return false;
+  return !sessionUserId;
 }
 
 /**
@@ -97,6 +137,58 @@ function markReloaded(renderedUserId: string, sessionUserId: string): void {
   }
 }
 
+/**
+ * Has this tab already reloaded once because its session went away, while
+ * rendered for this user?
+ *
+ * Deliberately NOT time-boxed, unlike the mismatch guard. A mismatch reload
+ * converges — client and server read the same cookie, so the new render matches
+ * the new session — and its cooldown exists only so a *different* mismatch can
+ * still heal. A signed-out reload has no such guarantee: if the server keeps
+ * rendering authenticated while the browser cannot read the cookie (a partitioned
+ * or blocked cookie jar, an extension, a proxy rewriting Set-Cookie), the reload
+ * lands on the same authenticated page with the same absent session and the poll
+ * fires again 60s later, forever. A cooldown would merely set the loop's period.
+ *
+ * So the bound is one reload per tab per rendered user, cleared only by evidence
+ * that the recovery is unnecessary (a real session for that user, see
+ * clearSignedOutReloadGuard). A non-converging environment costs exactly one
+ * extra reload instead of a permanent loop; a genuine sign-out gets its reload.
+ * Keyed by user so a sign-in/sign-out cycle in the same tab recovers again even
+ * if the guard was somehow not cleared.
+ */
+function hasReloadedForSignOut(renderedUserId: string): boolean {
+  try {
+    return window.sessionStorage.getItem(SIGNED_OUT_RELOAD_GUARD_KEY) === renderedUserId;
+  } catch {
+    // Same failure posture as readReloadGuard: assume we have NOT reloaded, so a
+    // real sign-out still heals. The browser's own reload throttling backstops.
+    return false;
+  }
+}
+
+function markReloadedForSignOut(renderedUserId: string): void {
+  try {
+    window.sessionStorage.setItem(SIGNED_OUT_RELOAD_GUARD_KEY, renderedUserId);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Forget any signed-out reload this tab performed. Called whenever a valid
+ * session for the rendered user is observed: that is proof the tab is in a
+ * consistent state, so a LATER sign-out in the same tab must be able to recover
+ * again rather than being suppressed by a stale marker from an earlier cycle.
+ */
+function clearSignedOutReloadGuard(): void {
+  try {
+    window.sessionStorage.removeItem(SIGNED_OUT_RELOAD_GUARD_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 // `window.location.reload` is non-configurable in jsdom, so the reload action is
 // injectable to keep this testable.
 const defaultReload = () => window.location.reload();
@@ -118,9 +210,21 @@ export function recoverFromForeignSession(
 }
 
 /**
+ * Reload once for a confirmed sign-out elsewhere. Returns true if a reload was
+ * performed, false if suppressed by the one-per-tab guard.
+ */
+export function recoverFromSignedOutSession(renderedUserId: string, reload: () => void = defaultReload): boolean {
+  if (typeof window === "undefined") return false;
+  if (hasReloadedForSignOut(renderedUserId)) return false;
+  markReloadedForSignOut(renderedUserId);
+  reload();
+  return true;
+}
+
+/**
  * Watch the auth session for the lifetime of the page and reload if it starts
- * belonging to someone other than `renderedUserId`. No-ops on the server.
- * Returns an uninstall function.
+ * belonging to someone other than `renderedUserId`, or stops existing at all.
+ * No-ops on the server. Returns an uninstall function.
  */
 export function installSessionUserRecovery({
   client,
@@ -137,7 +241,13 @@ export function installSessionUserRecovery({
 
   const check = (sessionUserId: string | null | undefined) => {
     if (!renderedUserId || !sessionUserId) return;
-    if (!isForeignSessionUser(renderedUserId, sessionUserId)) return;
+    if (!isForeignSessionUser(renderedUserId, sessionUserId)) {
+      // The tab holds a real session for the user it was rendered for, so it is
+      // demonstrably consistent. Drop any signed-out marker left by an earlier
+      // cycle so a future sign-out in this tab can still recover.
+      clearSignedOutReloadGuard();
+      return;
+    }
     recoverFromForeignSession(renderedUserId, sessionUserId, reload);
   };
 
@@ -149,12 +259,33 @@ export function installSessionUserRecovery({
 
   // Backstop for a tab that never goes hidden, where no auth event fires at all
   // (see SESSION_POLL_INTERVAL_MS).
+  //
+  // This is also the ONLY path that acts on a sign-out, deliberately. Sign-out
+  // here is a server action (`signOutAction` in app/actions.ts): it clears the
+  // shared cookie and redirects the initiating tab, and no browser client emits
+  // anything, so `onAuthStateChange` never fires in the tabs that need
+  // recovering. The event path is the wrong place to act on a null session
+  // anyway — INITIAL_SESSION arrives with none on any page that legitimately has
+  // no session yet, and treating that as a sign-out would reload the sign-in
+  // page. A poll tick, by contrast, is a positive statement about *now*.
   const poll = window.setInterval(() => {
     if (document.visibilityState !== "visible") return;
     void client.auth
       .getSession()
-      .then(({ data: { session } }) => check(session?.user?.id))
-      // A failed session read tells us nothing about identity; leave the tab be.
+      .then(({ data: { session }, error }) => {
+        const sessionUserId = session?.user?.id;
+        if (sessionUserId) {
+          check(sessionUserId);
+          return;
+        }
+        // No session. Only a CLEAN read proves the user is signed out rather
+        // than mid-failed-refresh (see isConfirmedAbsentSession).
+        if (!renderedUserId) return;
+        if (!isConfirmedAbsentSession(sessionUserId, error)) return;
+        recoverFromSignedOutSession(renderedUserId, reload);
+      })
+      // A failed session read tells us nothing — neither about identity nor
+      // about whether the user is still signed in. Leave the tab be.
       .catch(() => {});
   }, pollIntervalMs);
 

--- a/tests/unit/a11y-agent-tasks.test.ts
+++ b/tests/unit/a11y-agent-tasks.test.ts
@@ -104,17 +104,66 @@ describe("read-task predicates", () => {
 });
 
 describe("write-task predicates", () => {
+  /** The answers the task prompt dictates — a fully correct submission. */
+  const goodResponse = {
+    q1: "Ada Lovelace",
+    q2: "Just right",
+    q3: ["Graphs"],
+    q4: "The pace worked well for me."
+  };
+
   it("survey-complete demands is_submitted=true, not just a row", async () => {
     const notSubmitted = await SURVEY_COMPLETE_TASK.predicate(
       null,
-      ctx({ queryRow: async () => ({ is_submitted: false }) })
+      ctx({ queryRow: async () => ({ is_submitted: false, response: goodResponse }) })
     );
     expect(notSubmitted.success).toBe(false);
     const submitted = await SURVEY_COMPLETE_TASK.predicate(
       null,
-      ctx({ queryRow: async () => ({ is_submitted: true }) })
+      ctx({ queryRow: async () => ({ is_submitted: true, response: goodResponse }) })
     );
     expect(submitted.success).toBe(true);
+  });
+
+  // Issue #913: the NVDA driver's own sweep was arrowing through the q2 radio
+  // group, so the submitted answer was whichever option the last arrow landed
+  // on. `is_submitted === true` was the entire predicate, so the run stayed
+  // green and the defect was filed against the app instead of the driver.
+  it("survey-complete rejects a submitted survey whose pace answer was arrowed past", async () => {
+    for (const wrong of ["Too slow", "Too fast"]) {
+      const result = await SURVEY_COMPLETE_TASK.predicate(
+        null,
+        ctx({ queryRow: async () => ({ is_submitted: true, response: { ...goodResponse, q2: wrong } }) })
+      );
+      expect(result.success).toBe(false);
+      expect(result.detail).toContain("q2 (pace)");
+    }
+  });
+
+  it("survey-complete rejects a submitted survey with missing answers", async () => {
+    const noQ2 = await SURVEY_COMPLETE_TASK.predicate(
+      null,
+      ctx({ queryRow: async () => ({ is_submitted: true, response: { ...goodResponse, q2: undefined } }) })
+    );
+    expect(noQ2.success).toBe(false);
+    const noTopics = await SURVEY_COMPLETE_TASK.predicate(
+      null,
+      ctx({ queryRow: async () => ({ is_submitted: true, response: { ...goodResponse, q3: [] } }) })
+    );
+    expect(noTopics.success).toBe(false);
+    const blankComment = await SURVEY_COMPLETE_TASK.predicate(
+      null,
+      ctx({ queryRow: async () => ({ is_submitted: true, response: { ...goodResponse, q4: "   " } }) })
+    );
+    expect(blankComment.success).toBe(false);
+  });
+
+  it("survey-complete accepts the name in any casing — it travels through real keystrokes", async () => {
+    const result = await SURVEY_COMPLETE_TASK.predicate(
+      null,
+      ctx({ queryRow: async () => ({ is_submitted: true, response: { ...goodResponse, q1: "  ada LOVELACE " } }) })
+    );
+    expect(result.success).toBe(true);
   });
 
   it("discussion-reply rejects the marker text matching only the root thread", async () => {

--- a/tests/unit/a11y-judge-nvda-sweep-mutation.test.ts
+++ b/tests/unit/a11y-judge-nvda-sweep-mutation.test.ts
@@ -16,7 +16,7 @@
  * a11y-judge-report / a11y-judge-evidence tests).
  */
 import { describeSweepMutation, renderSummary, type TaskReport } from "../../tools/a11y-judge/nvda/report";
-import type { SweepMutation } from "../../tools/a11y-judge/nvda/nvdaHarness";
+import { ACT_LINE_NAMES_A_CONTROL, type SweepMutation } from "../../tools/a11y-judge/nvda/nvdaHarness";
 
 function mutation(overrides: Partial<SweepMutation> = {}): SweepMutation {
   return {
@@ -47,6 +47,42 @@ function report(overrides: Partial<TaskReport> = {}): TaskReport {
     ...overrides
   };
 }
+
+/**
+ * The discriminator retargetActToControl turns on, and the one that took three
+ * red lane runs to get right. Both cases below report a bare `label` navigator
+ * object, so the object alone cannot tell them apart — only the LINE can.
+ */
+describe("ACT_LINE_NAMES_A_CONTROL", () => {
+  // The defect: NVDA puts the SurveyJS choice's name on a line of its own with
+  // no role word, while the control sits on the previous line, nameless. Enter
+  // on these lines is a dead key (measured: nothing checked, activeElement BODY).
+  it("does not match a bare label-text line — the case that needs retargeting", () => {
+    for (const line of ["Just right", "Too slow", "Too fast", "Graphs", "DP", "Systems"]) {
+      expect(ACT_LINE_NAMES_A_CONTROL.test(line)).toBe(false);
+    }
+  });
+
+  // The counter-example that broke office-hours__help-request in run
+  // 31273130928: a `label` object too, but the line names its own role and Enter
+  // works, so this act must be left alone.
+  it("matches a line that announces its own control", () => {
+    const lines = [
+      "Privacy (Optional), check box, checked, Private requests are only visible to course staff",
+      "Just right, radio button, not checked",
+      "out of edit, clickable, button, Complete",
+      "Reference Assignment (Optional), combo box, collapsed, has auto complete, editable",
+      "Reply..., edit, multi line, blank",
+      "Sign in with magic link, link"
+    ];
+    for (const line of lines) expect(ACT_LINE_NAMES_A_CONTROL.test(line)).toBe(true);
+  });
+
+  it("tolerates NVDA's spacing of checkbox", () => {
+    expect(ACT_LINE_NAMES_A_CONTROL.test("Privacy, checkbox, checked")).toBe(true);
+    expect(ACT_LINE_NAMES_A_CONTROL.test("Privacy, check box, checked")).toBe(true);
+  });
+});
 
 describe("describeSweepMutation", () => {
   it("names the control and both answers, so the reader can see the sweep wrote", () => {

--- a/tests/unit/a11y-judge-nvda-sweep-mutation.test.ts
+++ b/tests/unit/a11y-judge-nvda-sweep-mutation.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the sweep-mutation reporting surface added for issue #913
+ * (tools/a11y-judge/nvda/report.ts).
+ *
+ * The defect these guard against is a REPORTING one as much as a driver one.
+ * #913 was filed against the app — "NVDA announces all three survey options as
+ * checked", WCAG 4.1.2 — when NVDA had reported the state correctly every time:
+ * the driver's own `next` sweep is ArrowDown, and in NVDA focus mode an arrow
+ * inside a radio group moves AND selects. The run stayed green because the
+ * survey lane asserted only `survey_responses.is_submitted === true` and nothing
+ * anywhere said the sweep had touched the answers. So a mutation must reach the
+ * summary, and it must say which way the answer moved.
+ *
+ * LOCATION NOTE: this repo's jest config only discovers tests under tests/unit,
+ * so the test lives here and imports from tools/ (matching the sibling
+ * a11y-judge-report / a11y-judge-evidence tests).
+ */
+import { describeSweepMutation, renderSummary, type TaskReport } from "../../tools/a11y-judge/nvda/report";
+import type { SweepMutation } from "../../tools/a11y-judge/nvda/nvdaHarness";
+
+function mutation(overrides: Partial<SweepMutation> = {}): SweepMutation {
+  return {
+    stepIndex: 42,
+    command: "next",
+    kind: "radio",
+    key: "q2_sq_7",
+    before: "Just right",
+    after: "Too fast",
+    leftFocusMode: true,
+    restore: "restored|q2_sq_7|Just right",
+    restored: true,
+    ...overrides
+  };
+}
+
+function report(overrides: Partial<TaskReport> = {}): TaskReport {
+  return {
+    id: "survey-taking__survey-complete",
+    pageId: "survey-taking",
+    taskId: "survey-complete",
+    taskKind: "write",
+    status: "passed",
+    durationMs: 61_000,
+    stepCount: 30,
+    resyncs: [],
+    steps: [],
+    ...overrides
+  };
+}
+
+describe("describeSweepMutation", () => {
+  it("names the control and both answers, so the reader can see the sweep wrote", () => {
+    const line = describeSweepMutation(mutation());
+    expect(line).toContain("step 42");
+    expect(line).toContain("next");
+    expect(line).toContain('"q2_sq_7"');
+    expect(line).toContain('"Just right"');
+    expect(line).toContain('"Too fast"');
+  });
+
+  it("distinguishes a confirmed restore from a failed one", () => {
+    expect(describeSweepMutation(mutation())).toContain("restore: confirmed");
+    const failed = describeSweepMutation(mutation({ restored: false, restore: "no-element|" }));
+    expect(failed).toContain("restore: FAILED");
+    expect(failed).toContain("no-element|");
+  });
+
+  // "The guard never ran" and "the guard ran and the arrow mutated anyway" are
+  // different bugs: only the second means NVDA was still in focus mode after an
+  // Escape, so the flag has to survive into the rendered line.
+  it("reports whether the pre-emptive exitFocusMode fired", () => {
+    expect(describeSweepMutation(mutation({ leftFocusMode: true }))).toContain("left focus mode first: true");
+    expect(describeSweepMutation(mutation({ leftFocusMode: false }))).toContain("left focus mode first: false");
+  });
+});
+
+describe("renderSummary sweep-mutation section", () => {
+  it("is absent when no sweep changed anything", () => {
+    const summary = renderSummary([report()], {});
+    expect(summary).not.toContain("Sweep mutations");
+  });
+
+  // The load-bearing case: the task PASSED its predicate, and the mutation is
+  // the only thing saying the recorded answer belongs to the driver.
+  it("appears for a PASSED task whose sweep changed an answer", () => {
+    const summary = renderSummary([report({ sweepMutations: [mutation()] })], {});
+    expect(summary).toContain("Sweep mutations");
+    expect(summary).toContain("survey-taking__survey-complete");
+    expect(summary).toContain('"Just right"');
+    expect(summary).toContain('"Too fast"');
+    expect(summary).toContain("#913");
+  });
+
+  it("lists every mutating step, not just the first", () => {
+    const summary = renderSummary(
+      [
+        report({
+          sweepMutations: [
+            mutation({ stepIndex: 10, after: "Too fast" }),
+            mutation({ stepIndex: 11, command: "previous", before: "Too fast", after: "Too slow" })
+          ]
+        })
+      ],
+      {}
+    );
+    expect(summary).toContain("step 10");
+    expect(summary).toContain("step 11");
+    expect(summary).toContain("previous");
+  });
+});

--- a/tests/unit/session-user-recovery.test.ts
+++ b/tests/unit/session-user-recovery.test.ts
@@ -364,6 +364,94 @@ describe("installSessionUserRecovery", () => {
     uninstall();
   });
 
+  // Raised in review: if the marker cannot be persisted, the one-reload bound is
+  // not a bound at all — every poll would see the same absent session and reload
+  // again, once a minute, forever. Stale content beats a page reloading out from
+  // under the user, so an unusable store suppresses the recovery instead.
+  it("does not reload at all when sessionStorage cannot persist the guard", async () => {
+    jest.useFakeTimers();
+    const getItem = jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const setItem = jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(10_000);
+      expect(reloadCalls).toBe(0);
+
+      uninstall();
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  // Raised in review: hidden tabs are not polled, so without a visibility hook a
+  // tab that was hidden during the sign-out keeps showing private data for up to
+  // a full interval after the user looks at it again.
+  it("checks immediately when a hidden tab becomes visible again", async () => {
+    jest.useFakeTimers();
+    let visibility: DocumentVisibilityState = "hidden";
+    const spy = jest.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 60_000
+      });
+
+      // Signed out elsewhere while this tab sat hidden: no poll runs.
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+
+      // The user comes back. This must not wait for the next 60s tick.
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(reloadCalls).toBe(1);
+
+      uninstall();
+    } finally {
+      spy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it("stops listening for visibility changes on uninstall", async () => {
+    jest.useFakeTimers();
+    let visibility: DocumentVisibilityState = "visible";
+    const spy = jest.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+    try {
+      const { client, setSession } = fakeClient();
+      installSessionUserRecovery({ client, renderedUserId: "user-a", reload, pollIntervalMs: 60_000 })();
+
+      setSession(null);
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(reloadCalls).toBe(0);
+    } finally {
+      spy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
   it("unsubscribes and stops polling on uninstall", async () => {
     jest.useFakeTimers();
     try {

--- a/tests/unit/session-user-recovery.test.ts
+++ b/tests/unit/session-user-recovery.test.ts
@@ -1,4 +1,4 @@
-import { installSessionUserRecovery, isForeignSessionUser } from "@/lib/sessionUserRecovery";
+import { installSessionUserRecovery, isConfirmedAbsentSession, isForeignSessionUser } from "@/lib/sessionUserRecovery";
 
 describe("isForeignSessionUser", () => {
   it("flags a session that belongs to a different user than the render", () => {
@@ -23,6 +23,28 @@ describe("isForeignSessionUser", () => {
   });
 });
 
+// The whole reason #902 left cross-tab sign-out alone: a null session means
+// either "signed out" or "the refresh failed", and only the error channel tells
+// them apart. Getting this predicate wrong throws people off a working page on
+// every network blip.
+describe("isConfirmedAbsentSession", () => {
+  it("confirms a clean read that found no session", () => {
+    expect(isConfirmedAbsentSession(null)).toBe(true);
+    expect(isConfirmedAbsentSession(undefined)).toBe(true);
+    expect(isConfirmedAbsentSession(null, null)).toBe(true);
+  });
+
+  it("refuses to confirm when the read reported an error — a failed refresh looks identical", () => {
+    expect(isConfirmedAbsentSession(null, new Error("refresh_token_not_found"))).toBe(false);
+    expect(isConfirmedAbsentSession(undefined, { message: "network error" })).toBe(false);
+  });
+
+  it("is never true while a session exists", () => {
+    expect(isConfirmedAbsentSession("user-a")).toBe(false);
+    expect(isConfirmedAbsentSession("user-a", new Error("boom"))).toBe(false);
+  });
+});
+
 describe("installSessionUserRecovery", () => {
   let reloadCalls: number;
   const reload = () => {
@@ -38,6 +60,10 @@ describe("installSessionUserRecovery", () => {
     type Session = { user: { id: string } } | null;
     let handler: ((event: string, session: Session) => void) | undefined;
     let session: Session = null;
+    // The discriminator between "signed out" and "a refresh failed": supabase-js
+    // reports the latter as an error alongside the null session.
+    let error: unknown = null;
+    let rejects = false;
     const unsubscribe = jest.fn();
     const sessionFor = (userId: string | null): Session => (userId === null ? null : { user: { id: userId } });
     const client = {
@@ -46,7 +72,10 @@ describe("installSessionUserRecovery", () => {
           handler = cb;
           return { data: { subscription: { unsubscribe } } };
         },
-        getSession: async () => ({ data: { session } })
+        getSession: async () => {
+          if (rejects) throw new Error("network down");
+          return { data: { session }, error };
+        }
       }
     };
     return {
@@ -55,9 +84,17 @@ describe("installSessionUserRecovery", () => {
       setSession: (userId: string | null) => {
         session = sessionFor(userId);
       },
+      /** Null session *with* an error — a failed refresh, not a sign-out. */
+      setSessionReadError: (err: unknown) => {
+        session = null;
+        error = err;
+      },
+      setRejects: (value: boolean) => {
+        rejects = value;
+      },
       emit: (userId: string | null) => {
         session = sessionFor(userId);
-        handler?.("SIGNED_IN", session);
+        handler?.(userId === null ? "SIGNED_OUT" : "SIGNED_IN", session);
       }
     };
   }
@@ -152,6 +189,179 @@ describe("installSessionUserRecovery", () => {
       visibility.mockRestore();
       jest.useRealTimers();
     }
+  });
+
+  // ---------------------------------------------------------------------
+  // Cross-tab sign-out (issue #911). signOutAction clears the shared cookie
+  // for every tab and redirects only the tab it ran in; the others keep a
+  // rendered, authenticated page full of private data until someone reloads
+  // by hand.
+  // ---------------------------------------------------------------------
+
+  it("reloads a tab whose session was signed out in another tab", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession("user-a");
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(0);
+
+      // Another tab signs out: the shared cookie is gone, no auth event fires.
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(1);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not reload when the session read errored — a failed refresh is not a sign-out", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSessionReadError } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSessionReadError(new Error("refresh_token_not_found"));
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not reload when the session read rejects outright", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setRejects } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setRejects(true);
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // The loop this bound exists for: if the server keeps rendering authenticated
+  // while the browser cannot read the cookie, the reload lands on the same page
+  // with the same absent session. One extra reload is acceptable; a 60s reload
+  // loop forever is not.
+  it("reloads at most once per tab for a sign-out that does not converge", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(1);
+
+      // The reload did not fix anything — the session is still absent.
+      await jest.advanceTimersByTimeAsync(60_000);
+      expect(reloadCalls).toBe(1);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("recovers again after a later sign-out once a valid session has been seen", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: "user-a",
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(1);
+
+      // Signed back in as the same user: the tab is consistent again, so the
+      // one-per-tab marker must be dropped...
+      setSession("user-a");
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(1);
+
+      // ...otherwise this second sign-out would be silently swallowed.
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(reloadCalls).toBe(2);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // The initiating tab is mid-redirect to /sign-in when the cookie clears, and
+  // the sign-in page renders no user. Acting there would reload the page the
+  // user is being sent to.
+  it("leaves a tab with no rendered user alone when there is no session", async () => {
+    jest.useFakeTimers();
+    try {
+      const { client, setSession } = fakeClient();
+      const uninstall = installSessionUserRecovery({
+        client,
+        renderedUserId: null,
+        reload,
+        pollIntervalMs: 1000
+      });
+
+      setSession(null);
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(reloadCalls).toBe(0);
+
+      uninstall();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // INITIAL_SESSION arrives with a null session on any page that legitimately
+  // has none yet, so the event path must stay inert; only a poll tick is a
+  // positive statement about the session right now.
+  it("does not act on a null session delivered as an auth event", () => {
+    const { client, emit } = fakeClient();
+    const uninstall = installSessionUserRecovery({ client, renderedUserId: "user-a", reload });
+
+    emit(null);
+    expect(reloadCalls).toBe(0);
+
+    uninstall();
   });
 
   it("unsubscribes and stops polling on uninstall", async () => {

--- a/tools/a11y-judge/agent/tasks.ts
+++ b/tools/a11y-judge/agent/tasks.ts
@@ -76,6 +76,17 @@ export const SURVEY_COMPLETE_TASK: TaskDefinition = {
     "answer the name question with 'Ada Lovelace', choose the middle option for the pace question,",
     "check at least one topic, add a short comment, then submit the survey with the Complete button."
   ].join(" "),
+  /**
+   * Asserts the ANSWERS, not just that a row was submitted.
+   *
+   * `is_submitted === true` alone was the whole predicate, and it is how issue
+   * #913 shipped: the NVDA driver's own arrow keys were re-selecting the q2
+   * radio group on every sweep press (in focus mode an arrow inside a radio
+   * group moves AND selects), so the submitted answer was whichever option the
+   * last press happened to land on — and nothing in a green run disagreed. The
+   * prompt above names an exact answer for each question, so the predicate can
+   * check each one; q2 in particular is the one a mutating sweep rewrites.
+   */
   predicate: async (_verdict, ctx) => {
     const row = await ctx.queryRow("survey_responses", {
       survey_id: ctx.seed.surveyId,
@@ -85,7 +96,36 @@ export const SURVEY_COMPLETE_TASK: TaskDefinition = {
     if (row.is_submitted !== true) {
       return { success: false, detail: `survey_responses row exists but is_submitted=${String(row.is_submitted)}` };
     }
-    return { success: true, detail: "survey_responses.is_submitted=true" };
+    const response = (row.response ?? {}) as Record<string, unknown>;
+    const problems: string[] = [];
+
+    // q2 — the pace radiogroup. Exact match on the middle choice: "the driver
+    // arrowed one past it" is precisely the failure being caught, and any
+    // looser check (non-empty, one-of-three) would pass it.
+    if (response.q2 !== "Just right") {
+      problems.push(`q2 (pace) is ${JSON.stringify(response.q2 ?? null)}, expected "Just right"`);
+    }
+    // q1 — free text. Compared case- and space-insensitively because the value
+    // travels through real keystrokes and NVDA's own field handling.
+    const q1 = typeof response.q1 === "string" ? response.q1.trim().toLowerCase() : "";
+    if (q1 !== "ada lovelace") {
+      problems.push(`q1 (name) is ${JSON.stringify(response.q1 ?? null)}, expected "Ada Lovelace"`);
+    }
+    // q3 — checkbox group. The prompt says "at least one", so the assertion is
+    // the same shape: a non-empty array drawn from the seeded choices.
+    const q3 = Array.isArray(response.q3) ? response.q3 : [];
+    if (q3.length === 0) {
+      problems.push(`q3 (topics) is ${JSON.stringify(response.q3 ?? null)}, expected at least one topic`);
+    }
+    // q4 — the prompt asks for "a short comment" without dictating its text, so
+    // only its presence can be asserted.
+    if (typeof response.q4 !== "string" || response.q4.trim().length === 0) {
+      problems.push(`q4 (comment) is ${JSON.stringify(response.q4 ?? null)}, expected a non-empty comment`);
+    }
+
+    return problems.length === 0
+      ? { success: true, detail: `survey submitted with q1/q2/q3/q4 as instructed (q2="${String(response.q2)}")` }
+      : { success: false, detail: `survey was submitted but the answers are wrong: ${problems.join("; ")}` };
   }
 };
 

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -680,11 +680,27 @@ function hostFieldWriteJs(text: string): string {
   })()`;
 }
 
+/** Parsed form of a sweep signature. `kind` is the discriminator; `none`/`safe`
+ *  are the two cheap exits (nothing focused / focus is not arrow-mutable). */
+interface SweepSignature {
+  kind: "none" | "safe" | "radio" | "value";
+  key: string;
+  value: string;
+}
+
+/** No selection at all — distinct from a control whose value is the empty
+ *  string, which is why it is a sentinel rather than "". */
+const SWEEP_NO_SELECTION = " none";
+
 /**
  * Page-side expression reading the ANSWER the focused arrow-mutable control
- * carries, as a comparable string. Returns 'none|', 'safe|<TAG>' (focus is not
- * on such a control — the overwhelmingly common case, and the cheap exit), or
- * '<kind>|<key>|<value>'.
+ * carries. Returns JSON: `{kind, key, value}`.
+ *
+ * JSON rather than a delimited string, because the fields are arbitrary DOM
+ * `name`/`value` content. A pipe-delimited encoding parsed with split("|") — the
+ * first version of this — truncates a legitimate option value like "A|one" to
+ * "A", so a change to "A|two" compares EQUAL and the guard silently misses the
+ * mutation it exists to catch.
  *
  * For a radio the value is the group's CHECKED member, not the focused one:
  * focus and selection are different things in a radio group, and it is the
@@ -695,19 +711,35 @@ function hostFieldWriteJs(text: string): string {
  */
 function sweepSignatureJs(remember: boolean): string {
   return `(() => {
+    const NONE = ${JSON.stringify(SWEEP_NO_SELECTION)};
     const el = ${remember ? "document.activeElement" : `window[${JSON.stringify(SWEEP_ELEMENT_KEY)}] || document.activeElement`};
     ${remember ? `window[${JSON.stringify(SWEEP_ELEMENT_KEY)}] = el;` : ""}
-    if (!el || el === document.body || !el.matches) return 'none|';
-    if (!el.matches(${JSON.stringify(ARROW_MUTABLE_SELECTOR)})) return 'safe|' + el.tagName;
+    const out = (kind, key, value) => JSON.stringify({ kind: kind, key: key, value: value });
+    if (!el || el === document.body || !el.matches) return out('none', '', '');
+    if (!el.matches(${JSON.stringify(ARROW_MUTABLE_SELECTOR)})) return out('safe', el.tagName, '');
     if (el.tagName === 'INPUT' && el.type === 'radio') {
-      if (!el.name) return 'radio|<unnamed>|' + (el.checked ? el.value : '<none>');
-      const picked = el.form
-        ? [...el.form.querySelectorAll('input[type=radio]')].find((r) => r.name === el.name && r.checked)
-        : [...document.querySelectorAll('input[type=radio]')].find((r) => r.name === el.name && r.checked);
-      return 'radio|' + el.name + '|' + (picked ? picked.value : '<none>');
+      if (!el.name) return out('radio', '<unnamed>', el.checked ? el.value : NONE);
+      const scope = el.form || document;
+      const picked = [...scope.querySelectorAll('input[type=radio]')].find((r) => r.name === el.name && r.checked);
+      return out('radio', el.name, picked ? picked.value : NONE);
     }
-    return 'value|' + (el.name || el.id || el.tagName) + '|' + String(el.value == null ? '' : el.value);
+    return out('value', el.name || el.id || el.tagName, String(el.value == null ? '' : el.value));
   })()`;
+}
+
+/** Parse a sweep signature; null when the host read failed or returned garbage,
+ *  which the caller must treat as "no evidence", never as "unchanged". */
+function parseSweepSignature(raw: string): SweepSignature | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { kind, key, value } = parsed as Partial<SweepSignature>;
+    if (kind !== "none" && kind !== "safe" && kind !== "radio" && kind !== "value") return null;
+    return { kind, key: typeof key === "string" ? key : "", value: typeof value === "string" ? value : "" };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -731,8 +763,12 @@ function sweepRestoreJs(kind: string, key: string, value: string): string {
       const scope = el.form || document;
       const group = [...scope.querySelectorAll('input[type=radio]')].filter((r) => r.name === key);
       if (!group.length) return 'no-group|' + key;
+      // No target: the group had NO selection before the arrow. Uncheck every
+      // member and notify on each, but say so — this is DOM-only, and a
+      // framework that keeps the answer in its own model (SurveyJS does) may
+      // re-derive it, so the caller must not report this as a verified restore.
       const target = group.find((r) => r.value === want);
-      if (!target) { group.forEach((r) => { r.checked = false; }); fire(el); return 'cleared|' + key; }
+      if (!target) { group.forEach((r) => { r.checked = false; fire(r); }); return 'cleared-dom-only|' + key; }
       const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked');
       if (desc && desc.set) { desc.set.call(target, true); } else { target.checked = true; }
       fire(target);
@@ -1290,6 +1326,9 @@ export class NvdaHarness implements AtDriver {
   private typeFidelity: TypeStepFidelity[] = [];
   private cursorChecks: NvdaCursorCheck[] = [];
   private sweepMutations: SweepMutation[] = [];
+  /** Which focused control this sweep has already left focus mode for, so the
+   *  Escape fires once rather than on every step (see arrowSweep). */
+  private sweepFocusModeExitKey: string | null = null;
   /** The interrogation the CURRENT command performed, if any — consumed by
    *  undoOracleEcho and cleared at the top of every run(). */
   private oracleEcho: CursorOracleReply | null = null;
@@ -1378,6 +1417,7 @@ export class NvdaHarness implements AtDriver {
     this.typeFidelity = [];
     this.cursorChecks = [];
     this.sweepMutations = [];
+    this.sweepFocusModeExitKey = null;
     this.oracleEcho = null;
     this.cursorGate = null;
     await this.enterWebArea();
@@ -2769,42 +2809,65 @@ export class NvdaHarness implements AtDriver {
   private async arrowSweep(command: "next" | "previous" | "readNext", arrow: () => Promise<void>): Promise<void> {
     if (!this.hostEval) return arrow();
 
-    const before = await this.hostEval(sweepSignatureJs(true)).catch(() => "");
-    const [kind, key = "", value = ""] = before.split("|");
+    const before = parseSweepSignature(await this.hostEval(sweepSignatureJs(true)).catch(() => ""));
     // 'none' (nothing focused) and 'safe' (focused, but arrows do not change its
     // value) are the overwhelmingly common readings on a reading sweep, and both
-    // exit before spending a single extra gesture.
-    if (kind !== "radio" && kind !== "value") return arrow();
+    // exit before spending a single extra gesture. An unreadable probe exits the
+    // same way: no evidence is not evidence of danger.
+    if (!before || (before.kind !== "radio" && before.kind !== "value")) return arrow();
+    const { kind, key, value } = before;
 
-    this.debug("sweep: focus is on an arrow-mutable control — leaving focus mode before arrowing", {
-      command,
-      kind,
-      key,
-      answer: value
-    });
-    let leftFocusMode = true;
-    await this.withTimeout(
-      "sweep:exitFocusMode",
-      this.nvda.perform(this.nvda.keyboardCommands.exitFocusMode, { capture: "initial" }),
-      FOCUS_RUNG_TIMEOUT_MS
-    ).catch((e) => {
-      leftFocusMode = false;
-      this.debug("sweep: exitFocusMode threw — arrowing anyway, the check below is the real guard", {
-        error: String(e)
+    // Escape ONLY on the first sweep step for a given focused control.
+    //
+    // Browse-mode arrows move the review cursor and leave DOM focus where it is,
+    // so once we have left focus mode this probe keeps reporting the same
+    // arrow-mutable element on every subsequent step. Re-sending Escape there is
+    // not a no-op: NVDA is already in browse mode, so the key reaches the PAGE,
+    // and a control inside a dialog or popover would have that UI dismissed by
+    // the very sweep that is supposed to be reading it (raised in review).
+    // The before/after check below is what actually protects the answer, so
+    // skipping the repeat costs nothing.
+    const focusKey = `${kind}:${key}`;
+    const alreadyLeft = this.sweepFocusModeExitKey === focusKey;
+    let leftFocusMode = alreadyLeft;
+    if (!alreadyLeft) {
+      this.debug("sweep: focus is on an arrow-mutable control — leaving focus mode before arrowing", {
+        command,
+        kind,
+        key,
+        answer: value
       });
-    });
+      leftFocusMode = true;
+      await this.withTimeout(
+        "sweep:exitFocusMode",
+        this.nvda.perform(this.nvda.keyboardCommands.exitFocusMode, { capture: "initial" }),
+        FOCUS_RUNG_TIMEOUT_MS
+      ).catch((e) => {
+        leftFocusMode = false;
+        this.debug("sweep: exitFocusMode threw — arrowing anyway, the check below is the real guard", {
+          error: String(e)
+        });
+      });
+      this.sweepFocusModeExitKey = focusKey;
+    }
 
     await arrow();
 
-    const after = await this.hostEval(sweepSignatureJs(false)).catch(() => "");
-    const afterValue = after.split("|")[2] ?? "";
+    const after = parseSweepSignature(await this.hostEval(sweepSignatureJs(false)).catch(() => ""));
     // An unreadable after-reading is not a mutation: a lost host probe has never
     // been treated as proof of failure anywhere else in this file either.
-    if (!after || after.split("|")[0] !== kind || afterValue === value) return;
+    if (!after || after.kind !== kind || after.value === value) return;
+    const afterValue = after.value;
 
     const restore = await this.hostEval(sweepRestoreJs(kind, key, value)).catch((e) => `threw|${String(e)}`);
-    const confirm = await this.hostEval(sweepSignatureJs(false)).catch(() => "");
-    const restored = (confirm.split("|")[2] ?? "") === value;
+    const confirmed = parseSweepSignature(await this.hostEval(sweepSignatureJs(false)).catch(() => ""));
+    // Clearing a radio group back to "no selection" is DOM-only and cannot be
+    // confirmed from here: frameworks keep the answer in their own model (raised
+    // in review — SurveyJS re-derives it, so autosave can still carry the
+    // driver's value while the DOM reads empty). Report that honestly rather
+    // than claiming a restore this cannot verify; run.ts fails the task on the
+    // mutation either way.
+    const restored = value === SWEEP_NO_SELECTION ? false : confirmed !== null && confirmed.value === value;
     this.debug("sweep: THE ARROW CHANGED THE ANSWER — this step read nothing, it wrote (issue #913)", {
       command,
       kind,

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -2871,7 +2871,13 @@ export class NvdaHarness implements AtDriver {
     // pure label text with no role word anywhere in it ("Just right"); the
     // working case names its own role. Only the former needs retargeting, and
     // only the former is proven to be a dead Enter.
-    const before = await this.itemTextSafe(ITEM_TEXT_PROBE_MS);
+    // undoOracleEcho, exactly as `case "interact"` does and for the same reason:
+    // itemText() is an alias for lastSpokenPhrase(), corroborateCursor has just
+    // interrogated the oracle for this very step, so without this the "line" read
+    // here is the oracle's own answer — "label" — which of course names no
+    // control. Run 31275593976 is what that cost: the stand-down never fired,
+    // privacy (optional) retargeted anyway and help-request failed a third time.
+    const before = this.undoOracleEcho(await this.itemTextSafe(ITEM_TEXT_PROBE_MS));
     if (ACT_LINE_NAMES_A_CONTROL.test(before)) {
       this.debug("act: line already announces a control — leaving this act alone", { item: before.slice(0, 120) });
       return "proceed";

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -2809,8 +2809,13 @@ export class NvdaHarness implements AtDriver {
    * that way would select "Too fast" when the plan asked for "Just right".
    *
    * Engages only on the exact signature of the defect — a milestone-bearing
-   * `act` whose oracle reply reduced to NO content words at all — so an `act` on
-   * a properly named control (every other one in the suite) is untouched.
+   * `act` whose oracle reply is a bare `label` — and accepts the hop only when
+   * EVERY milestone word is present on what it landed on. Both bounds were paid
+   * for in run 31270612942, where a looser version of each broke a task that had
+   * been passing: "nameless" alone caught ordinary prose ("paragraph") and
+   * suppressed a working Enter, and overlap-matching accepted "Reference
+   * Assignment (Optional)" for a milestone of "privacy (optional)" on the
+   * strength of the single word "optional".
    *
    * Returns "skip" when the hop did not reach a control matching the milestone.
    * Skipping is safe by construction: the Enter it suppresses is the one already
@@ -2825,8 +2830,16 @@ export class NvdaHarness implements AtDriver {
     const check = this.cursorChecks.at(-1);
     if (!check || check.stepIndex !== this.steps.length || check.command !== "act") return "proceed";
     if (check.verdict !== "abstained" || check.objectTokens.length > 0) return "proceed";
+    // The reply must be a bare LABEL, not merely nameless. Run 31270612942
+    // proved the difference matters: a milestone of "post" sat on ordinary prose
+    // whose reply was "paragraph", this guard engaged, the hop landed on the
+    // reply textarea and SUPPRESSED an Enter that had been working. "paragraph"
+    // is exactly the benign collapse NVDA_ROLE_TOKENS documents — plain text has
+    // no name to give. A `<label>` is different in kind: it is never a thing to
+    // activate, only ever a wrapper around the control that is.
+    if (clean(check.reply) !== "label") return "proceed";
 
-    this.debug("act: cursor is on a NAMELESS object — the milestone matched label text, not the control", {
+    this.debug("act: cursor is on a nameless LABEL — the milestone matched label text, not the control", {
       milestone,
       oracleReply: check.reply.slice(0, 120),
       hop: "previous form field (the control precedes its label text)"
@@ -2838,15 +2851,27 @@ export class NvdaHarness implements AtDriver {
     // ("Just right, radio button, not checked"), which is exactly the name the
     // line read omitted.
     const { content } = nvdaCursorTokens(item);
-    const shared = content.filter((token) => wanted.tokens.includes(token));
-    if (shared.length > 0) {
-      this.debug("act: retargeted onto the control the milestone names", { item: item.slice(0, 120), shared });
+    // EVERY milestone word must be present, not merely one. Overlap alone is far
+    // too weak for a gesture that picks WHICH control gets activated: in run
+    // 31270612942 a milestone of "privacy (optional)" shared its one word
+    // "optional" with "Reference Assignment (Optional), combo box" and this hop
+    // accepted it, so Enter opened a combo box instead of ticking the privacy
+    // checkbox and the whole help-request task failed. Overlap is the right rule
+    // for judgeCursorOracle, which only has to decide whether two readings
+    // describe the same place; it is the wrong rule here.
+    const missing = wanted.tokens.filter((token) => !content.includes(token));
+    if (missing.length === 0) {
+      this.debug("act: retargeted onto the control the milestone names", {
+        item: item.slice(0, 120),
+        matched: wanted.tokens
+      });
       return "proceed";
     }
     this.debug("act: RETARGET FAILED — not firing Enter, which would activate the wrong control", {
       milestone,
       landedOn: item.slice(0, 120),
-      wanted: wanted.tokens
+      wanted: wanted.tokens,
+      missing
     });
     return "skip";
   }

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -747,6 +747,26 @@ function sweepRestoreJs(kind: string, key: string, value: string): string {
   })()`;
 }
 
+/**
+ * Page-side "did that Enter do anything?" signature.
+ *
+ * The `act` retarget only ever engages on a line of bare label text (see
+ * retargetActToControl), and Enter on such a line either activates the control
+ * the label belongs to or does nothing at all — so checkable state, focus and
+ * location together are enough to tell those apart. Buttons and links never
+ * reach this path: their lines name their own role.
+ */
+function actStateSignatureJs(): string {
+  return `(() => {
+    const checked = [...document.querySelectorAll('input[type=checkbox],input[type=radio]')]
+      .filter((i) => i.checked)
+      .map((i) => (i.name || i.id || '?') + '=' + i.value)
+      .join(',');
+    const el = document.activeElement;
+    return checked + '|' + (el ? el.tagName + (el.id ? '#' + el.id : '') : 'none') + '|' + location.href;
+  })()`;
+}
+
 const tidyLabel = (s: string): string =>
   s
     .replace(/\s+/g, " ")
@@ -2822,27 +2842,62 @@ export class NvdaHarness implements AtDriver {
    * the next form field forward from line 4 is the following option — hopping
    * that way would select "Too fast" when the plan asked for "Just right".
    *
-   * THREE bounds, each paid for by a task this broke while too loose:
+   * Reached only as a FALLBACK, after an Enter that provably changed nothing
+   * (see `case "act"`). That ordering is the correction for three red runs spent
+   * trying to predict which widgets need it:
    *
    *  - the oracle reply must be a bare `label`. "Any nameless object" also
    *    catches ordinary prose, whose reply is "paragraph"; that suppressed a
    *    working Enter on a milestone of "post" (run 31270612942).
-   *  - the LINE must not announce a control. A `label` object alone does not
-   *    mean Enter is dead — the Chakra privacy checkbox reports one too, but its
-   *    line reads "Privacy (Optional), check box, checked, ..." and Enter works.
-   *    Suppressing it failed office-hours__help-request (run 31273130928).
+   *  - the LINE must not announce a control, which keeps buttons and links out.
    *  - EVERY milestone word must appear on what the hop landed on. Overlap
    *    accepted "Reference Assignment (Optional), combo box" for a milestone of
    *    "privacy (optional)" on the single word "optional", so Enter opened a
    *    combo box instead of ticking a checkbox (run 31270612942).
    *
-   * Together these admit the measured defect and nothing else in the suite.
+   * None of those was enough on its own, because the distinguishing fact is not
+   * visible in the announcement at all. Run 31286526726 measured the Chakra
+   * privacy checkbox presenting the SAME bare-label line as a SurveyJS choice
+   * ("Privacy (Optional)", no role word, `label` object) — yet Enter ticks it,
+   * because its `<label>` activates its input, while SurveyJS's leaves
+   * activeElement on BODY. No amount of reading the speech separates those. Only
+   * pressing the key and looking at the page does, which is why this now runs
+   * after the Enter rather than instead of it.
+   *
+   * `skip` therefore means "the Enter already happened and did nothing, and the
+   * hop could not find the control either" — a genuine dead end, not a
+   * suppressed keystroke.
    *
    * Returns "skip" when the hop did not reach a control matching the milestone.
    * Skipping is safe by construction: the Enter it suppresses is the one already
    * proven to be a no-op, so this is never worse than the behaviour it replaces,
    * and it is far better than firing Enter at whatever the hop landed on.
    */
+  /**
+   * Is this `act` sitting on the shape that MIGHT need retargeting — a line of
+   * bare label text, matched by a naming milestone, with a nameless `label`
+   * navigator object?
+   *
+   * Answering yes costs only the two host reads that bracket the Enter; it does
+   * not change what the Enter does. That is the whole point of the inversion:
+   * the previous shape decided to retarget INSTEAD of pressing Enter, and was
+   * wrong about which widgets need it (run 31286526726 — the Chakra privacy
+   * checkbox has exactly the same bare-label line as SurveyJS, but Enter on it
+   * works, because its `<label>` activates its input where SurveyJS's does not).
+   * Pressing first and checking after replaces that guess with a measurement.
+   */
+  private async actNeedsNoOpCheck(milestone: string | undefined): Promise<boolean> {
+    if (!this.hostEval) return false;
+    const wanted = cursorOracleApplies(milestone);
+    if (!wanted.applies) return false;
+    const check = this.cursorChecks.at(-1);
+    if (!check || check.stepIndex !== this.steps.length || check.command !== "act") return false;
+    if (check.verdict !== "abstained" || check.objectTokens.length > 0) return false;
+    if (clean(check.reply) !== "label") return false;
+    const line = this.undoOracleEcho(await this.itemTextSafe(ITEM_TEXT_PROBE_MS));
+    return !ACT_LINE_NAMES_A_CONTROL.test(line);
+  }
+
   private async retargetActToControl(milestone: string | undefined): Promise<"proceed" | "skip"> {
     const wanted = cursorOracleApplies(milestone);
     if (!wanted.applies) return "proceed";
@@ -2943,9 +2998,21 @@ export class NvdaHarness implements AtDriver {
       case "previous":
         return this.arrowSweep("previous", () => nvda.previous(opts));
       case "act": {
-        // A milestone can match the LABEL TEXT of a control instead of the
-        // control, and Enter there does nothing at all. Retarget first; a
-        // failed retarget must not fire Enter (see retargetActToControl).
+        // A milestone can match the LABEL TEXT of a control rather than the
+        // control. Enter there does nothing on some widgets and works fine on
+        // others, so the Enter goes FIRST and the retarget is the fallback for
+        // when it demonstrably did nothing (see retargetActToControl).
+        if (!(await this.actNeedsNoOpCheck(context?.milestone))) return nvda.act(opts);
+        const signature = () => this.hostEval!(actStateSignatureJs()).catch(() => "");
+        const before = await signature();
+        await nvda.act(opts);
+        const after = await signature();
+        if (!before || after !== before) {
+          this.debug("act: Enter on the label text did something — no retarget needed", {
+            milestone: context?.milestone
+          });
+          return;
+        }
         if ((await this.retargetActToControl(context?.milestone)) === "skip") return;
         return nvda.act(opts);
       }

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -1428,8 +1428,8 @@ export class NvdaHarness implements AtDriver {
 
   /**
    * Control-level cursor hop for replayPlan (AtDriver.moveToControl): browse-mode
-   * quick nav, B / Shift-B (guidepup keyCodeCommands.moveToNextButton /
-   * moveToPreviousButton).
+   * quick nav, F / Shift-F (guidepup keyCodeCommands.moveToNextFormField /
+   * moveToPreviousFormField).
    *
    * WHY a second mover at all. `next`/`previous` are ArrowDown/ArrowUp: they move
    * the browse caret by LINE and leave it at the line START. Run 30760469666's
@@ -1439,8 +1439,35 @@ export class NvdaHarness implements AtDriver {
    * (the line names Reply, and nvdaLineSegmentAlternates offers it) and the
    * cursor oracle answered "Like (0 likes), button" every time: `contradicted`,
    * correctly, 75 presses in a row. The matcher and the gate were both right; the
-   * ladder simply had no gesture that could reach the button. B is that gesture,
-   * and Reply is two hops from Like.
+   * ladder simply had no gesture that could reach the button. A quick-nav to the
+   * adjacent CONTROL is that gesture, and Reply is two hops from Like.
+   *
+   * WHY FORM FIELD (F) RATHER THAN BUTTON (B). This started as B, which fixed
+   * the discussion case and nothing else: a button hop can only ever reach a
+   * button, so a milestone naming a RADIO or a CHECKBOX had no resync gesture at
+   * all. That is the survey selection failure — measured on the seeded survey,
+   * NVDA's browse buffer splits every SurveyJS choice across two lines, the
+   * control's own line carrying role and state but NO name:
+   *
+   *   line 3  the radio       spoken "radio button, not checked"
+   *                           navigatorObject "Just right, radio button, ... 2 of 3"
+   *   line 4  the label text  spoken "Just right"    navigatorObject "label"
+   *
+   * so the milestone "just right" can only ever match line 4 — and Enter there
+   * does nothing at all (measured: nothing checked, activeElement BODY). Every
+   * line sweep in the ladder lands on text the `act` cannot use.
+   *
+   * F fixes it because NVDA's form-field quick-nav announces the control the way
+   * focus does, name included, and lands the caret on the control itself:
+   *
+   *   F-hop  spoken "Just right, radio button, not checked"
+   *          Enter -> checked=Just right, activeElement=INPUT#q2_1
+   *
+   * F is also a strict SUPERSET of B — NVDA's form fields are edits, buttons,
+   * checkboxes, radio buttons, combo boxes, list boxes and sliders — so the
+   * discussion-reply case this rung was built for still resolves, just through a
+   * gesture that can also reach the other three-quarters of a form. The cost is
+   * hops spent on non-button fields, which the sweep budget already absorbs.
    *
    * Reports nothing on purpose (see the hook's contract): the caller reads where
    * this landed with an ordinary `observe`, so the hop's speech goes through
@@ -1452,11 +1479,11 @@ export class NvdaHarness implements AtDriver {
    */
   async moveToControl(direction: ControlHopDirection): Promise<void> {
     const kc = this.nvda.keyboardCommands;
-    const gesture = direction === "next" ? kc.moveToNextButton : kc.moveToPreviousButton;
+    const gesture = direction === "next" ? kc.moveToNextFormField : kc.moveToPreviousFormField;
     // No "from" reading here on purpose: itemText() is a round trip, replayPlan
     // may spend 24 hops on one milestone, and the observe either side of every
     // hop already records where the cursor was and where it landed.
-    this.debug("control hop: quick-nav to the adjacent button", {
+    this.debug("control hop: quick-nav to the adjacent form control", {
       direction,
       gesture: gesture.representation
     });

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -1190,7 +1190,7 @@ export interface TypeStepFidelity {
 export interface SweepMutation {
   /** Index this step has in NvdaHarness.steps. */
   stepIndex: number;
-  command: "next" | "previous";
+  command: "next" | "previous" | "readNext";
   /** 'radio' or 'value' — which arrow-mutable control was under focus. */
   kind: string;
   /** Radio group name, or the control's name/id. */
@@ -2766,7 +2766,7 @@ export class NvdaHarness implements AtDriver {
    * floor: the probes are host-side, and a driver without one has never been able
    * to see this.
    */
-  private async arrowSweep(command: "next" | "previous", arrow: () => Promise<void>): Promise<void> {
+  private async arrowSweep(command: "next" | "previous" | "readNext", arrow: () => Promise<void>): Promise<void> {
     if (!this.hostEval) return arrow();
 
     const before = await this.hostEval(sweepSignatureJs(true)).catch(() => "");
@@ -3427,7 +3427,14 @@ export class NvdaHarness implements AtDriver {
       }
       case "readNext": {
         const n = Math.min(Math.max(parseInt(arg ?? "10", 10) || 10, 1), READ_NEXT_MAX);
-        for (let i = 0; i < n; i++) await nvda.next(opts);
+        // Through arrowSweep, exactly like `next`/`previous`: these are the SAME
+        // ArrowDown, and a read-ahead is if anything the more dangerous of the
+        // two because it fires up to READ_NEXT_MAX of them in a row. Calling
+        // nvda.next() directly here left the biggest sweep in the plans
+        // unguarded, which is why q2 kept coming back "Too slow" long after the
+        // `act` had correctly selected "Just right" (run 31315071708), and why
+        // the original #913 log shows 27-28 announcements of each option.
+        for (let i = 0; i < n; i++) await this.arrowSweep("readNext", () => nvda.next(opts));
         return;
       }
       case "restartFromTop":

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -2877,15 +2877,26 @@ export class NvdaHarness implements AtDriver {
     // here is the oracle's own answer — "label" — which of course names no
     // control. Run 31275593976 is what that cost: the stand-down never fired,
     // privacy (optional) retargeted anyway and help-request failed a third time.
-    const before = this.undoOracleEcho(await this.itemTextSafe(ITEM_TEXT_PROBE_MS));
+    const raw = await this.itemTextSafe(ITEM_TEXT_PROBE_MS);
+    const before = this.undoOracleEcho(raw);
     if (ACT_LINE_NAMES_A_CONTROL.test(before)) {
       this.debug("act: line already announces a control — leaving this act alone", { item: before.slice(0, 120) });
       return "proceed";
     }
 
+    // Everything the stand-down decision rests on. Run 31282511729 showed it not
+    // firing on the privacy checkbox with no way to tell WHY from the log: the
+    // pre-hop line was never recorded, only the oracle reply. These four fields
+    // separate the possibilities — the echo was not undone (raw === before and
+    // both are "label"), the tail was some third phrase entirely, or the line
+    // genuinely carries no role word at that moment.
     this.debug("act: cursor is on bare label text, not the control it names", {
       milestone,
       oracleReply: check.reply.slice(0, 120),
+      rawTail: raw.slice(0, 160),
+      lineAfterUndoEcho: before.slice(0, 160),
+      namesAControl: ACT_LINE_NAMES_A_CONTROL.test(before),
+      lastContentItem: this.lastContentItem?.raw.slice(0, 160) ?? "(none)",
       hop: "previous form field (the control precedes its label text)"
     });
     await this.moveToControl("previous");

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -2785,6 +2785,72 @@ export class NvdaHarness implements AtDriver {
     });
   }
 
+  /**
+   * Move the review cursor from a control's LABEL TEXT onto the control itself,
+   * so `act`'s Enter has something it can actually activate.
+   *
+   * The failure this exists for, measured on the seeded survey. NVDA's browse
+   * buffer splits a SurveyJS choice across two lines, and the control's own line
+   * carries role and state but NO name (the label text is already adjacent in
+   * the buffer, so NVDA does not repeat it):
+   *
+   *   line 3  the radio       spoken "radio button, not checked"
+   *   line 4  the label text  spoken "Just right"   navigatorObject "label"
+   *
+   * A milestone of "just right" can therefore ONLY match line 4 — and Enter
+   * there does nothing whatsoever (measured: nothing checked, activeElement
+   * BODY). Worse, the ladder never notices: the speech matches, the cursor
+   * oracle answers a bare "label" and correctly ABSTAINS, and the gate accepts
+   * on abstain, so zero resyncs fire and the control-hop rung never runs. The
+   * survey was submitted with whatever was checked by other means.
+   *
+   * BACKWARD, not forward: the control PRECEDES its label text in the buffer, so
+   * the next form field forward from line 4 is the following option — hopping
+   * that way would select "Too fast" when the plan asked for "Just right".
+   *
+   * Engages only on the exact signature of the defect — a milestone-bearing
+   * `act` whose oracle reply reduced to NO content words at all — so an `act` on
+   * a properly named control (every other one in the suite) is untouched.
+   *
+   * Returns "skip" when the hop did not reach a control matching the milestone.
+   * Skipping is safe by construction: the Enter it suppresses is the one already
+   * proven to be a no-op, so this is never worse than the behaviour it replaces,
+   * and it is far better than firing Enter at whatever the hop landed on.
+   */
+  private async retargetActToControl(milestone: string | undefined): Promise<"proceed" | "skip"> {
+    const wanted = cursorOracleApplies(milestone);
+    if (!wanted.applies) return "proceed";
+    // corroborateCursor ran for THIS step (run() calls it before execute) and
+    // stamped its record with the index this step is about to take.
+    const check = this.cursorChecks.at(-1);
+    if (!check || check.stepIndex !== this.steps.length || check.command !== "act") return "proceed";
+    if (check.verdict !== "abstained" || check.objectTokens.length > 0) return "proceed";
+
+    this.debug("act: cursor is on a NAMELESS object — the milestone matched label text, not the control", {
+      milestone,
+      oracleReply: check.reply.slice(0, 120),
+      hop: "previous form field (the control precedes its label text)"
+    });
+    await this.moveToControl("previous");
+    const item = await this.itemTextSafe(ITEM_TEXT_PROBE_MS);
+    // The hop's own speech is enough here and costs nothing extra: a form-field
+    // quick-nav announces the control the way focus does, name included
+    // ("Just right, radio button, not checked"), which is exactly the name the
+    // line read omitted.
+    const { content } = nvdaCursorTokens(item);
+    const shared = content.filter((token) => wanted.tokens.includes(token));
+    if (shared.length > 0) {
+      this.debug("act: retargeted onto the control the milestone names", { item: item.slice(0, 120), shared });
+      return "proceed";
+    }
+    this.debug("act: RETARGET FAILED — not firing Enter, which would activate the wrong control", {
+      milestone,
+      landedOn: item.slice(0, 120),
+      wanted: wanted.tokens
+    });
+    return "skip";
+  }
+
   private async execute(command: AtCommand, arg?: string, context?: AtStepContext): Promise<void> {
     const nvda = this.nvda;
     const kc = nvda.keyboardCommands;
@@ -2796,8 +2862,13 @@ export class NvdaHarness implements AtDriver {
         return this.arrowSweep("next", () => nvda.next(opts));
       case "previous":
         return this.arrowSweep("previous", () => nvda.previous(opts));
-      case "act":
+      case "act": {
+        // A milestone can match the LABEL TEXT of a control instead of the
+        // control, and Enter there does nothing at all. Retarget first; a
+        // failed retarget must not fire Enter (see retargetActToControl).
+        if ((await this.retargetActToControl(context?.milestone)) === "skip") return;
         return nvda.act(opts);
+      }
       case "interact": {
         // NVDA has no interaction levels; entering focus mode is the analogue.
         // But NVDA+Space is a TOGGLE, not a descent, and toggling focus mode onto

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -594,6 +594,20 @@ const FIELD_SELECTOR = `input${NON_TEXT_INPUT_TYPES.map((t) => `:not([type=${t}]
  *
  * `checkbox` is deliberately absent: Space toggles a checkbox, arrows do not.
  */
+/**
+ * Does a browse LINE announce a control of its own?
+ *
+ * The discriminator retargetActToControl turns on. NVDA renders a control the
+ * user can activate with its role in the line ("Privacy (Optional), check box,
+ * checked, ..."), whereas the SurveyJS choice defect leaves a line of pure label
+ * text with no role word at all ("Just right") while the control sits on the
+ * previous line, nameless. Enter works on the first and is a dead key on the
+ * second, and nothing else in the observation distinguishes them — both report a
+ * bare `label` navigator object.
+ */
+export const ACT_LINE_NAMES_A_CONTROL =
+  /\b(check ?box|radio button|button|link|edit|combo box|list box|slider|spin button|menu item|tab|tree view|graphic)\b/i;
+
 const ARROW_MUTABLE_SELECTOR = [
   "input[type=radio]",
   "input[type=range]",
@@ -2808,14 +2822,21 @@ export class NvdaHarness implements AtDriver {
    * the next form field forward from line 4 is the following option — hopping
    * that way would select "Too fast" when the plan asked for "Just right".
    *
-   * Engages only on the exact signature of the defect — a milestone-bearing
-   * `act` whose oracle reply is a bare `label` — and accepts the hop only when
-   * EVERY milestone word is present on what it landed on. Both bounds were paid
-   * for in run 31270612942, where a looser version of each broke a task that had
-   * been passing: "nameless" alone caught ordinary prose ("paragraph") and
-   * suppressed a working Enter, and overlap-matching accepted "Reference
-   * Assignment (Optional)" for a milestone of "privacy (optional)" on the
-   * strength of the single word "optional".
+   * THREE bounds, each paid for by a task this broke while too loose:
+   *
+   *  - the oracle reply must be a bare `label`. "Any nameless object" also
+   *    catches ordinary prose, whose reply is "paragraph"; that suppressed a
+   *    working Enter on a milestone of "post" (run 31270612942).
+   *  - the LINE must not announce a control. A `label` object alone does not
+   *    mean Enter is dead — the Chakra privacy checkbox reports one too, but its
+   *    line reads "Privacy (Optional), check box, checked, ..." and Enter works.
+   *    Suppressing it failed office-hours__help-request (run 31273130928).
+   *  - EVERY milestone word must appear on what the hop landed on. Overlap
+   *    accepted "Reference Assignment (Optional), combo box" for a milestone of
+   *    "privacy (optional)" on the single word "optional", so Enter opened a
+   *    combo box instead of ticking a checkbox (run 31270612942).
+   *
+   * Together these admit the measured defect and nothing else in the suite.
    *
    * Returns "skip" when the hop did not reach a control matching the milestone.
    * Skipping is safe by construction: the Enter it suppresses is the one already
@@ -2838,8 +2859,25 @@ export class NvdaHarness implements AtDriver {
     // no name to give. A `<label>` is different in kind: it is never a thing to
     // activate, only ever a wrapper around the control that is.
     if (clean(check.reply) !== "label") return "proceed";
+    // ...and the LINE must be bare text. A nameless `label` navigator object does
+    // NOT imply Enter is a no-op — that was measured on SurveyJS markup and does
+    // not generalise. Run 31273130928 proved the counter-example: the Chakra
+    // privacy checkbox also reports a `label` object, but its browse LINE already
+    // carries name and role ("Privacy (Optional), check box, checked, ...") and
+    // Enter on it works. Suppressing that Enter failed a task that had passed.
+    //
+    // What actually separates the two is whether the line NVDA matched the
+    // milestone against announced a control at all. The broken case is a line of
+    // pure label text with no role word anywhere in it ("Just right"); the
+    // working case names its own role. Only the former needs retargeting, and
+    // only the former is proven to be a dead Enter.
+    const before = await this.itemTextSafe(ITEM_TEXT_PROBE_MS);
+    if (ACT_LINE_NAMES_A_CONTROL.test(before)) {
+      this.debug("act: line already announces a control — leaving this act alone", { item: before.slice(0, 120) });
+      return "proceed";
+    }
 
-    this.debug("act: cursor is on a nameless LABEL — the milestone matched label text, not the control", {
+    this.debug("act: cursor is on bare label text, not the control it names", {
       milestone,
       oracleReply: check.reply.slice(0, 120),
       hop: "previous form field (the control precedes its label text)"

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -561,12 +561,62 @@ const NON_TEXT_INPUT_TYPES = [
 
 const FIELD_SELECTOR = `input${NON_TEXT_INPUT_TYPES.map((t) => `:not([type=${t}])`).join("")}, textarea, [contenteditable="true"]`;
 
+/**
+ * Controls whose VALUE an arrow key changes when NVDA is in focus mode — the
+ * reason `next`/`previous` are not the pure reading commands this driver treats
+ * them as.
+ *
+ * `next` is ArrowDown (see moveToControl's preamble). In BROWSE mode that moves
+ * the review caret by line and changes nothing. In FOCUS mode the keystroke goes
+ * to the control, and for a radio group ArrowDown does not merely move — it
+ * MOVES AND SELECTS, because that is native radio-group behaviour on every
+ * platform. So a sweep looking for a milestone rewrites the answer it is
+ * reading, once per press.
+ *
+ * That is the whole of issue #913, which was filed against the app as "NVDA
+ * announces all three survey options as checked". NVDA was right every time.
+ * Driving the seeded survey's q2 group in focus mode and reading the DOM back
+ * after each press:
+ *
+ *   press#1 spoken="Just right, radio button, checked, 2 of 3"  DOM=Just right
+ *   press#2 spoken="Too fast,   radio button, checked, 3 of 3"  DOM=Too fast
+ *   press#3 spoken="Too slow,   radio button, checked, 1 of 3"  DOM=Too slow
+ *
+ * Every named radio says "checked" because the arrow that reached it also
+ * checked it; the only "not checked" in the run is the first announcement, which
+ * focus (not an arrow) arrived at. VoiceOver never showed this because VO+arrow
+ * moves the VO cursor without activating, which is why the same commit read
+ * correctly on macOS and made the divergence look like an app bug.
+ *
+ * A browse-mode sweep over the same markup announces "not checked / checked /
+ * not checked", identical to plain `<input type=radio>` — so this list is about
+ * the DRIVER's gestures, not about any markup the app can fix.
+ *
+ * `checkbox` is deliberately absent: Space toggles a checkbox, arrows do not.
+ */
+const ARROW_MUTABLE_SELECTOR = [
+  "input[type=radio]",
+  "input[type=range]",
+  "input[type=number]",
+  "input[type=date]",
+  "input[type=datetime-local]",
+  "input[type=month]",
+  "input[type=time]",
+  "input[type=week]",
+  "select"
+].join(", ");
+
 /** Page-side globals: the element hostFocusField routed to (so verification can
  *  tell "the text landed" from "the text landed SOMEWHERE"), and the element the
  *  rung 0c probe measured (so before/after are the same element). Namespaced,
  *  and cleared/overwritten on every use — a page navigation drops them anyway. */
 const FOCUS_TARGET_KEY = "__a11yJudgeFocusTarget";
 const PROBE_ELEMENT_KEY = "__a11yJudgeProbeElement";
+/** The arrow-mutable control a sweep step is about to arrow past, remembered so
+ *  the after-reading and any restore address the SAME element (see hostFieldValue,
+ *  which learned the same lesson: a focus change mid-probe otherwise reads as a
+ *  successful move). */
+const SWEEP_ELEMENT_KEY = "__a11yJudgeSweepElement";
 
 const settle = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -613,6 +663,73 @@ function hostFieldWriteJs(text: string): string {
     el.dispatchEvent(new Event('change', { bubbles: true }));
     const back = el.isContentEditable ? (el.innerText || el.textContent || '') : String(el.value == null ? '' : el.value);
     return 'wrote|' + where + '|' + back;
+  })()`;
+}
+
+/**
+ * Page-side expression reading the ANSWER the focused arrow-mutable control
+ * carries, as a comparable string. Returns 'none|', 'safe|<TAG>' (focus is not
+ * on such a control — the overwhelmingly common case, and the cheap exit), or
+ * '<kind>|<key>|<value>'.
+ *
+ * For a radio the value is the group's CHECKED member, not the focused one:
+ * focus and selection are different things in a radio group, and it is the
+ * selection a sweep must not disturb. Everything else reports its own value.
+ *
+ * `remember` stashes the element so the reading taken after the arrow, and any
+ * restore, address the same node.
+ */
+function sweepSignatureJs(remember: boolean): string {
+  return `(() => {
+    const el = ${remember ? "document.activeElement" : `window[${JSON.stringify(SWEEP_ELEMENT_KEY)}] || document.activeElement`};
+    ${remember ? `window[${JSON.stringify(SWEEP_ELEMENT_KEY)}] = el;` : ""}
+    if (!el || el === document.body || !el.matches) return 'none|';
+    if (!el.matches(${JSON.stringify(ARROW_MUTABLE_SELECTOR)})) return 'safe|' + el.tagName;
+    if (el.tagName === 'INPUT' && el.type === 'radio') {
+      if (!el.name) return 'radio|<unnamed>|' + (el.checked ? el.value : '<none>');
+      const picked = el.form
+        ? [...el.form.querySelectorAll('input[type=radio]')].find((r) => r.name === el.name && r.checked)
+        : [...document.querySelectorAll('input[type=radio]')].find((r) => r.name === el.name && r.checked);
+      return 'radio|' + el.name + '|' + (picked ? picked.value : '<none>');
+    }
+    return 'value|' + (el.name || el.id || el.tagName) + '|' + String(el.value == null ? '' : el.value);
+  })()`;
+}
+
+/**
+ * Page-side expression putting back the selection a sweep step changed, through
+ * the same native-setter-plus-bubbling-events path hostFieldWriteJs uses (a
+ * plain assignment is swallowed by React's value tracker).
+ *
+ * This is a DOM write, and like rung 4's hostSetValue it is recorded rather than
+ * hidden — see SweepMutation. Restoring is nevertheless the right default: the
+ * alternative is that whatever the sweep last landed on gets submitted and then
+ * reported as the screen-reader user's answer, which is precisely how #913
+ * stayed invisible for as long as it did.
+ */
+function sweepRestoreJs(kind: string, key: string, value: string): string {
+  return `(() => {
+    const kind = ${JSON.stringify(kind)}, key = ${JSON.stringify(key)}, want = ${JSON.stringify(value)};
+    const el = window[${JSON.stringify(SWEEP_ELEMENT_KEY)}];
+    if (!el || !el.isConnected) return 'no-element|';
+    const fire = (n) => { n.dispatchEvent(new Event('input', { bubbles: true })); n.dispatchEvent(new Event('change', { bubbles: true })); };
+    if (kind === 'radio') {
+      const scope = el.form || document;
+      const group = [...scope.querySelectorAll('input[type=radio]')].filter((r) => r.name === key);
+      if (!group.length) return 'no-group|' + key;
+      const target = group.find((r) => r.value === want);
+      if (!target) { group.forEach((r) => { r.checked = false; }); fire(el); return 'cleared|' + key; }
+      const desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'checked');
+      if (desc && desc.set) { desc.set.call(target, true); } else { target.checked = true; }
+      fire(target);
+      return 'restored|' + key + '|' + target.value;
+    }
+    const proto = el.tagName === 'SELECT' ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+    if (!desc || !desc.set) return 'no-setter|' + key;
+    try { desc.set.call(el, want); } catch (e) { return 'setter-threw|' + key + '|' + String((e && e.message) || e); }
+    fire(el);
+    return 'restored|' + key + '|' + String(el.value == null ? '' : el.value);
   })()`;
 }
 
@@ -1011,6 +1128,42 @@ export interface TypeStepFidelity {
 }
 
 /**
+ * A `next`/`previous` step that changed the page's ANSWERS instead of merely
+ * reading them, drained per task by takeSweepMutations().
+ *
+ * It exists for the same reason TypeStepFidelity and NvdaCursorCheck do: the
+ * lane's whole claim is that a screen-reader user can complete the task, and a
+ * sweep that rewrites a radio group on its way past makes the recorded answer
+ * an artefact of the driver. Issue #913 spent its life as an app accessibility
+ * bug ("all three options announce as checked", filed against 4.1.2 Name, Role,
+ * Value) because nothing in the run said the sweep had touched anything, and the
+ * survey lane asserted only `survey_responses.is_submitted === true`.
+ *
+ * `restored` is a separate field from `mutated` on purpose: putting the value
+ * back keeps the REST of the task honest, but it does not make the step a
+ * reading, and run.ts fails the task on `mutated` regardless of whether the
+ * repair worked.
+ */
+export interface SweepMutation {
+  /** Index this step has in NvdaHarness.steps. */
+  stepIndex: number;
+  command: "next" | "previous";
+  /** 'radio' or 'value' — which arrow-mutable control was under focus. */
+  kind: string;
+  /** Radio group name, or the control's name/id. */
+  key: string;
+  /** The answer before the arrow, and after it. */
+  before: string;
+  after: string;
+  /** Did the pre-emptive exitFocusMode fire before the arrow? */
+  leftFocusMode: boolean;
+  /** Result of the restore attempt, verbatim ('restored|…', 'no-element|', …). */
+  restore: string;
+  /** Did a confirming read agree the answer is back? */
+  restored: boolean;
+}
+
+/**
  * What the cursor oracle said about one state-changing step, and what that
  * means. Five verdicts, because collapsing any two of them re-creates the bug:
  *  - "agreed"       the navigator object shares content words with the milestone;
@@ -1093,6 +1246,7 @@ export class NvdaHarness implements AtDriver {
   private lastContentItem: NvdaContentItem | null = null;
   private typeFidelity: TypeStepFidelity[] = [];
   private cursorChecks: NvdaCursorCheck[] = [];
+  private sweepMutations: SweepMutation[] = [];
   /** The interrogation the CURRENT command performed, if any — consumed by
    *  undoOracleEcho and cleared at the top of every run(). */
   private oracleEcho: CursorOracleReply | null = null;
@@ -1180,6 +1334,7 @@ export class NvdaHarness implements AtDriver {
     // step from the previous task must not be reported against this one.
     this.typeFidelity = [];
     this.cursorChecks = [];
+    this.sweepMutations = [];
     this.oracleEcho = null;
     this.cursorGate = null;
     await this.enterWebArea();
@@ -1207,6 +1362,16 @@ export class NvdaHarness implements AtDriver {
   takeCursorChecks(): NvdaCursorCheck[] {
     const collected = this.cursorChecks;
     this.cursorChecks = [];
+    return collected;
+  }
+
+  /**
+   * Hand over — and clear — the sweep steps that changed the page's answers.
+   * Drained rather than read, for the same reason the two above are.
+   */
+  takeSweepMutations(): SweepMutation[] {
+    const collected = this.sweepMutations;
+    this.sweepMutations = [];
     return collected;
   }
 
@@ -2509,6 +2674,90 @@ export class NvdaHarness implements AtDriver {
     return observation;
   }
 
+  /**
+   * Run one `next`/`previous` arrow without letting it answer the survey.
+   *
+   * Three parts, because neither half alone is enough (see
+   * ARROW_MUTABLE_SELECTOR for the measurement this is built on):
+   *
+   *  1. PREVENT. When DOM focus sits on an arrow-mutable control, leave focus
+   *     mode first. Escape (keyboardCommands.exitFocusMode) is the right gesture
+   *     precisely here: NVDA switches to focus mode AUTOMATICALLY when focus
+   *     reaches a form control, and Escape undoes an automatic switch. It is sent
+   *     ONLY in that case, never on every arrow, because in browse mode Escape
+   *     goes to the page and would dismiss a dialog.
+   *  2. VERIFY. Mode is not observable from the DOM — leaving focus mode moves no
+   *     focus and changes no attribute — so prevention cannot be confirmed by
+   *     asking. The answer itself can be: read it either side of the arrow.
+   *  3. RECORD, then repair. A step that still changed something is a finding
+   *     about the DRIVER, so it becomes a SweepMutation whatever the repair does.
+   *
+   * With no host channel this degrades to the old bare arrow. That is the honest
+   * floor: the probes are host-side, and a driver without one has never been able
+   * to see this.
+   */
+  private async arrowSweep(command: "next" | "previous", arrow: () => Promise<void>): Promise<void> {
+    if (!this.hostEval) return arrow();
+
+    const before = await this.hostEval(sweepSignatureJs(true)).catch(() => "");
+    const [kind, key = "", value = ""] = before.split("|");
+    // 'none' (nothing focused) and 'safe' (focused, but arrows do not change its
+    // value) are the overwhelmingly common readings on a reading sweep, and both
+    // exit before spending a single extra gesture.
+    if (kind !== "radio" && kind !== "value") return arrow();
+
+    this.debug("sweep: focus is on an arrow-mutable control — leaving focus mode before arrowing", {
+      command,
+      kind,
+      key,
+      answer: value
+    });
+    let leftFocusMode = true;
+    await this.withTimeout(
+      "sweep:exitFocusMode",
+      this.nvda.perform(this.nvda.keyboardCommands.exitFocusMode, { capture: "initial" }),
+      FOCUS_RUNG_TIMEOUT_MS
+    ).catch((e) => {
+      leftFocusMode = false;
+      this.debug("sweep: exitFocusMode threw — arrowing anyway, the check below is the real guard", {
+        error: String(e)
+      });
+    });
+
+    await arrow();
+
+    const after = await this.hostEval(sweepSignatureJs(false)).catch(() => "");
+    const afterValue = after.split("|")[2] ?? "";
+    // An unreadable after-reading is not a mutation: a lost host probe has never
+    // been treated as proof of failure anywhere else in this file either.
+    if (!after || after.split("|")[0] !== kind || afterValue === value) return;
+
+    const restore = await this.hostEval(sweepRestoreJs(kind, key, value)).catch((e) => `threw|${String(e)}`);
+    const confirm = await this.hostEval(sweepSignatureJs(false)).catch(() => "");
+    const restored = (confirm.split("|")[2] ?? "") === value;
+    this.debug("sweep: THE ARROW CHANGED THE ANSWER — this step read nothing, it wrote (issue #913)", {
+      command,
+      kind,
+      key,
+      before: value,
+      after: afterValue,
+      leftFocusMode,
+      restore,
+      restored
+    });
+    this.sweepMutations.push({
+      stepIndex: this.steps.length,
+      command,
+      kind,
+      key,
+      before: value,
+      after: afterValue,
+      leftFocusMode,
+      restore: restore.slice(0, 160),
+      restored
+    });
+  }
+
   private async execute(command: AtCommand, arg?: string, context?: AtStepContext): Promise<void> {
     const nvda = this.nvda;
     const kc = nvda.keyboardCommands;
@@ -2517,9 +2766,9 @@ export class NvdaHarness implements AtDriver {
       case "observe":
         return;
       case "next":
-        return nvda.next(opts);
+        return this.arrowSweep("next", () => nvda.next(opts));
       case "previous":
-        return nvda.previous(opts);
+        return this.arrowSweep("previous", () => nvda.previous(opts));
       case "act":
         return nvda.act(opts);
       case "interact": {

--- a/tools/a11y-judge/nvda/nvdaHarness.ts
+++ b/tools/a11y-judge/nvda/nvdaHarness.ts
@@ -748,22 +748,31 @@ function sweepRestoreJs(kind: string, key: string, value: string): string {
 }
 
 /**
- * Page-side "did that Enter do anything?" signature.
+ * Page-side "did that Enter change an ANSWER?" signature.
+ *
+ * Checkable state only — deliberately not focus, and not location. Run
+ * 31312543653 is why: this began as checked-state plus activeElement plus href,
+ * and Enter on a SurveyJS label moves focus to BODY while changing nothing at
+ * all, so the signature differed, the Enter was scored as effective and the
+ * retarget never ran. Focus moving is not an answer being given.
  *
  * The `act` retarget only ever engages on a line of bare label text (see
- * retargetActToControl), and Enter on such a line either activates the control
- * the label belongs to or does nothing at all — so checkable state, focus and
- * location together are enough to tell those apart. Buttons and links never
- * reach this path: their lines name their own role.
+ * retargetActToControl), where Enter either activates the control the label
+ * belongs to or does nothing — and every such control in these plans is a
+ * checkbox or a radio. Buttons and links never reach this path: their lines name
+ * their own role.
  */
+/** The prefix keeps "nothing is checked" (a real, common reading — the survey
+ *  starts blank) distinguishable from "the host read failed", which hostEval
+ *  reports as the empty string. */
+const ACT_SIGNATURE_PREFIX = "checked:";
+
 function actStateSignatureJs(): string {
   return `(() => {
-    const checked = [...document.querySelectorAll('input[type=checkbox],input[type=radio]')]
+    return ${JSON.stringify(ACT_SIGNATURE_PREFIX)} + [...document.querySelectorAll('input[type=checkbox],input[type=radio]')]
       .filter((i) => i.checked)
       .map((i) => (i.name || i.id || '?') + '=' + i.value)
       .join(',');
-    const el = document.activeElement;
-    return checked + '|' + (el ? el.tagName + (el.id ? '#' + el.id : '') : 'none') + '|' + location.href;
   })()`;
 }
 
@@ -3007,9 +3016,16 @@ export class NvdaHarness implements AtDriver {
         const before = await signature();
         await nvda.act(opts);
         const after = await signature();
-        if (!before || after !== before) {
-          this.debug("act: Enter on the label text did something — no retarget needed", {
-            milestone: context?.milestone
+        // A lost read (hostEval reports "") is not evidence either way, and must
+        // not be mistaken for "nothing is checked" — which is the survey's own
+        // starting state. Only two good reads that AGREE prove the key was dead.
+        const readable = before.startsWith(ACT_SIGNATURE_PREFIX) && after.startsWith(ACT_SIGNATURE_PREFIX);
+        if (!readable || after !== before) {
+          this.debug("act: Enter changed an answer, or the check was unreadable — no retarget", {
+            milestone: context?.milestone,
+            before,
+            after,
+            readable
           });
           return;
         }

--- a/tools/a11y-judge/nvda/report.ts
+++ b/tools/a11y-judge/nvda/report.ts
@@ -7,7 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { AtStepRecord } from "../agent/atHarness";
-import type { NvdaCursorCheck, TypeStepFidelity } from "./nvdaHarness";
+import type { NvdaCursorCheck, SweepMutation, TypeStepFidelity } from "./nvdaHarness";
 
 export const ARTIFACT_ROOT = "a11y-nvda-artifacts";
 
@@ -43,6 +43,11 @@ export interface TaskReport {
    *  passed tasks too — "0 resyncs" was the number that hid run 30483480823's
    *  wrong-element `act`, and these are what make that visible. */
   cursorChecks?: NvdaCursorCheck[];
+  /** One entry per `next`/`previous` step that changed an answer instead of
+   *  reading one. Kept for passed tasks too, for the reason issue #913 exists:
+   *  the survey lane asserted only `is_submitted`, so a sweep that rewrote the
+   *  radio group 27 times left no trace anywhere in a green run. */
+  sweepMutations?: SweepMutation[];
   recordingPath?: string;
   steps: AtStepRecord[];
 }
@@ -90,6 +95,23 @@ export function describeCursorContradiction(c: NvdaCursorCheck): string {
   return (
     `step ${c.stepIndex} (${c.command}): milestone ${JSON.stringify(c.milestone)} [${c.milestoneTokens.join(" ")}] ` +
     `but NVDA's navigator object was ${JSON.stringify(c.reply)} [${c.objectTokens.join(" ")}] — nothing in common`
+  );
+}
+
+/**
+ * One-line rendering of a sweep step that wrote instead of reading, shared by
+ * the console warning and summary.md.
+ *
+ * Both answers are printed, and so is whether the pre-emptive exitFocusMode
+ * fired: "the guard did not run" and "the guard ran and the arrow mutated
+ * anyway" are different bugs, and only the second one means NVDA was still in
+ * focus mode after an Escape.
+ */
+export function describeSweepMutation(m: SweepMutation): string {
+  return (
+    `step ${m.stepIndex} (${m.command}): arrowing past ${m.kind} ${JSON.stringify(m.key)} changed the answer ` +
+    `${JSON.stringify(m.before)} → ${JSON.stringify(m.after)} — this step wrote, it did not read ` +
+    `(left focus mode first: ${m.leftFocusMode}; restore: ${m.restored ? "confirmed" : `FAILED (${m.restore})`})`
   );
 }
 
@@ -175,6 +197,27 @@ export function renderSummary(reports: TaskReport[], meta: Record<string, string
       for (const c of r.cursorChecks!.filter((x) => x.verdict === "contradicted")) {
         lines.push(`- ${describeCursorContradiction(c)}`);
       }
+      lines.push("");
+    }
+  }
+  // Next, because a mutating sweep invalidates the answer a write task then
+  // asserts on — it has to be read before the predicate result is believed.
+  const mutatingReports = reports.filter((r) => (r.sweepMutations ?? []).length > 0);
+  if (mutatingReports.length > 0) {
+    lines.push(
+      "",
+      "## Sweep mutations (a reading step changed the page's answers)",
+      "",
+      "`next`/`previous` are ArrowDown/ArrowUp. In NVDA focus mode an arrow inside a radio group",
+      "moves AND selects, so a sweep looking for a milestone rewrites the answer it is reading.",
+      "Each line below is such a step: the recorded answer is the driver's, not the user's.",
+      "This is issue #913, which was filed against the app as an NVDA announcement bug — NVDA was",
+      "reporting the state correctly every time.",
+      ""
+    );
+    for (const r of mutatingReports) {
+      lines.push(`### ${r.id}`);
+      for (const m of r.sweepMutations!) lines.push(`- ${describeSweepMutation(m)}`);
       lines.push("");
     }
   }

--- a/tools/a11y-judge/nvda/run.ts
+++ b/tools/a11y-judge/nvda/run.ts
@@ -358,6 +358,14 @@ async function main(): Promise<void> {
     }
 
     let lastError = "";
+    // OUTSIDE the attempt loop, unlike the two per-attempt buffers below, and
+    // deliberately. A sweep mutation is a defect in the DRIVER, not a flake in
+    // the app: the retry cannot fix it, and re-declaring this per attempt meant
+    // a mutating first attempt followed by a clean second one returned
+    // status:"passed" with no mutation anywhere in the report — a green enforce
+    // run over a task the driver had answered itself, which is the exact failure
+    // the record exists to prevent. Raised in review by both reviewers.
+    let sweepMutations: SweepMutation[] = [];
     for (let attempt = 0; attempt <= TASK_RETRIES; attempt++) {
       const started = Date.now();
       const stepsBefore = harness.steps.length;
@@ -367,7 +375,6 @@ async function main(): Promise<void> {
       // other place these records are cleared.
       let fidelity: TypeStepFidelity[] = [];
       let cursorChecks: NvdaCursorCheck[] = [];
-      let sweepMutations: SweepMutation[] = [];
       const recordingPath = args.record ? path.join(ARTIFACT_ROOT, runId, "recordings", `${loaded.id}.mp4`) : undefined;
       const stopRecording = recordingPath ? startRecording(recordingPath) : () => {};
       try {
@@ -543,7 +550,12 @@ async function main(): Promise<void> {
           console.log(`[a11y:nvda]   ⚠️  SWEEP MUTATION — ${describeSweepMutation(m)}`);
         }
         sweepMutations = [...sweepMutations, ...undrainedMutations];
-        if (attempt === TASK_RETRIES) {
+        // A sweep mutation ends the task here rather than burning a retry. The
+        // driver wrote an answer it was supposed to be reading; running the plan
+        // again cannot un-write it, and the page it would re-run against now
+        // carries that write. Retrying could only launder the failure into a
+        // pass (see the declaration of sweepMutations above).
+        if (sweepMutations.length > 0 || attempt === TASK_RETRIES) {
           return {
             ...base,
             status: "failed",

--- a/tools/a11y-judge/nvda/run.ts
+++ b/tools/a11y-judge/nvda/run.ts
@@ -42,12 +42,13 @@ import {
   ARTIFACT_ROOT,
   describeCursorContradiction,
   describeHostClear,
+  describeSweepMutation,
   describeTypeDegradation,
   writeRunArtifacts,
   type CalibrationEntry,
   type TaskReport
 } from "./report";
-import { NvdaHarness, type NvdaCursorCheck, type TypeStepFidelity } from "./nvdaHarness";
+import { NvdaHarness, type NvdaCursorCheck, type SweepMutation, type TypeStepFidelity } from "./nvdaHarness";
 
 const REQUIRED_ENV = [
   "BASE_URL",
@@ -324,6 +325,14 @@ async function main(): Promise<void> {
         `— see summary.md`
     );
   }
+  const mutatingTasks = reports.filter((r) => (r.sweepMutations ?? []).length > 0);
+  if (mutatingTasks.length > 0) {
+    console.log(
+      `[a11y:nvda] ⚠️  ${mutatingTasks.length} task(s) where a READING sweep changed the page's answers (an ` +
+        `arrow inside a radio group selects — issue #913): ${mutatingTasks.map((r) => r.id).join(", ")} ` +
+        `— see summary.md`
+    );
+  }
   if (fatalError !== undefined) throw fatalError;
   if (failed.length > 0) process.exitCode = 1;
 
@@ -358,6 +367,7 @@ async function main(): Promise<void> {
       // other place these records are cleared.
       let fidelity: TypeStepFidelity[] = [];
       let cursorChecks: NvdaCursorCheck[] = [];
+      let sweepMutations: SweepMutation[] = [];
       const recordingPath = args.record ? path.join(ARTIFACT_ROOT, runId, "recordings", `${loaded.id}.mp4`) : undefined;
       const stopRecording = recordingPath ? startRecording(recordingPath) : () => {};
       try {
@@ -449,6 +459,16 @@ async function main(): Promise<void> {
           console.log(`[a11y:nvda]   ⚠️  CURSOR CONTRADICTION — ${describeCursorContradiction(c)}`);
         }
 
+        // Sweep mutations. `next`/`previous` are arrows, and in focus mode an
+        // arrow inside a radio group selects — so a reading sweep can answer the
+        // survey it is reading (issue #913). Drained BEFORE the write predicate
+        // below, because a mutating sweep is exactly what makes that predicate
+        // lie: the answer it finds is the driver's, not the user's.
+        sweepMutations = harness.takeSweepMutations();
+        for (const m of sweepMutations) {
+          console.log(`[a11y:nvda]   ⚠️  SWEEP MUTATION — ${describeSweepMutation(m)}`);
+        }
+
         if (plan.taskKind === "write" && !args.calibrate) {
           await sleep(WRITE_SETTLE_MS);
           const predicate = await getTask(plan.taskId)!.predicate(null, taskContext);
@@ -467,6 +487,15 @@ async function main(): Promise<void> {
               contradicted.map(describeCursorContradiction).join(" | ")
           );
         }
+        // Fails the task even when the restore succeeded: the repair keeps the
+        // rest of the run honest, it does not turn a write back into a read.
+        if (sweepMutations.length > 0 && !args.calibrate) {
+          throw new Error(
+            `a reading sweep changed the page's answers (see issue #913 — NVDA reports these controls ` +
+              `correctly; the driver's own arrow keys were selecting them): ` +
+              sweepMutations.map(describeSweepMutation).join(" | ")
+          );
+        }
 
         console.log(
           `[a11y:nvda] ✅ ${loaded.id} (${result.resyncs.length} resyncs, cursor oracle: ` +
@@ -481,6 +510,7 @@ async function main(): Promise<void> {
           calibration,
           typeFidelity: fidelity,
           cursorChecks,
+          sweepMutations,
           recordingPath,
           steps: harness.steps.slice(stepsBefore)
         };
@@ -505,6 +535,14 @@ async function main(): Promise<void> {
           console.log(`[a11y:nvda]   ⚠️  CURSOR CONTRADICTION — ${describeCursorContradiction(c)}`);
         }
         cursorChecks = [...cursorChecks, ...undrainedChecks];
+        // And the sweep mutations, for the same reason: an attempt that died
+        // mid-plan is when "did the driver answer the question itself?" matters
+        // most, because the write predicate never got to run.
+        const undrainedMutations = harness.takeSweepMutations();
+        for (const m of undrainedMutations) {
+          console.log(`[a11y:nvda]   ⚠️  SWEEP MUTATION — ${describeSweepMutation(m)}`);
+        }
+        sweepMutations = [...sweepMutations, ...undrainedMutations];
         if (attempt === TASK_RETRIES) {
           return {
             ...base,
@@ -515,6 +553,7 @@ async function main(): Promise<void> {
             resyncs: [],
             typeFidelity: fidelity,
             cursorChecks,
+            sweepMutations,
             recordingPath,
             steps: harness.steps.slice(stepsBefore)
           };


### PR DESCRIPTION
Closes #913.
Fixes #911.

This branch carries two unrelated fixes at the author's request: the NVDA sweep defect (#913, below) and the cross-tab sign-out defect (#911, see the commit `f5d06953` and the summary comment on this PR).

## #913 is not an app defect

The app is fine. NVDA is fine. **The test driver was answering the survey it was trying to read.**

`next`/`previous` in the NVDA harness are ArrowDown/ArrowUp. In browse mode those move a review caret; in focus mode they go to the control, and inside a radio group an arrow **moves and selects** — native behaviour on every platform. So the milestone resync sweep re-selected q2 on every press, ~27 times per option, and NVDA correctly announced each newly-selected option as `checked`. That is why zero named radios in the log ever said "not checked": by the time each was announced, it *was* checked.

## Evidence, on real NVDA

Two probes against NVDA 2026.1.1 + Chromium on the Windows runner.

**1. Browse-mode sweep.** One page, three radiogroups differing only in how the native input is hidden — (A) exact SurveyJS DOM + real `survey-core.css`, (B) same DOM with the input visible, (C) plain radios — each with the middle option pre-checked:

```
Group A (SurveyJS):  'radio button','not checked' | 'checked' | 'not checked'
Group C (plain):     'radio button','not checked' | 'checked' | 'not checked'
```

Identical. A real screen-reader user in browse mode hears the right thing.

**2. Focus-mode arrows, with the DOM read back after each press.** The issue's log is name-first with `N of 3`, which is focus mode:

```
press#1 spoken="Just right, radio button, checked, 2 of 3"  DOM_checked=Just right
press#2 spoken="Too fast,   radio button, checked, 3 of 3"  DOM_checked=Too fast
press#3 spoken="Too slow,   radio button, checked, 1 of 3"  DOM_checked=Too slow
```

NVDA told the truth every time. The only "not checked" in the run is the first announcement, which focus — not an arrow — arrived at.

VoiceOver never showed this because VO+arrow moves the VO cursor without activating, which is why the same commit read correctly on macOS and made the divergence look like an app bug. **4.1.2 is not violated and `components/Survey.tsx` is unchanged.**

## The fix

**`nvdaHarness.ts`** — `arrowSweep()` wraps every `next`/`previous`. When DOM focus is on an arrow-mutable control (radio, range, number, the date family, select — deliberately *not* checkbox, which Space toggles) it:

1. **Prevents** — leaves focus mode first via Escape. That is the correct gesture precisely here: NVDA's switch into focus mode on a form control is *automatic*, and Escape undoes an automatic switch. It is sent only in this case, never on every arrow, because in browse mode Escape reaches the page and would dismiss a dialog.
2. **Verifies** — mode is not observable from the DOM (leaving focus mode moves no focus and changes no attribute), so prevention cannot be confirmed by asking. The *answer* can be: it is read either side of the arrow.
3. **Records, then repairs** — a step that still moved the answer becomes a `SweepMutation` and is restored through the same native-setter-plus-bubbling-events path `hostFieldWriteJs` already uses.

With no host channel this degrades to the old bare arrow — the probes are host-side, and a driver without one has never been able to see this.

**`run.ts` / `report.ts`** — `SweepMutation` gets the same treatment `TypeStepFidelity` and `NvdaCursorCheck` already have: drained per attempt (including on the failure path), warned in the console, kept in the artifacts for passed tasks, given a `summary.md` section, and **failing the task in enforce mode even when the restore succeeded**. Repairing the value keeps the rest of the run honest; it does not turn a write back into a read.

**`tasks.ts`** — `survey-complete` asserted only `is_submitted === true`, which is exactly why this shipped green. It now checks all four answers the prompt dictates, with q2 an exact match on `"Just right"` — any looser check (non-empty, one-of-three) passes the arrowed-past value.

## Verification

- 137 a11y unit tests pass, including 4 new predicate tests and a new `a11y-judge-nvda-sweep-mutation.test.ts` covering the reporting surface.
- ESLint, Prettier and `tsc` clean on all changed files (`tsc` reports zero errors under `tools/a11y-judge/**`; the repo's 8 pre-existing errors are in files this PR does not touch).
- **Not yet run end-to-end.** The lane needs a live preview; that is the next step on this PR and the result will be posted here.

## Runner note (unrelated to #913, not fixed here)

`a11y:nvda:doctor` fails its navigation round-trip when invoked from an agent shell on `win-runner-9001`, because that shell is in **Windows session 0** while the interactive desktop is session 1 — NVDA launched from session 0 has no desktop and no foreground window, so every gesture returns silence. Driving it via `schtasks /ru <user> /it` reaches session 1 and works. Separately the box has **no audio device**, so NVDA's `oneCore` synth throws on startup and speaks nothing; `synth = silence` avoids that and remote speech capture still works. Both are worth teaching the doctor to detect, but that is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Survey completion now requires correct answers, a valid name, at least one selected topic, and a non-empty comment.
  * NVDA sweeps detect and restore unintended changes to form controls.
  * Enforce-mode checks now fail when accessibility navigation alters page answers.
  * Admin pages recover more reliably from confirmed sign-outs and stale sessions.

* **Reporting**
  * Reports and summaries identify sweep-induced mutations, affected values, restoration results, and focus-mode status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
