### PR TITLE
perf(scripts): raise bulk-submission throughput; link Sentry events to their GHA run

### DIFF
--- a/supabase/functions/_shared/workflowRunUrl.test.ts
+++ b/supabase/functions/_shared/workflowRunUrl.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "jsr:@std/assert@^1";
+import { attachWorkflowRunLink, GHA_RUN_URL_TAG, workflowRunUrl } from "./workflowRunUrl.ts";
+
+function fakeScope() {
+  const tags: Record<string, string> = {};
+  return {
+    tags,
+    setTag(key: string, value: string) {
+      tags[key] = value;
+    }
+  };
+}
+
+Deno.test("workflowRunUrl: builds an attempt-specific URL", () => {
+  assertEquals(
+    workflowRunUrl({ repository: "pawtograder-playground/test-repo", run_id: "123", run_attempt: "2" }),
+    "https://github.com/pawtograder-playground/test-repo/actions/runs/123/attempts/2"
+  );
+});
+
+Deno.test("workflowRunUrl: falls back to the run URL when the attempt is absent or unusable", () => {
+  const base = "https://github.com/org/repo/actions/runs/9";
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "9" }), base);
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "9", run_attempt: "" }), base);
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "9", run_attempt: "0" }), base);
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "9", run_attempt: "latest" }), base);
+});
+
+Deno.test("workflowRunUrl: accepts dots, dashes and underscores in repo names", () => {
+  assertEquals(
+    workflowRunUrl({ repository: "neu-cs2100/hw1_solution.v2", run_id: "1", run_attempt: "1" }),
+    "https://github.com/neu-cs2100/hw1_solution.v2/actions/runs/1/attempts/1"
+  );
+});
+
+Deno.test("workflowRunUrl: returns undefined rather than a plausible-but-wrong URL", () => {
+  // A wrong link is worse than no link, so anything unexpected is rejected outright.
+  assertEquals(workflowRunUrl({ repository: "no-slash", run_id: "1" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "org/repo/extra", run_id: "1" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "org/../../etc", run_id: "1" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "org/re po", run_id: "1" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "", run_id: "1" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "not-a-number" }), undefined);
+  assertEquals(workflowRunUrl({ repository: "org/repo", run_id: "" }), undefined);
+});
+
+Deno.test("attachWorkflowRunLink: tags the scope and returns the URL", () => {
+  const scope = fakeScope();
+  const url = attachWorkflowRunLink(scope, { repository: "org/repo", run_id: "7", run_attempt: "3" });
+  assertEquals(url, "https://github.com/org/repo/actions/runs/7/attempts/3");
+  assertEquals(scope.tags[GHA_RUN_URL_TAG], url);
+});
+
+Deno.test("attachWorkflowRunLink: leaves the scope untagged when no URL can be built", () => {
+  const scope = fakeScope();
+  assertEquals(attachWorkflowRunLink(scope, { repository: "bogus", run_id: "x" }), undefined);
+  assertEquals(scope.tags, {});
+});
+
+Deno.test("attachWorkflowRunLink: tolerates a missing scope", () => {
+  assertEquals(
+    attachWorkflowRunLink(undefined, { repository: "org/repo", run_id: "7" }),
+    "https://github.com/org/repo/actions/runs/7"
+  );
+});

