### PR TITLE
fix(build): route the Sentry deploy override past @sentry/nextjs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,6 +27,10 @@ const disableSentryReleaseFinalize = process.env.SENTRY_DISABLE_RELEASE_FINALIZE
 // whether `create` ran. Against Bugsink the release does not exist, so the deploy
 // fails with "Release not found" and `errorHandler` turns that into a red build.
 const disableSentryReleaseDeploy = process.env.SENTRY_DISABLE_RELEASE_DEPLOY === "1" || disableSentryReleaseCreate;
+// Only `undefined` re-arms that auto-detection, so switching the deploy off means
+// handing the plugin a value it reads as "set, but falsy". The published type
+// admits an options object and nothing else, hence the cast.
+const suppressedSentryDeploy = null as unknown as undefined;
 const disableSentrySourcemaps = process.env.SENTRY_DISABLE_SOURCEMAPS === "1";
 const useSentryRunAfterProductionCompileHook = process.env.SENTRY_USE_RUN_AFTER_PRODUCTION_COMPILE === "1";
 
@@ -215,11 +219,26 @@ const sentryConfig = {
   release: {
     create: !disableSentryReleaseCreate,
     finalize: !disableSentryReleaseFinalize,
-    // `undefined` is what re-arms the plugin's Vercel auto-detection, so the
-    // suppression has to be a value the plugin sees as "set but falsy". The public
-    // type only admits an options object, hence the cast.
-    ...(disableSentryReleaseDeploy ? { deploy: null as unknown as undefined } : {})
+    ...(disableSentryReleaseDeploy ? { deploy: suppressedSentryDeploy } : {})
   },
+  // …but with `create: false`, `release.deploy` above never reaches the bundler
+  // plugin. `withSentryConfig` resolves no release name when creation is off (it
+  // avoids baking a git hash into an otherwise deterministic build), and
+  // `getWebpackPluginOptions` answers a nameless release by discarding every
+  // release option we passed in favour of a hardcoded
+  // `{ inject: false, create: false, finalize: false }` — `deploy` dropped with
+  // the rest. The plugin then sees `deploy: undefined`, restores its Vercel
+  // default, and annotates a deploy onto a release Bugsink never created.
+  // `unstable_sentryWebpackPluginOptions` is spread over the computed options
+  // last, so it is the only way into that branch. Mirror the hardcoded block so
+  // the override changes nothing but the deploy.
+  ...(disableSentryReleaseCreate
+    ? {
+        unstable_sentryWebpackPluginOptions: {
+          release: { inject: false, create: false, finalize: false, deploy: suppressedSentryDeploy }
+        }
+      }
+    : {}),
   // Quiet for local dev, but never while actually uploading source maps: the
   // build runs inside Docker where CI is unset, and the upload report is the
   // only evidence the upload happened at all.


### PR DESCRIPTION
Follow-up to #928, which did not work. The production build still fails with the same error, now on the commit that carried that fix:

```
sentry-cli releases deploys f6c6eb2ee8ffe6cc9c8353a2dbc1cd4c9808c74c new \
  --env vercel-production --url https://pawtograder-webapp-es4xllrdb-pawtograder.vercel.app
error: Release not found.
```

## Why #928 was inert

`release.deploy` never reached the bundler plugin. Two layers:

1. `withSentryConfig.js:98-101` — when `release.create === false`, no release name is resolved (deliberate: it keeps a git hash out of an otherwise deterministic build).
2. `webpackPluginOptions.js:97-114` — a `releaseName` of `undefined` takes the else-branch, which throws away every release option we passed and substitutes a hardcoded `{ inject: false, create: false, finalize: false }`. Our `deploy` is dropped with the rest.

The plugin core then sees `deploy: undefined`, re-applies its Vercel default (`index.js:7972`), and calls `newDeploy()` against a release Bugsink never created — with the name it computes independently from `VERCEL_GIT_COMMIT_SHA`, which is why the error names a release `@sentry/nextjs` had decided not to have.

Every path that disables `create` also disables `deploy`, so this was unreachable-by-construction in the config yet reachable in the plugin. #928 verified only the plugin-core layer, which is why it looked correct.

## Fix

`unstable_sentryWebpackPluginOptions` is spread over the computed options last, making it the only way into that branch. It mirrors the hardcoded block so nothing but the deploy changes, and is applied only when `create` is disabled — the case where the else-branch is taken.

## Verification

Loaded the real `next.config.ts` with the failing build's environment (`VERCEL=1`, `VERCEL_TARGET_ENV=production`, `SENTRY_URL`, `SENTRY_AUTH_TOKEN`, that `VERCEL_GIT_COMMIT_SHA`), captured the options handed to `withSentryConfig`, and pushed them through both layers:

```
before (origin/main):
  release opts -> {"inject":false,"create":false,"finalize":false}
  deploy       -> {"env":"vercel-production","url":"https://pawtograder-webapp-es4xllrdb-..."}
  runs `releases deploys ... new` -> true      <- reproduces the failure exactly

after (this branch):
  release opts -> {"inject":false,"create":false,"finalize":false,"deploy":null}
  deploy       -> null
  runs `releases deploys ... new` -> false
```

`next.config.ts` typechecks and passes Prettier.

## Note on the green preview

Preview deployments cannot catch this. Without `SENTRY_AUTH_TOKEN` the release-management hook returns early (`bundler-plugin-core` `index.js:8996`), and the throwing `errorHandler` in `next.config.ts` is only installed when that token is set. If the token is Production-scoped, previews make no `sentry-cli releases` calls at all — the preview for #928 was green because nothing ran, not because the fix worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)