### PR TITLE
fix(github): bound repo-creation retries and dedupe repos by identity

### DIFF
--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -14,6 +14,7 @@ import {
   assignmentGroupLeave,
   EdgeFunctionError
 } from "@/lib/edgeFunctions";
+import { isValidGroupName } from "@/lib/groupNameValidation";
 import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { createClient } from "@/utils/supabase/client";
@@ -103,16 +104,17 @@ function CreateGroupButton({
               <Dialog.Title>Create a new group</Dialog.Title>
             </Dialog.Header>
             <Dialog.Body>
-              <Field.Root invalid={name.length > 0 && !/^[a-zA-Z0-9_-]{1,36}$/.test(name)}>
+              <Field.Root invalid={name.length > 0 && !isValidGroupName(name)}>
                 <Field.Label>Choose a name for your group</Field.Label>
                 <Input name="name" value={name} onChange={(e) => setName(e.target.value)} />
                 <Field.HelperText>
                   Other students will use this name to find your group, and instructors will use this name to identify
-                  the group. The name must consist only of alphanumeric, hyphens, or underscores, and be less than 36
-                  characters.
+                  the group. The name must consist only of alphanumeric, hyphens, or underscores, contain at least one
+                  letter or number, and be less than 36 characters.
                 </Field.HelperText>
                 <Field.ErrorText>
-                  The name must consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters.
+                  The name must consist only of alphanumeric, hyphens, or underscores, contain at least one letter or
+                  number, and be less than 36 characters.
                 </Field.ErrorText>
               </Field.Root>
               <Field.Root>
@@ -133,6 +135,7 @@ function CreateGroupButton({
               </Dialog.ActionTrigger>
               <Button
                 loading={isLoading}
+                disabled={!isValidGroupName(name)}
                 colorPalette="green"
                 onClick={() => {
                   setIsLoading(true);

--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -14,7 +14,7 @@ import {
   assignmentGroupLeave,
   EdgeFunctionError
 } from "@/lib/edgeFunctions";
-import { isValidGroupName } from "@/lib/groupNameValidation";
+import { groupNameRequirementsText, isValidGroupName } from "@/lib/groupNameValidation";
 import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { createClient } from "@/utils/supabase/client";
@@ -104,18 +104,14 @@ function CreateGroupButton({
               <Dialog.Title>Create a new group</Dialog.Title>
             </Dialog.Header>
             <Dialog.Body>
-              <Field.Root invalid={name.length > 0 && !isValidGroupName(name)}>
+              <Field.Root invalid={name.length > 0 && !isValidGroupName(name, assignment.repo_mode)}>
                 <Field.Label>Choose a name for your group</Field.Label>
                 <Input name="name" value={name} onChange={(e) => setName(e.target.value)} />
                 <Field.HelperText>
                   Other students will use this name to find your group, and instructors will use this name to identify
-                  the group. The name must consist only of letters, numbers, hyphens, or underscores, contain at least
-                  one letter or number, and be 36 characters or fewer.
+                  the group. {groupNameRequirementsText(assignment.repo_mode)}
                 </Field.HelperText>
-                <Field.ErrorText>
-                  The name must consist only of letters, numbers, hyphens, or underscores, contain at least one letter
-                  or number, and be 36 characters or fewer.
-                </Field.ErrorText>
+                <Field.ErrorText>{groupNameRequirementsText(assignment.repo_mode)}</Field.ErrorText>
               </Field.Root>
               <Field.Root>
                 <Field.Label>Invite other students to join your group</Field.Label>
@@ -135,7 +131,7 @@ function CreateGroupButton({
               </Dialog.ActionTrigger>
               <Button
                 loading={isLoading}
-                disabled={!isValidGroupName(name)}
+                disabled={!isValidGroupName(name, assignment.repo_mode)}
                 colorPalette="green"
                 onClick={() => {
                   setIsLoading(true);

--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -109,12 +109,12 @@ function CreateGroupButton({
                 <Input name="name" value={name} onChange={(e) => setName(e.target.value)} />
                 <Field.HelperText>
                   Other students will use this name to find your group, and instructors will use this name to identify
-                  the group. The name must consist only of alphanumeric, hyphens, or underscores, contain at least one
-                  letter or number, and be less than 36 characters.
+                  the group. The name must consist only of letters, numbers, hyphens, or underscores, contain at least
+                  one letter or number, and be 36 characters or fewer.
                 </Field.HelperText>
                 <Field.ErrorText>
-                  The name must consist only of alphanumeric, hyphens, or underscores, contain at least one letter or
-                  number, and be less than 36 characters.
+                  The name must consist only of letters, numbers, hyphens, or underscores, contain at least one letter
+                  or number, and be 36 characters or fewer.
                 </Field.ErrorText>
               </Field.Root>
               <Field.Root>

--- a/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/manageGroupWidget.tsx
@@ -14,7 +14,11 @@ import {
   assignmentGroupLeave,
   EdgeFunctionError
 } from "@/lib/edgeFunctions";
-import { groupNameRequirementsText, isValidGroupName } from "@/lib/groupNameValidation";
+import {
+  assignmentProvisionsRepositories,
+  groupNameRequirementsText,
+  isValidGroupName
+} from "@/lib/groupNameValidation";
 import { getStudentFacingErrorMessage } from "@/lib/studentFacingErrorMessages";
 import { sanitizeImageSrc } from "@/lib/sanitizeImageSrc";
 import { createClient } from "@/utils/supabase/client";
@@ -146,7 +150,15 @@ function CreateGroupButton({
                   )
                     .then(() => {
                       repositories.refetchAll().then(() => {
-                        toaster.create({ title: "Repositories created", description: "", type: "success" });
+                        toaster.create({
+                          //An assignment that provisions no repository still creates the group; saying otherwise
+                          //promises the student a repo that is never coming
+                          title: assignmentProvisionsRepositories(assignment.repo_mode)
+                            ? "Repositories created"
+                            : "Group created",
+                          description: "",
+                          type: "success"
+                        });
                         setOpen(false);
                         setName("");
                         setSelectedInvitees([]);

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
@@ -1,3 +1,4 @@
+import { isValidGroupName } from "@/lib/groupNameValidation";
 import { createClient } from "@/utils/supabase/client";
 import { Assignment, AssignmentGroupWithMembersAndMentor } from "@/utils/supabase/DatabaseTypes";
 import { Button, Dialog, Field, Flex, Input, Portal } from "@chakra-ui/react";
@@ -45,7 +46,7 @@ export default function CreateNewGroup({
             </Dialog.Header>
             <Dialog.Body>
               <Flex flexDir="column" gap="15px">
-                <Field.Root invalid={newGroupName.length > 0 && !/^[a-zA-Z0-9_-]{1,36}$/.test(newGroupName)}>
+                <Field.Root invalid={newGroupName.length > 0 && !isValidGroupName(newGroupName)}>
                   <Field.Label>
                     Choose a name for the group or
                     <Button
@@ -65,7 +66,8 @@ export default function CreateNewGroup({
                   </Field.Label>
                   <Input name="name" value={newGroupName} onChange={(e) => setNewGroupName(e.target.value)} />
                   <Field.ErrorText>
-                    The name must consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters.
+                    The name must consist only of alphanumeric, hyphens, or underscores, contain at least one letter or
+                    number, and be less than 36 characters.
                   </Field.ErrorText>
                 </Field.Root>
                 <Field.Root invalid={isGroupInvalid()}>
@@ -111,7 +113,7 @@ export default function CreateNewGroup({
                       setSelectedMembers([]);
                     }}
                     colorPalette={"green"}
-                    disabled={newGroupName.length === 0}
+                    disabled={!isValidGroupName(newGroupName)}
                   >
                     Save
                   </Button>

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
@@ -66,8 +66,8 @@ export default function CreateNewGroup({
                   </Field.Label>
                   <Input name="name" value={newGroupName} onChange={(e) => setNewGroupName(e.target.value)} />
                   <Field.ErrorText>
-                    The name must consist only of alphanumeric, hyphens, or underscores, contain at least one letter or
-                    number, and be less than 36 characters.
+                    The name must consist only of letters, numbers, hyphens, or underscores, contain at least one letter
+                    or number, and be 36 characters or fewer.
                   </Field.ErrorText>
                 </Field.Root>
                 <Field.Root invalid={isGroupInvalid()}>

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/groups/createNewGroupModal.tsx
@@ -1,4 +1,4 @@
-import { isValidGroupName } from "@/lib/groupNameValidation";
+import { groupNameRequirementsText, isValidGroupName } from "@/lib/groupNameValidation";
 import { createClient } from "@/utils/supabase/client";
 import { Assignment, AssignmentGroupWithMembersAndMentor } from "@/utils/supabase/DatabaseTypes";
 import { Button, Dialog, Field, Flex, Input, Portal } from "@chakra-ui/react";
@@ -46,7 +46,7 @@ export default function CreateNewGroup({
             </Dialog.Header>
             <Dialog.Body>
               <Flex flexDir="column" gap="15px">
-                <Field.Root invalid={newGroupName.length > 0 && !isValidGroupName(newGroupName)}>
+                <Field.Root invalid={newGroupName.length > 0 && !isValidGroupName(newGroupName, assignment.repo_mode)}>
                   <Field.Label>
                     Choose a name for the group or
                     <Button
@@ -65,10 +65,7 @@ export default function CreateNewGroup({
                     </Button>
                   </Field.Label>
                   <Input name="name" value={newGroupName} onChange={(e) => setNewGroupName(e.target.value)} />
-                  <Field.ErrorText>
-                    The name must consist only of letters, numbers, hyphens, or underscores, contain at least one letter
-                    or number, and be 36 characters or fewer.
-                  </Field.ErrorText>
+                  <Field.ErrorText>{groupNameRequirementsText(assignment.repo_mode)}</Field.ErrorText>
                 </Field.Root>
                 <Field.Root invalid={isGroupInvalid()}>
                   <Field.Label>Select unassigned students to place in the group</Field.Label>
@@ -113,7 +110,7 @@ export default function CreateNewGroup({
                       setSelectedMembers([]);
                     }}
                     colorPalette={"green"}
-                    disabled={!isValidGroupName(newGroupName)}
+                    disabled={!isValidGroupName(newGroupName, assignment.repo_mode)}
                   >
                     Save
                   </Button>

--- a/lib/groupNameValidation.ts
+++ b/lib/groupNameValidation.ts
@@ -1,0 +1,18 @@
+/**
+ * Client-side validation for assignment group names.
+ *
+ * A group name is not just a label: it becomes the trailing component of the team's GitHub
+ * repository name (`<class>-<assignment>-group-<name>`), which is sanitized down to the characters
+ * GitHub allows. Two kinds of name break repository creation, so both are rejected here as well as
+ * in the edge functions and the database:
+ *
+ * - a name with no letter or number (`---`, `_`) sanitizes to an empty component; and
+ * - two names that differ only in separators (`Team-One` and `Team--One`) sanitize to the same
+ *   component and collide on the repository name.
+ *
+ * Only the first is checkable without knowing the other groups, so that is all this covers; the
+ * collision check needs the assignment's other names and lives server-side.
+ */
+export function isValidGroupName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]{1,36}$/.test(name) && /[a-zA-Z0-9]/.test(name);
+}

--- a/lib/groupNameValidation.ts
+++ b/lib/groupNameValidation.ts
@@ -1,18 +1,45 @@
+import type { Assignment } from "@/utils/supabase/DatabaseTypes";
+
 /**
  * Client-side validation for assignment group names.
  *
- * A group name is not just a label: it becomes the trailing component of the team's GitHub
- * repository name (`<class>-<assignment>-group-<name>`), which is sanitized down to the characters
- * GitHub allows. Two kinds of name break repository creation, so both are rejected here as well as
- * in the edge functions and the database:
+ * Two separate rules apply, and they have different scopes:
  *
- * - a name with no letter or number (`---`, `_`) sanitizes to an empty component; and
- * - two names that differ only in separators (`Team-One` and `Team--One`) sanitize to the same
- *   component and collide on the repository name.
+ * - The character set and 36-character limit are about the label itself, so they always apply.
+ *   These live only in the app layer; the database deliberately does not enforce them, because
+ *   names with spaces are ordinary for callers such as the CSV import and copy_groups_from_assignment.
+ * - The requirement that a name hold at least one letter or number exists only to protect the
+ *   team's GitHub repository name (`<class>-<assignment>-group-<name>`), whose trailing component
+ *   is sanitized to the characters GitHub allows. A name of only separators sanitizes to nothing.
+ *   Assignments that never provision a repository are therefore exempt, matching
+ *   validate_assignment_group_name() in the database — on a paper assignment, `---` is a fine
+ *   name for a group.
  *
- * Only the first is checkable without knowing the other groups, so that is all this covers; the
- * collision check needs the assignment's other names and lives server-side.
+ * A third rule, that a name must not sanitize to the same value as another group's on the same
+ * assignment, is not checkable here: it needs the assignment's other names. It lives in the edge
+ * functions and the database trigger, under the same repo_mode exemption.
  */
-export function isValidGroupName(name: string): boolean {
-  return /^[a-zA-Z0-9_-]{1,36}$/.test(name) && /[a-zA-Z0-9]/.test(name);
+export function assignmentProvisionsRepositories(repoMode: Assignment["repo_mode"]): boolean {
+  return repoMode !== "none" && repoMode !== "no_submission";
+}
+
+function isValidGroupNameFormat(name: string): boolean {
+  return /^[a-zA-Z0-9_-]{1,36}$/.test(name);
+}
+
+export function isValidGroupName(name: string, repoMode: Assignment["repo_mode"]): boolean {
+  if (!isValidGroupNameFormat(name)) {
+    return false;
+  }
+  return !assignmentProvisionsRepositories(repoMode) || /[a-zA-Z0-9]/.test(name);
+}
+
+/**
+ * The requirements sentence shown as helper and error text. Built here so the two group-creation
+ * dialogs cannot drift from each other, or promise a rule that is not enforced on this assignment.
+ */
+export function groupNameRequirementsText(repoMode: Assignment["repo_mode"]): string {
+  return assignmentProvisionsRepositories(repoMode)
+    ? "The name must consist only of letters, numbers, hyphens, or underscores, contain at least one letter or number, and be 36 characters or fewer."
+    : "The name must consist only of letters, numbers, hyphens, or underscores, and be 36 characters or fewer.";
 }

--- a/lib/groupNameValidation.ts
+++ b/lib/groupNameValidation.ts
@@ -18,6 +18,9 @@ import type { Assignment } from "@/utils/supabase/DatabaseTypes";
  * A third rule, that a name must not sanitize to the same value as another group's on the same
  * assignment, is not checkable here: it needs the assignment's other names. It lives in the edge
  * functions and the database trigger, under the same repo_mode exemption.
+ *
+ * Deno cannot import this module, so the edge functions carry their own copy of the exemption
+ * predicate in supabase/functions/_shared/repoCreationStrategy.ts. The two must agree.
  */
 export function assignmentProvisionsRepositories(repoMode: Assignment["repo_mode"]): boolean {
   return repoMode !== "none" && repoMode !== "no_submission";

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -6612,10 +6612,12 @@ export type Database = {
           assignment_id: number;
           class_id: number;
           created_at: string;
+          creation_attempts: number;
           creation_error: string | null;
           desired_handout_sha: string | null;
           id: number;
           is_github_ready: boolean;
+          last_creation_attempt_at: string | null;
           profile_id: string | null;
           repository: string;
           rerun_queued_at: string | null;
@@ -6629,10 +6631,12 @@ export type Database = {
           assignment_id: number;
           class_id: number;
           created_at?: string;
+          creation_attempts?: number;
           creation_error?: string | null;
           desired_handout_sha?: string | null;
           id?: number;
           is_github_ready?: boolean;
+          last_creation_attempt_at?: string | null;
           profile_id?: string | null;
           repository: string;
           rerun_queued_at?: string | null;
@@ -6646,10 +6650,12 @@ export type Database = {
           assignment_id?: number;
           class_id?: number;
           created_at?: string;
+          creation_attempts?: number;
           creation_error?: string | null;
           desired_handout_sha?: string | null;
           id?: number;
           is_github_ready?: boolean;
+          last_creation_attempt_at?: string | null;
           profile_id?: string | null;
           repository?: string;
           rerun_queued_at?: string | null;
@@ -13710,6 +13716,7 @@ export type Database = {
         Args: { p_pattern: string; p_text: string };
         Returns: boolean;
       };
+      sanitize_repo_name_component: { Args: { raw: string }; Returns: string };
       save_error_pin: {
         Args: { p_error_pin: Json; p_rules: Json };
         Returns: Json;

--- a/supabase/functions/_shared/repoCreationStrategy.ts
+++ b/supabase/functions/_shared/repoCreationStrategy.ts
@@ -6,11 +6,21 @@
 import type { BranchProtectionConfig } from "./branchProtection.ts";
 
 export type AssignmentRepoMode =
-  | "none"
-  | "template_only_staff"
-  | "template_with_student_forks"
-  | "fork_from_prior_assignment"
-  | "no_submission";
+  "none" | "template_only_staff" | "template_with_student_forks" | "fork_from_prior_assignment" | "no_submission";
+
+/**
+ * Whether an assignment's mode provisions repositories at all. `none` and `no_submission` never
+ * do, so callers must skip repo-name derivation and the create-repo enqueue for both. The rules
+ * that exist only to protect a repository name (a group name needing a letter or number, and not
+ * colliding with a sibling once sanitized) are likewise exempt under these two modes.
+ *
+ * Twins that must agree: `assignmentProvisionsRepositories` in lib/groupNameValidation.ts on the
+ * Next side, and the repo_mode guards in validate_assignment_group_name() and
+ * create_all_repos_for_assignment_internal() in SQL.
+ */
+export function assignmentProvisionsRepositories(repoMode: AssignmentRepoMode): boolean {
+  return repoMode !== "none" && repoMode !== "no_submission";
+}
 
 export type AssignmentForRepoCreation = {
   id: number;

--- a/supabase/functions/_shared/repoCreationStrategy.ts
+++ b/supabase/functions/_shared/repoCreationStrategy.ts
@@ -6,7 +6,11 @@
 import type { BranchProtectionConfig } from "./branchProtection.ts";
 
 export type AssignmentRepoMode =
-  "none" | "template_only_staff" | "template_with_student_forks" | "fork_from_prior_assignment" | "no_submission";
+  | "none"
+  | "template_only_staff"
+  | "template_with_student_forks"
+  | "fork_from_prior_assignment"
+  | "no_submission";
 
 /**
  * Whether an assignment's mode provisions repositories at all. `none` and `no_submission` never

--- a/supabase/functions/assignment-group-create/index.ts
+++ b/supabase/functions/assignment-group-create/index.ts
@@ -4,6 +4,7 @@ import { TZDate } from "npm:@date-fns/tz";
 import { AssignmentGroupCreateRequest } from "../_shared/FunctionTypes.d.ts";
 import { IllegalArgumentError, SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
+import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
 import * as Sentry from "npm:@sentry/deno";
 
 async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
@@ -29,6 +30,11 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
     throw new IllegalArgumentError(
       "Group name consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters"
     );
+  }
+  //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and
+  //underscores sanitizes to nothing at all
+  if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+    throw new IllegalArgumentError("Group name must contain at least one letter or number");
   }
   const {
     data: { user }
@@ -84,6 +90,32 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
   if (existingAssignmentGroupWithSameName && existingAssignmentGroupWithSameName.length > 0) {
     scope.setTag("existing_group_id", existingAssignmentGroupWithSameName[0].id.toString());
     throw new IllegalArgumentError("A group with this name already exists for this assignment");
+  }
+
+  //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
+  //"Team-One"), and the two groups would then fight over the same repository name
+  const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
+  const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
+    .from("assignment_groups")
+    .select("id, name")
+    .eq("assignment_id", assignment_id);
+  if (assignmentGroupsError) {
+    console.error(assignmentGroupsError);
+    Sentry.captureException(assignmentGroupsError, scope);
+    throw new UserVisibleError(
+      "We could not check the group name against the other groups for this assignment. Try again in a moment."
+    );
+  }
+  const conflictingGroup = (assignmentGroups ?? []).find(
+    //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
+    //name that has at least one letter or number, so skip them
+    (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
+  );
+  if (conflictingGroup) {
+    scope.setTag("existing_group_id", conflictingGroup.id.toString());
+    throw new IllegalArgumentError(
+      `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
+    );
   }
 
   if (invitees.length > 0) {

--- a/supabase/functions/assignment-group-create/index.ts
+++ b/supabase/functions/assignment-group-create/index.ts
@@ -28,7 +28,7 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
   //Valid group names are alphanumeric, hyphens, or underscore, max 36 characters
   if (!/^[a-zA-Z0-9_-]{1,36}$/.test(trimmedName)) {
     throw new IllegalArgumentError(
-      "Group name consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters"
+      "Group name must consist only of letters, numbers, hyphens, or underscores, and be 36 characters or fewer"
     );
   }
   //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and

--- a/supabase/functions/assignment-group-create/index.ts
+++ b/supabase/functions/assignment-group-create/index.ts
@@ -5,6 +5,7 @@ import { AssignmentGroupCreateRequest } from "../_shared/FunctionTypes.d.ts";
 import { IllegalArgumentError, SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
+import { assignmentProvisionsRepositories } from "../_shared/repoCreationStrategy.ts";
 import * as Sentry from "npm:@sentry/deno";
 
 async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
@@ -132,9 +133,10 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
     throw new IllegalArgumentError("Assignment not found");
   }
 
-  //Both checks below exist only to protect the group's GitHub repository name, so they do not apply to assignments
-  //that never provision one. Mirrors the repo_mode exemption in validate_assignment_group_name().
-  if (assignment.repo_mode !== "none" && assignment.repo_mode !== "no_submission") {
+  //Neither the name rules below nor the repo enqueue further down apply to an assignment that never provisions a
+  //repository. Mirrors the repo_mode exemption in validate_assignment_group_name().
+  const providesRepositories = assignmentProvisionsRepositories(assignment.repo_mode);
+  if (providesRepositories) {
     if (!/[a-zA-Z0-9]/.test(trimmedName)) {
       throw new IllegalArgumentError("Group name must contain at least one letter or number");
     }
@@ -252,39 +254,43 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
     );
   }
 
-  //Enqueue async repo creation for the group
-  const repoName = `${profile.classes!.slug}-${assignment.slug}-group-${trimmedName}`;
-  scope.setTag("repo_name", repoName);
-  scope.setTag("repo_org", profile.classes!.github_org!);
+  //Enqueue async repo creation for the group, unless this assignment never provisions one
+  if (providesRepositories) {
+    //Sanitize the group-name component the same way every other repo-name derivation does, or this group's repository
+    //is named differently here than in github-user-sync and assignment-create-all-repos
+    const repoName = `${profile.classes!.slug}-${assignment.slug}-group-${sanitizeRepoNameComponent(trimmedName)}`;
+    scope.setTag("repo_name", repoName);
+    scope.setTag("repo_org", profile.classes!.github_org!);
 
-  // Gather GitHub usernames for all current members
-  const githubUsernames = profile.users.github_username ? [profile.users.github_username] : [];
+    // Gather GitHub usernames for all current members
+    const githubUsernames = profile.users.github_username ? [profile.users.github_username] : [];
 
-  // Enqueue the repo creation (this will create the repository record and enqueue the GitHub operations)
-  const { data: messageId, error: enqueueError } = await adminSupabase.rpc("enqueue_github_create_repo", {
-    p_class_id: assignment.class_id!,
-    p_org: profile.classes!.github_org!,
-    p_repo_name: repoName,
-    p_template_repo: assignment.template_repo!,
-    p_course_slug: profile.classes!.slug!,
-    p_github_usernames: githubUsernames,
-    p_is_template_repo: false,
-    p_debug_id: `group-create-${newGroup.id}`,
-    p_assignment_id: assignment.id,
-    p_profile_id: undefined, // Group repos don't have a profile_id
-    p_assignment_group_id: newGroup.id,
-    p_latest_template_sha: assignment.latest_template_sha ?? undefined
-  });
+    // Enqueue the repo creation (this will create the repository record and enqueue the GitHub operations)
+    const { data: messageId, error: enqueueError } = await adminSupabase.rpc("enqueue_github_create_repo", {
+      p_class_id: assignment.class_id!,
+      p_org: profile.classes!.github_org!,
+      p_repo_name: repoName,
+      p_template_repo: assignment.template_repo!,
+      p_course_slug: profile.classes!.slug!,
+      p_github_usernames: githubUsernames,
+      p_is_template_repo: false,
+      p_debug_id: `group-create-${newGroup.id}`,
+      p_assignment_id: assignment.id,
+      p_profile_id: undefined, // Group repos don't have a profile_id
+      p_assignment_group_id: newGroup.id,
+      p_latest_template_sha: assignment.latest_template_sha ?? undefined
+    });
 
-  if (enqueueError) {
-    console.error(enqueueError);
-    Sentry.captureException(enqueueError, scope);
-    throw new UserVisibleError(
-      "Your group was created, but we could not start creating the team GitHub repository. Your instructor may need to check the course GitHub connection or template repository. You can still try again from the assignment page in a few minutes."
-    );
+    if (enqueueError) {
+      console.error(enqueueError);
+      Sentry.captureException(enqueueError, scope);
+      throw new UserVisibleError(
+        "Your group was created, but we could not start creating the team GitHub repository. Your instructor may need to check the course GitHub connection or template repository. You can still try again from the assignment page in a few minutes."
+      );
+    }
+
+    console.log(`Enqueued repo creation for group ${newGroup.id}, message ID: ${messageId}`);
   }
-
-  console.log(`Enqueued repo creation for group ${newGroup.id}, message ID: ${messageId}`);
   return {
     message: `Group #${newGroup.id} created successfully`
   };

--- a/supabase/functions/assignment-group-create/index.ts
+++ b/supabase/functions/assignment-group-create/index.ts
@@ -31,11 +31,6 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
       "Group name must consist only of letters, numbers, hyphens, or underscores, and be 36 characters or fewer"
     );
   }
-  //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and
-  //underscores sanitizes to nothing at all
-  if (!/[a-zA-Z0-9]/.test(trimmedName)) {
-    throw new IllegalArgumentError("Group name must contain at least one letter or number");
-  }
   const {
     data: { user }
   } = await supabase.auth.getUser();
@@ -92,32 +87,6 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
     throw new IllegalArgumentError("A group with this name already exists for this assignment");
   }
 
-  //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
-  //"Team-One"), and the two groups would then fight over the same repository name
-  const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
-  const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
-    .from("assignment_groups")
-    .select("id, name")
-    .eq("assignment_id", assignment_id);
-  if (assignmentGroupsError) {
-    console.error(assignmentGroupsError);
-    Sentry.captureException(assignmentGroupsError, scope);
-    throw new UserVisibleError(
-      "We could not check the group name against the other groups for this assignment. Try again in a moment."
-    );
-  }
-  const conflictingGroup = (assignmentGroups ?? []).find(
-    //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
-    //name that has at least one letter or number, so skip them
-    (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
-  );
-  if (conflictingGroup) {
-    scope.setTag("existing_group_id", conflictingGroup.id.toString());
-    throw new IllegalArgumentError(
-      `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
-    );
-  }
-
   if (invitees.length > 0) {
     const { data: inviteeEnrollments, error: inviteeEnrollmentsError } = await adminSupabase
       .from("user_roles")
@@ -161,6 +130,39 @@ async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise
   const { data: assignment } = await adminSupabase.from("assignments").select("*").eq("id", assignment_id).single();
   if (!assignment) {
     throw new IllegalArgumentError("Assignment not found");
+  }
+
+  //Both checks below exist only to protect the group's GitHub repository name, so they do not apply to assignments
+  //that never provision one. Mirrors the repo_mode exemption in validate_assignment_group_name().
+  if (assignment.repo_mode !== "none" && assignment.repo_mode !== "no_submission") {
+    if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+      throw new IllegalArgumentError("Group name must contain at least one letter or number");
+    }
+    //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
+    //"Team-One"), and the two groups would then fight over the same repository name
+    const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
+    const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
+      .from("assignment_groups")
+      .select("id, name")
+      .eq("assignment_id", assignment_id);
+    if (assignmentGroupsError) {
+      console.error(assignmentGroupsError);
+      Sentry.captureException(assignmentGroupsError, scope);
+      throw new UserVisibleError(
+        "We could not check the group name against the other groups for this assignment. Try again in a moment."
+      );
+    }
+    const conflictingGroup = (assignmentGroups ?? []).find(
+      //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
+      //name that has at least one letter or number, so skip them
+      (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
+    );
+    if (conflictingGroup) {
+      scope.setTag("existing_group_id", conflictingGroup.id.toString());
+      throw new IllegalArgumentError(
+        `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
+      );
+    }
   }
   const timeZone = profile.classes.time_zone || "America/New_York";
   const groupFormationDeadline = assignment.group_formation_deadline;

--- a/supabase/functions/assignment-group-instructor-create/index.ts
+++ b/supabase/functions/assignment-group-instructor-create/index.ts
@@ -6,6 +6,7 @@ import {
 } from "../_shared/FunctionTypes.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
+import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
 import {
   SecurityError,
   UserVisibleError,
@@ -34,6 +35,11 @@ async function instructorCreateAutograderGroup(
     throw new IllegalArgumentError(
       "Group name consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters"
     );
+  }
+  //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and
+  //underscores sanitizes to nothing at all
+  if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+    throw new IllegalArgumentError("Group name must contain at least one letter or number");
   }
   console.log(course_id, assignment_id, trimmedName);
   const {
@@ -67,6 +73,31 @@ async function instructorCreateAutograderGroup(
     .eq("name", trimmedName);
   if (existingAssignmentGroupWithSameName && existingAssignmentGroupWithSameName.length > 0) {
     throw new IllegalArgumentError("A group with this name already exists for this assignment");
+  }
+
+  //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
+  //"Team-One"), and the two groups would then fight over the same repository name
+  const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
+  const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
+    .from("assignment_groups")
+    .select("id, name")
+    .eq("assignment_id", assignment_id);
+  if (assignmentGroupsError) {
+    console.error(assignmentGroupsError);
+    Sentry.captureException(assignmentGroupsError, scope);
+    throw new UserVisibleError(
+      "We could not check the group name against the other groups for this assignment. Try again in a moment."
+    );
+  }
+  const conflictingGroup = (assignmentGroups ?? []).find(
+    //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
+    //name that has at least one letter or number, so skip them
+    (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
+  );
+  if (conflictingGroup) {
+    throw new IllegalArgumentError(
+      `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
+    );
   }
 
   const { data: assignment } = await adminSupabase.from("assignments").select("*").eq("id", assignment_id).single();

--- a/supabase/functions/assignment-group-instructor-create/index.ts
+++ b/supabase/functions/assignment-group-instructor-create/index.ts
@@ -7,6 +7,7 @@ import {
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
+import { assignmentProvisionsRepositories } from "../_shared/repoCreationStrategy.ts";
 import {
   SecurityError,
   UserVisibleError,
@@ -75,9 +76,10 @@ async function instructorCreateAutograderGroup(
     throw new IllegalArgumentError("Assignment not found");
   }
 
-  //Both checks below exist only to protect the group's GitHub repository name, so they do not apply to assignments
-  //that never provision one. Mirrors the repo_mode exemption in validate_assignment_group_name().
-  if (assignment.repo_mode !== "none" && assignment.repo_mode !== "no_submission") {
+  //Neither the name rules below nor the repo enqueue further down apply to an assignment that never provisions a
+  //repository. Mirrors the repo_mode exemption in validate_assignment_group_name().
+  const providesRepositories = assignmentProvisionsRepositories(assignment.repo_mode);
+  if (providesRepositories) {
     if (!/[a-zA-Z0-9]/.test(trimmedName)) {
       throw new IllegalArgumentError("Group name must contain at least one letter or number");
     }
@@ -121,26 +123,30 @@ async function instructorCreateAutograderGroup(
     throw new UserVisibleError("Failed to create group");
   }
 
-  //Enqueue async repo creation for the group
-  const repoName = `${profile.classes!.slug}-${assignment.slug}-group-${trimmedName}`;
-  // Enqueue the repo creation (this will create the repository record and enqueue the GitHub operations)
-  const { error: enqueueError } = await adminSupabase.rpc("enqueue_github_create_repo", {
-    p_class_id: assignment.class_id!,
-    p_org: profile.classes!.github_org!,
-    p_repo_name: repoName,
-    p_template_repo: assignment.template_repo!,
-    p_course_slug: profile.classes!.slug!,
-    p_github_usernames: [],
-    p_is_template_repo: false,
-    p_debug_id: `group-create-${newGroup.id}`,
-    p_assignment_id: assignment.id,
-    p_profile_id: undefined, // Group repos don't have a profile_id
-    p_assignment_group_id: newGroup.id,
-    p_latest_template_sha: assignment.latest_template_sha ?? undefined
-  });
-  if (enqueueError) {
-    Sentry.captureException(enqueueError, scope);
-    throw new UserVisibleError(`Error enqueueing repo creation: ${enqueueError.message}`);
+  //Enqueue async repo creation for the group, unless this assignment never provisions one
+  if (providesRepositories) {
+    //Sanitize the group-name component the same way every other repo-name derivation does, or this group's repository
+    //is named differently here than in github-user-sync and assignment-create-all-repos
+    const repoName = `${profile.classes!.slug}-${assignment.slug}-group-${sanitizeRepoNameComponent(trimmedName)}`;
+    // Enqueue the repo creation (this will create the repository record and enqueue the GitHub operations)
+    const { error: enqueueError } = await adminSupabase.rpc("enqueue_github_create_repo", {
+      p_class_id: assignment.class_id!,
+      p_org: profile.classes!.github_org!,
+      p_repo_name: repoName,
+      p_template_repo: assignment.template_repo!,
+      p_course_slug: profile.classes!.slug!,
+      p_github_usernames: [],
+      p_is_template_repo: false,
+      p_debug_id: `group-create-${newGroup.id}`,
+      p_assignment_id: assignment.id,
+      p_profile_id: undefined, // Group repos don't have a profile_id
+      p_assignment_group_id: newGroup.id,
+      p_latest_template_sha: assignment.latest_template_sha ?? undefined
+    });
+    if (enqueueError) {
+      Sentry.captureException(enqueueError, scope);
+      throw new UserVisibleError(`Error enqueueing repo creation: ${enqueueError.message}`);
+    }
   }
   return {
     message: `Group #${newGroup.id} created successfully`,

--- a/supabase/functions/assignment-group-instructor-create/index.ts
+++ b/supabase/functions/assignment-group-instructor-create/index.ts
@@ -36,11 +36,6 @@ async function instructorCreateAutograderGroup(
       "Group name must consist only of letters, numbers, hyphens, or underscores, and be 36 characters or fewer"
     );
   }
-  //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and
-  //underscores sanitizes to nothing at all
-  if (!/[a-zA-Z0-9]/.test(trimmedName)) {
-    throw new IllegalArgumentError("Group name must contain at least one letter or number");
-  }
   console.log(course_id, assignment_id, trimmedName);
   const {
     data: { user }
@@ -75,34 +70,41 @@ async function instructorCreateAutograderGroup(
     throw new IllegalArgumentError("A group with this name already exists for this assignment");
   }
 
-  //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
-  //"Team-One"), and the two groups would then fight over the same repository name
-  const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
-  const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
-    .from("assignment_groups")
-    .select("id, name")
-    .eq("assignment_id", assignment_id);
-  if (assignmentGroupsError) {
-    console.error(assignmentGroupsError);
-    Sentry.captureException(assignmentGroupsError, scope);
-    throw new UserVisibleError(
-      "We could not check the group name against the other groups for this assignment. Try again in a moment."
-    );
-  }
-  const conflictingGroup = (assignmentGroups ?? []).find(
-    //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
-    //name that has at least one letter or number, so skip them
-    (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
-  );
-  if (conflictingGroup) {
-    throw new IllegalArgumentError(
-      `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
-    );
-  }
-
   const { data: assignment } = await adminSupabase.from("assignments").select("*").eq("id", assignment_id).single();
   if (!assignment) {
     throw new IllegalArgumentError("Assignment not found");
+  }
+
+  //Both checks below exist only to protect the group's GitHub repository name, so they do not apply to assignments
+  //that never provision one. Mirrors the repo_mode exemption in validate_assignment_group_name().
+  if (assignment.repo_mode !== "none" && assignment.repo_mode !== "no_submission") {
+    if (!/[a-zA-Z0-9]/.test(trimmedName)) {
+      throw new IllegalArgumentError("Group name must contain at least one letter or number");
+    }
+    //Two different names can still collide once sanitized for GitHub (e.g. "Team-One" and "Team--One" both become
+    //"Team-One"), and the two groups would then fight over the same repository name
+    const sanitizedName = sanitizeRepoNameComponent(trimmedName).toLowerCase();
+    const { data: assignmentGroups, error: assignmentGroupsError } = await adminSupabase
+      .from("assignment_groups")
+      .select("id, name")
+      .eq("assignment_id", assignment_id);
+    if (assignmentGroupsError) {
+      console.error(assignmentGroupsError);
+      Sentry.captureException(assignmentGroupsError, scope);
+      throw new UserVisibleError(
+        "We could not check the group name against the other groups for this assignment. Try again in a moment."
+      );
+    }
+    const conflictingGroup = (assignmentGroups ?? []).find(
+      //Names stored before this validation existed may sanitize to nothing (which throws); they cannot collide with a
+      //name that has at least one letter or number, so skip them
+      (group) => /[a-zA-Z0-9]/.test(group.name) && sanitizeRepoNameComponent(group.name).toLowerCase() === sanitizedName
+    );
+    if (conflictingGroup) {
+      throw new IllegalArgumentError(
+        `Group name is too similar to the existing group "${conflictingGroup.name}": both become "${sanitizedName}" once normalized for GitHub. Choose a more distinct name.`
+      );
+    }
   }
   //Create a new group
   const { data: newGroup, error: newGroupError } = await adminSupabase

--- a/supabase/functions/assignment-group-instructor-create/index.ts
+++ b/supabase/functions/assignment-group-instructor-create/index.ts
@@ -33,7 +33,7 @@ async function instructorCreateAutograderGroup(
   //Valid group names are alphanumeric, hyphens, or underscore, max 36 characters
   if (!/^[a-zA-Z0-9_-]{1,36}$/.test(trimmedName)) {
     throw new IllegalArgumentError(
-      "Group name consist only of alphanumeric, hyphens, or underscores, and be less than 36 characters"
+      "Group name must consist only of letters, numbers, hyphens, or underscores, and be 36 characters or fewer"
     );
   }
   //The group name becomes part of the team's GitHub repository name, and a name made up only of hyphens and

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -121,8 +121,12 @@ declare
   repo_id bigint;
   full_repo_name text;
   v_repo_name text;
+  v_existing_name text;
   v_args jsonb;
 begin
+  -- Sanitize the name the CALLER derived. Only a name we are about to store is
+  -- sanitized; a name read back off an existing row is authoritative and is used
+  -- verbatim (see below).
   v_repo_name := public.sanitize_repo_name_component(p_repo_name);
   full_repo_name := p_org || '/' || v_repo_name;
 
@@ -131,13 +135,21 @@ begin
   returning id into log_id;
 
   if p_assignment_id is not null then
-    select id into repo_id
+    -- Historic data contains rows that share an identity (no unique constraint enforces
+    -- one repo per assignment+profile / assignment+group). A bare `select ... into` over
+    -- those picks an arbitrary row, so a retry for one row could enqueue against another
+    -- row's repository. Prefer the row whose stored name is exactly the one the caller
+    -- asked for -- which is how enqueue_create_repo_for_repository addresses a specific
+    -- row -- and fall back to the lowest id so the choice is at least deterministic.
+    select id, repository into repo_id, v_existing_name
     from public.repositories
     where assignment_id = p_assignment_id
       and (
         (p_profile_id is not null and profile_id = p_profile_id) or
         (p_assignment_group_id is not null and assignment_group_id = p_assignment_group_id)
-      );
+      )
+    order by (repository = p_org || '/' || p_repo_name) desc, id
+    limit 1;
 
     if repo_id is null then
       insert into public.repositories(
@@ -158,7 +170,40 @@ begin
         p_latest_template_sha,
         false
       )
+      on conflict do nothing
       returning id into repo_id;
+
+      -- A concurrent enqueue for the same repo can win the race between the select
+      -- above and this insert. `unique_repo_name` turns that into a no-op rather than
+      -- a duplicate; re-read the winner's row so both callers enqueue against one row.
+      -- The re-read is constrained to the SAME identity: a row holding this name for a
+      -- different assignment/profile/group is a genuine name collision, and adopting it
+      -- would silently point this job at someone else's repository. Fail loudly instead,
+      -- which is what the bare unique violation did before.
+      if repo_id is null then
+        select id, repository into repo_id, v_existing_name
+        from public.repositories
+        where repository = full_repo_name
+          and assignment_id = p_assignment_id
+          and (
+            (p_profile_id is not null and profile_id = p_profile_id) or
+            (p_assignment_group_id is not null and assignment_group_id = p_assignment_group_id)
+          );
+        if repo_id is null then
+          raise exception 'Repository name % is already used by a different assignment, student or group', full_repo_name;
+        end if;
+        v_repo_name := split_part(v_existing_name, '/', 2);
+      end if;
+    else
+      -- An existing row's stored name is authoritative: it is what a GitHub repo was
+      -- (or will be) created as, what webhooks resolve against, and what
+      -- enqueue_create_repo_for_repository reads back on a retry. Re-sanitizing it
+      -- would retarget the job at a DIFFERENT repository -- `…-group-Team--One` is a
+      -- perfectly valid GitHub name, but the sanitizer collapses it to
+      -- `…-group-Team-One` -- and the worker marks the row ready by repo_id without
+      -- writing the name back, so the row would end up pointing at a repo nobody
+      -- created. Use the stored name and leave the row alone.
+      v_repo_name := split_part(v_existing_name, '/', 2);
     end if;
   end if;
 
@@ -390,7 +435,12 @@ begin
     perform public.enqueue_github_create_repo(
       v_course_id,
       v_org,
-      v_slug || '-' || v_assignment_slug || '-group-' || r_group_name,
+      -- Sanitize the group name as its own COMPONENT, exactly as the TypeScript paths
+      -- do. Sanitizing only the assembled name would let two groups whose names are
+      -- entirely illegal characters ("###" and "@@@") both collapse to
+      -- `<slug>-<assignment>-group` and collide on one repository; per-component
+      -- sanitization raises on such a name instead, matching sanitizeRepoNameComponent.
+      v_slug || '-' || v_assignment_slug || '-group-' || public.sanitize_repo_name_component(r_group_name),
       coalesce(v_template_repo, r_source_repo),
       v_slug,
       r_members,
@@ -618,15 +668,22 @@ begin
     raise exception 'Not authorized to retry repository creation for this class';
   end if;
 
-  -- Clear the error AND the attempt counter: an instructor retry is a deliberate
-  -- statement that the underlying problem has been fixed, so the row gets a full
-  -- automatic retry budget again rather than being re-parked on the next tick.
   update public.repositories
-     set creation_error = null,
-         creation_attempts = 0
+     set creation_error = null
    where id = p_repository_id;
 
   v_msg_id := public.enqueue_create_repo_for_repository(p_repository_id);
+
+  -- Zero the counter AFTER the enqueue, not before: enqueue_create_repo_for_repository
+  -- increments it, so resetting first would leave the instructor with seven automatic
+  -- retries rather than the full budget. A deliberate manual retry states that the
+  -- underlying problem is fixed, so it does not spend an automatic attempt. The
+  -- updated_at bump from the enqueue survives (this write refreshes it again), so the
+  -- reconciler's stale window still keeps a second job from racing this one.
+  update public.repositories
+     set creation_attempts = 0
+   where id = p_repository_id;
+
   return v_msg_id;
 end;
 $$;
@@ -715,8 +772,17 @@ comment on function public.reconcile_stuck_repo_creations(int) is
 -- times get parked now rather than being handed a fresh retry budget by the new
 -- backoff. They become visible to instructors via creation_error and the Retry
 -- button, which is the correct end state for a repo that has never once succeeded.
--- Deliberately conservative: only rows in classes that have ended, or stuck longer
+-- Deliberately conservative: only rows in classes that have ended, or pending longer
 -- than a week in a running class.
+--
+-- Keyed on updated_at, NOT created_at: a repository row can be created once and go
+-- pending much later. assignment-create-all-repos flips an existing row back to
+-- is_github_ready = false when a permission sync finds no valid usernames or skips
+-- collaborator removals, and the async worker leaves a row pending when it cannot mark
+-- it ready. Keying on created_at would park those the instant they go pending, purely
+-- because the row itself is old, and the reconciler would then skip them until an
+-- instructor retried by hand. updated_at measures the thing this cutoff is about: how
+-- long THIS pending state has lasted.
 update public.repositories rp
    set creation_attempts = 8,
        creation_error = 'Repository creation did not succeed after repeated automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.'
@@ -729,5 +795,5 @@ update public.repositories rp
    and a.repo_mode not in ('none', 'no_submission')
    and (
      not public.is_class_active(c.archived, c.end_date)
-     or rp.created_at < now() - interval '7 days'
+     or rp.updated_at < now() - interval '7 days'
    );

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -812,6 +812,9 @@ declare
   v_count integer := 0;
   v_max_attempts constant integer := 8;
   v_max_backoff_doublings constant integer := 5;  -- caps the interval at 32x p_stale_minutes
+  -- Longest single requeue github-async-worker can apply to one job (12h for an extreme
+  -- rate limit), plus an hour of margin. See the park comment below.
+  v_worker_max_requeue constant interval := interval '13 hours';
 begin
   -- Park anything that has exhausted its automatic retries AND has gone quiet for the
   -- interval its next attempt would have waited. Done as a set operation before the loop
@@ -824,8 +827,21 @@ begin
   -- Retry button they are being pointed at enqueues a second create_repo racing the
   -- first. Reusing the retry loop's own backoff interval -- deliberately the same
   -- expression, not a second timing rule that could drift from it -- parks a row exactly
-  -- when it would otherwise have become eligible for attempt nine, which is the moment
-  -- the previous attempt is known not to be coming back.
+  -- when it would otherwise have become eligible for attempt nine.
+  --
+  -- That expression alone is not long enough, though: it tops out at
+  -- 15 min * 2^5 = 8 hours, while the worker can hold a single job longer than that.
+  -- supabase/functions/github-async-worker/index.ts requeues an `extreme` rate limit
+  -- with a default of 43200s = 12 hours (the baseDefault around line 2315) and requeues
+  -- with 28800s = 8 hours when the error circuit breaker trips (around lines 2397 and
+  -- 2461). An eighth attempt that hit an extreme rate limit is therefore still sitting
+  -- in the queue, invisible to us, four hours before the backoff expression would call
+  -- it dead. The floor of 13 hours covers the 12-hour worst case with an hour of margin
+  -- for queue latency and reconciler tick spacing.
+  --
+  -- This couples the migration to the worker's retry policy: if those delays change,
+  -- this floor has to change with them, or we go back to parking rows whose last
+  -- attempt is still alive.
   update public.repositories rp
      set creation_error = format(
            'Repository creation did not succeed after %s automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.',
@@ -835,8 +851,11 @@ begin
      and rp.is_github_ready = false
      and rp.creation_error is null
      and rp.creation_attempts >= v_max_attempts
-     and rp.updated_at < now() - make_interval(
-           mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+     and rp.updated_at < now() - greatest(
+           make_interval(
+             mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+           ),
+           v_worker_max_requeue
          )
      and a.repo_mode not in ('none', 'no_submission');
 
@@ -849,8 +868,48 @@ begin
        and rp.creation_error is null
        and rp.creation_attempts < v_max_attempts
        and a.repo_mode not in ('none', 'no_submission')
-       -- Recurring per-class work must not run for courses that have ended.
-       and public.is_class_active(c.archived, c.end_date)
+       -- Recurring per-class work must not run for courses that have ended -- EXCEPT to
+       -- finish following up an attempt somebody actually made. retry_repository_creation
+       -- clears creation_error and zeroes the counter, so on an archived class (or one
+       -- ended over 30 days ago) the row it queued would fall outside this scan entirely:
+       -- if that job is lost, or exhausts the worker's generic retries without writing a
+       -- terminal error, the row sits at is_github_ready = false with no error, the UI
+       -- shows it as pending, the Retry affordance is gone, and nothing can ever make it
+       -- actionable again. Following up on a human's retry is not recurring work; it is
+       -- one bounded sequence with an end.
+       --
+       -- Bounded by the same ceiling as everything else, which is what keeps this from
+       -- being the side door back to the unbounded behavior this migration removed. An
+       -- inactive-class row can only be picked up here while creation_attempts is under
+       -- the ceiling, and the park UPDATE above -- which deliberately has no class filter
+       -- -- ends the sequence by setting creation_error. Worst case after one click:
+       -- 8 attempts over roughly 32 hours, then parked with an error the instructor can
+       -- see. The row converges on ready or on parked, and either way stops being scanned.
+       --
+       -- Sizing the window. Every re-enqueue rewrites last_creation_attempt_at, so the
+       -- window does not have to cover a whole retry sequence -- only the longest gap
+       -- between two consecutive attempts, which is the 13-hour park floor above. Seven
+       -- days is deliberately far above that minimum: a worker paused for a few days, or
+       -- a queue that backed up over a weekend, should not permanently strand a row
+       -- halfway through its sequence. It is still short enough that a dead class goes
+       -- quiet within a week of the last attempt anyone made on it.
+       --
+       -- last_creation_attempt_at is written only when a job is actually queued, by
+       -- enqueue_create_repo_for_repository, so a row nobody has touched in a dead class
+       -- has an old or null value and stays out entirely.
+       --
+       -- The honest consequence: this follows up recent AUTOMATIC attempts too, not only
+       -- human ones -- nothing on the row distinguishes them, and retry_repository_
+       -- creation's counter reset is not a reliable marker. So archiving a class does not
+       -- stop work on it the same instant; a row still pending finishes its remaining
+       -- attempts (at most 8, roughly 32 hours) and is then parked with an error. That is
+       -- bounded per row and terminal, which is the property this migration is about --
+       -- unlike the behavior it replaced, where every not-ready row in the instance was
+       -- re-enqueued every 15 minutes with no counter and no end.
+       and (
+         public.is_class_active(c.archived, c.end_date)
+         or rp.last_creation_attempt_at > now() - interval '7 days'
+       )
        -- Exponential backoff: each failed attempt doubles the wait, capped.
        and rp.updated_at < now() - make_interval(
              mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
@@ -959,6 +1018,11 @@ update public.repositories rp
 -- enforces is narrower and mechanical: whatever the name is, it must survive the
 -- derivation and land on a repository name no sibling group also lands on.
 --
+-- Groups on assignments that never provision a repository ('none', 'no_submission') are
+-- exempt from both rules -- there is no repository name to protect, so the rules would
+-- only be rejecting labels. See the trigger body for how that interacts with an
+-- assignment whose mode changes later.
+--
 -- Existing rows are grandfathered. The trigger fires on `update of name`, so a legacy
 -- group that already violates either rule keeps its name, keeps its repository and
 -- keeps working until somebody renames it -- at which point the new name has to be
@@ -976,10 +1040,34 @@ security definer
 set search_path = ''
 as $$
 declare
+  v_repo_mode text;
   v_sanitized text;
   v_other text;
   r record;
 begin
+  -- Both rules below exist only to protect a GitHub repository name. Two assignment
+  -- modes never provision one -- create_all_repos_for_assignment_internal() returns
+  -- early for 'no_submission' and 'none' -- so on a manual or paper assignment these
+  -- checks reject group names for a repository that will never be created: `Team-One`
+  -- beside `Team--One` is two perfectly good labels colliding over nothing, and `---`
+  -- is a fine name for a group that submits on paper.
+  --
+  -- The exemption is evaluated per write, not stored, so an assignment that later moves
+  -- to a repo-provisioning mode carries names admitted under it. Nothing retro-validates
+  -- them, deliberately: that is the same grandfathering this migration applies to legacy
+  -- rows, and it is why section 3 makes create_all_repos_for_assignment_internal() warn
+  -- and skip a group whose name will not sanitize rather than abort the whole pass. The
+  -- assignment still provisions every other group, the instructor gets a warning naming
+  -- the group that did not, and renaming it goes through this trigger -- which by then
+  -- does apply -- so the repair sticks.
+  select a.repo_mode::text into v_repo_mode
+    from public.assignments a
+   where a.id = new.assignment_id;
+
+  if v_repo_mode in ('none', 'no_submission') then
+    return new;
+  end if;
+
   begin
     v_sanitized := public.sanitize_repo_name_component(new.name);
   exception
@@ -1091,7 +1179,15 @@ declare
   v_colliding_names int := 0;
   v_collision_clusters int := 0;
 begin
-  for r in select ag.id, ag.assignment_id, ag.name from public.assignment_groups ag loop
+  -- Same exemption the trigger applies: a group on a no-repo assignment has no repo
+  -- name to violate, and counting it would send whoever reads this log after names that
+  -- are fine.
+  for r in
+    select ag.id, ag.assignment_id, ag.name
+      from public.assignment_groups ag
+      join public.assignments a on a.id = ag.assignment_id
+     where a.repo_mode not in ('none', 'no_submission')
+  loop
     begin
       v_keys := v_keys || (r.assignment_id::text || ':' || lower(public.sanitize_repo_name_component(r.name)));
     exception

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -25,7 +25,9 @@
 --    then multiplied it: R rows written x (mismatched groups + students without repos).
 --
 -- This migration:
---   1. sanitize_repo_name_component() -- the SQL twin of _shared/repoNames.ts.
+--   1. sanitize_repo_name_component() -- the SQL twin of _shared/repoNames.ts, applied
+--      per COMPONENT, plus sanitize_repo_name() -- a weaker whole-name net that only
+--      maps illegal characters, so it can never alter an already-valid assembled name.
 --   2. Sanitization applies only where a name is FIRST derived and stored: the insert
 --      path of enqueue_github_create_repo(), plus the group-name component in
 --      create_all_repos_for_assignment_internal(). A name read back off an existing row
@@ -47,10 +49,16 @@
 -- ============================================================================
 
 -- Kept byte-for-byte equivalent to sanitizeRepoNameComponent() so a name derived in
--- SQL and the same name derived in TypeScript resolve to one repository. Applied to
--- the whole assembled name rather than per component: the class and assignment slugs
--- are already URL-safe, so the result is identical, and one call site covers every
--- caller instead of every concatenation site.
+-- SQL and the same name derived in TypeScript resolve to one repository.
+--
+-- Apply this to a single COMPONENT (a group name), never to an assembled repo name.
+-- The TypeScript paths sanitize only the group-name component and leave the class and
+-- assignment slugs untouched, so running the collapse and trim rules over a whole name
+-- would diverge from them: an assignment slugged `hw--1` assembles to
+-- `course-hw--1-group-Team` in TypeScript but would collapse to `course-hw-1-group-Team`
+-- here, and github-user-sync would then sync permissions against a repo that does not
+-- exist. Nothing constrains slugs to make that collapse a no-op. Use
+-- sanitize_repo_name() below for the whole-name safety net.
 create or replace function public.sanitize_repo_name_component(raw text)
 returns text
 language plpgsql
@@ -88,6 +96,31 @@ comment on function public.sanitize_repo_name_component(text) is
   'Normalize a repo name to the character set GitHub accepts. SQL twin of sanitizeRepoNameComponent() in supabase/functions/_shared/repoNames.ts; the two must stay in sync or SQL- and TS-derived names diverge and dedupe by name breaks.';
 
 grant execute on function public.sanitize_repo_name_component(text) to authenticated, service_role;
+
+-- Whole-assembled-name safety net. Deliberately WEAKER than the component sanitizer:
+-- it only maps characters GitHub rejects onto hyphens, and never collapses runs, trims
+-- separators or raises. That restraint is the point -- this runs over names assembled
+-- by callers that have already sanitized their own components, so it must be a no-op
+-- on any name that is already valid. It exists for the SQL callers that still
+-- concatenate a raw group name (publish_assignment_group_changes), so those cannot put
+-- a space into a repo name; those sites should move to per-component sanitization,
+-- after which this becomes dead weight rather than a behavior.
+create or replace function public.sanitize_repo_name(raw text)
+returns text
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select case when raw is null then null
+              else regexp_replace(raw, '[^A-Za-z0-9._-]+', '-', 'g')
+         end;
+$$;
+
+comment on function public.sanitize_repo_name(text) is
+  'Map characters GitHub rejects in a repo name onto hyphens. A last-resort net over an assembled name; it must never alter an already-valid name, so it does not collapse or trim. Per-component normalization belongs to sanitize_repo_name_component().';
+
+grant execute on function public.sanitize_repo_name(text) to authenticated, service_role;
 
 -- ============================================================================
 -- 2. Sanitize at the enqueue choke point
@@ -131,10 +164,12 @@ declare
   v_existing_name text;
   v_args jsonb;
 begin
-  -- Sanitize the name the CALLER derived. Only a name we are about to store is
-  -- sanitized; a name read back off an existing row is authoritative and is used
-  -- verbatim (see below).
-  v_repo_name := public.sanitize_repo_name_component(p_repo_name);
+  -- Net the name the CALLER derived. sanitize_repo_name (not the component sanitizer)
+  -- so a caller that already normalized its components keeps them byte-for-byte -- an
+  -- assignment slugged `hw--1` must survive, because the TypeScript paths preserve it.
+  -- Only a name we are about to store is netted; a name read back off an existing row
+  -- is authoritative and is used verbatim (see below).
+  v_repo_name := public.sanitize_repo_name(p_repo_name);
   full_repo_name := p_org || '/' || v_repo_name;
 
   insert into public.api_gateway_calls(method, status_code, class_id, debug_id)
@@ -614,7 +649,21 @@ begin
   end if;
 
   if r.repo_mode = 'fork_from_prior_assignment' and v_source_repo is null then
-    raise warning 'No source repository resolved for repository % (fork_from_prior_assignment); skipping', p_repository_id;
+    -- Deterministic failure, not a transient one: there is no repository on the source
+    -- assignment to fork, and no amount of retrying creates one. Returning here without
+    -- touching the retry state left the row stale-and-unparked forever -- the reconciler
+    -- counted the call as a success, the attempt ceiling was never approached and
+    -- creation_error was never set, so it came back every 15 minutes and never surfaced
+    -- the instructor Retry action. Park it instead; that is exactly what creation_error
+    -- is for, and it takes the row out of reconcile_stuck_repo_creations' scan.
+    update public.repositories
+       set creation_error = format(
+             'No repository found on the source assignment (id %s) to fork from. Create the source repositories first, then use Retry.',
+             r.source_assignment_id),
+           last_creation_attempt_at = now(),
+           updated_at = now()
+     where id = p_repository_id;
+    raise warning 'No source repository resolved for repository % (fork_from_prior_assignment); parked for instructor retry', p_repository_id;
     return null;
   end if;
 

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -248,7 +248,7 @@ begin
         if repo_id is null then
           raise exception 'Repository name % is already used by a different assignment, student or group', full_repo_name;
         end if;
-        v_repo_name := split_part(v_existing_name, '/', 2);
+        v_repo_name := substring(v_existing_name from position('/' in v_existing_name) + 1);
       end if;
     else
       -- An existing row's stored name is authoritative: it is what a GitHub repo was
@@ -259,7 +259,7 @@ begin
       -- `…-group-Team-One` -- and the worker marks the row ready by repo_id without
       -- writing the name back, so the row would end up pointing at a repo nobody
       -- created. Use the stored name and leave the row alone.
-      v_repo_name := split_part(v_existing_name, '/', 2);
+      v_repo_name := substring(v_existing_name from position('/' in v_existing_name) + 1);
     end if;
   end if;
 
@@ -637,7 +637,12 @@ begin
   end if;
 
   v_creation_method := case when r.repo_mode = 'template_only_staff' then 'template' else 'fork' end;
-  v_repo_name := split_part(r.repository, '/', 2);
+  -- Strip only the org, i.e. everything up to the FIRST slash. split_part(..., '/', 2)
+  -- would truncate at the SECOND one, and a repository name can legitimately contain a
+  -- slash: nothing constrains class or assignment slugs, and e2e class slugs carry a
+  -- formatted timestamp (`dd/MM/yy`). That truncation silently enqueued a shortened repo
+  -- name for every such class.
+  v_repo_name := substring(r.repository from position('/' in r.repository) + 1);
 
   if r.assignment_group_id is not null then
     -- Group repo: collect member usernames; resolve the prior-assignment source by group name.

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -817,36 +817,65 @@ declare
   v_count integer := 0;
   v_max_attempts constant integer := 8;
   v_max_backoff_doublings constant integer := 5;  -- caps the interval at 32x p_stale_minutes
-  -- Longest single requeue github-async-worker can apply to one job (12h for an extreme
-  -- rate limit), plus an hour of margin. See the park comment below.
-  v_worker_max_requeue constant interval := interval '13 hours';
+  -- Repository ids that still have a create_repo message sitting in a queue. Collected
+  -- once per tick rather than probed per row: the queue tables have no index on the
+  -- envelope's repo_id, so a NOT EXISTS per candidate would scan them once per candidate.
+  v_inflight_repo_ids text[];
 begin
-  -- Park anything that has exhausted its automatic retries AND has gone quiet for the
-  -- interval its next attempt would have waited. Done as a set operation before the loop
-  -- so a row is parked exactly once, and so the loop below never sees it again.
+  select coalesce(array_agg(distinct s.rid), '{}'::text[])
+    into v_inflight_repo_ids
+    from (
+      select q.message->>'repo_id' as rid
+        from pgmq.q_async_calls q
+       where q.message->>'method' = 'create_repo'
+      union all
+      select q.message->>'repo_id' as rid
+        from pgmq.q_async_calls_low_priority q
+       where q.message->>'method' = 'create_repo'
+    ) s
+   where s.rid is not null;
+
+  -- Park anything that has exhausted its automatic retries, whose last job is no longer
+  -- anywhere in a queue, and which has gone quiet for the interval its next attempt
+  -- would have waited. Done as a set operation before the loop so a row is parked
+  -- exactly once, and so the loop below never sees it again.
   --
-  -- The staleness term is not belt-and-braces. Attempt eight is enqueued, not completed:
-  -- the job can sit in the queue, and github-async-worker requeues a rate-limited create
-  -- with a long delay. Parking on the attempt count alone means the very next tick
-  -- reports a failure to the instructor while that attempt is still pending, and the
-  -- Retry button they are being pointed at enqueues a second create_repo racing the
-  -- first. Reusing the retry loop's own backoff interval -- deliberately the same
-  -- expression, not a second timing rule that could drift from it -- parks a row exactly
-  -- when it would otherwise have become eligible for attempt nine.
+  -- Park on evidence, not on a timer. Attempt eight is ENQUEUED, not completed, and a
+  -- create_repo job can legitimately live far longer than any interval we would guess:
+  -- github-async-worker requeues an `extreme` rate limit for 12 hours and lets an
+  -- envelope do that up to retry_count 5 before it goes to the DLQ (the retry_count
+  -- check and the requeue sit around lines 2372-2404 of
+  -- supabase/functions/github-async-worker/index.ts), so one attempt can span roughly
+  -- 60 hours. requeueWithDelay never touches the repository row, so updated_at stays
+  -- pinned at the eighth enqueue for that whole time. Parking on elapsed time therefore
+  -- means telling the instructor a repo failed while its job is still alive, and the
+  -- Retry we point them at races the job that is about to run.
   --
-  -- That expression alone is not long enough, though: it tops out at
-  -- 15 min * 2^5 = 8 hours, while the worker can hold a single job longer than that.
-  -- supabase/functions/github-async-worker/index.ts requeues an `extreme` rate limit
-  -- with a default of 43200s = 12 hours (the baseDefault around line 2315) and requeues
-  -- with 28800s = 8 hours when the error circuit breaker trips (around lines 2397 and
-  -- 2461). An eighth attempt that hit an extreme rate limit is therefore still sitting
-  -- in the queue, invisible to us, four hours before the backoff expression would call
-  -- it dead. The floor of 13 hours covers the 12-hour worst case with an hour of margin
-  -- for queue latency and reconciler tick spacing.
+  -- Any fixed floor -- 13 hours, 60 hours -- would be a copy of the worker's retry
+  -- policy living in SQL, silently wrong the moment that policy changes. The queue is a
+  -- table, so ask it instead: a pgmq message stays in q_<queue> until it is archived,
+  -- including while a worker holds it invisible, and the create_repo envelope carries
+  -- repo_id. Requeueing sends the new message BEFORE archiving the old one, so a job
+  -- being retried is never briefly absent from this check. Absence means the job really
+  -- is gone: archived after success, moved to the DLQ, or lost.
   --
-  -- This couples the migration to the worker's retry policy: if those delays change,
-  -- this floor has to change with them, or we go back to parking rows whose last
-  -- attempt is still alive.
+  -- Matched as TEXT, never cast. Casting message->>'repo_id' to bigint would raise
+  -- inside the reconciler the first time an envelope carried a null or non-numeric
+  -- repo_id -- enqueue_github_create_repo writes 'repo_id', null whenever it is called
+  -- without an assignment -- and a raise here would take out the whole tick, not one
+  -- row. Text comparison against rp.id::text cannot raise and matches a repo_id written
+  -- as either a JSON number or a JSON string.
+  --
+  -- Both live queues are scanned. create_repo is only ever produced onto async_calls
+  -- today, but the worker drains async_calls_low_priority when the main queue is empty
+  -- and requeues onto whichever queue it read from, so covering both costs one more scan
+  -- and removes a way for this to be quietly wrong later. The DLQ is deliberately NOT
+  -- scanned: a message that reached it is dead, and treating it as live would leave the
+  -- row unparked forever.
+  --
+  -- The backoff interval stays as a floor, so a row is not parked the instant its last
+  -- message is archived -- there is a moment between a worker archiving a create_repo
+  -- and the row being marked ready -- but the queue check is what actually decides.
   update public.repositories rp
      set creation_error = format(
            'Repository creation did not succeed after %s automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.',
@@ -856,11 +885,9 @@ begin
      and rp.is_github_ready = false
      and rp.creation_error is null
      and rp.creation_attempts >= v_max_attempts
-     and rp.updated_at < now() - greatest(
-           make_interval(
-             mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
-           ),
-           v_worker_max_requeue
+     and rp.id::text <> all (v_inflight_repo_ids)
+     and rp.updated_at < now() - make_interval(
+           mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
          )
      and a.repo_mode not in ('none', 'no_submission');
 
@@ -915,6 +942,12 @@ begin
          public.is_class_active(c.archived, c.end_date)
          or rp.last_creation_attempt_at > now() - interval '7 days'
        )
+       -- Same evidence the park uses, for the same reason in reverse: updated_at cannot
+       -- tell a lost job from one the worker is holding for a 12-hour rate-limit delay,
+       -- so re-enqueueing on elapsed time alone puts a second create_repo in the queue
+       -- for a repository that already has one. Skip a row whose job is still there and
+       -- let it run; if it is gone, this is the path that replaces it.
+       and rp.id::text <> all (v_inflight_repo_ids)
        -- Exponential backoff: each failed attempt doubles the wait, capped.
        and rp.updated_at < now() - make_interval(
              mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
@@ -1241,8 +1274,18 @@ $$;
 -- create_all_repos_for_assignment_internal(). Everything around it -- the class and
 -- assignment slugs -- stays byte-for-byte, because TypeScript leaves them alone too.
 --
--- The body below is the live 20260624000000 definition re-emitted verbatim, with that
--- single expression changed and nothing else touched. It is copied rather than patched
+-- The body below is the live 20260624000000 definition re-emitted verbatim, with three
+-- changes and nothing else touched, so a diff against 20260624000000 has exactly three
+-- hunks:
+--   1. the group-name component above is wrapped in sanitize_repo_name_component();
+--   2. and 3. the two `split_part(repository, '/', 2)` calls that feed
+--      enqueue_github_archive_repo and enqueue_github_sync_repo_permissions now strip
+--      everything up to the FIRST slash instead. split_part truncates at the SECOND one,
+--      so a repository whose name contains a slash -- which nothing forbids, and which
+--      any class slug carrying a date does -- was archived or permission-synced under a
+--      shortened name that matches no repo on GitHub. Same defect, and same fix, as in
+--      enqueue_create_repo_for_repository in section 5.
+-- It is copied rather than patched
 -- because Postgres has no way to edit one expression of a function in place; when this
 -- function is next revised, that revision supersedes this copy and must carry the
 -- sanitize forward. The trigger in section 9 is the backstop that keeps the group name
@@ -1570,7 +1613,9 @@ begin
                 perform public.enqueue_github_archive_repo(
                     p_class_id,
                     v_github_org,
-                    split_part(v_repo_record.repository, '/', 2),
+                    -- everything after the FIRST slash: the org is one segment, the repo
+                    -- name that follows can itself contain a slash
+                    substring(v_repo_record.repository from position('/' in v_repo_record.repository) + 1),
                     'batch-dissolve-' || v_empty_gid::text
                 );
             end if;
@@ -1621,7 +1666,8 @@ begin
                     perform public.enqueue_github_sync_repo_permissions(
                         p_class_id,
                         v_github_org,
-                        split_part(v_repo_record.repository, '/', 2),
+                        -- everything after the FIRST slash; see the archive call above
+                        substring(v_repo_record.repository from position('/' in v_repo_record.repository) + 1),
                         v_course_slug,
                         coalesce(v_usernames, '{}'),
                         'batch-publish-' || p_assignment_id::text || '-g' || v_repo_record.assignment_group_id::text

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -813,9 +813,19 @@ declare
   v_max_attempts constant integer := 8;
   v_max_backoff_doublings constant integer := 5;  -- caps the interval at 32x p_stale_minutes
 begin
-  -- Park anything that has exhausted its automatic retries. Done as a set operation
-  -- before the loop so a row is parked exactly once, and so the loop below never sees
-  -- it again.
+  -- Park anything that has exhausted its automatic retries AND has gone quiet for the
+  -- interval its next attempt would have waited. Done as a set operation before the loop
+  -- so a row is parked exactly once, and so the loop below never sees it again.
+  --
+  -- The staleness term is not belt-and-braces. Attempt eight is enqueued, not completed:
+  -- the job can sit in the queue, and github-async-worker requeues a rate-limited create
+  -- with a long delay. Parking on the attempt count alone means the very next tick
+  -- reports a failure to the instructor while that attempt is still pending, and the
+  -- Retry button they are being pointed at enqueues a second create_repo racing the
+  -- first. Reusing the retry loop's own backoff interval -- deliberately the same
+  -- expression, not a second timing rule that could drift from it -- parks a row exactly
+  -- when it would otherwise have become eligible for attempt nine, which is the moment
+  -- the previous attempt is known not to be coming back.
   update public.repositories rp
      set creation_error = format(
            'Repository creation did not succeed after %s automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.',
@@ -825,6 +835,9 @@ begin
      and rp.is_github_ready = false
      and rp.creation_error is null
      and rp.creation_attempts >= v_max_attempts
+     and rp.updated_at < now() - make_interval(
+           mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+         )
      and a.repo_mode not in ('none', 'no_submission');
 
   for r in
@@ -880,6 +893,15 @@ comment on function public.reconcile_stuck_repo_creations(int) is
 -- because the row itself is old, and the reconciler would then skip them until an
 -- instructor retried by hand. updated_at measures the thing this cutoff is about: how
 -- long THIS pending state has lasted.
+--
+-- This does NOT need the in-flight guard the reconciler's park just grew. Both cutoffs
+-- here are already staleness cutoffs on updated_at, and both are enormous next to the
+-- reconciler's longest backoff of eight hours: a week of silence in a running class, or
+-- a class that has ended and whose rows the reconciler no longer scans at all. Nothing
+-- plausibly in flight survives either. And parking is recoverable in any case -- if a
+-- late job does succeed, reset_repo_creation_attempts_on_ready clears creation_error and
+-- the attempt count as the row flips ready, so a parked row heals itself rather than
+-- needing the instructor to undo anything.
 update public.repositories rp
    set creation_attempts = 8,
        creation_error = 'Repository creation did not succeed after repeated automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.'
@@ -965,6 +987,37 @@ begin
       raise exception 'Group name "%" cannot be used: a group name needs at least one letter or number in it. This group''s repository is named after it, and GitHub will not accept a name made only of dashes, underscores or dots. Pick a different name for the group.', new.name
         using errcode = 'check_violation';
   end;
+
+  -- Serialize every writer of group names within one assignment. The scan below reads
+  -- committed sibling rows, so without this two concurrent transactions -- one naming a
+  -- group `Team-One`, one naming it `Team--One` -- each scan before the other's row is
+  -- visible, both pass, both commit, and the pair that this trigger exists to prevent
+  -- lands anyway. Neither unique index catches it: the stored names genuinely differ,
+  -- and it is only the NORMALIZED forms that collide, which surfaces later as a
+  -- unique_repo_name violation inside a worker. Assignment-scoped rather than global so
+  -- unrelated classes never wait on each other.
+  --
+  -- A unique index on lower(sanitize_repo_name_component(name)) would be the tempting
+  -- "upgrade" here. It is not available: the function raises on separator-only names, so
+  -- the index expression is not total over existing data, and grandfathered rows that
+  -- already collide (this migration's audit reports them rather than rewriting them)
+  -- would make CREATE INDEX fail and take the deploy with it -- the same reason this PR
+  -- declined a unique index over derived repository names. A lock plus a scan enforces
+  -- the rule for new writes without demanding that history already obey it.
+  --
+  -- Deadlock analysis. This lock is taken in exactly one place, this trigger, and only
+  -- for an insert or a rename of a group. A transaction normally touches one assignment
+  -- -- the student create/join flow, an instructor rename, publish_assignment_group_
+  -- changes and copy_groups_from_assignment all work against a single assignment_id --
+  -- so it is one key per transaction and there is no second key to order against.
+  -- copy_groups_from_assignment inserts many groups into its target and so reaches this
+  -- line once per row, which is free: advisory locks are re-entrant, and repeat
+  -- acquisitions of a key the transaction already holds only bump a reference count. It
+  -- also takes its own `copy_groups:<class>:<target>` lock first and always in that
+  -- order, so the two lock namespaces are acquired in a consistent sequence.
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(pg_catalog.format('assignment_group_name:%s', new.assignment_id), 0)
+  );
 
   -- Row-at-a-time rather than one set query so that a grandfathered sibling whose own
   -- name does not sanitize cannot make this trigger raise on an unrelated group: a

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -26,23 +26,39 @@
 --
 -- This migration:
 --   1. sanitize_repo_name_component() -- the SQL twin of _shared/repoNames.ts, applied
---      per COMPONENT, plus sanitize_repo_name() -- a weaker whole-name net that only
---      maps illegal characters, so it can never alter an already-valid assembled name.
---   2. Sanitization applies only where a name is FIRST derived and stored: the insert
---      path of enqueue_github_create_repo(), plus the group-name component in
---      create_all_repos_for_assignment_internal(). A name read back off an existing row
---      is authoritative and is used verbatim -- it is what a GitHub repo was created as
---      and what webhooks resolve against, and `is_github_ready = false` does not mean no
---      GitHub repo exists (the worker can create the repo and fail to mark the row).
---      So new rows converge on the name GitHub will actually create, and existing rows
---      keep resolving to their real repository. Renaming the rows that already diverged
---      is a data migration, deliberately not folded in here.
+--      per COMPONENT and never to an assembled name.
+--   2. Sanitization happens at the sites that DERIVE a name, on the one component that
+--      needs it: the group name, in create_all_repos_for_assignment_internal() and in
+--      publish_assignment_group_changes(). enqueue_github_create_repo() passes the name
+--      its caller derived straight through.
+--
+--      Nothing normalizes an assembled name, and that restraint is load-bearing rather
+--      than laziness: TypeScript sanitizes the group-name component alone and leaves the
+--      class and assignment slugs byte-for-byte, so ANY pass over the whole name -- even
+--      one restricted to characters GitHub rejects -- makes SQL derive a different
+--      repository than TypeScript for the same group, which is precisely the divergence
+--      this migration exists to close. Slugs really do carry such characters: the e2e
+--      harness builds a `dd/MM/yy HH:mm:ss#suffix` stamp into a class slug, so a
+--      whole-name net rewrites `/`, `:` and `#` and every derived name stops matching.
+--      Sanitizing an assembled name is therefore a bug, not a safety net.
+--
+--      A name read back off an existing row is authoritative and is used verbatim -- it
+--      is what a GitHub repo was created as and what webhooks resolve against, and
+--      `is_github_ready = false` does not mean no GitHub repo exists (the worker can
+--      create the repo and fail to mark the row). So new rows converge on the name
+--      GitHub will actually create, and existing rows keep resolving to their real
+--      repository. Renaming the rows that already diverged is a data migration,
+--      deliberately not folded in here.
 --   3. create_all_repos_for_assignment_internal() dedupes on identity, not on name.
 --   4. repositories.creation_attempts / .last_creation_attempt_at + a reset trigger.
 --   5. reconcile_stuck_repo_creations() gains exponential backoff, an attempt ceiling
 --      that parks the row for an instructor, and active-class scoping.
 --   6. A one-time backfill that parks rows already stuck long enough to have been
 --      retried hundreds of times, so the backlog drains instead of replaying.
+--   7. A trigger on assignment_groups that refuses a group name with no repo-name form
+--      ("---") and one that normalizes onto a sibling's ("Team--One" beside "Team-One").
+--      Both pass today's app-layer validators and then produce a group that can never
+--      get a repository, which is a class of stuck row rather than a stuck retry.
 
 -- ============================================================================
 -- 1. Repo-name sanitizer (SQL twin of supabase/functions/_shared/repoNames.ts)
@@ -57,8 +73,11 @@
 -- would diverge from them: an assignment slugged `hw--1` assembles to
 -- `course-hw--1-group-Team` in TypeScript but would collapse to `course-hw-1-group-Team`
 -- here, and github-user-sync would then sync permissions against a repo that does not
--- exist. Nothing constrains slugs to make that collapse a no-op. Use
--- sanitize_repo_name() below for the whole-name safety net.
+-- exist. Nothing constrains slugs to make that collapse a no-op -- and a class slug can
+-- hold characters GitHub rejects outright (`/`, `:`, `#`), which TypeScript passes
+-- through untouched, so even a gentler whole-name pass diverges. There is deliberately
+-- no whole-name sanitizer to reach for: normalize components, assemble, and leave the
+-- assembled name alone.
 create or replace function public.sanitize_repo_name_component(raw text)
 returns text
 language plpgsql
@@ -97,42 +116,36 @@ comment on function public.sanitize_repo_name_component(text) is
 
 grant execute on function public.sanitize_repo_name_component(text) to authenticated, service_role;
 
--- Whole-assembled-name safety net. Deliberately WEAKER than the component sanitizer:
--- it only maps characters GitHub rejects onto hyphens, and never collapses runs, trims
--- separators or raises. That restraint is the point -- this runs over names assembled
--- by callers that have already sanitized their own components, so it must be a no-op
--- on any name that is already valid. It exists for the SQL callers that still
--- concatenate a raw group name (publish_assignment_group_changes), so those cannot put
--- a space into a repo name; those sites should move to per-component sanitization,
--- after which this becomes dead weight rather than a behavior.
-create or replace function public.sanitize_repo_name(raw text)
-returns text
-language sql
-immutable
-parallel safe
-set search_path = ''
-as $$
-  select case when raw is null then null
-              else regexp_replace(raw, '[^A-Za-z0-9._-]+', '-', 'g')
-         end;
-$$;
-
-comment on function public.sanitize_repo_name(text) is
-  'Map characters GitHub rejects in a repo name onto hyphens. A last-resort net over an assembled name; it must never alter an already-valid name, so it does not collapse or trim. Per-component normalization belongs to sanitize_repo_name_component().';
-
-grant execute on function public.sanitize_repo_name(text) to authenticated, service_role;
+-- An earlier revision of this migration also shipped sanitize_repo_name(), a weaker
+-- pass over the ASSEMBLED name that only mapped characters GitHub rejects onto hyphens.
+-- It is dropped rather than kept unused: however gentle, a whole-name pass rewrites
+-- parts of the name no TypeScript path touches. A class slug carrying `/`, `:` or `#`
+-- -- which the e2e harness generates on every run, and which nothing forbids in
+-- production -- came out of it hyphenated, so the queued repoName stopped matching the
+-- name every TypeScript path derives for the same repository, and repo lookups by name
+-- missed. Dropped explicitly so an environment that already applied that revision does
+-- not keep a function whose only correct number of callers is zero.
+drop function if exists public.sanitize_repo_name(text);
 
 -- ============================================================================
--- 2. Sanitize at the enqueue choke point
+-- 2. One repository row per identity at the enqueue choke point
 -- ============================================================================
 --
--- Unchanged from 20260530120200 except for the sanitize of p_repo_name. Every SQL
--- path that creates a repo goes through here (create_all_repos_for_assignment_internal,
--- publish_assignment_group_changes, copy_groups_from_assignment,
--- enqueue_create_repo_for_repository), so this is the one place that has to apply it.
--- Before this, a group named "Team 1" was stored as `org/course-hw1-group-Team 1`
--- while GitHub coerced the actual repo to `Team-1` -- which also broke webhook
--- lookups that resolve a repository row by name.
+-- Every SQL path that creates a repo goes through here
+-- (create_all_repos_for_assignment_internal, publish_assignment_group_changes,
+-- copy_groups_from_assignment, enqueue_create_repo_for_repository). Unchanged from
+-- 20260530120200 except for how it picks the row to enqueue against and which name it
+-- queues: the lookup now breaks ties deterministically, an insert that loses a race
+-- re-reads the winner instead of raising, and a name read back off an existing row is
+-- queued verbatim.
+--
+-- What this function deliberately does NOT do is sanitize. It queues p_repo_name as the
+-- caller assembled it. Normalizing here would look like the obvious choke point and be
+-- wrong: the caller has already sanitized the one component that needs it, and the rest
+-- of the name -- the class and assignment slugs -- must stay byte-identical to what the
+-- TypeScript paths produce, including characters GitHub itself rejects. A slug of
+-- `e2e-17/08/26-00:34:10#f3oe` is not ours to fix here; rewriting it makes this the only
+-- deriver in the system that disagrees with all the others.
 create or replace function public.enqueue_github_create_repo(
   p_class_id bigint,
   p_org text,
@@ -164,12 +177,13 @@ declare
   v_existing_name text;
   v_args jsonb;
 begin
-  -- Net the name the CALLER derived. sanitize_repo_name (not the component sanitizer)
-  -- so a caller that already normalized its components keeps them byte-for-byte -- an
-  -- assignment slugged `hw--1` must survive, because the TypeScript paths preserve it.
-  -- Only a name we are about to store is netted; a name read back off an existing row
-  -- is authoritative and is used verbatim (see below).
-  v_repo_name := public.sanitize_repo_name(p_repo_name);
+  -- The caller's name, byte-for-byte. Callers sanitize the group-name COMPONENT before
+  -- they assemble (create_all_repos_for_assignment_internal,
+  -- publish_assignment_group_changes), matching what TypeScript does; anything this
+  -- function did to the assembled name on top of that would only make SQL and
+  -- TypeScript derive different repositories. v_repo_name exists because a name read
+  -- back off an existing row overrides it below, not because it gets rewritten here.
+  v_repo_name := p_repo_name;
   full_repo_name := p_org || '/' || v_repo_name;
 
   insert into public.api_gateway_calls(method, status_code, class_id, debug_id)
@@ -880,3 +894,605 @@ update public.repositories rp
      not public.is_class_active(c.archived, c.end_date)
      or rp.updated_at < now() - interval '7 days'
    );
+
+-- ============================================================================
+-- 9. Reject group names that cannot become a repository name
+-- ============================================================================
+--
+-- A group repository is named
+--   <class_slug>-<assignment_slug>-group-<sanitize_repo_name_component(group.name)>
+-- which makes the group name the only user-authored component of a GitHub repo name.
+-- Two shapes of name pass the app-layer validators (`^[a-zA-Z0-9_-]{1,36}$` in the
+-- create-group form, in publish_assignment_group_changes and in the bulk-import path)
+-- and then have nowhere to go on the other side of that derivation:
+--
+--   * Separator-only names -- `---`, `_`, `-_-`. sanitize_repo_name_component() trims
+--     them to the empty string and raises, so what the student sees is not "pick
+--     another name" at the moment they pick it, but a create-all-repos call or an
+--     async worker job failing later with a message about repo-name components. The
+--     group exists, has members, and can never get a repository.
+--   * Names that differ only in characters the sanitizer folds away: `Team-One` and
+--     `Team--One` both normalize to `Team-One`. Both are legal, distinct rows under
+--     unique_assignment_group_name; both derive the same repository name; and the
+--     second one to reach the queue trips the unique_repo_name index on
+--     repositories.repository. Which group loses is a race, and the loser's failure
+--     surfaces in a worker rather than at the keyboard of whoever named it.
+--
+-- The uniqueness comparison is case-insensitive because GitHub is: `team-one` and
+-- `Team-One` are one repository there, so two groups holding those names collide on
+-- creation even though both rows are distinct. publish_assignment_group_changes
+-- already refuses a case-insensitive duplicate of the plain name (and
+-- unique_assignment_groups_name_assignment_id enforces it); this extends that same
+-- rule to the sanitized form, which is what actually reaches GitHub.
+--
+-- This lives in the database rather than in one more validator because group rows are
+-- written from several places -- the student-facing join/create flow, the instructor
+-- RPCs, copy_groups_from_assignment, the CSV import, seeds -- and only the table sees
+-- all of them.
+--
+-- Deliberately NOT enforced here: the character set and the 36-character limit. Those
+-- stay exactly where they are, in the app layer. Names with spaces (`Brand New Team 9`)
+-- are ordinary and sanitize cleanly to `Brand-New-Team-9`; rejecting them at the table
+-- would break existing callers, seeds and rows for no gain. The rule this trigger
+-- enforces is narrower and mechanical: whatever the name is, it must survive the
+-- derivation and land on a repository name no sibling group also lands on.
+--
+-- Existing rows are grandfathered. The trigger fires on `update of name`, so a legacy
+-- group that already violates either rule keeps its name, keeps its repository and
+-- keeps working until somebody renames it -- at which point the new name has to be
+-- valid. The audit at the end of this section reports the legacy violations into the
+-- deploy log without failing the deploy.
+
+-- security definer because RLS on assignment_groups scopes SELECT to the caller's
+-- class enrollment, and the collision check has to see every sibling group regardless
+-- of who is writing. A definer-less check would silently pass for a caller who cannot
+-- read the row it collides with, which is the exact case this is meant to catch.
+create or replace function public.validate_assignment_group_name()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_sanitized text;
+  v_other text;
+  r record;
+begin
+  begin
+    v_sanitized := public.sanitize_repo_name_component(new.name);
+  exception
+    when others then
+      raise exception 'Group name "%" cannot be used: a group name needs at least one letter or number in it. This group''s repository is named after it, and GitHub will not accept a name made only of dashes, underscores or dots. Pick a different name for the group.', new.name
+        using errcode = 'check_violation';
+  end;
+
+  -- Row-at-a-time rather than one set query so that a grandfathered sibling whose own
+  -- name does not sanitize cannot make this trigger raise on an unrelated group: a
+  -- name with no repo-name form has no repository, so nothing can collide with it.
+  --
+  -- The scan skips any sibling whose name is byte-identical to the incoming one, and
+  -- that exclusion is load-bearing -- do NOT simplify it away as redundant with the id
+  -- guard:
+  --
+  --   A BEFORE INSERT trigger fires before ON CONFLICT arbitration, and identity
+  --   defaults are already filled in by the time it runs. So an upsert that Postgres
+  --   is about to route into an UPDATE of an existing row arrives here looking like a
+  --   brand-new row with a fresh id, colliding with itself; `id is distinct from
+  --   new.id` cannot tell the two apart. copy_groups_from_assignment reuses target
+  --   groups exactly that way -- INSERT ... ON CONFLICT (assignment_id, name) DO
+  --   UPDATE, so repository and submission history survive a re-copy -- and without
+  --   this exclusion every copy into a target that already holds a same-named group
+  --   aborts on a collision of a group with itself. That is an instructor's ordinary
+  --   "copy groups from lab 1 to lab 2, then fix a roster and copy again" workflow.
+  --
+  -- Skipping those rows gives up no protection. A byte-identical duplicate is already
+  -- rejected by unique_assignment_group_name (assignment_id, name), and a duplicate
+  -- differing only in capitalization by unique_assignment_groups_name_assignment_id
+  -- (lower(name), assignment_id). What those indexes cannot see, and what this trigger
+  -- exists for, is a pair that is distinct as stored yet identical once sanitized --
+  -- `Team--One` against `Team-One` -- and such a pair is never byte-identical, so it
+  -- still reaches the comparison below.
+  for r in
+    select ag.id, ag.name
+      from public.assignment_groups ag
+     where ag.assignment_id = new.assignment_id
+       and ag.id is distinct from new.id
+       and ag.name is distinct from new.name
+  loop
+    begin
+      v_other := lower(public.sanitize_repo_name_component(r.name));
+    exception
+      when others then
+        v_other := null;
+    end;
+
+    if v_other is not null and v_other = lower(v_sanitized) then
+      raise exception 'Group name "%" is too similar to the existing group "%" on this assignment. GitHub ignores capitalization and treats repeated dashes as one, so both group names turn into the same repository name ("%") and only one of the two groups could ever get its repository. Rename one of them so they differ by a letter or a number, not only by punctuation or capitalization.', new.name, r.name, v_sanitized
+        using errcode = 'unique_violation';
+    end if;
+  end loop;
+
+  return new;
+end;
+$$;
+
+comment on function public.validate_assignment_group_name() is
+  'Reject an assignment group name that cannot become a repository name: one that sanitize_repo_name_component() empties, or one that normalizes to the same component as a sibling group in the same assignment (compared case-insensitively, as GitHub does). Does not police character set or length -- those stay in the app layer, and names with spaces are valid here.';
+
+drop trigger if exists validate_assignment_group_name on public.assignment_groups;
+create trigger validate_assignment_group_name
+  before insert or update of name on public.assignment_groups
+  for each row
+  execute function public.validate_assignment_group_name();
+
+-- One-time audit of what the rules would have caught, reported and not enforced.
+-- Renaming existing groups is a data decision (their repositories already exist under
+-- the old names), so this only puts the counts in the deploy log for whoever has to
+-- make it. Wrapped so that it can never fail the migration: an audit that aborts a
+-- deploy is worse than no audit.
+do $$
+declare
+  r record;
+  v_keys text[] := '{}';
+  v_unnameable int := 0;
+  v_colliding_names int := 0;
+  v_collision_clusters int := 0;
+begin
+  for r in select ag.id, ag.assignment_id, ag.name from public.assignment_groups ag loop
+    begin
+      v_keys := v_keys || (r.assignment_id::text || ':' || lower(public.sanitize_repo_name_component(r.name)));
+    exception
+      when others then
+        v_unnameable := v_unnameable + 1;
+    end;
+  end loop;
+
+  select coalesce(count(*), 0), coalesce(sum(k.n), 0)
+    into v_collision_clusters, v_colliding_names
+    from (
+      select count(*) as n
+        from unnest(v_keys) as sanitized_key
+       group by sanitized_key
+      having count(*) > 1
+    ) k;
+
+  if v_unnameable > 0 then
+    raise warning 'assignment_groups audit: % existing group name(s) do not sanitize to a usable repo-name component. They are grandfathered; renaming one now requires a valid name.', v_unnameable;
+  end if;
+  if v_collision_clusters > 0 then
+    raise warning 'assignment_groups audit: % existing group name(s), in % collision set(s), normalize to the same repo-name component as a sibling group in the same assignment. They are grandfathered; only one group per set can hold the derived repository.', v_colliding_names, v_collision_clusters;
+  end if;
+exception
+  when others then
+    raise warning 'assignment_groups audit skipped: %', sqlerrm;
+end;
+$$;
+
+-- ============================================================================
+-- 10. Sanitize the group-name component in publish_assignment_group_changes
+-- ============================================================================
+--
+-- The last SQL site that assembled a repo name out of a RAW group name. It builds
+-- `<class_slug>-<assignment_slug>-group-<group name>` when it enqueues creation for a
+-- group an instructor just published, and with no whole-name net left (section 1) that
+-- concatenation is the one place SQL can still derive a name TypeScript never would: a
+-- group named `Team--One` gives `-group-Team--One` here and `-group-Team-One` in
+-- github-user-sync and in create_all_repos_for_assignment_internal. The repository row
+-- then holds a name no GitHub repo has, permission sync misses, and the reconciler
+-- re-enqueues it forever -- the failure mode this migration is about, arriving through
+-- the one door left open.
+--
+-- The fix is one component, not the assembled name: wrap v_group_name in
+-- sanitize_repo_name_component(), exactly as section 3 does in
+-- create_all_repos_for_assignment_internal(). Everything around it -- the class and
+-- assignment slugs -- stays byte-for-byte, because TypeScript leaves them alone too.
+--
+-- The body below is the live 20260624000000 definition re-emitted verbatim, with that
+-- single expression changed and nothing else touched. It is copied rather than patched
+-- because Postgres has no way to edit one expression of a function in place; when this
+-- function is next revised, that revision supersedes this copy and must carry the
+-- sanitize forward. The trigger in section 9 is the backstop that keeps the group name
+-- itself derivable, but it cannot make this site agree with TypeScript -- only
+-- sanitizing here can.
+create or replace function public.publish_assignment_group_changes(
+    p_class_id       bigint,
+    p_assignment_id  bigint,
+    p_groups_to_create jsonb default '[]'::jsonb,
+    p_moves_to_fulfill jsonb default '[]'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+    v_caller_profile_id uuid;
+    v_course_slug       text;
+    v_github_org        text;
+    v_template_repo     text;
+    v_latest_sha        text;
+    v_assignment_slug   text;
+
+    v_repo_mode            public.assignment_repo_mode;
+    v_source_assignment_id bigint;
+    v_branch_protection    jsonb;
+    v_creation_method      text;
+    v_group_source_repo    text;
+
+    v_group             jsonb;
+    v_move              jsonb;
+    v_group_name        text;
+    v_new_group_id      bigint;
+    v_member_id         uuid;
+    v_member_ids        jsonb;
+
+    v_old_gid           bigint;
+    v_new_gid           bigint;
+    v_profile_id        uuid;
+    v_empty_gid         bigint;
+
+    v_membership_id     bigint;
+    v_repo_record       record;
+
+    v_affected_groups   bigint[] := '{}';
+    v_deleted_groups    bigint[] := '{}';
+    -- empty groups we intentionally keep (they have submissions); excluded from
+    -- the permission sync so their preserved repo's GitHub access is left as-is
+    v_preserved_groups  bigint[] := '{}';
+
+    v_groups_created    integer := 0;
+    v_members_added     integer := 0;
+    v_members_moved     integer := 0;
+    v_groups_dissolved  integer := 0;
+    v_syncs_enqueued    integer := 0;
+    v_errors            jsonb[] := '{}';
+begin
+    -- auth
+    if auth.uid() is null then
+        raise exception 'Not authenticated';
+    end if;
+    if not exists (
+        select 1 from public.user_privileges up
+        where up.user_id = auth.uid()
+          and (up.role = 'admin' or (up.class_id = p_class_id and up.role = 'instructor'))
+    ) then
+        raise exception 'Only instructors can publish group changes';
+    end if;
+
+    select private_profile_id into v_caller_profile_id
+    from public.user_roles
+    where user_id = auth.uid()
+      and class_id = p_class_id
+      and role = 'instructor'
+    limit 1;
+
+    -- class + assignment metadata (one query), incl. repo_mode config
+    select c.slug, c.github_org, a.slug, a.template_repo, a.latest_template_sha,
+           a.repo_mode, a.source_assignment_id,
+           jsonb_build_object(
+             'blockForcePush', coalesce(a.protect_block_force_push, true),
+             'requirePullRequest', coalesce(a.protect_require_pull_request, false),
+             'requiredReviewers', coalesce(a.protect_required_reviewers, 0)
+           )
+    into   v_course_slug, v_github_org, v_assignment_slug, v_template_repo, v_latest_sha,
+           v_repo_mode, v_source_assignment_id, v_branch_protection
+    from   public.assignments a
+    join   public.classes c on c.id = a.class_id
+    where  a.id = p_assignment_id and a.class_id = p_class_id;
+
+    if v_course_slug is null then
+        raise exception 'Assignment % not found in class %', p_assignment_id, p_class_id;
+    end if;
+
+    -- Phase 1: process moves on existing groups
+    for v_move in select * from jsonb_array_elements(p_moves_to_fulfill)
+    loop
+        v_profile_id := (v_move->>'profile_id')::uuid;
+        v_old_gid    := (v_move->>'old_group_id')::bigint;
+        v_new_gid    := (v_move->>'new_group_id')::bigint;
+
+        begin
+            if v_old_gid is not null and not exists (
+                select 1 from public.assignment_groups
+                where id = v_old_gid
+                  and assignment_id = p_assignment_id
+                  and class_id = p_class_id
+            ) then
+                v_errors := array_append(v_errors, jsonb_build_object(
+                    'profile_id', v_profile_id,
+                    'error', format('Group %s does not belong to assignment %s', v_old_gid, p_assignment_id)
+                ));
+                continue;
+            end if;
+            if v_new_gid is not null and not exists (
+                select 1 from public.assignment_groups
+                where id = v_new_gid
+                  and assignment_id = p_assignment_id
+                  and class_id = p_class_id
+            ) then
+                v_errors := array_append(v_errors, jsonb_build_object(
+                    'profile_id', v_profile_id,
+                    'error', format('Group %s does not belong to assignment %s', v_new_gid, p_assignment_id)
+                ));
+                continue;
+            end if;
+
+            if v_old_gid is not null then
+                select id into v_membership_id
+                from public.assignment_groups_members
+                where assignment_group_id = v_old_gid
+                  and profile_id = v_profile_id
+                  and class_id = p_class_id;
+
+                if v_membership_id is null then
+                    v_errors := array_append(v_errors, jsonb_build_object(
+                        'profile_id', v_profile_id,
+                        'error', format('Student not in group %s', v_old_gid)
+                    ));
+                    continue;
+                end if;
+
+                delete from public.assignment_groups_members where id = v_membership_id;
+                v_affected_groups := array_append(v_affected_groups, v_old_gid);
+            end if;
+
+            if v_new_gid is not null then
+                if v_old_gid is null then
+                    update public.submissions
+                    set is_active = false
+                    where assignment_id = p_assignment_id
+                      and profile_id = v_profile_id;
+                end if;
+
+                insert into public.assignment_groups_members
+                    (assignment_group_id, profile_id, assignment_id, class_id, added_by)
+                values
+                    (v_new_gid, v_profile_id, p_assignment_id, p_class_id, v_caller_profile_id);
+
+                v_affected_groups := array_append(v_affected_groups, v_new_gid);
+            end if;
+
+            v_members_moved := v_members_moved + 1;
+
+        exception when others then
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'profile_id', v_profile_id,
+                'error', SQLERRM
+            ));
+        end;
+    end loop;
+
+    -- Phase 2: create new groups and add their initial members
+    for v_group in select * from jsonb_array_elements(p_groups_to_create)
+    loop
+        v_group_name := trim(v_group->>'name');
+        v_member_ids := v_group->'member_ids';
+
+        begin
+            if v_group_name = '' or v_group_name is null then
+                raise exception 'Group name cannot be empty';
+            end if;
+            if length(v_group_name) > 36 then
+                raise exception 'Group name too long (max 36 chars)';
+            end if;
+            if v_group_name !~ '^[a-zA-Z0-9_-]+$' then
+                raise exception 'Group name must be alphanumeric, hyphens, or underscores';
+            end if;
+
+            if exists (
+                select 1 from public.assignment_groups
+                where assignment_id = p_assignment_id and lower(name) = lower(v_group_name)
+            ) then
+                raise exception 'Group "%" already exists', v_group_name;
+            end if;
+
+            -- Resolve the creation strategy from repo_mode BEFORE creating the
+            -- group, so a fork-mode group with no source repo is reported as an
+            -- error without leaving a half-created group behind.
+            v_creation_method := null;
+            v_group_source_repo := null;
+            if v_repo_mode not in ('none', 'no_submission') then
+                if v_repo_mode = 'fork_from_prior_assignment' then
+                    select r.repository into v_group_source_repo
+                      from public.repositories r
+                      join public.assignment_groups ag on ag.id = r.assignment_group_id
+                     where r.assignment_id = v_source_assignment_id
+                       and ag.name = v_group_name
+                     limit 1;
+                    if v_group_source_repo is null then
+                        raise exception 'No source repository for group "%" on source assignment %', v_group_name, v_source_assignment_id;
+                    end if;
+                    v_creation_method := 'fork';
+                elsif v_repo_mode = 'template_with_student_forks' then
+                    v_group_source_repo := v_template_repo;
+                    v_creation_method := 'fork';
+                else  -- template_only_staff
+                    v_group_source_repo := v_template_repo;
+                    v_creation_method := 'template';
+                end if;
+            end if;
+
+            insert into public.assignment_groups (name, assignment_id, class_id)
+            values (v_group_name, p_assignment_id, p_class_id)
+            returning id into v_new_group_id;
+
+            v_groups_created := v_groups_created + 1;
+
+            -- enqueue repo creation per repo_mode (empty usernames; permission sync below)
+            if v_creation_method is not null
+               and v_github_org is not null
+               and (v_repo_mode = 'fork_from_prior_assignment'
+                    or (v_template_repo is not null and v_template_repo != '')) then
+                perform public.enqueue_github_create_repo(
+                    p_class_id,
+                    v_github_org,
+                    v_course_slug || '-' || v_assignment_slug || '-group-' || public.sanitize_repo_name_component(v_group_name),
+                    coalesce(v_template_repo, v_group_source_repo),
+                    v_course_slug,
+                    '{}'::text[],
+                    false,
+                    'batch-group-create-' || v_new_group_id::text,
+                    p_assignment_id,
+                    null::uuid,
+                    v_new_group_id,
+                    v_latest_sha,
+                    v_creation_method,
+                    v_group_source_repo,
+                    v_branch_protection,
+                    null
+                );
+            end if;
+
+            if v_member_ids is not null and jsonb_array_length(v_member_ids) > 0 then
+                for v_member_id in
+                    select (value#>>'{}')::uuid from jsonb_array_elements(v_member_ids) as value
+                loop
+                    update public.submissions
+                    set is_active = false
+                    where assignment_id = p_assignment_id
+                      and profile_id = v_member_id;
+
+                    insert into public.assignment_groups_members
+                        (assignment_group_id, profile_id, assignment_id, class_id, added_by)
+                    values
+                        (v_new_group_id, v_member_id, p_assignment_id, p_class_id, v_caller_profile_id);
+
+                    v_members_added := v_members_added + 1;
+                end loop;
+            end if;
+
+            v_affected_groups := array_append(v_affected_groups, v_new_group_id);
+
+        exception when others then
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'group_name', v_group_name,
+                'error', SQLERRM
+            ));
+        end;
+    end loop;
+
+    -- Phase 2b: dissolve empty groups (batch-final state after moves + creates)
+    for v_empty_gid in
+        select ag.id
+        from public.assignment_groups ag
+        where ag.assignment_id = p_assignment_id
+          and ag.class_id = p_class_id
+          and not exists (
+              select 1 from public.assignment_groups_members agm
+              where agm.assignment_group_id = ag.id
+          )
+    loop
+        -- Preserve groups that still have submissions. Their repo holds
+        -- graded/active work and is referenced by submissions (repository_id and
+        -- repository_check_run_id), so deleting it would violate those FKs and
+        -- destroy history. Keep the group, repo, check runs, and submissions
+        -- intact; only fully dissolve groups whose repos have no submissions.
+        if exists (
+            select 1 from public.submissions s
+            where s.assignment_group_id = v_empty_gid
+        ) or exists (
+            select 1
+            from public.submissions s
+            join public.repositories r on r.id = s.repository_id
+            where r.assignment_group_id = v_empty_gid
+        ) then
+            v_preserved_groups := array_append(v_preserved_groups, v_empty_gid);
+            continue;
+        end if;
+
+        delete from public.assignment_group_invitations
+        where assignment_group_id = v_empty_gid;
+        delete from public.assignment_group_join_request
+        where assignment_group_id = v_empty_gid;
+
+        for v_repo_record in
+            select r.id, r.repository
+            from public.repositories r
+            where r.assignment_group_id = v_empty_gid
+              and r.repository is not null
+              and position('/' in r.repository) > 0
+        loop
+            if v_github_org is not null then
+                perform public.enqueue_github_archive_repo(
+                    p_class_id,
+                    v_github_org,
+                    split_part(v_repo_record.repository, '/', 2),
+                    'batch-dissolve-' || v_empty_gid::text
+                );
+            end if;
+            delete from public.repository_check_runs where repository_id = v_repo_record.id;
+            delete from public.repositories where id = v_repo_record.id;
+        end loop;
+
+        delete from public.assignment_groups where id = v_empty_gid;
+        v_deleted_groups := array_append(v_deleted_groups, v_empty_gid);
+        v_groups_dissolved := v_groups_dissolved + 1;
+    end loop;
+
+    -- Phase 3: enqueue ONE permission sync per affected repo
+    -- Deduplicate and exclude dissolved + preserved groups.
+    -- Enqueue the sync even for repos that aren't GitHub-ready yet: newly-created
+    -- group repos are created via enqueue_github_create_repo with an EMPTY
+    -- collaborator list, so this sync is the only path that grants member access.
+    -- The async worker requeues sync_repo_permissions until is_github_ready=true
+    -- (so it can't race create_repo), then applies the real member list. Skipping
+    -- not-ready repos here would strand those members without GitHub access.
+    for v_repo_record in
+        select distinct r.id           as repo_id,
+               r.repository,
+               r.assignment_group_id,
+               r.is_github_ready
+        from   unnest(v_affected_groups) as gid(g)
+        join   public.repositories r on r.assignment_group_id = gid.g
+        where  not (gid.g = any(v_deleted_groups))
+          and  not (gid.g = any(v_preserved_groups))
+    loop
+        begin
+            declare
+                v_usernames text[];
+            begin
+                select coalesce(array_remove(array_agg(u.github_username), null), '{}')
+                into v_usernames
+                from public.assignment_groups_members agm
+                join public.user_roles ur on ur.private_profile_id = agm.profile_id
+                join public.users u on u.user_id = ur.user_id
+                where agm.assignment_group_id = v_repo_record.assignment_group_id
+                  and ur.class_id = p_class_id
+                  and ur.role = 'student'
+                  and ur.github_org_confirmed = true
+                  and u.github_username is not null
+                  and u.github_username != '';
+
+                if v_repo_record.repository is not null and position('/' in v_repo_record.repository) > 0 then
+                    perform public.enqueue_github_sync_repo_permissions(
+                        p_class_id,
+                        v_github_org,
+                        split_part(v_repo_record.repository, '/', 2),
+                        v_course_slug,
+                        coalesce(v_usernames, '{}'),
+                        'batch-publish-' || p_assignment_id::text || '-g' || v_repo_record.assignment_group_id::text
+                    );
+                    v_syncs_enqueued := v_syncs_enqueued + 1;
+                end if;
+            end;
+        exception when others then
+            v_errors := array_append(v_errors, jsonb_build_object(
+                'repository_id', v_repo_record.repo_id,
+                'error', SQLERRM
+            ));
+        end;
+    end loop;
+
+    return jsonb_build_object(
+        'groups_created',   v_groups_created,
+        'members_added',    v_members_added,
+        'members_moved',    v_members_moved,
+        'groups_dissolved', v_groups_dissolved,
+        'syncs_enqueued',   v_syncs_enqueued,
+        'errors',           to_jsonb(v_errors)
+    );
+end;
+$$;
+
+revoke all on function public.publish_assignment_group_changes(bigint, bigint, jsonb, jsonb) from public;
+grant execute on function public.publish_assignment_group_changes(bigint, bigint, jsonb, jsonb) to authenticated;

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -474,29 +474,48 @@ begin
       r_source_repo := v_default_source;
     end if;
 
-    perform public.enqueue_github_create_repo(
-      v_course_id,
-      v_org,
-      -- Sanitize the group name as its own COMPONENT, exactly as the TypeScript paths
-      -- do. Sanitizing only the assembled name would let two groups whose names are
-      -- entirely illegal characters ("###" and "@@@") both collapse to
-      -- `<slug>-<assignment>-group` and collide on one repository; per-component
-      -- sanitization raises on such a name instead, matching sanitizeRepoNameComponent.
-      v_slug || '-' || v_assignment_slug || '-group-' || public.sanitize_repo_name_component(r_group_name),
-      coalesce(v_template_repo, r_source_repo),
-      v_slug,
-      r_members,
-      false,
-      null,
-      v_assignment_id,
-      null,
-      r_group_id,
-      v_latest_template_sha,
-      v_creation_method,
-      r_source_repo,
-      v_branch_protection,
-      null
-    );
+    -- One unusable group name must not take down the assignment-wide pass. This runs
+    -- inside the FOR EACH ROW trigger on assignment_groups_members, so an exception here
+    -- aborts whatever transaction touched membership -- a student's group join, say.
+    -- Two reachable cases, both allowed by the group-name validators
+    -- (`^[a-zA-Z0-9_-]{1,36}$` in the UI and edge functions, `^[a-zA-Z0-9_-]+$` in the
+    -- SQL RPCs), neither of which the sanitizer can express:
+    --   * separator-only names ("---", "_") trim to an empty component and raise;
+    --   * "Team-One" and "Team--One" both collapse to "Team-One" and collide on
+    --     unique_repo_name.
+    -- The TypeScript paths hit exactly the same two walls, since they call
+    -- sanitizeRepoNameComponent on the same input -- so skipping is the consistent
+    -- outcome, not a SQL-only quirk. Warn, skip that group, keep going. Validating
+    -- names against the sanitizer at group-creation time (with post-sanitization
+    -- uniqueness) is the real fix and belongs with the group-creation paths.
+    begin
+      perform public.enqueue_github_create_repo(
+        v_course_id,
+        v_org,
+        -- Sanitize the group name as its own COMPONENT, exactly as the TypeScript paths
+        -- do, so a name derived here and the same name derived there agree. Netting only
+        -- the assembled name would leave "Team--One" uncollapsed in SQL while TypeScript
+        -- collapses it -- the divergence this migration exists to close.
+        v_slug || '-' || v_assignment_slug || '-group-' || public.sanitize_repo_name_component(r_group_name),
+        coalesce(v_template_repo, r_source_repo),
+        v_slug,
+        r_members,
+        false,
+        null,
+        v_assignment_id,
+        null,
+        r_group_id,
+        v_latest_template_sha,
+        v_creation_method,
+        r_source_repo,
+        v_branch_protection,
+        null
+      );
+    exception
+      when others then
+        raise warning 'Could not enqueue a repo for group "%" (id %) on assignment %: %. Rename the group to something that survives repo-name normalization, then use Retry.',
+          r_group_name, r_group_id, v_assignment_id, sqlerrm;
+    end;
   end loop;
 end;
 $$;

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -1,0 +1,733 @@
+-- Stop the github-async-worker from thrashing on unbounded create_repo enqueues.
+--
+-- Two independent mechanisms were re-enqueueing the same repositories forever.
+--
+-- 1. reconcile_stuck_repo_creations() (pg_cron, every 15 minutes) re-enqueued EVERY
+--    repository row with is_github_ready = false and creation_error IS NULL, across
+--    every class in the instance, with no attempt counter, no backoff and no ceiling.
+--    enqueue_create_repo_for_repository() bumps updated_at, which only suppresses a
+--    duplicate inside the 15-minute stale window; the next tick re-enqueued the whole
+--    set again. A repository that fails in a way that does not set creation_error
+--    (only NonRetryableRepoError does; a generic throw leaves it NULL) therefore
+--    generated 96 create_repo jobs per day, forever, each with the worker's own retry
+--    budget on top.
+--
+-- 2. create_all_repos_for_assignment_internal() decided "does this repo already
+--    exist?" by string-comparing a DERIVED repo name against repositories.repository,
+--    while enqueue_github_create_repo() dedupes the row on
+--    (assignment_id, profile_id | assignment_group_id). Whenever the stored name and
+--    the derived name disagreed, the existence check missed, the enqueue found the
+--    existing row and did not insert, and the stored name never converged -- so the
+--    next call enqueued again. Permanently. The names diverge when a group name needs
+--    sanitizing (every TS path applies sanitizeRepoNameComponent, no SQL path did),
+--    when a student's GitHub login is renamed, or when a class/assignment slug is
+--    edited after repos exist. The FOR EACH ROW trigger on assignment_groups_members
+--    then multiplied it: R rows written x (mismatched groups + students without repos).
+--
+-- This migration:
+--   1. sanitize_repo_name_component() -- the SQL twin of _shared/repoNames.ts.
+--   2. enqueue_github_create_repo() sanitizes the repo name at the single choke point
+--      every SQL caller already goes through, so the row and GitHub agree.
+--   3. create_all_repos_for_assignment_internal() dedupes on identity, not on name.
+--   4. repositories.creation_attempts / .last_creation_attempt_at + a reset trigger.
+--   5. reconcile_stuck_repo_creations() gains exponential backoff, an attempt ceiling
+--      that parks the row for an instructor, and active-class scoping.
+--   6. A one-time backfill that parks rows already stuck long enough to have been
+--      retried hundreds of times, so the backlog drains instead of replaying.
+
+-- ============================================================================
+-- 1. Repo-name sanitizer (SQL twin of supabase/functions/_shared/repoNames.ts)
+-- ============================================================================
+
+-- Kept byte-for-byte equivalent to sanitizeRepoNameComponent() so a name derived in
+-- SQL and the same name derived in TypeScript resolve to one repository. Applied to
+-- the whole assembled name rather than per component: the class and assignment slugs
+-- are already URL-safe, so the result is identical, and one call site covers every
+-- caller instead of every concatenation site.
+create or replace function public.sanitize_repo_name_component(raw text)
+returns text
+language plpgsql
+immutable
+parallel safe
+set search_path = ''
+as $$
+declare
+  v_sanitized text;
+begin
+  if raw is null then
+    return null;
+  end if;
+
+  v_sanitized := normalize(raw, NFKD);
+  -- spaces & other characters GitHub does not accept in a repo name -> hyphen
+  v_sanitized := regexp_replace(v_sanitized, '[^A-Za-z0-9._-]+', '-', 'g');
+  -- collapse runs
+  v_sanitized := regexp_replace(v_sanitized, '-{2,}', '-', 'g');
+  -- trim leading/trailing separators
+  v_sanitized := regexp_replace(v_sanitized, '^[-_.]+|[-_.]+$', '', 'g');
+
+  -- An input made up entirely of illegal characters collapses to '', and GitHub
+  -- rejects that. Fail loudly here rather than letting an unusable name reach the
+  -- queue, matching the TypeScript helper.
+  if v_sanitized = '' then
+    raise exception 'sanitize_repo_name_component: input "%" produced an empty repo-name component', raw;
+  end if;
+
+  return v_sanitized;
+end;
+$$;
+
+comment on function public.sanitize_repo_name_component(text) is
+  'Normalize a repo name to the character set GitHub accepts. SQL twin of sanitizeRepoNameComponent() in supabase/functions/_shared/repoNames.ts; the two must stay in sync or SQL- and TS-derived names diverge and dedupe by name breaks.';
+
+grant execute on function public.sanitize_repo_name_component(text) to authenticated, service_role;
+
+-- ============================================================================
+-- 2. Sanitize at the enqueue choke point
+-- ============================================================================
+--
+-- Unchanged from 20260530120200 except for the sanitize of p_repo_name. Every SQL
+-- path that creates a repo goes through here (create_all_repos_for_assignment_internal,
+-- publish_assignment_group_changes, copy_groups_from_assignment,
+-- enqueue_create_repo_for_repository), so this is the one place that has to apply it.
+-- Before this, a group named "Team 1" was stored as `org/course-hw1-group-Team 1`
+-- while GitHub coerced the actual repo to `Team-1` -- which also broke webhook
+-- lookups that resolve a repository row by name.
+create or replace function public.enqueue_github_create_repo(
+  p_class_id bigint,
+  p_org text,
+  p_repo_name text,
+  p_template_repo text,
+  p_course_slug text,
+  p_github_usernames text[],
+  p_is_template_repo boolean default false,
+  p_debug_id text default null,
+  p_assignment_id bigint default null,
+  p_profile_id uuid default null,
+  p_assignment_group_id bigint default null,
+  p_latest_template_sha text default null,
+  p_creation_method text default 'template',           -- 'template' | 'fork'
+  p_source_repo text default null,                     -- owner/repo to fork when method='fork'
+  p_branch_protection jsonb default null,              -- {blockForcePush, requirePullRequest, requiredReviewers}
+  p_student_team_permission text default null          -- 'pull' (mode 2 handout) | null
+) returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  log_id bigint;
+  message_id bigint;
+  repo_id bigint;
+  full_repo_name text;
+  v_repo_name text;
+  v_args jsonb;
+begin
+  v_repo_name := public.sanitize_repo_name_component(p_repo_name);
+  full_repo_name := p_org || '/' || v_repo_name;
+
+  insert into public.api_gateway_calls(method, status_code, class_id, debug_id)
+  values ('create_repo', 0, p_class_id, p_debug_id)
+  returning id into log_id;
+
+  if p_assignment_id is not null then
+    select id into repo_id
+    from public.repositories
+    where assignment_id = p_assignment_id
+      and (
+        (p_profile_id is not null and profile_id = p_profile_id) or
+        (p_assignment_group_id is not null and assignment_group_id = p_assignment_group_id)
+      );
+
+    if repo_id is null then
+      insert into public.repositories(
+        profile_id,
+        assignment_group_id,
+        assignment_id,
+        repository,
+        class_id,
+        synced_handout_sha,
+        is_github_ready
+      )
+      values (
+        p_profile_id,
+        p_assignment_group_id,
+        p_assignment_id,
+        full_repo_name,
+        p_class_id,
+        p_latest_template_sha,
+        false
+      )
+      returning id into repo_id;
+    end if;
+  end if;
+
+  v_args := jsonb_build_object(
+    'org', p_org,
+    'repoName', v_repo_name,
+    'templateRepo', p_template_repo,
+    'isTemplateRepo', p_is_template_repo,
+    'courseSlug', p_course_slug,
+    'githubUsernames', p_github_usernames
+  );
+  if p_creation_method is not null and p_creation_method <> 'template' then
+    v_args := v_args || jsonb_build_object('creationMethod', p_creation_method);
+  end if;
+  if p_source_repo is not null then
+    v_args := v_args || jsonb_build_object('sourceRepo', p_source_repo);
+  end if;
+  if p_branch_protection is not null then
+    v_args := v_args || jsonb_build_object('branchProtection', p_branch_protection);
+  end if;
+  if p_student_team_permission is not null then
+    v_args := v_args || jsonb_build_object('studentTeamPermission', p_student_team_permission);
+  end if;
+
+  select pgmq_public.send(
+    'async_calls',
+    jsonb_build_object(
+      'method', 'create_repo',
+      'class_id', p_class_id,
+      'debug_id', p_debug_id,
+      'log_id', log_id,
+      'repo_id', repo_id,
+      'args', v_args
+    )
+  ) into message_id;
+
+  return message_id;
+end;
+$$;
+
+grant execute on function public.enqueue_github_create_repo(
+  bigint, text, text, text, text, text[], boolean, text, bigint, uuid, bigint, text,
+  text, text, jsonb, text
+) to service_role;
+
+-- ============================================================================
+-- 3. Dedupe on identity, not on a derived name
+-- ============================================================================
+--
+-- Unchanged from 20260530120200 except for the two existence checks, which now key on
+-- the same (assignment_id, profile_id) / (assignment_id, assignment_group_id) identity
+-- that enqueue_github_create_repo uses to decide whether to insert a row. Comparing
+-- derived names could never converge: a mismatch made the check miss on every call
+-- while the enqueue kept reusing the existing row.
+create or replace function public.create_all_repos_for_assignment_internal(
+  course_id bigint, assignment_id bigint, p_force boolean default false
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_course_id bigint := course_id;
+  v_assignment_id bigint := assignment_id;
+  v_slug text;
+  v_org text;
+  v_template_repo text;
+  v_assignment_slug text;
+  v_latest_template_sha text;
+  v_repo_mode public.assignment_repo_mode;
+  v_source_assignment_id bigint;
+  v_branch_protection jsonb;
+  v_creation_method text;
+  v_default_source text;
+  r_user_id uuid;
+  r_username text;
+  r_profile_id uuid;
+  r_group_id bigint;
+  r_group_name text;
+  r_members text[];
+  r_source_repo text;
+begin
+  if v_course_id is null or v_assignment_id is null then
+    raise warning 'create_all_repos_for_assignment_internal called with NULL parameters, skipping';
+    return;
+  end if;
+
+  select c.slug, c.github_org, a.template_repo, a.slug, a.latest_template_sha,
+         a.repo_mode, a.source_assignment_id,
+         jsonb_build_object(
+           'blockForcePush', coalesce(a.protect_block_force_push, true),
+           'requirePullRequest', coalesce(a.protect_require_pull_request, false),
+           'requiredReviewers', coalesce(a.protect_required_reviewers, 0)
+         )
+    into v_slug, v_org, v_template_repo, v_assignment_slug, v_latest_template_sha,
+         v_repo_mode, v_source_assignment_id, v_branch_protection
+    from public.assignments a
+    join public.classes c on c.id = a.class_id
+   where a.id = v_assignment_id and a.class_id = v_course_id;
+
+  if v_slug is null or v_org is null then
+    raise exception 'Invalid class/assignment (class_id %, assignment_id %)', course_id, assignment_id;
+  end if;
+
+  if v_repo_mode = 'no_submission' then
+    -- No git repos for this mode; instead make sure every student/group has an
+    -- empty 'manual' submission so graders see a row for everyone.
+    perform public.create_all_manual_submissions_for_assignment(v_course_id, v_assignment_id);
+    return;
+  end if;
+
+  if v_repo_mode = 'none' then
+    raise notice 'Assignment % has repo_mode=none; nothing to enqueue', v_assignment_id;
+    return;
+  end if;
+
+  if v_repo_mode in ('template_only_staff', 'template_with_student_forks')
+     and (v_template_repo is null or v_template_repo = '')
+  then
+    raise exception 'Assignment % is missing template_repo for mode %', v_assignment_id, v_repo_mode;
+  end if;
+
+  if v_repo_mode = 'fork_from_prior_assignment' and v_source_assignment_id is null then
+    raise exception 'Assignment % has repo_mode=fork_from_prior_assignment but no source_assignment_id', v_assignment_id;
+  end if;
+
+  v_creation_method := case
+    when v_repo_mode = 'template_only_staff' then 'template'
+    else 'fork'
+  end;
+  v_default_source := v_template_repo;
+
+  -- Enqueue individual repos for students not in groups.
+  for r_user_id, r_username, r_profile_id in
+    select ur.user_id, u.github_username, ur.private_profile_id
+    from public.user_roles ur
+    join public.users u on u.user_id = ur.user_id
+    where ur.class_id = v_course_id
+      and ur.role = 'student'
+      and ur.disabled = false
+      and u.github_username is not null
+      and not exists (
+        select 1 from public.assignment_groups_members agm
+        join public.assignment_groups ag on ag.id = agm.assignment_group_id
+        where ag.assignment_id = v_assignment_id and agm.profile_id = ur.private_profile_id
+      )
+      and (
+        p_force
+        -- Identity, not name: this is the key enqueue_github_create_repo dedupes on.
+        or not exists (
+          select 1 from public.repositories r
+          where r.assignment_id = v_assignment_id
+            and r.profile_id = ur.private_profile_id
+        )
+      )
+  loop
+    if v_repo_mode = 'fork_from_prior_assignment' then
+      select r.repository into r_source_repo
+        from public.repositories r
+       where r.assignment_id = v_source_assignment_id
+         and r.profile_id = r_profile_id
+       limit 1;
+      if r_source_repo is null then
+        raise warning 'No source repository for profile % on assignment %; skipping', r_profile_id, v_source_assignment_id;
+        continue;
+      end if;
+    else
+      r_source_repo := v_default_source;
+    end if;
+
+    perform public.enqueue_github_create_repo(
+      v_course_id,
+      v_org,
+      v_slug || '-' || v_assignment_slug || '-' || r_username,
+      coalesce(v_template_repo, r_source_repo),
+      v_slug,
+      array[r_username],
+      false,
+      null,
+      v_assignment_id,
+      r_profile_id,
+      null,
+      v_latest_template_sha,
+      v_creation_method,
+      r_source_repo,
+      v_branch_protection,
+      null
+    );
+  end loop;
+
+  -- Enqueue group repos.
+  for r_group_id, r_group_name, r_members in
+    select distinct on (ag.id)
+           ag.id as group_id,
+           ag.name as group_name,
+           array_remove(array_agg(u.github_username), null) as members
+    from public.assignment_groups ag
+    left join public.assignment_groups_members agm on agm.assignment_group_id = ag.id
+    left join public.user_roles ur on ur.private_profile_id = agm.profile_id and ur.disabled = false
+    left join public.users u on u.user_id = ur.user_id
+    where ag.assignment_id = v_assignment_id
+      and (
+        p_force
+        -- Identity, not name. A renamed group used to miss here forever.
+        or not exists (
+          select 1 from public.repositories r
+          where r.assignment_id = v_assignment_id
+            and r.assignment_group_id = ag.id
+        )
+      )
+    group by ag.id, ag.name
+    having array_length(array_remove(array_agg(u.github_username), null), 1) > 0
+  loop
+    if v_repo_mode = 'fork_from_prior_assignment' then
+      select r.repository into r_source_repo
+        from public.repositories r
+        join public.assignment_groups ag on ag.id = r.assignment_group_id
+       where r.assignment_id = v_source_assignment_id
+         and ag.name = r_group_name
+       limit 1;
+      if r_source_repo is null then
+        raise warning 'No source repository for group % on assignment %; skipping', r_group_name, v_source_assignment_id;
+        continue;
+      end if;
+    else
+      r_source_repo := v_default_source;
+    end if;
+
+    perform public.enqueue_github_create_repo(
+      v_course_id,
+      v_org,
+      v_slug || '-' || v_assignment_slug || '-group-' || r_group_name,
+      coalesce(v_template_repo, r_source_repo),
+      v_slug,
+      r_members,
+      false,
+      null,
+      v_assignment_id,
+      null,
+      r_group_id,
+      v_latest_template_sha,
+      v_creation_method,
+      r_source_repo,
+      v_branch_protection,
+      null
+    );
+  end loop;
+end;
+$$;
+
+revoke all on function public.create_all_repos_for_assignment_internal(bigint, bigint, boolean) from public;
+grant execute on function public.create_all_repos_for_assignment_internal(bigint, bigint, boolean) to postgres;
+
+comment on function public.create_all_repos_for_assignment_internal(bigint, bigint, boolean) is
+  'Enqueue repo creation for an assignment per its repo_mode (template/fork/none) without auth.uid()/instructor checks; for triggers and other trusted callers. Skips students/groups that already have a repository row for this assignment, keyed on identity (profile_id / assignment_group_id) to match enqueue_github_create_repo -- never on a derived repo name, which cannot converge once it diverges.';
+
+-- ============================================================================
+-- 4. Attempt accounting on repositories
+-- ============================================================================
+
+alter table public.repositories
+  add column if not exists creation_attempts integer not null default 0,
+  add column if not exists last_creation_attempt_at timestamptz;
+
+comment on column public.repositories.creation_attempts is
+  'How many times automatic reconciliation has re-enqueued creation for this repo. Drives the reconciler backoff and ceiling; reset to 0 when the repo becomes ready or an instructor retries.';
+comment on column public.repositories.last_creation_attempt_at is
+  'When reconciliation last re-enqueued creation for this repo.';
+
+-- Partial index matching the reconciler's scan: the pending set is tiny next to the
+-- table, and the reconciler runs every 15 minutes.
+create index if not exists repositories_pending_creation_idx
+  on public.repositories (updated_at)
+  where is_github_ready = false and creation_error is null;
+
+-- Reset the counter the moment a repo becomes ready, whichever of the four creation
+-- paths got it there (async worker, assignment-create-all-repos, github-user-sync,
+-- autograder-create-repos-for-student). Keeping this in SQL means a row that later
+-- flips back to not-ready starts a fresh retry budget rather than inheriting a stale
+-- count, without every TS caller having to remember.
+create or replace function public.reset_repo_creation_attempts_on_ready()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.is_github_ready and not coalesce(old.is_github_ready, false) then
+    new.creation_attempts := 0;
+    new.creation_error := null;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists reset_repo_creation_attempts_on_ready on public.repositories;
+create trigger reset_repo_creation_attempts_on_ready
+  before update on public.repositories
+  for each row
+  execute function public.reset_repo_creation_attempts_on_ready();
+
+-- ============================================================================
+-- 5. Count the attempt when reconciliation re-enqueues
+-- ============================================================================
+--
+-- Unchanged from 20260709130000 except for the final UPDATE, which now records the
+-- attempt as well as bumping updated_at.
+create or replace function public.enqueue_create_repo_for_repository(p_repository_id bigint)
+returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  r record;
+  v_creation_method text;
+  v_source_repo text;
+  v_usernames text[];
+  v_repo_name text;
+  v_msg_id bigint;
+begin
+  select rp.id, rp.class_id, rp.assignment_id, rp.profile_id, rp.assignment_group_id, rp.repository,
+         a.repo_mode, a.template_repo, a.source_assignment_id, a.latest_template_sha,
+         a.slug as assignment_slug,
+         c.slug as course_slug, c.github_org,
+         jsonb_build_object(
+           'blockForcePush', coalesce(a.protect_block_force_push, true),
+           'requirePullRequest', coalesce(a.protect_require_pull_request, false),
+           'requiredReviewers', coalesce(a.protect_required_reviewers, 0)
+         ) as branch_protection
+    into r
+    from public.repositories rp
+    join public.assignments a on a.id = rp.assignment_id
+    join public.classes c on c.id = rp.class_id
+   where rp.id = p_repository_id;
+
+  if not found then
+    raise exception 'Repository % not found', p_repository_id;
+  end if;
+
+  if r.repo_mode in ('none', 'no_submission') then
+    raise notice 'Repository % assignment repo_mode=%; nothing to enqueue', p_repository_id, r.repo_mode;
+    return null;
+  end if;
+
+  v_creation_method := case when r.repo_mode = 'template_only_staff' then 'template' else 'fork' end;
+  v_repo_name := split_part(r.repository, '/', 2);
+
+  if r.assignment_group_id is not null then
+    -- Group repo: collect member usernames; resolve the prior-assignment source by group name.
+    select array_remove(array_agg(u.github_username), null)
+      into v_usernames
+      from public.assignment_groups_members agm
+      join public.user_roles ur on ur.private_profile_id = agm.profile_id and ur.disabled = false
+      join public.users u on u.user_id = ur.user_id
+     where agm.assignment_group_id = r.assignment_group_id;
+
+    if r.repo_mode = 'fork_from_prior_assignment' then
+      select pr.repository
+        into v_source_repo
+        from public.repositories pr
+        join public.assignment_groups ag on ag.id = pr.assignment_group_id
+        join public.assignment_groups cur on cur.id = r.assignment_group_id
+       where pr.assignment_id = r.source_assignment_id
+         and ag.name = cur.name
+       limit 1;
+    else
+      v_source_repo := r.template_repo;
+    end if;
+  else
+    -- Individual repo: single owner username; resolve prior-assignment source by profile.
+    -- Filter out disabled (dropped) roles, matching the group path above and create_all_repos_for_assignment,
+    -- so a dropped student is not re-granted repo access on reconcile/retry.
+    select array[u.github_username]
+      into v_usernames
+      from public.user_roles ur
+      join public.users u on u.user_id = ur.user_id
+     where ur.private_profile_id = r.profile_id
+       and ur.disabled = false
+       and u.github_username is not null
+     limit 1;
+
+    if r.repo_mode = 'fork_from_prior_assignment' then
+      select pr.repository
+        into v_source_repo
+        from public.repositories pr
+       where pr.assignment_id = r.source_assignment_id
+         and pr.profile_id = r.profile_id
+       limit 1;
+    else
+      v_source_repo := r.template_repo;
+    end if;
+  end if;
+
+  if v_usernames is null then
+    v_usernames := array[]::text[];
+  end if;
+
+  if r.repo_mode = 'fork_from_prior_assignment' and v_source_repo is null then
+    raise warning 'No source repository resolved for repository % (fork_from_prior_assignment); skipping', p_repository_id;
+    return null;
+  end if;
+
+  select public.enqueue_github_create_repo(
+    r.class_id,
+    r.github_org,
+    v_repo_name,
+    coalesce(r.template_repo, v_source_repo),
+    r.course_slug,
+    v_usernames,
+    false, -- p_is_template_repo
+    'reconcile-repo-' || p_repository_id || '-' || extract(epoch from now())::bigint, -- p_debug_id
+    r.assignment_id,
+    r.profile_id,
+    r.assignment_group_id,
+    r.latest_template_sha,
+    v_creation_method,
+    v_source_repo,
+    r.branch_protection,
+    null -- p_student_team_permission
+  ) into v_msg_id;
+
+  -- Record the attempt. updated_at feeds the reconciler's stale window (so a second
+  -- job cannot race one still in flight) and creation_attempts feeds its backoff and
+  -- ceiling -- without the counter, a repo that can never succeed was re-enqueued
+  -- every 15 minutes forever.
+  update public.repositories
+     set updated_at = now(),
+         creation_attempts = creation_attempts + 1,
+         last_creation_attempt_at = now()
+   where id = p_repository_id;
+
+  return v_msg_id;
+end;
+$$;
+
+revoke all on function public.enqueue_create_repo_for_repository(bigint) from public;
+grant execute on function public.enqueue_create_repo_for_repository(bigint) to service_role;
+
+-- ============================================================================
+-- 6. Instructor retry clears the parked state
+-- ============================================================================
+create or replace function public.retry_repository_creation(p_repository_id bigint)
+returns bigint
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_class_id bigint;
+  v_msg_id bigint;
+begin
+  select class_id into v_class_id from public.repositories where id = p_repository_id;
+  if not found then
+    raise exception 'Repository % not found', p_repository_id;
+  end if;
+  if not public.authorizeforclassinstructor(v_class_id) then
+    raise exception 'Not authorized to retry repository creation for this class';
+  end if;
+
+  -- Clear the error AND the attempt counter: an instructor retry is a deliberate
+  -- statement that the underlying problem has been fixed, so the row gets a full
+  -- automatic retry budget again rather than being re-parked on the next tick.
+  update public.repositories
+     set creation_error = null,
+         creation_attempts = 0
+   where id = p_repository_id;
+
+  v_msg_id := public.enqueue_create_repo_for_repository(p_repository_id);
+  return v_msg_id;
+end;
+$$;
+
+revoke all on function public.retry_repository_creation(bigint) from public;
+grant execute on function public.retry_repository_creation(bigint) to authenticated;
+
+-- ============================================================================
+-- 7. Bounded reconciliation
+-- ============================================================================
+--
+-- Three bounds the previous version had none of:
+--   * Active classes only. The old scan covered every repository row ever created,
+--     so finished courses kept generating GitHub calls indefinitely. Matches the
+--     scoping #924 applied to the Discord role sync.
+--   * Exponential backoff on creation_attempts: 15m, 30m, 1h, 2h, 4h, then 8h.
+--   * A ceiling. At MAX_ATTEMPTS the row is parked with creation_error set, which
+--     both removes it from this scan and surfaces it to the instructor's Retry
+--     button and the reconciler edge function's >12h Sentry alert. Roughly 32h of
+--     automatic retries before a human is asked to look.
+create or replace function public.reconcile_stuck_repo_creations(p_stale_minutes int default 15)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  r record;
+  v_count integer := 0;
+  v_max_attempts constant integer := 8;
+  v_max_backoff_doublings constant integer := 5;  -- caps the interval at 32x p_stale_minutes
+begin
+  -- Park anything that has exhausted its automatic retries. Done as a set operation
+  -- before the loop so a row is parked exactly once, and so the loop below never sees
+  -- it again.
+  update public.repositories rp
+     set creation_error = format(
+           'Repository creation did not succeed after %s automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.',
+           v_max_attempts)
+    from public.assignments a
+   where a.id = rp.assignment_id
+     and rp.is_github_ready = false
+     and rp.creation_error is null
+     and rp.creation_attempts >= v_max_attempts
+     and a.repo_mode not in ('none', 'no_submission');
+
+  for r in
+    select rp.id
+      from public.repositories rp
+      join public.assignments a on a.id = rp.assignment_id
+      join public.classes c on c.id = rp.class_id
+     where rp.is_github_ready = false
+       and rp.creation_error is null
+       and rp.creation_attempts < v_max_attempts
+       and a.repo_mode not in ('none', 'no_submission')
+       -- Recurring per-class work must not run for courses that have ended.
+       and public.is_class_active(c.archived, c.end_date)
+       -- Exponential backoff: each failed attempt doubles the wait, capped.
+       and rp.updated_at < now() - make_interval(
+             mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+           )
+  loop
+    begin
+      perform public.enqueue_create_repo_for_repository(r.id);
+      v_count := v_count + 1;
+    exception
+      when others then
+        raise warning 'reconcile: failed to enqueue repository %: %', r.id, sqlerrm;
+    end;
+  end loop;
+  return v_count;
+end;
+$$;
+
+revoke all on function public.reconcile_stuck_repo_creations(int) from public;
+grant execute on function public.reconcile_stuck_repo_creations(int) to service_role;
+
+comment on function public.reconcile_stuck_repo_creations(int) is
+  'Re-enqueue transient stuck repo creations for active classes, with exponential backoff and an attempt ceiling that parks the row for an instructor. Bounded by design: an unbounded version re-enqueued every not-ready repo in the instance every 15 minutes.';
+
+-- ============================================================================
+-- 8. One-time backlog drain
+-- ============================================================================
+--
+-- Rows that have been stuck long enough to have already been re-enqueued hundreds of
+-- times get parked now rather than being handed a fresh retry budget by the new
+-- backoff. They become visible to instructors via creation_error and the Retry
+-- button, which is the correct end state for a repo that has never once succeeded.
+-- Deliberately conservative: only rows in classes that have ended, or stuck longer
+-- than a week in a running class.
+update public.repositories rp
+   set creation_attempts = 8,
+       creation_error = 'Repository creation did not succeed after repeated automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.'
+  from public.assignments a,
+       public.classes c
+ where a.id = rp.assignment_id
+   and c.id = rp.class_id
+   and rp.is_github_ready = false
+   and rp.creation_error is null
+   and a.repo_mode not in ('none', 'no_submission')
+   and (
+     not public.is_class_active(c.archived, c.end_date)
+     or rp.created_at < now() - interval '7 days'
+   );

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -263,6 +263,28 @@ begin
     end if;
   end if;
 
+  -- Record that creation has been enqueued for this row, on BOTH paths above: the row
+  -- this call just inserted, and an existing row it is reusing. Before this, only
+  -- enqueue_create_repo_for_repository wrote the column, so a repository whose FIRST
+  -- attempt happened in an inactive class -- or whose class went inactive while that
+  -- first job was in flight -- kept a null timestamp forever. The reconciler's
+  -- inactive-class follow-up window keys on this column, so such a row was excluded from
+  -- it permanently, never reached the attempt ceiling either, and sat at
+  -- is_github_ready = false with no creation_error: pending in the UI, with no Retry
+  -- affordance and nothing that could ever make it actionable. The column now means what
+  -- its comment says -- when creation was last enqueued for this row -- rather than
+  -- "when the reconciler last touched it". Nothing outside this migration reads it.
+  --
+  -- The updated_at bump this write causes (via set_updated_at_on_repositories) is
+  -- correct, not collateral: updated_at is the reconciler's "a job was just queued, do
+  -- not queue another" window, and a job has just been queued. It is the same bump
+  -- enqueue_create_repo_for_repository already makes explicitly.
+  if repo_id is not null then
+    update public.repositories
+       set last_creation_attempt_at = now()
+     where id = repo_id;
+  end if;
+
   v_args := jsonb_build_object(
     'org', p_org,
     'repoName', v_repo_name,
@@ -559,7 +581,7 @@ alter table public.repositories
 comment on column public.repositories.creation_attempts is
   'How many times automatic reconciliation has re-enqueued creation for this repo. Drives the reconciler backoff and ceiling; reset to 0 when the repo becomes ready or an instructor retries.';
 comment on column public.repositories.last_creation_attempt_at is
-  'When reconciliation last re-enqueued creation for this repo.';
+  'When creation was last enqueued for this repo, by any path -- the initial enqueue_github_create_repo as well as reconciliation and instructor retries. Drives the reconciler''s follow-up window for classes that are no longer active; a null here means no creation has ever been queued for the row.';
 
 -- Partial index matching the reconciler's scan: the pending set is tiny next to the
 -- table, and the reconciler runs every 15 minutes.
@@ -796,6 +818,48 @@ grant execute on function public.retry_repository_creation(bigint) to authentica
 -- ============================================================================
 -- 7. Bounded reconciliation
 -- ============================================================================
+
+-- "Is a create_repo job still out there for this repository?" -- the one definition of
+-- still-trying, shared by the reconciler below and the one-time backfill in section 8.
+-- A single function rather than the same predicate written twice, because the two
+-- disagreeing about what counts as in flight is exactly how one of them starts parking
+-- rows whose job is alive.
+--
+-- Matched as TEXT, never cast: enqueue_github_create_repo writes 'repo_id', null when it
+-- is called without an assignment, and (message->>'repo_id')::bigint on such an envelope
+-- would raise inside the caller -- taking out a whole reconciler tick, or the migration
+-- itself. Text comparison cannot raise and matches a repo_id written as a JSON number or
+-- a JSON string.
+--
+-- Both live queues are scanned. create_repo is only produced onto async_calls today, but
+-- the worker drains async_calls_low_priority when the main queue is empty and requeues
+-- onto whichever queue it read from. The DLQ is deliberately NOT scanned: a message that
+-- reached it is dead, and treating it as live would leave the row unparked forever.
+create or replace function public.repo_ids_with_queued_create()
+returns text[]
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(array_agg(distinct s.rid), '{}'::text[])
+    from (
+      select q.message->>'repo_id' as rid
+        from pgmq.q_async_calls q
+       where q.message->>'method' = 'create_repo'
+      union all
+      select q.message->>'repo_id' as rid
+        from pgmq.q_async_calls_low_priority q
+       where q.message->>'method' = 'create_repo'
+    ) s
+   where s.rid is not null;
+$$;
+
+comment on function public.repo_ids_with_queued_create() is
+  'repositories.id (as text) for every create_repo message still sitting in a live async queue, worker-invisible ones included. The shared in-flight test for the reconciler and the backfill: a row whose id appears here has a creation attempt that has not finished, so it must not be parked or re-enqueued.';
+
+revoke all on function public.repo_ids_with_queued_create() from public;
+grant execute on function public.repo_ids_with_queued_create() to service_role;
 --
 -- Three bounds the previous version had none of:
 --   * Active classes only. The old scan covered every repository row ever created,
@@ -822,18 +886,7 @@ declare
   -- envelope's repo_id, so a NOT EXISTS per candidate would scan them once per candidate.
   v_inflight_repo_ids text[];
 begin
-  select coalesce(array_agg(distinct s.rid), '{}'::text[])
-    into v_inflight_repo_ids
-    from (
-      select q.message->>'repo_id' as rid
-        from pgmq.q_async_calls q
-       where q.message->>'method' = 'create_repo'
-      union all
-      select q.message->>'repo_id' as rid
-        from pgmq.q_async_calls_low_priority q
-       where q.message->>'method' = 'create_repo'
-    ) s
-   where s.rid is not null;
+  v_inflight_repo_ids := public.repo_ids_with_queued_create();
 
   -- Park anything that has exhausted its automatic retries, whose last job is no longer
   -- anywhere in a queue, and which has gone quiet for the interval its next attempt
@@ -859,19 +912,9 @@ begin
   -- being retried is never briefly absent from this check. Absence means the job really
   -- is gone: archived after success, moved to the DLQ, or lost.
   --
-  -- Matched as TEXT, never cast. Casting message->>'repo_id' to bigint would raise
-  -- inside the reconciler the first time an envelope carried a null or non-numeric
-  -- repo_id -- enqueue_github_create_repo writes 'repo_id', null whenever it is called
-  -- without an assignment -- and a raise here would take out the whole tick, not one
-  -- row. Text comparison against rp.id::text cannot raise and matches a repo_id written
-  -- as either a JSON number or a JSON string.
-  --
-  -- Both live queues are scanned. create_repo is only ever produced onto async_calls
-  -- today, but the worker drains async_calls_low_priority when the main queue is empty
-  -- and requeues onto whichever queue it read from, so covering both costs one more scan
-  -- and removes a way for this to be quietly wrong later. The DLQ is deliberately NOT
-  -- scanned: a message that reached it is dead, and treating it as live would leave the
-  -- row unparked forever.
+  -- The in-flight set is read once per tick, not probed per row: the queue tables have
+  -- no index on the envelope's repo_id. See repo_ids_with_queued_create() above for why
+  -- it compares as text and which queues it covers.
   --
   -- The backoff interval stays as a floor, so a row is not parked the instant its last
   -- message is archived -- there is a moment between a worker archiving a create_repo
@@ -927,8 +970,9 @@ begin
        -- quiet within a week of the last attempt anyone made on it.
        --
        -- last_creation_attempt_at is written only when a job is actually queued, by
-       -- enqueue_create_repo_for_repository, so a row nobody has touched in a dead class
-       -- has an old or null value and stays out entirely.
+       -- every path that queues one -- the initial enqueue_github_create_repo as well as
+       -- reconciliation and instructor retries -- so a row nobody has ever queued work
+       -- for, or has not in a long time, has a null or old value and stays out entirely.
        --
        -- The honest consequence: this follows up recent AUTOMATIC attempts too, not only
        -- human ones -- nothing on the row distinguishes them, and retry_repository_
@@ -991,26 +1035,43 @@ comment on function public.reconcile_stuck_repo_creations(int) is
 -- instructor retried by hand. updated_at measures the thing this cutoff is about: how
 -- long THIS pending state has lasted.
 --
--- This does NOT need the in-flight guard the reconciler's park just grew. Both cutoffs
--- here are already staleness cutoffs on updated_at, and both are enormous next to the
--- reconciler's longest backoff of eight hours: a week of silence in a running class, or
--- a class that has ended and whose rows the reconciler no longer scans at all. Nothing
--- plausibly in flight survives either. And parking is recoverable in any case -- if a
--- late job does succeed, reset_repo_creation_attempts_on_ready clears creation_error and
--- the attempt count as the row flips ready, so a parked row heals itself rather than
--- needing the instructor to undo anything.
+-- Two conditions, and the inactive-class branch needs both of them.
+--
+-- The in-flight guard is repo_ids_with_queued_create(), the same function the reconciler
+-- parks on, so the two cannot drift into disagreeing about what "still trying" means. A
+-- one-time backfill is the worst place to get that wrong: it runs once, at deploy, with
+-- nobody watching, and a row it parks while a create_repo job is queued gets an error
+-- message and a Retry button that races the job about to run.
+--
+-- The staleness term is what makes the inactive-class branch safe. `not is_class_active`
+-- alone parks on a property of the CLASS, not of the row: a class archived five minutes
+-- ago, with a create_repo enqueued four minutes ago, satisfied it. Requiring a day of
+-- silence as well means the class being over is a reason to stop retrying, not a reason
+-- to declare this particular attempt dead. A day sits well above the worker's 8-hour
+-- circuit-breaker requeue while staying far below the running-class cutoff of a week;
+-- the queue check is what actually decides, and this is the floor under it.
+--
+-- Parking stays recoverable either way: if a late job does succeed,
+-- reset_repo_creation_attempts_on_ready clears creation_error and the attempt count as
+-- the row flips ready, so a parked row heals itself rather than needing an instructor to
+-- undo anything.
 update public.repositories rp
    set creation_attempts = 8,
        creation_error = 'Repository creation did not succeed after repeated automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.'
   from public.assignments a,
-       public.classes c
+       public.classes c,
+       (select public.repo_ids_with_queued_create() as ids) q
  where a.id = rp.assignment_id
    and c.id = rp.class_id
    and rp.is_github_ready = false
    and rp.creation_error is null
    and a.repo_mode not in ('none', 'no_submission')
+   -- Never park a repository whose creation job is still in a queue. Read once, in the
+   -- FROM list, rather than per candidate row.
+   and rp.id::text <> all (q.ids)
    and (
-     not public.is_class_active(c.archived, c.end_date)
+     (not public.is_class_active(c.archived, c.end_date)
+      and rp.updated_at < now() - interval '1 day')
      or rp.updated_at < now() - interval '7 days'
    );
 

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -26,8 +26,15 @@
 --
 -- This migration:
 --   1. sanitize_repo_name_component() -- the SQL twin of _shared/repoNames.ts.
---   2. enqueue_github_create_repo() sanitizes the repo name at the single choke point
---      every SQL caller already goes through, so the row and GitHub agree.
+--   2. Sanitization applies only where a name is FIRST derived and stored: the insert
+--      path of enqueue_github_create_repo(), plus the group-name component in
+--      create_all_repos_for_assignment_internal(). A name read back off an existing row
+--      is authoritative and is used verbatim -- it is what a GitHub repo was created as
+--      and what webhooks resolve against, and `is_github_ready = false` does not mean no
+--      GitHub repo exists (the worker can create the repo and fail to mark the row).
+--      So new rows converge on the name GitHub will actually create, and existing rows
+--      keep resolving to their real repository. Renaming the rows that already diverged
+--      is a data migration, deliberately not folded in here.
 --   3. create_all_repos_for_assignment_internal() dedupes on identity, not on name.
 --   4. repositories.creation_attempts / .last_creation_attempt_at + a reset trigger.
 --   5. reconcile_stuck_repo_creations() gains exponential backoff, an attempt ceiling

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -798,6 +798,26 @@ begin
 
   v_msg_id := public.enqueue_create_repo_for_repository(p_repository_id);
 
+  if v_msg_id is null then
+    -- Nothing was queued, so clearing the error above would strand the row: it would sit
+    -- at is_github_ready = false with no error, which the UI reads as "creation pending"
+    -- and which hides the Retry button, while the reconciler skips it too. That is the
+    -- same dead end this migration keeps closing, reached through the Retry button.
+    --
+    -- enqueue_create_repo_for_repository returns null in two cases. For repo_mode 'none'
+    -- and 'no_submission' it queues nothing because those assignments never get a
+    -- repository -- most likely a leftover row from before the mode was changed, which an
+    -- instructor should be told about rather than left to click Retry forever. For an
+    -- unresolvable fork source it has already written its own, more specific error, so
+    -- coalesce keeps that rather than overwriting it with this generic one.
+    update public.repositories
+       set creation_error = coalesce(
+             creation_error,
+             'This assignment no longer creates GitHub repositories, so this leftover repository row cannot be created. It can be removed.')
+     where id = p_repository_id;
+    return null;
+  end if;
+
   -- Zero the counter AFTER the enqueue, not before: enqueue_create_repo_for_repository
   -- increments it, so resetting first would leave the instructor with seven automatic
   -- retries rather than the full budget. A deliberate manual retry states that the

--- a/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
+++ b/supabase/migrations/20260816120000_bound_repo_creation_retries.sql
@@ -512,8 +512,16 @@ begin
         null
       );
     exception
-      when others then
-        raise warning 'Could not enqueue a repo for group "%" (id %) on assignment %: %. Rename the group to something that survives repo-name normalization, then use Retry.',
+      -- Narrow on purpose. raise_exception covers the two name failures this handler
+      -- exists for -- sanitize_repo_name_component rejecting a separator-only name, and
+      -- the same-name-different-identity guard in enqueue_github_create_repo --
+      -- and unique_violation covers two allowed names colliding after collapse.
+      -- Everything else (a pgmq send failure, a deadlock, a permission error) propagates
+      -- as before: those are not a property of this group's name, they affect every
+      -- group in the pass, and swallowing them would report a success that never
+      -- happened.
+      when raise_exception or unique_violation then
+        raise warning 'Could not enqueue a repo for group "%" (id %) on assignment %: %. Rename the group to something that survives repo-name normalization; no repository will be created for it until then.',
           r_group_name, r_group_id, v_assignment_id, sqlerrm;
     end;
   end loop;

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -6612,10 +6612,12 @@ export type Database = {
           assignment_id: number;
           class_id: number;
           created_at: string;
+          creation_attempts: number;
           creation_error: string | null;
           desired_handout_sha: string | null;
           id: number;
           is_github_ready: boolean;
+          last_creation_attempt_at: string | null;
           profile_id: string | null;
           repository: string;
           rerun_queued_at: string | null;
@@ -6629,10 +6631,12 @@ export type Database = {
           assignment_id: number;
           class_id: number;
           created_at?: string;
+          creation_attempts?: number;
           creation_error?: string | null;
           desired_handout_sha?: string | null;
           id?: number;
           is_github_ready?: boolean;
+          last_creation_attempt_at?: string | null;
           profile_id?: string | null;
           repository: string;
           rerun_queued_at?: string | null;
@@ -6646,10 +6650,12 @@ export type Database = {
           assignment_id?: number;
           class_id?: number;
           created_at?: string;
+          creation_attempts?: number;
           creation_error?: string | null;
           desired_handout_sha?: string | null;
           id?: number;
           is_github_ready?: boolean;
+          last_creation_attempt_at?: string | null;
           profile_id?: string | null;
           repository?: string;
           rerun_queued_at?: string | null;
@@ -13710,6 +13716,7 @@ export type Database = {
         Args: { p_pattern: string; p_text: string };
         Returns: boolean;
       };
+      sanitize_repo_name_component: { Args: { raw: string }; Returns: string };
       save_error_pin: {
         Args: { p_error_pin: Json; p_rules: Json };
         Returns: Json;


### PR DESCRIPTION
Two paths re-enqueued `create_repo` for the same repositories without limit, saturating the GitHub async worker.

## Mechanism

**1. Unbounded reconciliation.** `reconcile_stuck_repo_creations()` re-enqueued every repository row with `is_github_ready = false` and `creation_error IS NULL`, across every class in the instance, every 15 minutes, with no attempt counter, no backoff and no ceiling. `enqueue_create_repo_for_repository()` bumps `updated_at`, which only suppresses a duplicate *inside* the 15-minute stale window; the next tick re-enqueued the whole set again. A repository that fails in a way that does not set `creation_error` (only a non-retryable failure does; a generic throw leaves it NULL) therefore generated 96 jobs a day, indefinitely, each with the worker's own retry budget on top.

**2. Dedupe by derived name.** `create_all_repos_for_assignment_internal()` decided "does this repo already exist?" by string-comparing a derived repo name against `repositories.repository`, while `enqueue_github_create_repo()` dedupes the row on `(assignment_id, profile_id | assignment_group_id)`. Once the two disagreed, the existence check missed, the enqueue found the existing row and did not insert, and the stored name never converged — so the next call enqueued again. Permanently.

The names diverge when:
- a group name needs sanitizing — every TypeScript path applies `sanitizeRepoNameComponent` (`_shared/repoNames.ts`), no SQL path did, so a group named `Team 1` was stored as `…-group-Team-1` and re-derived as `…-group-Team 1`;
- a student's GitHub login is renamed (#888 added re-resolution of renamed logins);
- a class or assignment slug is edited after repos exist.

The `FOR EACH ROW` trigger on `assignment_groups_members` then multiplied it: R rows written × (mismatched groups + students without repos).

## Changes

- `sanitize_repo_name_component()`, the SQL twin of `_shared/repoNames.ts`, applied inside `enqueue_github_create_repo` — the single choke point every SQL caller already goes through, so no large RPC needed rewriting. Group repo rows now carry the name GitHub actually creates, which also fixes webhook lookups that resolve a repository row by name.
- `create_all_repos_for_assignment_internal` dedupes on identity. `create_repos_for_student` already did this; the assignment-wide function was the outlier.
- `repositories.creation_attempts` / `.last_creation_attempt_at`, zeroed by a `BEFORE UPDATE` trigger the moment a repo becomes ready — so all four creation paths get it right without any TypeScript change.
- `reconcile_stuck_repo_creations` gains exponential backoff (15m doubling to an 8h cap), an 8-attempt ceiling that parks the row with `creation_error` for the instructor Retry button, and active-class scoping via `is_class_active()` (matching the scoping #924 applied to the Discord role sync). Roughly 32h of automatic retries before a human is asked to look.
- `retry_repository_creation` clears the attempt counter, so a manual retry gets a full budget rather than being re-parked on the next tick.
- A one-time backfill parks rows already stuck past a week or in ended classes, so the backlog drains instead of replaying.

## Verification

Against local Supabase, in rolled-back transactions:

| scenario | before | after |
| --- | --- | --- |
| assignment with 15 divergent group names, 3 reconciliation passes | 15, 30, 45 enqueues | 0 |
| new group `Brand New Team 9` | 1 enqueue, stored `…-group-Brand New Team 9` | 1 enqueue, stored `…-group-Brand-New-Team-9` |
| reconciler pass 1 — 5 stuck repos, one budget-exhausted, one in an ended class | — | 3 enqueued, 1 parked, 1 skipped |
| reconciler pass 2 immediately / at 16 min / at 31 min | — | 0 / 0 / 3 |

The 15 → 30 → 45 progression is the loop reproduced directly; it never converges. The 16-minute pass confirms the backoff doubling actually gates rather than just the base window.

`sanitize_repo_name_component` was diffed against the TypeScript helper on seven inputs including `Grüße/Ärger` — both yield `Gru-e-A-rger`.

`npx tsc --noEmit` reports 305 errors both with and without this change; the generated-type additions introduce none. The two `SupabaseTypes.d.ts` files were hand-patched with the three real additions rather than fully regenerated, because `npm run client-local` also reflows unrelated union types under a different prettier version — both files already fail `prettier --check` at HEAD.

## Rolling it

The migration does not touch messages already in `pgmq.q_async_calls`; purge those separately or let the worker drain them. If the reconciler cron was unscheduled as a mitigation, re-schedule it after this lands:

```sql
select cron.schedule('github-repo-reconciler', '*/15 * * * *',
  $$select public.invoke_github_repo_reconciler_background_task();$$);
```

Afterwards, `api_gateway_calls` grouped by `debug_id` distinguishes the two sources — `reconcile-repo-%` is the cron, NULL is `create_all_repos_for_assignment_internal` — and should confirm which one dominated.

## Not included

Making the `assignment_groups_members` trigger statement-level. With identity dedupe in place, a trigger firing on an assignment where everyone has a repo enqueues zero jobs, so the fan-out is a query-cost problem rather than a queue storm, and `publish_assignment_group_changes` and `copy_groups_from_assignment` already suppress it via the `pawtograder.suppress_repo_sync` GUC. Doing it properly needs transition-table triggers (one per event) or a deferred constraint trigger, which changes error timing on student group-join — not something to ride along with this.

## Not verified

`.env.local` points at staging, so the Playwright suite was not run. `tests/e2e/repo-config-enqueue.spec.ts` was reviewed statically: T3's group name is alphanumeric so sanitizing is a no-op there, and T4 exercises `create_repos_for_student`, which is unchanged. Worth running that spec against a local stack before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoqFWkoah9DaqH1ozwm7dC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retry handling for failed repository creation, including instructor-triggered retries.
  * Improved repository naming sanitization and prevented duplicate repositories.
  * Added repository-mode-aware group-name validation with clearer requirements and collision checks.
  * Added creation-attempt tracking and clearer retry status handling.

* **Bug Fixes**
  * Limited retries after repeated failures and surfaced enqueue errors.
  * Parked repositories with missing fork sources for later retry.
  * Improved reconciliation to focus on active classes and reset retry tracking when repositories become ready.
  * Skipped repository-name validation for assignments that do not provision repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->