--- a/supabase/functions/_shared/workflowRunUrl.ts
+++ b/supabase/functions/_shared/workflowRunUrl.ts
@@ -1,0 +1,72 @@
+// Turn the OIDC claims of a grading run into the URL of the GitHub Actions run that made the request.
+//
+// Every OIDC-authenticated function already tagged `repository`, `run_id` and `run_attempt`
+// separately, which is enough information but not enough *affordance*: triaging a Sentry event meant
+// reading three tags, remembering the /actions/runs/<id>/attempts/<n> shape, and pasting a URL
+// together by hand — per event. The claims are right there at the top of every handler, so the link
+// may as well be built once and stamped where both audiences can reach it: a `gha_run_url` tag for
+// Sentry, and a log line for whoever is tailing the function logs instead.
+//
+// Deliberately free of any Sentry import so it stays a pure unit under `deno test`; callers pass
+// anything with `setTag`, which the real `Sentry.Scope` satisfies structurally.
+
+/** The subset of `Sentry.Scope` this module needs. */
+export interface TaggableScope {
+  setTag(key: string, value: string): void;
+}
+
+/** The OIDC claims naming a run. Field names match the token, so callers can pass it straight through. */
+export interface WorkflowRunRef {
+  repository: string;
+  run_id: string;
+  run_attempt?: string;
+}
+
+/** Sentry tag under which the link is stamped. */
+export const GHA_RUN_URL_TAG = "gha_run_url";
+
+// GitHub owner and repo names; anything else is not ours to guess at. Rejecting an odd value yields
+// no link, which is strictly better than emitting a plausible-looking URL built from an unexpected
+// claim — the whole point of the tag is that clicking it lands on the right run.
+const REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const NUMERIC_PATTERN = /^[0-9]+$/;
+
+/**
+ * The Actions run URL, or undefined when the claims cannot form one.
+ *
+ * A missing or unparseable `run_attempt` degrades to the plain run URL rather than dropping the link
+ * — GitHub redirects that to the latest attempt, which is the right destination in the overwhelmingly
+ * common case of a run that was never re-run.
+ */
+export function workflowRunUrl({ repository, run_id, run_attempt }: WorkflowRunRef): string | undefined {
+  if (!REPOSITORY_PATTERN.test(repository ?? "") || !NUMERIC_PATTERN.test(run_id ?? "")) {
+    return undefined;
+  }
+  const base = `https://github.com/${repository}/actions/runs/${run_id}`;
+  const attempt = run_attempt ?? "";
+  if (NUMERIC_PATTERN.test(attempt) && Number(attempt) > 0) {
+    return `${base}/attempts/${attempt}`;
+  }
+  return base;
+}
+
+/**
+ * Stamp the run link on the Sentry scope and echo it to the logs. Returns the URL so a caller can
+ * reuse it (in a user-visible message, say) without rebuilding it.
+ *
+ * Call this once, immediately after decoding the token: the scope is threaded through the whole
+ * handler, so every event the request goes on to report carries the tag.
+ */
+export function attachWorkflowRunLink(
+  scope: TaggableScope | undefined,
+  ref: WorkflowRunRef,
+  label = "Triggered by GitHub Actions run"
+): string | undefined {
+  const url = workflowRunUrl(ref);
+  if (!url) {
+    return undefined;
+  }
+  scope?.setTag(GHA_RUN_URL_TAG, url);
+  console.log(`${label}: ${url}`);
+  return url;
+}

--- a/supabase/functions/autograder-create-regression-test-run/index.ts
+++ b/supabase/functions/autograder-create-regression-test-run/index.ts
@@ -8,6 +8,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
 import { getRepoTarballURL, validateOIDCToken } from "../_shared/GitHubWrapper.ts";
 import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import * as Sentry from "npm:@sentry/deno";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
@@ -23,8 +24,10 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
   }
   scope?.setTag("regression_test_id", regression_test_id.toString());
   const decoded = await validateOIDCToken(req.headers.get("Authorization")!);
-  const { repository, sha, workflow_ref } = decoded;
+  const { repository, sha, workflow_ref, run_id, run_attempt } = decoded;
   console.log("Creating regression test run for", repository, sha, workflow_ref, regression_test_id);
