### PR TITLE
fix(build): stop the Vercel build failing on a Bugsink release deploy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,13 @@ const disableSentryRouteManifestInjection =
 const usingBugsink = !!process.env.SENTRY_URL;
 const disableSentryReleaseCreate = process.env.SENTRY_DISABLE_RELEASE_CREATE === "1" || usingBugsink;
 const disableSentryReleaseFinalize = process.env.SENTRY_DISABLE_RELEASE_FINALIZE === "1" || usingBugsink;
+// The deploy step is part of that same unimplemented release API. It also has to
+// be disabled explicitly: on Vercel the bundler plugin fills `release.deploy` in
+// from VERCEL_TARGET_ENV whenever we leave it undefined, and then runs
+// `sentry-cli releases deploys <version> new` after the upload regardless of
+// whether `create` ran. Against Bugsink the release does not exist, so the deploy
+// fails with "Release not found" and `errorHandler` turns that into a red build.
+const disableSentryReleaseDeploy = process.env.SENTRY_DISABLE_RELEASE_DEPLOY === "1" || disableSentryReleaseCreate;
 const disableSentrySourcemaps = process.env.SENTRY_DISABLE_SOURCEMAPS === "1";
 const useSentryRunAfterProductionCompileHook = process.env.SENTRY_USE_RUN_AFTER_PRODUCTION_COMPILE === "1";
 
@@ -207,7 +214,11 @@ const sentryConfig = {
   useRunAfterProductionCompileHook: useSentryRunAfterProductionCompileHook,
   release: {
     create: !disableSentryReleaseCreate,
-    finalize: !disableSentryReleaseFinalize
+    finalize: !disableSentryReleaseFinalize,
+    // `undefined` is what re-arms the plugin's Vercel auto-detection, so the
+    // suppression has to be a value the plugin sees as "set but falsy". The public
+    // type only admits an options object, hence the cast.
+    ...(disableSentryReleaseDeploy ? { deploy: null as unknown as undefined } : {})
   },
   // Quiet for local dev, but never while actually uploading source maps: the
   // build runs inside Docker where CI is unset, and the upload report is the


### PR DESCRIPTION
## The failure

The Vercel production build failed in `next build`:

```
sentry-cli releases deploys 54b63eef93d55344e8f8a9c7e81ad85203323f69 new \
  --env vercel-production --url https://pawtograder-webapp-mas0sk48h-pawtograder.vercel.app
error: Release not found. Ensure that you configured the correct release, project, and organization.
```

## Why

`next.config.ts` already turns off Sentry release *create* and *finalize* when `SENTRY_URL` points at the self-hosted Bugsink, which implements the source-map upload endpoints but not the release API. The *deploy* call is part of that same unimplemented API and was not covered:

- The bundler plugin auto-fills `release.deploy` from `VERCEL_TARGET_ENV` whenever the option is left `undefined` (`@sentry/bundler-plugin-core` `index.js:7972`) — which is exactly the `--env vercel-production --url …` in the error.
- Its release-management hook then calls `releases.newDeploy()` gated only on `release.deploy` being truthy (`index.js:9094`); it never checks `release.create`. So the build annotated a deploy onto a release that does not exist on Bugsink.
- `SENTRY_AUTH_TOKEN` is set on Vercel, so `errorHandler` rethrew and failed the build — after the source maps had already uploaded successfully. Only the deploy annotation was broken.

Only Vercel was affected: `VERCEL`/`VERCEL_TARGET_ENV` are unset in the Docker/Helm build path.

## The fix

Disable the deploy alongside create/finalize, with a `SENTRY_DISABLE_RELEASE_DEPLOY` escape hatch mirroring the neighbouring flags. Passing `undefined` is what re-arms the plugin's auto-detection, so the suppression has to be a value the plugin sees as set-but-falsy; the public type only admits an options object, hence the cast.

## Verification

Exported the plugin's internal `normalizeUserOptions` from a throwaway copy and ran it with the failing build's environment (`VERCEL=1`, `VERCEL_TARGET_ENV=production`, `SENTRY_URL` set):

```
before fix (deploy undefined): {"env":"vercel-production","url":"https://pawtograder-webapp-x.vercel.app"}
after  fix (deploy: null)    : null | plugin skips newDeploy: true
```

`next.config.ts` typechecks and passes Prettier.

## Left alone

`setCommits` is also auto-configured on Vercel production and will 404 against Bugsink, but the plugin sets `shouldNotThrowOnFailure: true` there, so it stays a debug log rather than a build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)