### PR TITLE
fix(mcp-tokens): make token revocation idempotent

### DIFF
--- a/components/settings/MCPTokensMenu.tsx
+++ b/components/settings/MCPTokensMenu.tsx
@@ -48,6 +48,9 @@ export default function MCPTokensMenu() {
   const [newTokenType, setNewTokenType] = useState<TokenType>("mcp");
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<string | null>(null);
   const [copiedTokenId, setCopiedTokenId] = useState<string | null>(null);
+  // Which token is mid-revoke. The row only disappears once the refetch lands, so without this the
+  // button stays live for the whole round trip and a second click fires a second DELETE.
+  const [revokingTokenId, setRevokingTokenId] = useState<string | null>(null);
 
   const fetchTokens = useCallback(async () => {
     setLoading(true);
@@ -111,6 +114,8 @@ export default function MCPTokensMenu() {
   };
 
   const revokeToken = async (tokenId: string) => {
+    if (revokingTokenId) return;
+    setRevokingTokenId(tokenId);
     try {
       const supabase = createClient();
       await mcpTokensRevoke({ token_id: tokenId }, supabase);
@@ -125,6 +130,8 @@ export default function MCPTokensMenu() {
         title: "Error revoking token",
         description: error instanceof Error ? error.message : "Unknown error"
       });
+    } finally {
+      setRevokingTokenId(null);
     }
   };
 
@@ -312,6 +319,8 @@ export default function MCPTokensMenu() {
                                     size="sm"
                                     variant="ghost"
                                     colorPalette="red"
+                                    loading={revokingTokenId === token.token_id}
+                                    disabled={revokingTokenId !== null}
                                     onClick={() => revokeToken(token.token_id)}
                                   >
                                     <LuTrash2 />

--- a/supabase/functions/_shared/ErrorDetail.test.ts
+++ b/supabase/functions/_shared/ErrorDetail.test.ts
@@ -7,7 +7,7 @@
  * Run from supabase/functions:  deno test --no-check _shared/ErrorDetail.test.ts
  */
 import { assertEquals } from "jsr:@std/assert@^1";
-import { describeCause } from "./ErrorDetail.ts";
+import { describeCause, isDuplicateKey } from "./ErrorDetail.ts";
 
 Deno.test("describeCause: a PostgREST error object keeps its message and code", () => {
   // Verbatim shape from a Dev-project event.
@@ -47,4 +47,32 @@ Deno.test("describeCause: primitives stringify", () => {
   assertEquals(describeCause("plain string"), "plain string");
   assertEquals(describeCause(null), "null");
   assertEquals(describeCause(undefined), "undefined");
+});
+
+Deno.test("isDuplicateKey: a PostgREST unique violation matches", () => {
+  // Verbatim shape from the prod `handleDelete` events (revoked_token_ids_pkey).
+  assertEquals(
+    isDuplicateKey({
+      code: "23505",
+      details: "Key (token_id)=(d30dc25a-839c-4fe3-ae82-1ab815227eb6) already exists.",
+      hint: null,
+      message: 'duplicate key value violates unique constraint "revoked_token_ids_pkey"'
+    }),
+    true
+  );
+});
+
+Deno.test("isDuplicateKey: other Postgres errors do not match", () => {
+  // 23503 is a foreign-key violation — a real inconsistency, not an idempotent repeat.
+  assertEquals(isDuplicateKey({ code: "23503", message: "violates foreign key constraint" }), false);
+  assertEquals(isDuplicateKey({ code: "PGRST116", message: "no rows" }), false);
+  // A transport failure has no code at all and must never be mistaken for a benign duplicate.
+  assertEquals(isDuplicateKey({ message: "An invalid response was received from the upstream server" }), false);
+});
+
+Deno.test("isDuplicateKey: non-objects are safe", () => {
+  assertEquals(isDuplicateKey(null), false);
+  assertEquals(isDuplicateKey(undefined), false);
+  assertEquals(isDuplicateKey("23505"), false);
+  assertEquals(isDuplicateKey(new Error("duplicate key value violates unique constraint")), false);
 });

--- a/supabase/functions/_shared/ErrorDetail.ts
+++ b/supabase/functions/_shared/ErrorDetail.ts
@@ -1,5 +1,5 @@
 /**
- * One-line descriptions of thrown values, for error messages that a human has to act on.
+ * Reading structured Postgres/PostgREST errors: describing them, and classifying the benign ones.
  *
  * PostgREST and GoTrue hand back plain structured objects rather than `Error` instances, so the
  * reflexive `cause instanceof Error ? cause.message : String(cause)` yields `[object Object]` — which
@@ -27,4 +27,20 @@ export function describeCause(cause: unknown): string {
     }
   }
   return String(cause);
+}
+
+/** Postgres `unique_violation`. */
+export const UNIQUE_VIOLATION = "23505";
+
+/**
+ * True when `error` is a Postgres unique-constraint violation.
+ *
+ * Useful where an insert is really an assertion that a row exists: for an idempotent write, 23505 is
+ * the success case arriving late, not a fault. Callers should still scope this narrowly — swallow it
+ * for the specific insert whose duplicate is harmless, never as a blanket ignore, since the same code
+ * on a different table can mean genuinely conflicting data.
+ */
+export function isDuplicateKey(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return (error as { code?: unknown }).code === UNIQUE_VIOLATION;
 }

--- a/supabase/functions/mcp-tokens/index.ts
+++ b/supabase/functions/mcp-tokens/index.ts
@@ -20,7 +20,7 @@ import * as Sentry from "npm:@sentry/deno";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { createApiToken, MCPScope, VALID_SCOPES } from "../_shared/MCPAuth.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
-import { describeCause } from "../_shared/ErrorDetail.ts";
+import { describeCause, isDuplicateKey } from "../_shared/ErrorDetail.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
 
 // Initialize Sentry if configured
@@ -269,11 +269,16 @@ async function handleDelete(authHeader: string | null, body: DeleteTokenRequest)
     });
   }
 
-  // Update token to mark as revoked
+  // Mark as revoked, but only if it is not already. `.is("revoked_at", null)` is what keeps this
+  // idempotent: an unqualified update rewrites the timestamp on every repeat call, so revoking a
+  // second time silently replaced the record of when the credential was FIRST withdrawn — the one
+  // fact a revocation audit trail exists to preserve. A no-op update is not an error here; the
+  // token ends up revoked either way, which is all the caller asked for.
   const { error: updateError } = await supabase
     .from("api_tokens")
     .update({ revoked_at: new Date().toISOString() })
-    .eq("id", token.id);
+    .eq("id", token.id)
+    .is("revoked_at", null);
 
   if (updateError) {
     Sentry.captureException(updateError, {
@@ -292,7 +297,12 @@ async function handleDelete(authHeader: string | null, body: DeleteTokenRequest)
     .from("revoked_token_ids")
     .insert({ token_id: body.token_id });
 
-  if (revokeInsertError) {
+  // A duplicate key here means the id is ALREADY in the revocation list — the exact state this call
+  // set out to reach, reached by an earlier call. Reporting it produced a steady trickle of prod
+  // Sentry issues (`handleDelete`, 23505 on revoked_token_ids) for revokes that succeeded from the
+  // user's point of view and left the token correctly revoked. Every other insert failure still
+  // reports: those leave the fast-lookup table genuinely out of step with api_tokens.
+  if (revokeInsertError && !isDuplicateKey(revokeInsertError)) {
     // Log but don't fail - the token is already marked revoked in api_tokens
     // The revoked_token_ids table is just for fast lookup optimization
     Sentry.captureException(revokeInsertError, {


### PR DESCRIPTION
Revoking an already-revoked MCP token reported a prod Sentry error on every attempt — `handleDelete`, 23505 on `revoked_token_ids_pkey`. Two events in Khoury Prod, most recently 2026-08-10.

Nothing was actually broken: the user saw "Token revoked", the token *was* revoked, and the code already declined to fail the request. Only the reporting was wrong. A duplicate key on that insert is the exact state the call set out to reach, reached by an earlier call.

The breadcrumb trail is the same in both events:

```
GET   /auth/v1/user                                   200
GET   /api_tokens?token_id=eq.<id>&user_id=eq.<uid>   200   ← token found
PATCH /api_tokens?id=eq.<row>                         204   ← revoked_at overwritten
POST  /revoked_token_ids                              409   ← 23505, already present
```

## Three parts, from the cause outward

**The UI had no in-flight guard.** `components/settings/MCPTokensMenu.tsx` correctly hides the Revoke button once `revoked_at` is set, but the row only disappears after the refetch lands — so the button stayed live for the whole round trip and a second click fired a second DELETE. That is the most likely origin of both prod events (same user, two weeks apart, single occurrences each). The button is now disabled and spinning while a revoke is in flight, with an early return so a queued double-click cannot re-enter.

**`revoked_at` was rewritten unconditionally.** A second revoke silently replaced the record of when the credential was *first* withdrawn — the one fact a revocation audit trail exists to preserve. The update is now scoped with `.is("revoked_at", null)`. A no-op update is not an error here; the token ends up revoked either way, which is all the caller asked for.

**23505 on the `revoked_token_ids` insert is no longer captured.** Every other insert error still reports, because those leave the fast-lookup table genuinely out of step with `api_tokens`. The predicate lives in `_shared/ErrorDetail.ts` beside `describeCause` so it is testable without a `Deno.serve` host, and it is deliberately narrow — the docstring warns against using it as a blanket ignore, since the same code on a different table can mean genuinely conflicting data.

## Verification

- 135 `_shared` Deno tests pass, 3 new — pinned to the verbatim PostgREST error object from the prod event, plus negative cases for 23503, PGRST116, and a transport failure with no code at all.
- `deno check` on the touched files: 1 error before and after, the known pre-existing `SupabaseTypes.d.ts` ambient-const issue. Zero delta.
- `tsc` reports 8 errors repo-wide, the same as clean staging, none in `MCPTokensMenu.tsx`.
- eslint and prettier clean.

## Note

Found while triaging recent Khoury Prod errors. Two related things came out of that pass and are deliberately **not** here:

- The `Invalid UTF-8 sequence` corrupt-session issue — already self-heals via `lib/corruptSessionRecovery.ts`; it still reports only because Sentry's global handlers register before the recovery listener, so `preventDefault()` cannot unsend. Being muted for now.
- Frontend stack traces are unminifiable in Bugsink. Debug IDs *are* injected and Bugsink accepts `artifact_bundles`; the only missing piece is `SENTRY_AUTH_TOKEN` + `SENTRY_URL` in the build, so maps are generated and discarded. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)