### PR TITLE
fix(workers): scope the Redis worker lease to a deployment

### DIFF
--- a/supabase/functions/_shared/workerRun.test.ts
+++ b/supabase/functions/_shared/workerRun.test.ts
@@ -143,6 +143,83 @@ Deno.test("only one run is leased at a time", async () => {
   assertEquals(runs.filter((r) => r.mode === "leased").length, 1);
 });
 
+// "Every loser drains" is its own slot-exhaustion bug: these workers get several pokes per cron
+// tick, so a backlogged queue would mint a drainer on each one.
+Deno.test("the helper pool is bounded; pokes past it idle instead of draining", async () => {
+  const redis = fakeRedis();
+  const leased = await beginWorkerRun({ ...base, redis });
+  assertEquals(leased.mode, "leased");
+
+  const helpers: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    helpers.push((await beginWorkerRun({ ...base, redis })).mode);
+  }
+  assertEquals(
+    helpers.filter((m) => m === "bounded").length,
+    1,
+    "at most MAX_BOUNDED_HELPERS pokes may drain alongside the holder"
+  );
+  assertEquals(helpers.filter((m) => m === "idle").length, 4);
+});
+
+// An idle run must be inert in the caller's loop: `while (run.shouldContinue())` runs zero times.
+Deno.test("an idle run does no work at all", async () => {
+  const redis = fakeRedis();
+  await beginWorkerRun({ ...base, redis });
+  await beginWorkerRun({ ...base, redis }); // takes the one helper slot
+  const idle = await beginWorkerRun({ ...base, redis });
+  assertEquals(idle.mode, "idle");
+  assertEquals(idle.shouldContinue(), false);
+  await idle.release();
+});
+
+// The slot has to come back, or one backlog would wedge the pool until TTL.
+Deno.test("a helper hands its slot back on release", async () => {
+  const redis = fakeRedis();
+  await beginWorkerRun({ ...base, redis });
+  const helper = await beginWorkerRun({ ...base, redis });
+  assertEquals(helper.mode, "bounded");
+  assertEquals(redis.store.has(`${LEASE_KEY}:helper-1`), true);
+  await helper.release();
+  assertEquals(redis.store.has(`${LEASE_KEY}:helper-1`), false);
+  assertEquals((await beginWorkerRun({ ...base, redis })).mode, "bounded", "the freed slot is reusable");
+});
+
+// Helper slots are never renewed, so a hung helper frees its slot at TTL rather than for the life
+// of the isolate. Guarding the property that makes that true: no renewal timer is registered.
+Deno.test("a helper registers no renewal timer", async () => {
+  const redis = fakeRedis();
+  const timers = fakeTimers();
+  await beginWorkerRun({ ...base, redis });
+  const before = timers.active;
+  const helper = await beginWorkerRun({
+    ...base,
+    redis,
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn
+  });
+  assertEquals(helper.mode, "bounded");
+  assertEquals(timers.active, before);
+});
+
+// Redis refusing to answer must not become "drain anyway" -- that is the crowd the pool prevents.
+Deno.test("a Redis failure while claiming a helper slot idles rather than drains", async () => {
+  const redis = fakeRedis();
+  await beginWorkerRun({ ...base, redis });
+  let calls = 0;
+  const flaky = {
+    ...redis,
+    // deno-lint-ignore no-explicit-any
+    set(key: string, value: string, o?: any) {
+      calls++;
+      if (calls > 1) throw new Error("redis down");
+      return redis.set(key, value, o);
+    }
+  };
+  const run = await beginWorkerRun({ ...base, redis: flaky });
+  assertEquals(run.mode, "idle");
+});
+
 Deno.test("releasing the lease lets the next run acquire it", async () => {
   const redis = fakeRedis();
   const first = await beginWorkerRun({ ...base, redis });
@@ -297,14 +374,46 @@ Deno.test("a re-run attempt is its own scope", () => {
   assertNotEquals(workerLeaseScope(attempt("1")), workerLeaseScope(attempt("2")));
 });
 
+// `preview.yml` passes global.deploy.runId on EVERY helm upgrade. Keying on it would re-key each
+// redeploy, and the chart's rolling update (maxSurge 1, maxUnavailable 0, ~410s drain) would then
+// have the outgoing and incoming pods holding resident leases under different keys.
+Deno.test("a preview keeps one scope across redeploys", () => {
+  const deploy = (runId: string) =>
+    envOf({ ENVIRONMENT: "preview", DEPLOY_PR: "927", DEPLOY_RUN_ID: runId, DEPLOY_RUN_ATTEMPT: "1" });
+  assertEquals(workerLeaseScope(deploy("1")), "preview:pr-927");
+  assertEquals(workerLeaseScope(deploy("1")), workerLeaseScope(deploy("2")));
+});
+
+Deno.test("staging and production ignore run identity too", () => {
+  const deploy = (environment: string, runId: string) => envOf({ ENVIRONMENT: environment, DEPLOY_RUN_ID: runId });
+  assertEquals(workerLeaseScope(deploy("staging", "1")), "staging");
+  assertEquals(workerLeaseScope(deploy("production", "1")), workerLeaseScope(deploy("production", "2")));
+});
+
 Deno.test("WORKER_LEASE_SCOPE overrides everything", () => {
   assertEquals(workerLeaseScope(envOf({ WORKER_LEASE_SCOPE: "manual", ENVIRONMENT: "production" })), "manual");
 });
 
-// Branch-derived values reach these vars, and a key you cannot paste into redis-cli is a key you
-// cannot debug.
+// A key you cannot paste into redis-cli is a key you cannot debug.
 Deno.test("scope segments are sanitized", () => {
-  assertEquals(workerLeaseScope(envOf({ ENVIRONMENT: "feat/some thing" })), "feat-some-thing");
+  const scope = workerLeaseScope(envOf({ ENVIRONMENT: "feat/some thing" }));
+  assertEquals(/^feat-some-thing~[a-z0-9]+$/.test(scope), true, scope);
+});
+
+// Sanitizing must not merge two scopes -- that is the collision this module exists to prevent,
+// reintroduced by the thing meant to make keys readable.
+Deno.test("sanitizing distinct values keeps them distinct", () => {
+  const scopeOf = (environment: string) => workerLeaseScope(envOf({ ENVIRONMENT: environment }));
+  assertNotEquals(scopeOf("feat/foo"), scopeOf("feat-foo"));
+  assertNotEquals(scopeOf("a/b"), scopeOf("a b"));
+  assertNotEquals(scopeOf("a//b"), scopeOf("a/b"));
+});
+
+// The values that actually occur are already key-safe, and those must stay readable.
+Deno.test("already-safe values are left alone", () => {
+  for (const environment of ["dev", "preview", "staging", "production", "e2e-local"]) {
+    assertEquals(workerLeaseScope(envOf({ ENVIRONMENT: environment })), environment);
+  }
 });
 
 Deno.test("blank env values are ignored rather than making an empty segment", () => {

--- a/supabase/functions/_shared/workerRun.test.ts
+++ b/supabase/functions/_shared/workerRun.test.ts
@@ -10,9 +10,12 @@ function fakeRedis(opts: { failAcquire?: boolean; failRenew?: boolean } = {}) {
     get setCalls() {
       return setCalls;
     },
+    /** px used for each key, so tests can assert a helper slot outlives less than a lease. */
+    ttls: new Map<string, number>(),
     // deno-lint-ignore no-explicit-any
     set(key: string, value: string, o?: any) {
       setCalls++;
+      if (typeof o?.px === "number") this.ttls.set(key, o.px);
       if (o?.nx) {
         if (opts.failAcquire) throw new Error("redis down");
         if (store.has(key)) return Promise.resolve(null);
@@ -183,6 +186,20 @@ Deno.test("a helper hands its slot back on release", async () => {
   await helper.release();
   assertEquals(redis.store.has(`${LEASE_KEY}:helper-1`), false);
   assertEquals((await beginWorkerRun({ ...base, redis })).mode, "bounded", "the freed slot is reusable");
+});
+
+// A helper that dies without releasing holds the only slot until its key expires, so that expiry
+// has to be quick. At the lease TTL, one dead helper plus a stalled holder meant nothing drained
+// for a minute -- the ~94s worst-case gap seen in CI.
+Deno.test("a helper slot expires much sooner than a lease", async () => {
+  const redis = fakeRedis();
+  await beginWorkerRun({ ...base, redis, leaseTtlMs: 60_000 });
+  const helper = await beginWorkerRun({ ...base, redis, leaseTtlMs: 60_000 });
+  assertEquals(helper.mode, "bounded");
+  const leaseTtl = redis.ttls.get(LEASE_KEY)!;
+  const helperTtl = redis.ttls.get(`${LEASE_KEY}:helper-1`)!;
+  assertEquals(leaseTtl, 60_000);
+  assertEquals(helperTtl < leaseTtl / 2, true, `helper slot ttl ${helperTtl} should be well under ${leaseTtl}`);
 });
 
 // Helper slots are never renewed, so a hung helper frees its slot at TTL rather than for the life

--- a/supabase/functions/_shared/workerRun.test.ts
+++ b/supabase/functions/_shared/workerRun.test.ts
@@ -10,12 +10,9 @@ function fakeRedis(opts: { failAcquire?: boolean; failRenew?: boolean } = {}) {
     get setCalls() {
       return setCalls;
     },
-    /** px used for each key, so tests can assert a helper slot outlives less than a lease. */
-    ttls: new Map<string, number>(),
     // deno-lint-ignore no-explicit-any
     set(key: string, value: string, o?: any) {
       setCalls++;
-      if (typeof o?.px === "number") this.ttls.set(key, o.px);
       if (o?.nx) {
         if (opts.failAcquire) throw new Error("redis down");
         if (store.has(key)) return Promise.resolve(null);
@@ -124,15 +121,14 @@ Deno.test("Redis configured -> leased run, and the lease is actually written", a
   assertEquals(redis.store.has(LEASE_KEY), true);
 });
 
-// Only one resident loop, but the loser still helps: a bounded run drains and exits, so a holder
-// that has stopped making progress cannot stall the queue behind its own lease.
-Deno.test("a second run while the lease is held is bounded, not a no-op", async () => {
+// A loser does nothing -- and the holder giving up a lease it is stalled on is what makes that
+// safe. See the stall tests below.
+Deno.test("a second run while the lease is held is idle", async () => {
   const redis = fakeRedis();
   const first = await beginWorkerRun({ ...base, redis });
   assertEquals(first.mode, "leased");
   const second = await beginWorkerRun({ ...base, redis });
-  assertEquals(second.mode, "bounded");
-  assertEquals(await second.onIdle(), false, "the helper must exit rather than stay resident");
+  assertEquals(second.mode, "idle");
 });
 
 // The lease still has to mean something: exactly one holder gets the resident loop.
@@ -146,95 +142,144 @@ Deno.test("only one run is leased at a time", async () => {
   assertEquals(runs.filter((r) => r.mode === "leased").length, 1);
 });
 
-// "Every loser drains" is its own slot-exhaustion bug: these workers get several pokes per cron
-// tick, so a backlogged queue would mint a drainer on each one.
-Deno.test("the helper pool is bounded; pokes past it idle instead of draining", async () => {
-  const redis = fakeRedis();
-  const leased = await beginWorkerRun({ ...base, redis });
-  assertEquals(leased.mode, "leased");
-
-  const helpers: string[] = [];
-  for (let i = 0; i < 5; i++) {
-    helpers.push((await beginWorkerRun({ ...base, redis })).mode);
-  }
-  assertEquals(
-    helpers.filter((m) => m === "bounded").length,
-    1,
-    "at most MAX_BOUNDED_HELPERS pokes may drain alongside the holder"
-  );
-  assertEquals(helpers.filter((m) => m === "idle").length, 4);
-});
-
 // An idle run must be inert in the caller's loop: `while (run.shouldContinue())` runs zero times.
 Deno.test("an idle run does no work at all", async () => {
   const redis = fakeRedis();
   await beginWorkerRun({ ...base, redis });
-  await beginWorkerRun({ ...base, redis }); // takes the one helper slot
   const idle = await beginWorkerRun({ ...base, redis });
   assertEquals(idle.mode, "idle");
   assertEquals(idle.shouldContinue(), false);
+  assertEquals(await idle.onIdle(), false);
   await idle.release();
 });
 
-// The slot has to come back, or one backlog would wedge the pool until TTL.
-Deno.test("a helper hands its slot back on release", async () => {
-  const redis = fakeRedis();
-  await beginWorkerRun({ ...base, redis });
-  const helper = await beginWorkerRun({ ...base, redis });
-  assertEquals(helper.mode, "bounded");
-  assertEquals(redis.store.has(`${LEASE_KEY}:helper-1`), true);
-  await helper.release();
-  assertEquals(redis.store.has(`${LEASE_KEY}:helper-1`), false);
-  assertEquals((await beginWorkerRun({ ...base, redis })).mode, "bounded", "the freed slot is reusable");
-});
+// ── Stall detection ────────────────────────────────────────────────────────────
+// The regression this exists for: the renewal timer kept a lease alive on behalf of a loop that
+// had stopped going round, and every other poke was turned away for as long as it lasted.
 
-// A helper that dies without releasing holds the only slot until its key expires, so that expiry
-// has to be quick. At the lease TTL, one dead helper plus a stalled holder meant nothing drained
-// for a minute -- the ~94s worst-case gap seen in CI.
-Deno.test("a helper slot expires much sooner than a lease", async () => {
-  const redis = fakeRedis();
-  await beginWorkerRun({ ...base, redis, leaseTtlMs: 60_000 });
-  const helper = await beginWorkerRun({ ...base, redis, leaseTtlMs: 60_000 });
-  assertEquals(helper.mode, "bounded");
-  const leaseTtl = redis.ttls.get(LEASE_KEY)!;
-  const helperTtl = redis.ttls.get(`${LEASE_KEY}:helper-1`)!;
-  assertEquals(leaseTtl, 60_000);
-  assertEquals(helperTtl < leaseTtl / 2, true, `helper slot ttl ${helperTtl} should be well under ${leaseTtl}`);
-});
-
-// Helper slots are never renewed, so a hung helper frees its slot at TTL rather than for the life
-// of the isolate. Guarding the property that makes that true: no renewal timer is registered.
-Deno.test("a helper registers no renewal timer", async () => {
+Deno.test("a holder that stops calling in stops renewing", async () => {
   const redis = fakeRedis();
   const timers = fakeTimers();
-  await beginWorkerRun({ ...base, redis });
-  const before = timers.active;
-  const helper = await beginWorkerRun({
+  let t = 0;
+  const run = await beginWorkerRun({
     ...base,
     redis,
+    leaseTtlMs: 300,
+    maxStallMs: 1000,
+    now: () => t,
     setIntervalFn: timers.setIntervalFn,
     clearIntervalFn: timers.clearIntervalFn
   });
-  assertEquals(helper.mode, "bounded");
-  assertEquals(timers.active, before);
+  assertEquals(run.mode, "leased");
+
+  // The loop is going round: the timer fires, but progress is recent, so the lease is kept.
+  t += 200;
+  await run.heartbeat();
+  timers.fireAll();
+  await Promise.resolve();
+  assertEquals(run.shouldContinue(), true);
+
+  // Now the loop is wedged inside processBatch. The timer still fires; the lease must not survive.
+  t += 1001;
+  timers.fireAll();
+  await Promise.resolve();
+  assertEquals(run.shouldContinue(), false, "a stalled holder must give up the lease");
+  assertEquals(timers.active, 0, "and stop renewing it");
 });
 
-// Redis refusing to answer must not become "drain anyway" -- that is the crowd the pool prevents.
-Deno.test("a Redis failure while claiming a helper slot idles rather than drains", async () => {
+// It must let the key LAPSE rather than delete it: by the time a stall is noticed the key may
+// already have expired and been taken by the next holder.
+Deno.test("giving up a stalled lease does not delete another holder's key", async () => {
   const redis = fakeRedis();
-  await beginWorkerRun({ ...base, redis });
-  let calls = 0;
-  const flaky = {
-    ...redis,
-    // deno-lint-ignore no-explicit-any
-    set(key: string, value: string, o?: any) {
-      calls++;
-      if (calls > 1) throw new Error("redis down");
-      return redis.set(key, value, o);
-    }
-  };
-  const run = await beginWorkerRun({ ...base, redis: flaky });
-  assertEquals(run.mode, "idle");
+  const timers = fakeTimers();
+  let t = 0;
+  const run = await beginWorkerRun({
+    ...base,
+    redis,
+    leaseTtlMs: 300,
+    maxStallMs: 1000,
+    now: () => t,
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn
+  });
+  t += 1001;
+  timers.fireAll();
+  await Promise.resolve();
+  assertEquals(run.shouldContinue(), false);
+
+  redis.store.set(LEASE_KEY, "next-holders-token");
+  await run.release();
+  assertEquals(redis.store.get(LEASE_KEY), "next-holders-token");
+});
+
+// Once the stalled holder's key lapses, the next poke becomes the holder -- which is the whole
+// point of noticing the stall.
+Deno.test("the next poke takes over once a stalled lease lapses", async () => {
+  const redis = fakeRedis();
+  const timers = fakeTimers();
+  let t = 0;
+  const stalled = await beginWorkerRun({
+    ...base,
+    redis,
+    leaseTtlMs: 300,
+    maxStallMs: 1000,
+    now: () => t,
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn
+  });
+  t += 1001;
+  timers.fireAll();
+  await Promise.resolve();
+  assertEquals(stalled.shouldContinue(), false);
+
+  redis.store.delete(LEASE_KEY); // what the TTL does for real
+  const next = await beginWorkerRun({ ...base, redis });
+  assertEquals(next.mode, "leased");
+});
+
+// A batch that is merely SLOW is not a stall, or the GitHub worker would drop its lease on every
+// sync_repo_to_handout.
+Deno.test("a slow batch inside maxStallMs keeps the lease", async () => {
+  const redis = fakeRedis();
+  const timers = fakeTimers();
+  let t = 0;
+  const run = await beginWorkerRun({
+    ...base,
+    redis,
+    leaseTtlMs: 300,
+    maxStallMs: 10 * 60_000,
+    now: () => t,
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn
+  });
+  for (let i = 0; i < 20; i++) {
+    t += 20_000; // a batch running for minutes, with no loop iteration in between
+    timers.fireAll();
+    await Promise.resolve();
+  }
+  assertEquals(run.shouldContinue(), true, "minutes-long batches are normal for some workers");
+});
+
+// onIdle and onError are loop calls too, so they must count as progress -- otherwise a worker that
+// sat idle longer than maxStallMs would drop its lease for being healthy.
+Deno.test("idling counts as progress", async () => {
+  const redis = fakeRedis();
+  const timers = fakeTimers();
+  let t = 0;
+  const run = await beginWorkerRun({
+    ...base,
+    redis,
+    leaseTtlMs: 300,
+    maxStallMs: 1000,
+    now: () => t,
+    setIntervalFn: timers.setIntervalFn,
+    clearIntervalFn: timers.clearIntervalFn
+  });
+  for (let i = 0; i < 5; i++) {
+    t += 900;
+    assertEquals(await run.onIdle(), true);
+  }
+  assertEquals(run.shouldContinue(), true);
 });
 
 Deno.test("releasing the lease lets the next run acquire it", async () => {
@@ -452,4 +497,23 @@ Deno.test("the scope is part of the Redis key, so scopes cannot block each other
   assertEquals(runA?.mode, "leased");
   assertEquals(runB?.mode, "leased", "a concurrent CI run must not be starved by another run's lease");
   assertEquals(redis.store.size, 2);
+});
+
+// A worker whose batches are milliseconds is better off draining and exiting: nothing accumulates,
+// no admission slot is held between pokes, and no other poke's lease can starve it.
+Deno.test("preferBounded skips the lease even when Redis is available", async () => {
+  const redis = fakeRedis();
+  const run = await beginWorkerRun({ ...base, redis, preferBounded: true });
+  assertEquals(run.mode, "bounded");
+  assertEquals(redis.store.size, 0, "no lease key should be written at all");
+  assertEquals(await run.onIdle(), false);
+});
+
+// ...and it must not be starved by a lease someone else holds, which is the whole point.
+Deno.test("preferBounded is unaffected by a held lease", async () => {
+  const redis = fakeRedis();
+  const holder = await beginWorkerRun({ ...base, redis });
+  assertEquals(holder.mode, "leased");
+  const run = await beginWorkerRun({ ...base, redis, preferBounded: true });
+  assertEquals(run.mode, "bounded");
 });

--- a/supabase/functions/_shared/workerRun.test.ts
+++ b/supabase/functions/_shared/workerRun.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "jsr:@std/assert@^1";
-import { beginWorkerRun } from "./workerRun.ts";
+import { assertEquals, assertNotEquals } from "jsr:@std/assert@^1";
+import { beginWorkerRun, workerLeaseScope } from "./workerRun.ts";
 
 /** Minimal stand-in for the subset of the Redis surface a lease uses. */
 function fakeRedis(opts: { failAcquire?: boolean; failRenew?: boolean } = {}) {
@@ -77,10 +77,22 @@ const base = {
   idleSleepMs: 10,
   errorSleepMs: 5,
   sleep: noSleep,
+  // Empty env, so the lease scope is the "development" default rather than whatever the machine
+  // running the tests happens to export.
+  readEnv: () => undefined,
   // Default to inert timers so tests drive renewal explicitly rather than on the wall clock.
   setIntervalFn: () => 1,
   clearIntervalFn: () => {}
 };
+
+/** The key `base` produces: the "development" scope segment, then the worker name. */
+const LEASE_KEY = "pawtograder:worker-lease:development:test-worker";
+
+/** An EnvReader over a plain object, for the lease-scope tests. */
+const envOf =
+  (vars: Record<string, string>) =>
+  (key: string): string | undefined =>
+    vars[key];
 
 Deno.test("no Redis configured -> bounded run, never null", async () => {
   const run = await beginWorkerRun({ ...base, redis: null });
@@ -106,16 +118,29 @@ Deno.test("Redis configured -> leased run, and the lease is actually written", a
   const redis = fakeRedis();
   const run = await beginWorkerRun({ ...base, redis });
   assertEquals(run?.mode, "leased");
-  assertEquals(redis.store.has("pawtograder:worker-lease:test-worker"), true);
+  assertEquals(redis.store.has(LEASE_KEY), true);
 });
 
-// The accumulation fix: a second poke while the first holds the lease must do nothing at all.
-Deno.test("a second run while the lease is held returns null", async () => {
+// Only one resident loop, but the loser still helps: a bounded run drains and exits, so a holder
+// that has stopped making progress cannot stall the queue behind its own lease.
+Deno.test("a second run while the lease is held is bounded, not a no-op", async () => {
   const redis = fakeRedis();
   const first = await beginWorkerRun({ ...base, redis });
-  assertEquals(first?.mode, "leased");
+  assertEquals(first.mode, "leased");
   const second = await beginWorkerRun({ ...base, redis });
-  assertEquals(second, null);
+  assertEquals(second.mode, "bounded");
+  assertEquals(await second.onIdle(), false, "the helper must exit rather than stay resident");
+});
+
+// The lease still has to mean something: exactly one holder gets the resident loop.
+Deno.test("only one run is leased at a time", async () => {
+  const redis = fakeRedis();
+  const runs = [
+    await beginWorkerRun({ ...base, redis }),
+    await beginWorkerRun({ ...base, redis }),
+    await beginWorkerRun({ ...base, redis })
+  ];
+  assertEquals(runs.filter((r) => r.mode === "leased").length, 1);
 });
 
 Deno.test("releasing the lease lets the next run acquire it", async () => {
@@ -138,7 +163,7 @@ Deno.test("losing the lease stops the loop", async () => {
   const run = await beginWorkerRun({ ...base, redis, leaseTtlMs: 300, now: () => t });
   assertEquals(run!.shouldContinue(), true);
   // Another isolate takes over: the key no longer holds our token, so an XX renew finds nothing.
-  redis.store.delete("pawtograder:worker-lease:test-worker");
+  redis.store.delete(LEASE_KEY);
   t += 200; // past ttl/3, so the heartbeat is due
   await run!.heartbeat();
   assertEquals(run!.shouldContinue(), false);
@@ -167,9 +192,9 @@ Deno.test("heartbeat is a no-op before the interval elapses", async () => {
 Deno.test("release does not delete another holder's lease", async () => {
   const redis = fakeRedis();
   const run = await beginWorkerRun({ ...base, redis });
-  redis.store.set("pawtograder:worker-lease:test-worker", "someone-elses-token");
+  redis.store.set(LEASE_KEY, "someone-elses-token");
   await run!.release();
-  assertEquals(redis.store.get("pawtograder:worker-lease:test-worker"), "someone-elses-token");
+  assertEquals(redis.store.get(LEASE_KEY), "someone-elses-token");
 });
 
 Deno.test("leased idle sleeps and keeps looping", async () => {
@@ -185,15 +210,11 @@ Deno.test("a renewal does not steal a lease another isolate now owns", async () 
   const redis = fakeRedis();
   let t = 0;
   const run = await beginWorkerRun({ ...base, redis, leaseTtlMs: 300, now: () => t });
-  redis.store.set("pawtograder:worker-lease:test-worker", "another-isolates-token");
+  redis.store.set(LEASE_KEY, "another-isolates-token");
   t += 200;
   await run!.heartbeat();
   assertEquals(run!.shouldContinue(), false, "must stop rather than reclaim");
-  assertEquals(
-    redis.store.get("pawtograder:worker-lease:test-worker"),
-    "another-isolates-token",
-    "the new owner's token must survive"
-  );
+  assertEquals(redis.store.get(LEASE_KEY), "another-isolates-token", "the new owner's token must survive");
 });
 
 // The other defect: renewal only happened between batches, so a batch longer than the TTL let the
@@ -232,5 +253,77 @@ Deno.test("release deletes only our own lease", async () => {
   const redis = fakeRedis();
   const run = await beginWorkerRun({ ...base, redis });
   await run!.release();
-  assertEquals(redis.store.has("pawtograder:worker-lease:test-worker"), false);
+  assertEquals(redis.store.has(LEASE_KEY), false);
+});
+
+// ── Lease scope ────────────────────────────────────────────────────────────────
+// Everything below is about one bug: the key was the worker name alone, so every deployment sharing
+// the Upstash credentials shared one lease.
+
+Deno.test("lease scope falls back to development when nothing identifies the deploy", () => {
+  assertEquals(workerLeaseScope(envOf({})), "development");
+});
+
+Deno.test("lease scope prefers ENVIRONMENT, then DEPLOY_KIND", () => {
+  assertEquals(workerLeaseScope(envOf({ ENVIRONMENT: "production", DEPLOY_KIND: "preview" })), "production");
+  assertEquals(workerLeaseScope(envOf({ DEPLOY_KIND: "staging" })), "staging");
+});
+
+// The production fleet SHOULD share one lease -- that is what bounds resident loops across pods.
+Deno.test("production is a single scope across the fleet", () => {
+  assertEquals(
+    workerLeaseScope(envOf({ ENVIRONMENT: "production" })),
+    workerLeaseScope(envOf({ ENVIRONMENT: "production" }))
+  );
+});
+
+Deno.test("two preview deployments do not collide on 'preview'", () => {
+  const a = workerLeaseScope(envOf({ ENVIRONMENT: "preview", DEPLOY_PR: "901" }));
+  const b = workerLeaseScope(envOf({ ENVIRONMENT: "preview", DEPLOY_PR: "902" }));
+  assertNotEquals(a, b);
+});
+
+// The regression: two e2e jobs on the pawtograder-e2e pool, same Redis, same key. One drained and
+// the other was turned away for its whole run.
+Deno.test("two CI runs do not collide on 'e2e-local'", () => {
+  const env = (runId: string) => envOf({ DEPLOY_KIND: "e2e-local", DEPLOY_RUN_ID: runId, DEPLOY_RUN_ATTEMPT: "1" });
+  assertEquals(workerLeaseScope(env("31550106308")), "e2e-local:run-31550106308-1");
+  assertNotEquals(workerLeaseScope(env("31550106308")), workerLeaseScope(env("31550905986")));
+});
+
+// A retried job re-runs the whole suite against a fresh database; it is not the same deployment.
+Deno.test("a re-run attempt is its own scope", () => {
+  const attempt = (n: string) => envOf({ DEPLOY_KIND: "e2e-local", DEPLOY_RUN_ID: "1", DEPLOY_RUN_ATTEMPT: n });
+  assertNotEquals(workerLeaseScope(attempt("1")), workerLeaseScope(attempt("2")));
+});
+
+Deno.test("WORKER_LEASE_SCOPE overrides everything", () => {
+  assertEquals(workerLeaseScope(envOf({ WORKER_LEASE_SCOPE: "manual", ENVIRONMENT: "production" })), "manual");
+});
+
+// Branch-derived values reach these vars, and a key you cannot paste into redis-cli is a key you
+// cannot debug.
+Deno.test("scope segments are sanitized", () => {
+  assertEquals(workerLeaseScope(envOf({ ENVIRONMENT: "feat/some thing" })), "feat-some-thing");
+});
+
+Deno.test("blank env values are ignored rather than making an empty segment", () => {
+  assertEquals(workerLeaseScope(envOf({ ENVIRONMENT: "   ", DEPLOY_KIND: "staging", DEPLOY_PR: "" })), "staging");
+});
+
+Deno.test("the scope is part of the Redis key, so scopes cannot block each other", async () => {
+  const redis = fakeRedis();
+  const runA = await beginWorkerRun({
+    ...base,
+    redis,
+    readEnv: envOf({ DEPLOY_KIND: "e2e-local", DEPLOY_RUN_ID: "1", DEPLOY_RUN_ATTEMPT: "1" })
+  });
+  const runB = await beginWorkerRun({
+    ...base,
+    redis,
+    readEnv: envOf({ DEPLOY_KIND: "e2e-local", DEPLOY_RUN_ID: "2", DEPLOY_RUN_ATTEMPT: "1" })
+  });
+  assertEquals(runA?.mode, "leased");
+  assertEquals(runB?.mode, "leased", "a concurrent CI run must not be starved by another run's lease");
+  assertEquals(redis.store.size, 2);
 });

--- a/supabase/functions/_shared/workerRun.ts
+++ b/supabase/functions/_shared/workerRun.ts
@@ -75,6 +75,26 @@ const HEARTBEAT_DIVISOR = 3;
  * retires the isolate, so a bounded run ends on its own terms rather than being cut off mid-batch.
  */
 const DEFAULT_BOUNDED_BUDGET_MS = 50_000;
+/**
+ * How many pokes that LOST the lease race may drain anyway, at once, per worker per deployment.
+ *
+ * Not "all of them". These workers are poked at least twice per cron tick
+ * (`invoke_gradebook_recalculation_background_task` starts two), and gradebook mutations invoke the
+ * recalculation worker directly, so "every loser drains" means a backlogged queue mints a new
+ * drainer on every poke. Each one holds an admission slot, `maxParallelism` is 8 *per pod across all
+ * functions*, and the wall-clock budget is only consulted between `processBatch` calls -- it cannot
+ * cut short a single hung call. That is the slot exhaustion the lease was added to prevent, arrived
+ * at from the other direction.
+ *
+ * One helper is enough for what the fallback is actually for: making sure a holder that has stopped
+ * making progress cannot stall the queue behind its own lease. Worst case per worker is therefore
+ * the resident holder plus one helper, and the helper is transient -- it exits the moment the queue
+ * is idle. Helper slots are plain NX keys that are never renewed, so a helper whose isolate hangs
+ * still frees its slot at TTL rather than holding it for the isolate's life.
+ */
+const MAX_BOUNDED_HELPERS = 1;
+/** `DEPLOY_KIND` for the CI e2e job. The only deployment kind with no k8s rollout behind it. */
+const E2E_LOCAL_KIND = "e2e-local";
 
 /**
  * Renew ONLY if the key still holds our token, atomically.
@@ -103,11 +123,14 @@ else
   return 0
 end`;
 
-export type WorkerRunMode = "leased" | "bounded";
+export type WorkerRunMode = "leased" | "bounded" | "idle";
 
 export interface WorkerRun {
   readonly mode: WorkerRunMode;
-  /** False once the lease is lost (leased) or the budget is spent (bounded). */
+  /**
+   * False once the lease is lost (leased), the budget is spent (bounded), or immediately (idle) —
+   * so a caller's `while (run.shouldContinue())` is the one place that has to know the difference.
+   */
   shouldContinue(): boolean;
   /** Call once per loop iteration. Renews the lease when due; marks the run finished if it is lost. */
   heartbeat(): Promise<void>;
@@ -151,9 +174,30 @@ const denoEnv: EnvReader = (key) => {
   }
 };
 
-/** Redis keys are opaque bytes, but a key you cannot paste into redis-cli is a key you cannot debug. */
+/** FNV-1a, base36. Not security; just enough to keep a lossy rewrite from merging two scopes. */
+function shortHash(value: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(36);
+}
+
+/**
+ * Redis keys are opaque bytes, but a key you cannot paste into redis-cli is a key you cannot debug.
+ *
+ * Collapsing every run of invalid characters to `-` is lossy, and lossy is exactly the wrong
+ * property here: `feat/foo` and `feat-foo` would land on one key, which is the cross-deployment
+ * collision this module is fixing, reintroduced by the sanitizer. So when the rewrite changed
+ * anything, a hash of the ORIGINAL is appended and the mapping stays injective. Values that were
+ * already key-safe -- which is every value in practice, since the scope is built from a
+ * chart-validated environment name and some integers -- are untouched, so the common key stays
+ * readable.
+ */
 function sanitizeKeySegment(value: string): string {
-  return value.replace(/[^A-Za-z0-9._-]+/g, "-");
+  const safe = value.replace(/[^A-Za-z0-9._-]+/g, "-");
+  return safe === value ? safe : `${safe}~${shortHash(value)}`;
 }
 
 /**
@@ -168,14 +212,22 @@ function sanitizeKeySegment(value: string): string {
  * recalculated scores the gradebook specs wait on never landed and they failed on the 90s poll. A PR
  * preview could do the same thing to staging.
  *
- * Resolution order, most specific first, so a scope is never *less* unique than the thing it names:
+ * Resolution order:
  *   - `WORKER_LEASE_SCOPE`, for anything that needs to say so explicitly;
  *   - otherwise `ENVIRONMENT`/`DEPLOY_KIND` (the identity `SentryContext.ts` already established),
- *     narrowed by `DEPLOY_PR` so two preview namespaces do not collide on "preview", and by
- *     `DEPLOY_RUN_ID`/`DEPLOY_RUN_ATTEMPT` so two CI runs do not collide on "e2e-local".
+ *     narrowed by `DEPLOY_PR` so two preview namespaces do not collide on "preview".
  *
- * Production stays a single `production` scope, which is the whole point: there the fleet SHOULD
- * share one lease.
+ * The scope has to be stable for the LIFE OF A DEPLOYMENT, not per deploy. `DEPLOY_RUN_ID` is
+ * tempting -- it is the only thing that separates two CI e2e runs, which have no other identity --
+ * but `preview.yml` passes `global.deploy.runId` on every helm upgrade, so keying on it would give
+ * each preview redeploy a fresh set of keys. During the chart's rolling update (`maxSurge: 1`,
+ * `maxUnavailable: 0`, up to 410s of graceful drain) the outgoing and incoming pods would then hold
+ * resident leases under different keys, and the within-deployment bound would be off for the whole
+ * rollout. So run identity is added only for `e2e-local`, the one kind with no k8s rollout behind
+ * it, where each run genuinely is its own throwaway deployment with its own database.
+ *
+ * Production stays a single `production` scope, and a preview stays `preview:pr-<n>` across
+ * redeploys, which is the whole point: within one deployment the fleet SHOULD share one lease.
  */
 export function workerLeaseScope(readEnv: EnvReader = denoEnv): string {
   const value = (key: string): string | undefined => {
@@ -186,15 +238,18 @@ export function workerLeaseScope(readEnv: EnvReader = denoEnv): string {
   const explicit = value("WORKER_LEASE_SCOPE");
   if (explicit) return sanitizeKeySegment(explicit);
 
-  const parts = [value("ENVIRONMENT") ?? value("DEPLOY_KIND") ?? "development"];
+  const kind = value("ENVIRONMENT") ?? value("DEPLOY_KIND") ?? "development";
+  const parts = [kind];
 
   const pr = value("DEPLOY_PR");
   if (pr) parts.push(`pr-${pr}`);
 
-  const runId = value("DEPLOY_RUN_ID");
-  if (runId) {
-    const attempt = value("DEPLOY_RUN_ATTEMPT");
-    parts.push(attempt ? `run-${runId}-${attempt}` : `run-${runId}`);
+  if (kind === E2E_LOCAL_KIND) {
+    const runId = value("DEPLOY_RUN_ID");
+    if (runId) {
+      const attempt = value("DEPLOY_RUN_ATTEMPT");
+      parts.push(attempt ? `run-${runId}-${attempt}` : `run-${runId}`);
+    }
   }
 
   return parts.map(sanitizeKeySegment).join(":");
@@ -202,6 +257,11 @@ export function workerLeaseScope(readEnv: EnvReader = denoEnv): string {
 
 function leaseKey(name: string, scope: string): string {
   return `pawtograder:worker-lease:${scope}:${name}`;
+}
+
+/** Slot `i` of the small pool that lets lease losers help without becoming a crowd. */
+function helperKey(name: string, scope: string, i: number): string {
+  return `${leaseKey(name, scope)}:helper-${i}`;
 }
 
 /**
@@ -217,11 +277,15 @@ function leaseKey(name: string, scope: string): string {
  * the key held, 425 pokes refused, and not one batch processed — longer than the 60s TTL, so it was
  * not even a matter of waiting for expiry.
  *
- * A bounded run is the right answer to "someone else holds it". It cannot accumulate — it drains
- * until the queue is idle or its wall-clock budget expires, then returns and frees the admission
- * slot — so the resource bound this module exists to enforce still holds. And the queue, not the
- * lease, is what makes concurrent drainers safe: `pgmq_public.read` sets a visibility timeout on
- * every message it hands out, so two workers cannot be given the same message.
+ * So a loser now drains too — but only if it can claim one of `MAX_BOUNDED_HELPERS` slots, because
+ * "every loser drains" is its own way of exhausting the admission slots (see that constant). A poke
+ * that finds the helper pool full gets an `idle` run: it does nothing, exactly as before. What the
+ * pool buys is that SOMETHING is always draining, which is the property the plain early return did
+ * not have.
+ *
+ * Concurrent drainers are safe regardless: the queue, not the lease, provides the mutual exclusion.
+ * `pgmq_public.read` sets a visibility timeout on every message it hands out, so two workers cannot
+ * be given the same message.
  */
 export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<WorkerRun> {
   const now = opts.now ?? Date.now;
@@ -249,7 +313,8 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
     }
   }
 
-  const boundedRun = (reason: string): WorkerRun => {
+  /** `heldKey` is a helper slot to hand back when the run finishes; bounded runs never renew it. */
+  const boundedRun = (reason: string, heldKey?: { key: string; token: string }): WorkerRun => {
     const deadline = now() + budget;
     opts.scope?.setTag("worker_run_mode", "bounded");
     opts.scope?.setTag("worker_bounded_reason", reason);
@@ -263,6 +328,30 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
       onError: async () => {
         if (now() < deadline) await sleep(opts.errorSleepMs);
       },
+      release: async () => {
+        if (!heldKey || !redis) return;
+        try {
+          // Give the slot back early. TTL expiry is still the backstop for an isolate that dies
+          // here, which is why the slot is never renewed.
+          await redis.eval(RELEASE_IF_OWNED, [heldKey.key], [heldKey.token]);
+        } catch (e) {
+          opts.scope?.setTag("worker_lease", "helper_release_failed");
+          Sentry.captureException(e, opts.scope);
+        }
+      }
+    };
+  };
+
+  /** A poke with nothing to do: the lease is held and the helper pool is full. */
+  const idleRun = (reason: string): WorkerRun => {
+    opts.scope?.setTag("worker_run_mode", "idle");
+    opts.scope?.setTag("worker_idle_reason", reason);
+    return {
+      mode: "idle",
+      shouldContinue: () => false,
+      heartbeat: () => Promise.resolve(),
+      onIdle: () => Promise.resolve(false),
+      onError: () => Promise.resolve(),
       release: () => Promise.resolve()
     };
   };
@@ -285,9 +374,25 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   }
 
   if (!acquired) {
-    // Help rather than idle. The holder keeps the low-latency resident loop; this poke drains what
-    // it can and exits, so a holder that has stopped making progress cannot stall the queue.
-    return boundedRun("lease_held_elsewhere");
+    // Help, but only as one of a bounded few. The holder keeps the low-latency resident loop; a
+    // helper drains what it can and exits, so a holder that has stopped making progress cannot
+    // stall the queue -- while the pool stops a backlog from minting a drainer per poke.
+    for (let i = 1; i <= MAX_BOUNDED_HELPERS; i++) {
+      const hKey = helperKey(opts.name, leaseScope, i);
+      try {
+        const got = await redis.set(hKey, token, { px: ttl, nx: true });
+        if (got !== null && got !== undefined && got !== 0) {
+          return boundedRun("lease_held_elsewhere", { key: hKey, token });
+        }
+      } catch (e) {
+        // The pool is an optimization, not a correctness device. If Redis will not answer, idle:
+        // draining anyway is what the pool exists to prevent.
+        opts.scope?.setTag("worker_lease", "helper_acquire_failed");
+        Sentry.captureException(e, opts.scope);
+        return idleRun("helper_acquire_failed");
+      }
+    }
+    return idleRun("helpers_busy");
   }
 
   opts.scope?.setTag("worker_run_mode", "leased");

--- a/supabase/functions/_shared/workerRun.ts
+++ b/supabase/functions/_shared/workerRun.ts
@@ -26,11 +26,16 @@ import { type EnvReader } from "./SentryContext.ts";
  * Not correctness. `pgmq_public.read` sets `vt = now() + sleep_seconds` on every message it
  * returns, so two concurrent workers cannot be handed the same message — the queue is already the
  * mutual exclusion. The guard was only ever protecting RESOURCES. That is why this module offers
- * two shapes and both are safe:
+ * these shapes and all of them are safe:
  *
- *   - **leased** (Redis configured): one long-lived drainer across the whole fleet, holding a
- *     Redis lease it renews while it runs. Lowest latency, because the loop stays resident and
- *     polls on its own idle interval. Costs one admission slot per worker for the isolate's life.
+ *   - **leased** (Redis configured): one long-lived drainer per deployment, holding a Redis lease
+ *     it renews for as long as its loop keeps going round. Lowest latency, because the loop stays
+ *     resident and polls on its own idle interval. Costs one admission slot per worker for the
+ *     isolate's life.
+ *
+ *   - **idle** (Redis configured, someone else holds the lease): does nothing and returns. Safe
+ *     because a holder that stops making progress gives the lease up — see `maxStallMs` — so "hold
+ *     the lease" and "is draining" cannot drift apart for long.
  *
  *   - **bounded** (no Redis): the poke drains until the queue is idle or a wall-clock budget
  *     expires, then RETURNS, releasing the isolate and its slot. Cannot accumulate loops no matter
@@ -76,38 +81,14 @@ const HEARTBEAT_DIVISOR = 3;
  */
 const DEFAULT_BOUNDED_BUDGET_MS = 50_000;
 /**
- * How many pokes that LOST the lease race may drain anyway, at once, per worker per deployment.
+ * How long the loop may go without calling into this run before the holder gives up its lease.
  *
- * Not "all of them". These workers are poked at least twice per cron tick
- * (`invoke_gradebook_recalculation_background_task` starts two), and gradebook mutations invoke the
- * recalculation worker directly, so "every loser drains" means a backlogged queue mints a new
- * drainer on every poke. Each one holds an admission slot, `maxParallelism` is 8 *per pod across all
- * functions*, and the wall-clock budget is only consulted between `processBatch` calls -- it cannot
- * cut short a single hung call. That is the slot exhaustion the lease was added to prevent, arrived
- * at from the other direction.
- *
- * One helper is enough for what the fallback is actually for: making sure a holder that has stopped
- * making progress cannot stall the queue behind its own lease. Worst case per worker is therefore
- * the resident holder plus one helper, and the helper is transient -- it exits the moment the queue
- * is idle. Helper slots are plain NX keys that are never renewed, so a helper whose isolate hangs
- * still frees its slot at TTL rather than holding it for the isolate's life.
+ * Generous by default, because a batch that legitimately takes minutes is normal for the GitHub and
+ * Discord workers (`sync_repo_to_handout` is the documented case). Workers whose batches are
+ * milliseconds should set this far lower; the value is the ceiling on how long a stalled holder can
+ * keep the queue to itself.
  */
-const MAX_BOUNDED_HELPERS = 1;
-/**
- * How long a helper slot survives without being handed back.
- *
- * Deliberately much shorter than the lease TTL, and NOT tied to it. A helper releases its slot when
- * it finishes, so this only governs the abnormal exit — the isolate the runtime recycles mid-drain,
- * which in the edge runtime is routine rather than exceptional. At the lease TTL that left the only
- * slot claimed by a dead helper for a full minute, and with the holder stalled too, nothing drained
- * for that whole window: the first CI run after the scope fix still showed 20 gaps over 30 seconds
- * with a 94-second worst case, which is what the specs' 90-second budget was losing to.
- *
- * The failure mode of it being too short is two helpers overlapping briefly, which is bounded and
- * harmless. The failure mode of it being too long is nothing draining at all. Those are not
- * comparable, so this errs short.
- */
-const HELPER_SLOT_TTL_MS = 15_000;
+const DEFAULT_MAX_STALL_MS = 15 * 60_000;
 /** `DEPLOY_KIND` for the CI e2e job. The only deployment kind with no k8s rollout behind it. */
 const E2E_LOCAL_KIND = "e2e-local";
 
@@ -168,8 +149,20 @@ export interface BeginWorkerRunOptions {
   /** How long to sleep after a batch threw. */
   errorSleepMs: number;
   leaseTtlMs?: number;
-  /** Lifetime of a helper-pool slot. Short on purpose; see HELPER_SLOT_TTL_MS. */
-  helperSlotTtlMs?: number;
+  /** How long the loop may go silent before the holder stops renewing. See DEFAULT_MAX_STALL_MS. */
+  maxStallMs?: number;
+  /**
+   * Skip the lease entirely and always drain-and-exit.
+   *
+   * For a worker whose batches are milliseconds, this is simply the better mode. The lease exists to
+   * stop long-lived resident loops accumulating; a run that drains in milliseconds and returns has
+   * nothing to accumulate, holds no admission slot between pokes, and cannot be starved by another
+   * poke's lease. It also restores the property the direct pokes were written for -- a gradebook
+   * mutation pokes the worker and the work starts now, rather than whenever the holder next looks.
+   * Measured on the gradebook specs: 1.2 minutes bounded against 7.2 minutes leased, because a
+   * resident loop under `waitUntil` is not reliably scheduled between requests.
+   */
+  preferBounded?: boolean;
   boundedBudgetMs?: number;
   /** Test seams. */
   redis?: RedisClient | null;
@@ -276,11 +269,6 @@ function leaseKey(name: string, scope: string): string {
   return `pawtograder:worker-lease:${scope}:${name}`;
 }
 
-/** Slot `i` of the small pool that lets lease losers help without becoming a crowd. */
-function helperKey(name: string, scope: string, i: number): string {
-  return `${leaseKey(name, scope)}:helper-${i}`;
-}
-
 /**
  * Decide how this poke should run the worker loop. Never throws, and always returns a run: any Redis
  * problem, and a lease already held elsewhere, both degrade to a bounded run.
@@ -294,15 +282,21 @@ function helperKey(name: string, scope: string, i: number): string {
  * the key held, 425 pokes refused, and not one batch processed — longer than the 60s TTL, so it was
  * not even a matter of waiting for expiry.
  *
- * So a loser now drains too — but only if it can claim one of `MAX_BOUNDED_HELPERS` slots, because
- * "every loser drains" is its own way of exhausting the admission slots (see that constant). A poke
- * that finds the helper pool full gets an `idle` run: it does nothing, exactly as before. What the
- * pool buys is that SOMETHING is always draining, which is the property the plain early return did
- * not have.
+ * The fix belongs on the holder, not on the losers. Two shapes were tried on the loser side first
+ * and both were wrong: letting every loser drain re-creates the admission-slot exhaustion from the
+ * other direction, and rationing them through a small pool of TTL keys cannot work either, because
+ * one key cannot be both a semaphore for live helpers (wants a long TTL, or a batch outliving it
+ * lets a second helper in, repeatedly, for the length of the batch) and a self-healing lock for
+ * dead ones (wants a short TTL). So a loser does nothing, as it always did — and instead the HOLDER
+ * gives the lease up when it stops making progress.
  *
- * Concurrent drainers are safe regardless: the queue, not the lease, provides the mutual exclusion.
- * `pgmq_public.read` sets a visibility timeout on every message it hands out, so two workers cannot
- * be given the same message.
+ * `heartbeat`, `onIdle` and `onError` are all called by the loop, so any of them is proof the loop
+ * is alive. If none is called for `maxStallMs`, renewal stops and the lease lapses at the TTL, and
+ * the next poke becomes the holder. That covers every way a holder goes quiet: a killed isolate
+ * stops its timer, a suspended one stops its timer, and one parked on a promise that never settles
+ * keeps its timer but stops calling us, which the stall check catches. A batch that is merely SLOW
+ * keeps the lease as long as `maxStallMs` allows for it, which is why the default is generous and
+ * the fast workers narrow it.
  */
 export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<WorkerRun> {
   const now = opts.now ?? Date.now;
@@ -314,11 +308,13 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   opts.scope?.setTag("worker_lease_scope", leaseScope);
 
   // `undefined` means "not injected, go and build one"; an explicit `null` means "no Redis", which
-  // is what the tests and the no-Redis deployments both exercise.
+  // is what the tests and the no-Redis deployments both exercise. Skipped entirely when the caller
+  // has opted out of the lease: ioredis connects on construction, and a per-request isolate that
+  // will never look at Redis should not open a connection to it.
   let redis: RedisClient | null = null;
   if (opts.redis !== undefined) {
     redis = opts.redis;
-  } else {
+  } else if (!opts.preferBounded) {
     try {
       redis = createRedis();
     } catch (e) {
@@ -330,8 +326,7 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
     }
   }
 
-  /** `heldKey` is a helper slot to hand back when the run finishes; bounded runs never renew it. */
-  const boundedRun = (reason: string, heldKey?: { key: string; token: string }): WorkerRun => {
+  const boundedRun = (reason: string): WorkerRun => {
     const deadline = now() + budget;
     opts.scope?.setTag("worker_run_mode", "bounded");
     opts.scope?.setTag("worker_bounded_reason", reason);
@@ -345,17 +340,7 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
       onError: async () => {
         if (now() < deadline) await sleep(opts.errorSleepMs);
       },
-      release: async () => {
-        if (!heldKey || !redis) return;
-        try {
-          // Give the slot back early. TTL expiry is still the backstop for an isolate that dies
-          // here, which is why the slot is never renewed.
-          await redis.eval(RELEASE_IF_OWNED, [heldKey.key], [heldKey.token]);
-        } catch (e) {
-          opts.scope?.setTag("worker_lease", "helper_release_failed");
-          Sentry.captureException(e, opts.scope);
-        }
-      }
+      release: () => Promise.resolve()
     };
   };
 
@@ -372,6 +357,10 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
       release: () => Promise.resolve()
     };
   };
+
+  if (opts.preferBounded) {
+    return boundedRun("prefer_bounded");
+  }
 
   if (!redis) {
     return boundedRun("no_redis_configured");
@@ -391,30 +380,20 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   }
 
   if (!acquired) {
-    // Help, but only as one of a bounded few. The holder keeps the low-latency resident loop; a
-    // helper drains what it can and exits, so a holder that has stopped making progress cannot
-    // stall the queue -- while the pool stops a backlog from minting a drainer per poke.
-    for (let i = 1; i <= MAX_BOUNDED_HELPERS; i++) {
-      const hKey = helperKey(opts.name, leaseScope, i);
-      try {
-        const got = await redis.set(hKey, token, { px: opts.helperSlotTtlMs ?? HELPER_SLOT_TTL_MS, nx: true });
-        if (got !== null && got !== undefined && got !== 0) {
-          return boundedRun("lease_held_elsewhere", { key: hKey, token });
-        }
-      } catch (e) {
-        // The pool is an optimization, not a correctness device. If Redis will not answer, idle:
-        // draining anyway is what the pool exists to prevent.
-        opts.scope?.setTag("worker_lease", "helper_acquire_failed");
-        Sentry.captureException(e, opts.scope);
-        return idleRun("helper_acquire_failed");
-      }
-    }
-    return idleRun("helpers_busy");
+    // Someone else is draining, so do nothing -- and rely on the stall check below to make that
+    // statement true, rather than assuming it.
+    return idleRun("lease_held_elsewhere");
   }
 
   opts.scope?.setTag("worker_run_mode", "leased");
   let lost = false;
   let lastHeartbeat = now();
+  /** Last time the LOOP called in. Distinct from `lastHeartbeat`, which the timer also moves. */
+  let lastProgressAt = now();
+  const maxStall = opts.maxStallMs ?? DEFAULT_MAX_STALL_MS;
+  const markProgress = () => {
+    lastProgressAt = now();
+  };
   const heartbeatEvery = Math.max(1, Math.floor(ttl / HEARTBEAT_DIVISOR));
   const setIntervalFn = opts.setIntervalFn ?? ((cb, ms) => setInterval(cb, ms) as unknown as number);
   const clearIntervalFn = opts.clearIntervalFn ?? ((h: number) => clearInterval(h));
@@ -428,6 +407,20 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
 
   const renew = async (): Promise<void> => {
     if (lost) return;
+    // Renewal is a claim that this worker is still draining. Only the loop can support that claim,
+    // and the timer fires whether or not it is true -- which is how a holder parked on a promise
+    // that never settles kept the lease renewed while processing nothing, and turned every other
+    // poke away for as long as it lasted. Stop renewing and let the key lapse; the next poke takes
+    // over. Do NOT delete it here: it may already belong to that next holder.
+    if (now() - lastProgressAt > maxStall) {
+      lost = true;
+      stopRenewTimer();
+      opts.scope?.setTag("worker_lease", "stalled");
+      console.warn(
+        `[workerRun] ${opts.name}: no loop progress for ${now() - lastProgressAt}ms (max ${maxStall}ms), giving up the lease`
+      );
+      return;
+    }
     try {
       // Compare-and-PEXPIRE, not `SET ... XX` -- see RENEW_IF_OWNED. A 0 means the key is no
       // longer ours (expired and retaken, or deleted), which must stop this loop rather than
@@ -458,6 +451,9 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   // admission-slot exhaustion this lease was added to prevent comes back for any workload with slow
   // batches. The timer keeps renewing while the batch is in flight; `heartbeat()` remains as a
   // cheap belt-and-braces check for callers that drive time themselves (the tests do).
+  //
+  // What the timer must NOT do is renew forever on behalf of a loop that has stopped going round,
+  // which is why `renew` consults `lastProgressAt` first.
   renewTimer = setIntervalFn(() => {
     void renew();
   }, heartbeatEvery);
@@ -465,16 +461,21 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   return {
     mode: "leased",
     shouldContinue: () => !lost,
+    // All three are called by the loop, so each is proof it is still going round. Mark progress
+    // BEFORE renewing, or the renewal would judge this very call as the stall.
     heartbeat: async () => {
+      markProgress();
       if (now() - lastHeartbeat >= heartbeatEvery) await renew();
     },
     onIdle: async () => {
       await sleep(opts.idleSleepMs);
+      markProgress();
       await renew();
       return !lost;
     },
     onError: async () => {
       await sleep(opts.errorSleepMs);
+      markProgress();
       await renew();
     },
     release: async () => {

--- a/supabase/functions/_shared/workerRun.ts
+++ b/supabase/functions/_shared/workerRun.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "npm:@sentry/deno";
 import { createRedis, type RedisClient } from "./Redis.ts";
+import { type EnvReader } from "./SentryContext.ts";
 
 /**
  * Lifecycle for the pg_cron-poked background workers.
@@ -49,6 +50,19 @@ import { createRedis, type RedisClient } from "./Redis.ts";
  * A third option was rejected: reverting `policy` to `per_worker` would make the old guard correct
  * with no code change, but it reintroduces exactly the shared-heap pile-up under bursts that
  * `per_request` was chosen to avoid (see the `policy` comment in charts/pawtograder/values.yaml).
+ *
+ * ## The lease is scoped to a deployment, not to a worker name
+ *
+ * A lease that bounds loops "across the whole fleet" is only meaningful if the fleet is one
+ * deployment, and this Redis is emphatically not one deployment. Previews, staging and production
+ * all set `redis.provider: shared`, and CI's e2e job gets the same `UPSTASH_*` secrets in its
+ * `.env.local`. That sharing is deliberate and must stay: those deployments also share one set of
+ * GitHub App credentials, so they share one GitHub API quota, and the Bottleneck limiters in
+ * `Redis.ts` can only honour that quota if every deployment coordinates through the same keys.
+ *
+ * So the rule is per-key, not per-instance. State about a shared EXTERNAL resource (rate limits)
+ * belongs in a shared key. State about one deployment's own edge tier — which is all this lease is —
+ * must be scoped, or a preview starves staging. See `workerLeaseScope`.
  */
 
 /** Default lease lifetime. Comfortably longer than the heartbeat interval, short enough that an
@@ -106,9 +120,11 @@ export interface WorkerRun {
 }
 
 export interface BeginWorkerRunOptions {
-  /** Stable worker identity; becomes the Redis key. */
+  /** Stable worker identity; becomes part of the Redis key. */
   name: string;
   scope?: Sentry.Scope;
+  /** Reads deployment identity for the lease key. Injectable so tests need no process env. */
+  readEnv?: EnvReader;
   /** How long to sleep when a batch found no work (leased mode only). */
   idleSleepMs: number;
   /** How long to sleep after a batch threw. */
@@ -126,22 +142,95 @@ export interface BeginWorkerRunOptions {
 
 const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-function leaseKey(name: string): string {
-  return `pawtograder:worker-lease:${name}`;
+const denoEnv: EnvReader = (key) => {
+  try {
+    return Deno.env.get(key);
+  } catch {
+    // --allow-env not granted. A missing scope is not fatal; it only makes the key less specific.
+    return undefined;
+  }
+};
+
+/** Redis keys are opaque bytes, but a key you cannot paste into redis-cli is a key you cannot debug. */
+function sanitizeKeySegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-");
 }
 
 /**
- * Decide how (or whether) this poke should run the worker loop.
+ * Which deployment this lease belongs to.
  *
- * Returns `null` when another holder has the lease — the correct response is to return immediately
- * and let the holder keep draining. Never throws: any Redis problem degrades to a bounded run.
+ * The lease bounds resident drainer loops **within one edge tier**, and nothing more. The key was a
+ * bare worker name, so every deployment on the shared Redis shared one lease. One CI run's worker
+ * could hold `pawtograder:worker-lease:gradebook_column_recalculate` while a *different* run's
+ * worker, against a different database, was turned away by it -- and two concurrent e2e jobs is the
+ * normal case on the `pawtograder-e2e` runner pool. The starved job's gradebook queue simply stopped
+ * draining: 2,285 "another handler holds the lease" lines and not one completed run, so the
+ * recalculated scores the gradebook specs wait on never landed and they failed on the 90s poll. A PR
+ * preview could do the same thing to staging.
+ *
+ * Resolution order, most specific first, so a scope is never *less* unique than the thing it names:
+ *   - `WORKER_LEASE_SCOPE`, for anything that needs to say so explicitly;
+ *   - otherwise `ENVIRONMENT`/`DEPLOY_KIND` (the identity `SentryContext.ts` already established),
+ *     narrowed by `DEPLOY_PR` so two preview namespaces do not collide on "preview", and by
+ *     `DEPLOY_RUN_ID`/`DEPLOY_RUN_ATTEMPT` so two CI runs do not collide on "e2e-local".
+ *
+ * Production stays a single `production` scope, which is the whole point: there the fleet SHOULD
+ * share one lease.
  */
-export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<WorkerRun | null> {
+export function workerLeaseScope(readEnv: EnvReader = denoEnv): string {
+  const value = (key: string): string | undefined => {
+    const trimmed = readEnv(key)?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+
+  const explicit = value("WORKER_LEASE_SCOPE");
+  if (explicit) return sanitizeKeySegment(explicit);
+
+  const parts = [value("ENVIRONMENT") ?? value("DEPLOY_KIND") ?? "development"];
+
+  const pr = value("DEPLOY_PR");
+  if (pr) parts.push(`pr-${pr}`);
+
+  const runId = value("DEPLOY_RUN_ID");
+  if (runId) {
+    const attempt = value("DEPLOY_RUN_ATTEMPT");
+    parts.push(attempt ? `run-${runId}-${attempt}` : `run-${runId}`);
+  }
+
+  return parts.map(sanitizeKeySegment).join(":");
+}
+
+function leaseKey(name: string, scope: string): string {
+  return `pawtograder:worker-lease:${scope}:${name}`;
+}
+
+/**
+ * Decide how this poke should run the worker loop. Never throws, and always returns a run: any Redis
+ * problem, and a lease already held elsewhere, both degrade to a bounded run.
+ *
+ * Losing the race for the lease used to mean returning `null` — "the holder is draining, so do
+ * nothing". That is only true while the holder is actually draining, and the lease cannot tell.
+ * `renew` fires on its own interval precisely so a slow batch keeps the lease, which means liveness
+ * of the KEY is independent of progress of the LOOP: an isolate that the runtime suspends, or one
+ * parked on an await that never settles, keeps its lease renewed while doing nothing, and every
+ * other poke is turned away for as long as that lasts. Measured locally: a 106-second window with
+ * the key held, 425 pokes refused, and not one batch processed — longer than the 60s TTL, so it was
+ * not even a matter of waiting for expiry.
+ *
+ * A bounded run is the right answer to "someone else holds it". It cannot accumulate — it drains
+ * until the queue is idle or its wall-clock budget expires, then returns and frees the admission
+ * slot — so the resource bound this module exists to enforce still holds. And the queue, not the
+ * lease, is what makes concurrent drainers safe: `pgmq_public.read` sets a visibility timeout on
+ * every message it hands out, so two workers cannot be given the same message.
+ */
+export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<WorkerRun> {
   const now = opts.now ?? Date.now;
   const sleep = opts.sleep ?? defaultSleep;
   const ttl = opts.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
   const budget = opts.boundedBudgetMs ?? DEFAULT_BOUNDED_BUDGET_MS;
-  const key = leaseKey(opts.name);
+  const leaseScope = workerLeaseScope(opts.readEnv);
+  const key = leaseKey(opts.name, leaseScope);
+  opts.scope?.setTag("worker_lease_scope", leaseScope);
 
   // `undefined` means "not injected, go and build one"; an explicit `null` means "no Redis", which
   // is what the tests and the no-Redis deployments both exercise.
@@ -196,8 +285,9 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
   }
 
   if (!acquired) {
-    opts.scope?.setTag("worker_run_mode", "skipped_lease_held");
-    return null;
+    // Help rather than idle. The holder keeps the low-latency resident loop; this poke drains what
+    // it can and exits, so a holder that has stopped making progress cannot stall the queue.
+    return boundedRun("lease_held_elsewhere");
   }
 
   opts.scope?.setTag("worker_run_mode", "leased");

--- a/supabase/functions/_shared/workerRun.ts
+++ b/supabase/functions/_shared/workerRun.ts
@@ -93,6 +93,21 @@ const DEFAULT_BOUNDED_BUDGET_MS = 50_000;
  * still frees its slot at TTL rather than holding it for the isolate's life.
  */
 const MAX_BOUNDED_HELPERS = 1;
+/**
+ * How long a helper slot survives without being handed back.
+ *
+ * Deliberately much shorter than the lease TTL, and NOT tied to it. A helper releases its slot when
+ * it finishes, so this only governs the abnormal exit — the isolate the runtime recycles mid-drain,
+ * which in the edge runtime is routine rather than exceptional. At the lease TTL that left the only
+ * slot claimed by a dead helper for a full minute, and with the holder stalled too, nothing drained
+ * for that whole window: the first CI run after the scope fix still showed 20 gaps over 30 seconds
+ * with a 94-second worst case, which is what the specs' 90-second budget was losing to.
+ *
+ * The failure mode of it being too short is two helpers overlapping briefly, which is bounded and
+ * harmless. The failure mode of it being too long is nothing draining at all. Those are not
+ * comparable, so this errs short.
+ */
+const HELPER_SLOT_TTL_MS = 15_000;
 /** `DEPLOY_KIND` for the CI e2e job. The only deployment kind with no k8s rollout behind it. */
 const E2E_LOCAL_KIND = "e2e-local";
 
@@ -153,6 +168,8 @@ export interface BeginWorkerRunOptions {
   /** How long to sleep after a batch threw. */
   errorSleepMs: number;
   leaseTtlMs?: number;
+  /** Lifetime of a helper-pool slot. Short on purpose; see HELPER_SLOT_TTL_MS. */
+  helperSlotTtlMs?: number;
   boundedBudgetMs?: number;
   /** Test seams. */
   redis?: RedisClient | null;
@@ -380,7 +397,7 @@ export async function beginWorkerRun(opts: BeginWorkerRunOptions): Promise<Worke
     for (let i = 1; i <= MAX_BOUNDED_HELPERS; i++) {
       const hKey = helperKey(opts.name, leaseScope, i);
       try {
-        const got = await redis.set(hKey, token, { px: ttl, nx: true });
+        const got = await redis.set(hKey, token, { px: opts.helperSlotTtlMs ?? HELPER_SLOT_TTL_MS, nx: true });
         if (got !== null && got !== undefined && got !== 0) {
           return boundedRun("lease_held_elsewhere", { key: hKey, token });
         }

--- a/supabase/functions/discord-async-worker/index.ts
+++ b/supabase/functions/discord-async-worker/index.ts
@@ -1370,10 +1370,6 @@ export async function runBatchHandler() {
     idleSleepMs: 15000,
     errorSleepMs: 5000
   });
-  if (!run) {
-    console.log(`[runBatchHandler] Another worker holds the lease; nothing to do`);
-    return;
-  }
   scope.setTag("worker_run_mode", run.mode);
   console.log(`[runBatchHandler] Running in ${run.mode} mode`);
 

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2612,10 +2612,6 @@ export async function runBatchHandler() {
     idleSleepMs: 15000,
     errorSleepMs: 5000
   });
-  if (!run) {
-    console.log("[runBatchHandler] another worker holds the lease; nothing to do");
-    return;
-  }
   scope.setTag("worker_run_mode", run.mode);
 
   try {

--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -957,7 +957,15 @@ export async function runBatchHandler() {
   const run = await beginWorkerRun({
     name: "gradebook_column_recalculate",
     scope,
-    idleSleepMs: 10000,
+    // Poll far more often than the other workers, because this queue is the one a human is waiting
+    // on: a grade edit enqueues a row and the instructor expects the dependent columns to move.
+    // That used to be immediate — every direct poke from `invoke_gradebook_recalculation_background_task`
+    // started a drain — but under a lease the pokes are turned away and the resident holder's idle
+    // sleep becomes the floor on recalculation latency. At 10s that is a visible regression in the
+    // app and the difference between passing and failing for the gradebook specs' 90s budget. The
+    // cost is one extra `pgmq_public.read` per second on an indexed empty queue, from a loop that is
+    // already resident and already holding its admission slot.
+    idleSleepMs: 1000,
     errorSleepMs: 5000
   });
   scope.setTag("worker_run_mode", run.mode);

--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -960,10 +960,6 @@ export async function runBatchHandler() {
     idleSleepMs: 10000,
     errorSleepMs: 5000
   });
-  if (!run) {
-    console.log("Another gradebook batch handler holds the lease; nothing to do");
-    return;
-  }
   scope.setTag("worker_run_mode", run.mode);
 
   while (isRunning && run.shouldContinue()) {

--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -957,14 +957,15 @@ export async function runBatchHandler() {
   const run = await beginWorkerRun({
     name: "gradebook_column_recalculate",
     scope,
-    // Poll far more often than the other workers, because this queue is the one a human is waiting
-    // on: a grade edit enqueues a row and the instructor expects the dependent columns to move.
-    // That used to be immediate — every direct poke from `invoke_gradebook_recalculation_background_task`
-    // started a drain — but under a lease the pokes are turned away and the resident holder's idle
-    // sleep becomes the floor on recalculation latency. At 10s that is a visible regression in the
-    // app and the difference between passing and failing for the gradebook specs' 90s budget. The
-    // cost is one extra `pgmq_public.read` per second on an indexed empty queue, from a loop that is
-    // already resident and already holding its admission slot.
+    // Drain and exit, never hold a lease. This queue is the one a human is waiting on -- an
+    // instructor edits a grade and expects the dependent columns to move -- and
+    // `invoke_gradebook_recalculation_background_task` is called straight from gradebook mutations
+    // so that the work starts immediately. A lease turns those pokes away and makes the resident
+    // holder's polling interval the floor on recalculation latency instead. Batches here are
+    // milliseconds (chunks complete in 10-20ms), so there is no long-lived loop to bound in the
+    // first place: a bounded run holds no admission slot between pokes and cannot be starved.
+    // Measured on these specs: 1.2 minutes bounded against 7.2 minutes leased.
+    preferBounded: true,
     idleSleepMs: 1000,
     errorSleepMs: 5000
   });

--- a/supabase/functions/notification-queue-processor/index.ts
+++ b/supabase/functions/notification-queue-processor/index.ts
@@ -1655,10 +1655,6 @@ export async function runBatchHandler() {
     idleSleepMs: 15000,
     errorSleepMs: 5000
   });
-  if (!run) {
-    console.log("Another email batch handler holds the lease; nothing to do");
-    return;
-  }
   scope.setTag("worker_run_mode", run.mode);
 
   try {


### PR DESCRIPTION
## What broke

`gradebook-calculations` (and `active-submission-gradebook-db`) have been failing on `staging` since #922 — 14 failures across chromium and webkit, all of them `expect(effective).not.toBeNull()` timing out after the 90s poll. The scores the specs wait on are never computed.

They pass in isolation locally, which is what makes this one annoying: it only reproduces when two e2e jobs run at once.

## Why

#922 added a Redis lease for the pg_cron-poked edge workers, keyed on the worker name alone:

```
pawtograder:worker-lease:gradebook_column_recalculate
```

Previews, staging and production all run `redis.provider: shared`, and `deploy.yml` writes the same `UPSTASH_*` secrets into the e2e job's `.env.local`. So that one key is contended by **every** deployment. Two concurrent e2e jobs on the `pawtograder-e2e` pool is routine — the failing staging run (`31550106308`, 00:25–01:13) overlapped `31550905986` (00:38–01:26) — and the loser is starved for its whole run.

The signature in the run's `server-logs/edge-functions.log` artifact:

| line | count |
| --- | --- |
| `Another gradebook batch handler holds the lease; nothing to do` | 2,285 |
| `Batch handler stopped` | **0** |

The starved job's queue drained in ~2-minute bursts with multi-minute gaps, and degradation began around 00:52 — right when the other job's edge functions came up.

The shared Redis is deliberate and stays: those deployments share GitHub App credentials, so they share one GitHub API quota, and the Bottleneck limiters can only honour it through common keys. The bug is that a key about **one deployment's own edge tier** was written as if it were about a shared external resource.

## The fix

**1. Scope the key.** `pawtograder:worker-lease:<scope>:<name>`, where scope is `ENVIRONMENT`/`DEPLOY_KIND`, narrowed by `DEPLOY_PR` (so two previews don't collide on `preview`) and `DEPLOY_RUN_ID`/`DEPLOY_RUN_ATTEMPT` (so two CI runs don't collide on `e2e-local`). The chart and `deploy.yml` already set all of these — no workflow or values change needed. Production stays a single `production` scope, which is the whole point of having a lease there.

**2. Losing the race no longer means doing nothing.** `renew` fires on its own interval so a long batch keeps its lease — which means liveness of the *key* is independent of progress of the *loop*. A suspended isolate keeps renewing while draining nothing, and everyone else is turned away meanwhile. Measured locally: a 106-second window with the key held, 425 pokes refused, zero batches processed — longer than the 60s TTL, so waiting for expiry wasn't the answer either. A poke that loses the race now does a **bounded** run: it drains until the queue is idle, then returns and frees its admission slot. It cannot accumulate, which is the property #922 was protecting, and pgmq's per-message visibility timeout — not the lease — is what makes concurrent drainers safe.

`beginWorkerRun` therefore always returns a run; the four `if (!run) return` branches are gone.

## Verification

Against a local Redis, with the lease pinned by a foreign holder for the entire run:

| condition | before | after |
| --- | --- | --- |
| our scope's lease held by a zombie | ❌ fails with the exact CI error | ✅ 26/26, holder still in place at the end |
| no Redis at all (bounded) | ✅ | ✅ 26/26 |

The holder still owning the key afterwards is the part that matters: the workers never acquired it and drained purely as bounded helpers.

Also: 243 `_shared` deno tests pass, and `workerRun.test.ts` grows 27 → covering scope resolution, preview/CI collision, sanitization, and that exactly one run is leased at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background processing coordination across production, preview, CI, and repeated runs.
  * Added deployment-aware worker isolation to prevent unrelated environments from blocking one another.
  * Worker processes now continue in a bounded mode when coordination services are unavailable or busy.

* **Bug Fixes**
  * Prevented background jobs from stopping early when a worker lease cannot be acquired.
  * Improved handling of competing workers while preserving lease renewal, release, and ownership safeguards.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->