+  // One click from any event this request reports to the run that caused it.
+  attachWorkflowRunLink(scope, { repository, run_id, run_attempt });
 
   const adminSupabase = createClient<Database>(
     Deno.env.get("SUPABASE_URL") || "",

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -22,6 +22,7 @@ import {
   SecondaryRateLimitError
 } from "../_shared/GitHubWrapper.ts";
 import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import {
   ingestSubmissionFilesFromZip,
   SubmissionFileTooLargeError,
@@ -544,6 +545,8 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
   scope?.setTag("run_id", run_id);
   scope?.setTag("run_attempt", run_attempt);
   scope?.setTag("is_e2e_run", isE2ERun.toString());
+  // One click from any event this request reports to the run that caused it.
+  attachWorkflowRunLink(scope, { repository, run_id, run_attempt });
 
   // Circuit breaker: check if org-level circuit is open for GitHub API calls
   const adminSupabase = createClient<Database>(

--- a/supabase/functions/autograder-retrieve-autograder-regression-tests/index.ts
+++ b/supabase/functions/autograder-retrieve-autograder-regression-tests/index.ts
@@ -2,6 +2,7 @@ import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { validateOIDCToken } from "../_shared/GitHubWrapper.ts";
 import { UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import * as Sentry from "npm:@sentry/deno";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
@@ -16,6 +17,8 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
   );
   scope?.setTag("repository", decoded.repository);
+  // One click from any event this request reports to the run that caused it.
+  attachWorkflowRunLink(scope, decoded);
   const { data, error } = await adminSupabase
     .from("autograder_regression_test_by_grader")
     .select("*")

--- a/supabase/functions/autograder-submit-feedback/index.ts
+++ b/supabase/functions/autograder-submit-feedback/index.ts
@@ -19,6 +19,7 @@ import {
   PrimaryRateLimitError
 } from "../_shared/GitHubWrapper.ts";
 import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import { Database, Json } from "../_shared/SupabaseTypes.d.ts";
 import {
   fetchDefaultGradeTargetStudentProfileId,
@@ -435,6 +436,8 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<GradeRe
   scope?.setTag("sha", sha);
   scope?.setTag("run_id", run_id);
   scope?.setTag("run_attempt", run_attempt);
+  // One click from any event this request reports to the run that caused it.
+  attachWorkflowRunLink(scope, { repository, run_id, run_attempt });
   scope?.setTag("autograder_regression_test_id", autograder_regression_test_id?.toString() || "(null)");
   let class_id: number | null = null;
   let assignment_id: number | null = null;

--- a/supabase/functions/scripts/TriggerBulkSubmissions.ts
+++ b/supabase/functions/scripts/TriggerBulkSubmissions.ts
@@ -4,19 +4,20 @@
  * TriggerBulkSubmissions - Deno script to trigger multiple grading workflows
  *
  * Usage:
- *   # Basic usage with defaults (10 submissions, 10 per minute)
+ *   # Basic usage with defaults (10 submissions, 60 per minute)
  *   deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts <submission_id>
  *
  *   # Custom parameters
- *   deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts <submission_id> <max_per_minute> <total_submissions>
+ *   deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts <submission_id> <max_per_minute> <total_submissions> [concurrency]
  *
- *   # Example: 5 submissions, 3 per minute
- *   deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts 123 3 5
+ *   # Example: 200 submissions at 120 per minute
+ *   deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts 123 120 200
  *
  * Parameters:
  *   submission_id: The submission ID to trigger (required)
- *   max_per_minute: Maximum submissions per minute (default: 10)
+ *   max_per_minute: Maximum submissions per minute (default: 60)
  *   total_submissions: Total number of submissions to make (default: 10)
+ *   concurrency: Maximum in-flight dispatches (default: derived from max_per_minute)
  *
  * Environment Variables (from .env.local):
  *   SUPABASE_URL: Supabase project URL
@@ -24,18 +25,32 @@
  *   GITHUB_APP_ID: GitHub App ID
  *   GITHUB_PRIVATE_KEY_STRING: GitHub App private key
  *
- * The script fetches the actual repository and SHA from the database
- * and triggers workflow requests asynchronously with controlled concurrency.
+ * The script fetches the actual repository and SHA from the database, creates the
+ * submission tag once, then issues one workflow dispatch per submission.
+ *
+ * Why this does not call `triggerWorkflow` from GitHubWrapper: that helper creates the
+ * tag object and ref on every call (three write requests per submission, two of which are
+ * redundant here because every iteration reuses the same repo and SHA), and it runs through
+ * the shared Redis-backed @octokit/plugin-throttling limiter. That limiter serializes writes
+ * at one per second across every edge replica, so it capped this script at ~20 submissions
+ * per minute no matter what was requested, and stole write budget from production while it
+ * ran. This script uses its own unthrottled installation client and paces itself, so
+ * `max_per_minute` is the real throughput knob.
+ *
+ * GitHub's secondary rate limit for content-creating requests is about 80 per minute per
+ * installation; above that expect 403s and retries.
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import { triggerWorkflow } from "../_shared/GitHubWrapper.ts";
+import { createAppAuth } from "https://esm.sh/@octokit/auth-app?dts";
+import { Octokit } from "https://esm.sh/octokit?dts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 
 interface Args {
   submissionId: number;
   maxPerMinute: number;
   totalSubmissions: number;
+  concurrency: number;
 }
 
 interface SubmissionData {
@@ -44,100 +59,77 @@ interface SubmissionData {
   sha: string;
 }
 
-interface WorkflowResult {
-  index: number;
-  success: boolean;
-  error?: string;
-  timestamp: Date;
+const WORKFLOW_NAME = "grade.yml";
+const MAX_ATTEMPTS = 4;
+const SECONDARY_LIMIT_WARNING_THRESHOLD = 80;
+
+// Octokit defaults to 2022-11-28, which GitHub deprecated when 2026-03-10 shipped; every
+// request then comes back with Deprecation/Sunset headers and @octokit/request logs a
+// warning per call. Pinning the current version silences that and opts into its behavior:
+// `GET /rate_limit` drops the top-level `rate` property (read `resources.core` instead) and
+// workflow dispatches return 200 with the run details rather than an empty 204.
+const API_VERSION_HEADER = { "X-GitHub-Api-Version": "2026-03-10" };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Rate limiter class to control throughput
-class RateLimiter {
-  private tokens: number;
-  private lastRefill: number;
-  private readonly maxTokens: number;
-  private readonly refillRate: number; // tokens per millisecond
+function errorStatus(error: unknown): number | undefined {
+  const status = (error as { status?: unknown })?.status;
+  return typeof status === "number" ? status : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Retry-After (seconds) or x-ratelimit-reset (epoch seconds) from a GitHub error response,
+ * converted to milliseconds to wait. GitHub sends one or the other on a 403/429.
+ */
+function retryDelayFromHeaders(error: unknown): number | undefined {
+  const headers = (error as { response?: { headers?: Record<string, string> } })?.response?.headers;
+  if (!headers) {
+    return undefined;
+  }
+  const retryAfter = Number(headers["retry-after"]);
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return retryAfter * 1000;
+  }
+  const reset = Number(headers["x-ratelimit-reset"]);
+  if (Number.isFinite(reset) && reset > 0) {
+    return Math.max(0, reset * 1000 - Date.now());
+  }
+  return undefined;
+}
+
+function isRetryable(error: unknown): boolean {
+  const status = errorStatus(error);
+  if (status === undefined) {
+    // Network-level failure (connection reset, DNS, timeout) — worth another try.
+    return true;
+  }
+  return status === 403 || status === 429 || status >= 500;
+}
+
+/**
+ * Evenly paced admission control. Each caller reserves the next slot synchronously, so
+ * concurrent workers can never claim the same one, then sleeps until that slot opens.
+ */
+class Pacer {
+  private nextSlot = Date.now();
+  private readonly intervalMs: number;
 
   constructor(maxPerMinute: number) {
-    this.maxTokens = maxPerMinute;
-    this.tokens = maxPerMinute;
-    this.lastRefill = Date.now();
-    this.refillRate = maxPerMinute / 60000; // Convert per minute to per millisecond
+    this.intervalMs = 60000 / maxPerMinute;
   }
 
   async acquire(): Promise<void> {
-    while (this.tokens < 1) {
-      this.refill();
-      if (this.tokens < 1) {
-        // Wait for next refill cycle
-        const waitTime = Math.ceil((1 - this.tokens) / this.refillRate);
-        await new Promise((resolve) => setTimeout(resolve, waitTime));
-      }
-    }
-    this.tokens--;
-  }
-
-  private refill(): void {
     const now = Date.now();
-    const timePassed = now - this.lastRefill;
-    const tokensToAdd = timePassed * this.refillRate;
-
-    this.tokens = Math.min(this.maxTokens, this.tokens + tokensToAdd);
-    this.lastRefill = now;
-  }
-}
-
-// Concurrency limiter class to control maximum concurrent requests
-class ConcurrencyLimiter {
-  private running = 0;
-  private readonly maxConcurrent: number;
-  private readonly queue: Array<() => Promise<void>> = [];
-
-  constructor(maxConcurrent: number) {
-    this.maxConcurrent = maxConcurrent;
-  }
-
-  async run<T>(fn: () => Promise<T>): Promise<T> {
-    if (this.running >= this.maxConcurrent) {
-      // Wait for a slot to become available
-      return new Promise((resolve, reject) => {
-        this.queue.push(async () => {
-          try {
-            const result = await fn();
-            resolve(result);
-          } catch (error) {
-            reject(error);
-          }
-        });
-      });
-    }
-
-    this.running++;
-    try {
-      const result = await fn();
-      return result;
-    } finally {
-      this.running--;
-      this.processQueue();
-    }
-  }
-
-  private processQueue(): void {
-    if (this.queue.length > 0 && this.running < this.maxConcurrent) {
-      const next = this.queue.shift();
-      if (next) {
-        this.running++;
-        next().finally(() => {
-          this.running--;
-          this.processQueue();
-        });
-      }
-    }
-  }
-
-  async waitForAll(): Promise<void> {
-    while (this.running > 0 || this.queue.length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    const slot = Math.max(this.nextSlot, now);
+    this.nextSlot = slot + this.intervalMs;
+    if (slot > now) {
+      await sleep(slot - now);
     }
   }
 }
@@ -147,20 +139,21 @@ function parseArgs(): Args {
 
   if (args.length < 1) {
     console.error(
-      "Usage: deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts <submission_id> [max_per_minute] [total_submissions]"
+      "Usage: deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts <submission_id> [max_per_minute] [total_submissions] [concurrency]"
     );
     console.error("  submission_id: The submission ID to trigger");
-    console.error("  max_per_minute: Maximum submissions per minute (default: 10)");
+    console.error("  max_per_minute: Maximum submissions per minute (default: 60)");
     console.error("  total_submissions: Total number of submissions to make (default: 10)");
+    console.error("  concurrency: Maximum in-flight dispatches (default: derived from max_per_minute)");
     console.error("");
     console.error(
-      "Example: deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts 123 3 5"
+      "Example: deno run --allow-env --allow-net --env-file=.env.local supabase/functions/scripts/TriggerBulkSubmissions.ts 123 120 200"
     );
     Deno.exit(1);
   }
 
   const submissionId = parseInt(args[0]);
-  const maxPerMinute = args[1] ? parseInt(args[1]) : 10;
+  const maxPerMinute = args[1] ? parseInt(args[1]) : 60;
   const totalSubmissions = args[2] ? parseInt(args[2]) : 10;
 
   if (isNaN(submissionId) || submissionId <= 0) {
@@ -178,10 +171,21 @@ function parseArgs(): Args {
     Deno.exit(1);
   }
 
+  // Enough in-flight requests to keep the pacer saturated at ~2s per dispatch, plus headroom
+  // for the slow tail, capped by the number of submissions we actually have to send.
+  const defaultConcurrency = Math.ceil(maxPerMinute / 30) + 2;
+  const concurrency = args[3] ? parseInt(args[3]) : defaultConcurrency;
+
+  if (isNaN(concurrency) || concurrency <= 0) {
+    console.error("Error: concurrency must be a positive number");
+    Deno.exit(1);
+  }
+
   return {
     submissionId,
     maxPerMinute,
-    totalSubmissions
+    totalSubmissions,
+    concurrency: Math.min(concurrency, totalSubmissions)
   };
 }
 
@@ -201,7 +205,91 @@ async function getSubmissionData(submissionId: number): Promise<SubmissionData> 
     throw new Error(`Failed to fetch submission ${submissionId}: ${error?.message || "Submission not found"}`);
   }
 
-  return data;
+  if (!data.repository || !data.sha) {
+    throw new Error(`Submission ${submissionId} has no repository or SHA to trigger`);
+  }
+
+  return { id: data.id, repository: data.repository, sha: data.sha };
+}
+
+/**
+ * Installation-scoped client for one repo, without the shared production throttle. The
+ * token is minted up front so the concurrent dispatches below don't all stall on auth.
+ */
+async function getInstallationOctokit(owner: string, repo: string): Promise<Octokit> {
+  const appId = Deno.env.get("GITHUB_APP_ID");
+  const privateKey = Deno.env.get("GITHUB_PRIVATE_KEY_STRING");
+
+  if (!appId || !privateKey) {
+    throw new Error("Missing GITHUB_APP_ID or GITHUB_PRIVATE_KEY_STRING");
+  }
+
+  const appOctokit = new Octokit({ authStrategy: createAppAuth, auth: { appId, privateKey } });
+  appOctokit.request = appOctokit.request.defaults({ headers: API_VERSION_HEADER });
+  const { data: installation } = await appOctokit.request("GET /repos/{owner}/{repo}/installation", { owner, repo });
+
+  const octokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: { appId, privateKey, installationId: installation.id }
+  });
+  octokit.request = octokit.request.defaults({ headers: API_VERSION_HEADER });
+
+  // Reads `resources.core`, not `rate` — the latter is gone in 2026-03-10.
+  const { data: limits } = await octokit.request("GET /rate_limit");
+  console.log(`  Installation: ${installation.id}`);
+  console.log(`  Core rate limit remaining: ${limits.resources.core.remaining}/${limits.resources.core.limit}`);
+
+  return octokit;
+}
+
+/**
+ * Create the tag the workflow dispatches against, once for the whole run. Every submission
+ * reuses the same repo and SHA, so the tag only has to exist — re-creating it per dispatch
+ * (as `triggerWorkflow` does) just burns two write requests against the secondary limit.
+ */
+async function ensureSubmissionTag(octokit: Octokit, owner: string, repo: string, sha: string): Promise<string> {
+  const ref = `pawtograder-submit/${sha}`;
+
+  try {
+    await octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", { owner, repo, ref: `tags/${ref}` });
+    console.log(`  Tag ${ref} already exists`);
+    return ref;
+  } catch (error) {
+    if (errorStatus(error) !== 404) {
+      throw error;
+    }
+  }
+
+  await octokit.request("POST /repos/{owner}/{repo}/git/tags", {
+    owner,
+    repo,
+    tag: ref,
+    message: "pawtograder submission",
+    object: sha,
+    type: "commit",
+    tagger: {
+      name: "pawtograder",
+      email: "khoury-pawtograder-app@ccs.neu.edu",
+      date: new Date().toISOString()
+    }
+  });
+
+  try {
+    await octokit.request("POST /repos/{owner}/{repo}/git/refs", {
+      owner,
+      repo,
+      ref: `refs/tags/${ref}`,
+      sha
+    });
+  } catch (error) {
+    // Another run may have created it between our GET and POST.
+    if (!errorMessage(error).includes("Reference already exists")) {
+      throw error;
+    }
+  }
+
+  console.log(`  Created tag ${ref}`);
+  return ref;
 }
 
 async function triggerBulkSubmissions(args: Args): Promise<void> {
@@ -209,85 +297,103 @@ async function triggerBulkSubmissions(args: Args): Promise<void> {
   console.log(`  Submission ID: ${args.submissionId}`);
   console.log(`  Target throughput: ${args.maxPerMinute} per minute`);
   console.log(`  Total submissions: ${args.totalSubmissions}`);
-  console.log(`  Max concurrent requests: 20`);
+  console.log(`  Max concurrent requests: ${args.concurrency}`);
 
-  // Fetch the actual submission data from the database
+  if (args.maxPerMinute > SECONDARY_LIMIT_WARNING_THRESHOLD) {
+    console.warn(
+      `  WARNING: ${args.maxPerMinute}/min exceeds GitHub's ~${SECONDARY_LIMIT_WARNING_THRESHOLD}/min secondary limit for content-creating requests; expect throttling`
+    );
+  }
+
   const submissionData = await getSubmissionData(args.submissionId);
+  const [owner, repo] = submissionData.repository.split("/");
   console.log(`  Repository: ${submissionData.repository}`);
   console.log(`  SHA: ${submissionData.sha}`);
 
-  const startTime = Date.now();
-  const results: WorkflowResult[] = [];
+  const octokit = await getInstallationOctokit(owner, repo);
+  const ref = await ensureSubmissionTag(octokit, owner, repo, submissionData.sha);
 
-  // Initialize rate limiter and concurrency limiter
-  const rateLimiter = new RateLimiter(args.maxPerMinute);
-  const concurrencyLimiter = new ConcurrencyLimiter(20);
+  const startTime = Date.now();
+  const durations: number[] = [];
+  const failures = new Map<string, number>();
+  let completed = 0;
+  let succeeded = 0;
+  let retried = 0;
+
+  const pacer = new Pacer(args.maxPerMinute);
+  let nextIndex = 0;
+
+  const dispatch = async (): Promise<void> => {
+    const taskStartTime = Date.now();
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        await octokit.request("POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches", {
+          owner,
+          repo,
+          workflow_id: WORKFLOW_NAME,
+          ref
+        });
+        durations.push(Date.now() - taskStartTime);
+        succeeded++;
+        return;
+      } catch (error) {
+        if (attempt === MAX_ATTEMPTS || !isRetryable(error)) {
+          const key = `${errorStatus(error) ?? "network"}: ${errorMessage(error)}`;
+          failures.set(key, (failures.get(key) ?? 0) + 1);
+          return;
+        }
+        retried++;
+        const backoffMs = retryDelayFromHeaders(error) ?? 1000 * 2 ** (attempt - 1);
+        await sleep(backoffMs);
+      }
+    }
+  };
 
   console.log(`\nStarting asynchronous workflow triggers...`);
 
-  // Create all submission tasks
-  const tasks = Array.from({ length: args.totalSubmissions }, (_, index) => {
-    return async (): Promise<void> => {
-      const submissionIndex = index + 1;
-      const taskStartTime = Date.now();
+  const progressTimer = setInterval(() => {
+    const elapsedMinutes = (Date.now() - startTime) / 60000;
+    const rate = elapsedMinutes > 0 ? completed / elapsedMinutes : 0;
+    console.log(`  ${completed}/${args.totalSubmissions} dispatched (${rate.toFixed(1)}/min, ${succeeded} ok)`);
+  }, 5000);
 
-      try {
-        // Wait for rate limiter to allow this request
-        await rateLimiter.acquire();
-
-        console.log(`  [${submissionIndex}/${args.totalSubmissions}] Triggering workflow...`);
-
-        // Use the actual repository and SHA from the database
-        await triggerWorkflow(submissionData.repository, submissionData.sha, "grade.yml");
-
-        const duration = Date.now() - taskStartTime;
-        console.log(`  [${submissionIndex}/${args.totalSubmissions}] ✓ Success (${duration}ms)`);
-
-        results.push({
-          index: submissionIndex,
-          success: true,
-          timestamp: new Date()
-        });
-      } catch (error) {
-        const duration = Date.now() - taskStartTime;
-        console.error(`  [${submissionIndex}/${args.totalSubmissions}] ✗ Failed (${duration}ms):`, error);
-
-        results.push({
-          index: submissionIndex,
-          success: false,
-          error: error instanceof Error ? error.message : String(error),
-          timestamp: new Date()
-        });
+  const workers = Array.from({ length: args.concurrency }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= args.totalSubmissions) {
+        return;
       }
-    };
+      await pacer.acquire();
+      await dispatch();
+      completed++;
+    }
   });
 
-  // Execute all tasks with concurrency control
-  const executionPromises = tasks.map((task) => concurrencyLimiter.run(task));
-
-  // Wait for all tasks to complete
-  await Promise.all(executionPromises);
-  await concurrencyLimiter.waitForAll();
+  await Promise.all(workers);
+  clearInterval(progressTimer);
 
   const totalDuration = Date.now() - startTime;
-  const successfulSubmissions = results.filter((r) => r.success).length;
-  const failedSubmissions = results.filter((r) => !r.success).length;
-  const actualThroughput = (successfulSubmissions / totalDuration) * 60000; // per minute
+  const failedSubmissions = args.totalSubmissions - succeeded;
+  const actualThroughput = (succeeded / totalDuration) * 60000;
+  const sorted = durations.slice().sort((a, b) => a - b);
+  const percentile = (p: number) =>
+    sorted.length ? sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] : 0;
 
   console.log(`\n=== Bulk submission trigger completed ===`);
   console.log(`  Total duration: ${totalDuration}ms`);
-  console.log(`  Successful: ${successfulSubmissions}/${args.totalSubmissions}`);
+  console.log(`  Successful: ${succeeded}/${args.totalSubmissions}`);
   console.log(`  Failed: ${failedSubmissions}/${args.totalSubmissions}`);
+  console.log(`  Retries: ${retried}`);
+  console.log(`  Dispatch latency: p50 ${percentile(0.5)}ms, p95 ${percentile(0.95)}ms`);
   console.log(`  Actual throughput: ${actualThroughput.toFixed(2)} per minute`);
   console.log(`  Target throughput: ${args.maxPerMinute} per minute`);
 
-  if (failedSubmissions > 0) {
-    console.log(`\nFailed submissions:`);
-    results
-      .filter((r) => !r.success)
-      .forEach((r) => {
-        console.log(`  [${r.index}]: ${r.error}`);
-      });
+  if (failures.size > 0) {
+    console.log(`\nFailures:`);
+    for (const [message, count] of [...failures].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${count}x ${message}`);
+    }
   }
 }
 

--- a/supabase/functions/scripts/TriggerBulkSubmissions.ts
+++ b/supabase/functions/scripts/TriggerBulkSubmissions.ts
@@ -324,9 +324,14 @@ async function triggerBulkSubmissions(args: Args): Promise<void> {
   let nextIndex = 0;
 
   const dispatch = async (): Promise<void> => {
-    const taskStartTime = Date.now();
-
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      // Every attempt takes a paced slot, retries included. Pacing only first attempts would
+      // let a burst of retryable 5xxs double the request rate — the other workers keep
+      // admitting first attempts meanwhile — so `max_per_minute` would stop being an upper
+      // bound on GitHub requests at exactly the moment GitHub is asking us to back off.
+      await pacer.acquire();
+      // After the wait, so the reported latency is the request itself and not the pacing.
+      const requestStartTime = Date.now();
       try {
         await octokit.request("POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches", {
           owner,
@@ -334,7 +339,7 @@ async function triggerBulkSubmissions(args: Args): Promise<void> {
           workflow_id: WORKFLOW_NAME,
           ref
         });
-        durations.push(Date.now() - taskStartTime);
+        durations.push(Date.now() - requestStartTime);
         succeeded++;
         return;
       } catch (error) {
@@ -364,7 +369,6 @@ async function triggerBulkSubmissions(args: Args): Promise<void> {
       if (index >= args.totalSubmissions) {
         return;
       }
-      await pacer.acquire();
       await dispatch();
       completed++;
     }


### PR DESCRIPTION
Two independent changes to the grading pipeline's operability.

## 1. `TriggerBulkSubmissions` throughput

The `max_per_minute` knob was fiction — the script was capped near **20/min** regardless of what was asked for. Two causes:

- **`triggerWorkflow` makes three write requests per submission** (`git/tags`, `git/refs`, `dispatches`), but every iteration reuses the same repo and SHA, so two are redundant. The ref POST failed with "Reference already exists" and was swallowed; the tag POST created a fresh dangling tag object each time.
- **The shared throttle serializes writes at 1/sec.** `getOctoKit` attaches the Redis-backed `@octokit/plugin-throttling` limiter, whose `octokit-write` group is `maxConcurrent: 1, minTime: 1000` (verified in the cached v11.0.3 source). Three serialized writes → ~3s per submission, and `ConcurrencyLimiter(20)` bought nothing because it sat upstream of the limiter. The load test was also spending production's global write budget.

Now: create the tag once (a `GET` first means a re-run against the same SHA skips both writes), then one dispatch per submission through a script-local installation client with no shared throttle. The token bucket and `ConcurrencyLimiter` are replaced by an evenly-spaced pacer plus a fixed worker pool — which also drops the latter's 10ms busy-poll and its double-increment of `running` for queued tasks. Adds retries honoring `retry-after`, and reports p50/p95 dispatch latency.

Realistic ceiling is now GitHub's, not ours: ~80 content-creating requests/min per installation. The script warns above that.

### API version deprecation

Also pins `X-GitHub-Api-Version: 2026-03-10`. Octokit defaults to `2022-11-28`, which GitHub deprecated when the new version shipped, so every dispatch logged:

> `[@octokit/request] "POST .../dispatches" is deprecated. It is scheduled to be removed on Fri, 10 Mar 2028`

The endpoint is not deprecated — the API version is. Confirmed with a side-effect-free probe (404 against a nonexistent workflow):

```
--- 2022-11-28 ---  Deprecation: Tue, 10 Mar 2026   Sunset: Fri, 10 Mar 2028
                    Link: <...api-versions>; rel="deprecation"
--- 2026-03-10 ---  (no deprecation headers)
```

Both breaking changes in the new version are already safe here: `GET /rate_limit` drops top-level `rate` (we read `resources.core`), and dispatches return `200` with run details instead of `204` (we ignore the body).

## 2. Sentry → GitHub Actions run, in one click

Going from a Sentry event to the run behind it meant reading three tags, remembering the `/actions/runs/<id>/attempts/<n>` shape, and assembling a URL by hand, per event.

New `_shared/workflowRunUrl.ts` builds the link once and stamps it as a `gha_run_url` Sentry tag plus a log line. Wired into all four OIDC-authenticated handlers, one line each, right after the token decode — so the scope carries the tag into every event the request later reports:

| Function | Before |
|---|---|
| `autograder-create-submission` | `repository`/`run_id`/`run_attempt` as separate tags |
| `autograder-submit-feedback` | same |
| `autograder-create-regression-test-run` | no run tags at all |
| `autograder-retrieve-autograder-regression-tests` | no run tags at all |

Two deliberate behaviors: a missing or unparseable `run_attempt` degrades to the plain run URL (GitHub redirects to the latest attempt) rather than dropping the link; and anything not matching `owner/repo` plus a numeric run id yields no link and leaves the scope untagged, since a plausible URL landing on the wrong run defeats the purpose.

The helper takes a structural `{ setTag }` instead of importing Sentry, keeping it a pure unit under `deno test` — same instinct as `EnvReader` in `SentryContext.ts`.

## Verification

- `npm run test:functions` → **232 passed, 0 failed** (7 new).
- No new type errors. `autograder-create-submission` reports 14 both with and without the change (verified by stashing it); the unmodified `autograder-trigger-grading-workflow` reports the same 6 baseline errors. All originate in `GitHubWrapper.ts` (`Endpoints` missing from octokit 5.0.5) and the generated `SupabaseTypes.d.ts` — pre-existing and untouched.
- Prettier clean on all changed files.

## Notes for review

- The log line is unconditional, so it emits ~1 line per grading run rather than only on failures. Moving it into `wrapRequestHandler`'s catch would restrict it to errors, at the cost of losing the link when tailing logs for a run that didn't error.
- **Not addressed here:** the deprecated API version is repo-wide, not script-specific. `GitHubWrapper.ts` pins `2022-11-28` explicitly at `:2779` and `:2848`, and everything else takes octokit's default — so all ~49 edge functions carry the same warning on the same 2028-03-10 sunset. Migrating them needs an audit against the two breaking changes above (notably `triggerWorkflow` itself). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)