### PR TITLE
fix(edge-functions): bound the demuxer's eszip cache (the prod OOM), pin @sentry/deno, flush Sentry, fix the OOM alerts

### DIFF
--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -204,9 +204,21 @@ Deno.serve(async (req: Request) => {
 
   const servicePath = `/home/deno/functions/${serviceName}`;
 
-  const eszip = await loadEszip(serviceName);
-
-  const createWorker = () => {
+  const createWorker = async () => {
+    // Loaded HERE rather than once per request, so this reference lives only for
+    // the duration of create() instead of for the whole request.
+    //
+    // It used to be hoisted above callWorker, which meant the closure held a
+    // 19-59MB buffer for as long as worker.fetch() ran — up to the 400s worker
+    // lifetime. Bundles the LRU has evicted, or that were too big to admit, are
+    // not counted by residentBytes, so a cold burst could hold well over
+    // eszipCacheMaxMb in buffers the budget knew nothing about. Narrowing the
+    // window to create() does not make that term zero, but it takes it from
+    // "the length of a request" to "the length of an admission", and the
+    // remainder is covered by eszipColdLoadHeadroomMb in the chart's budget
+    // assertion. A cache hit returns the already-counted buffer, so the steady
+    // state after warmup costs nothing extra.
+    const eszip = await loadEszip(serviceName);
     const opts: Record<string, unknown> = {
       servicePath,
       memoryLimitMb: MEMORY_LIMIT_MB,

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -264,7 +264,7 @@ function enforceBudget(): void {
 const envVars = Object.entries(Deno.env.toObject()) as [string, string][];
 
 /**
- * Run `use` with this function's bundle, holding the bundle's bytes against a
+ * Run `runWithBundle` with this function's bundle, holding the bundle's bytes against a
  * budget for exactly as long as the reference is live.
  *
  * Two cases, deliberately different:
@@ -283,18 +283,18 @@ const envVars = Object.entries(Deno.env.toObject()) as [string, string][];
  */
 async function withEszip<T>(
   name: string,
-  use: (eszip: Uint8Array | null) => Promise<T>
+  runWithBundle: (eszip: Uint8Array | null) => Promise<T>
 ): Promise<T> {
   if (resident.has(name)) {
     pin(name);
     try {
-      return await use(await loadEszip(name));
+      return await runWithBundle(await loadEszip(name));
     } finally {
       unpin(name);
     }
   }
 
-  if (missing.has(name)) return await use(null);
+  if (missing.has(name)) return await runWithBundle(null);
 
   let size = 0;
   try {
@@ -302,12 +302,12 @@ async function withEszip<T>(
   } catch {
     // No bundle (or unreadable): loadEszip records the negative result and the
     // caller falls back to the raw servicePath. Nothing to reserve.
-    return await use(await loadEszip(name));
+    return await runWithBundle(await loadEszip(name));
   }
 
   await acquireCold(size);
   try {
-    return await use(await loadEszip(name));
+    return await runWithBundle(await loadEszip(name));
   } finally {
     releaseCold(size);
   }
@@ -406,7 +406,10 @@ Deno.serve(async (req: Request) => {
       opts.maybeEszip = eszip;
       opts.maybeEntrypoint = `file:///home/deno/functions/${serviceName}/index.ts`;
     }
-      // @ts-ignore EdgeRuntime is provided by supabase/edge-runtime
+      // @ts-expect-error EdgeRuntime is an untyped global provided by
+      // supabase/edge-runtime, so this reference always errors under a plain
+      // type-check -- which is what makes expect-error (rather than ignore) the
+      // correct directive here.
       return await EdgeRuntime.userWorkers.create(opts);
     });
 

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -71,13 +71,76 @@ const MAX_RETIRED_RETRIES = 5;
 // dropdown is built from. Set EDGE_ACCESS_LOG=0 to silence it (no rebuild).
 const ACCESS_LOG = (Deno.env.get("EDGE_ACCESS_LOG") ?? "1") !== "0";
 
-// Cache of loaded eszip bytes, keyed by function name. The value is a Promise
-// so concurrent first-requests for the same function share a single disk read
-// rather than each allocating their own ~40MB buffer (which under a 50-burst
-// would be ~2GB of transient allocation in this main isolate). A resolved
-// `null` means "no eszip on disk for this function" — fall back to raw
-// servicePath and don't keep re-stat-ing the filesystem.
-const eszipCache = new Map<string, Promise<Uint8Array | null>>();
+// Resident eszip bytes, keyed by function name, bounded by total BYTES held.
+//
+// 2026-08-19: this was an unbounded `Map<string, Promise<Uint8Array>>` and it
+// was the edge tier's memory problem. Every eszip a pod had ever served stayed
+// pinned in this main isolate, which lives as long as the pod, so RSS was
+// "floor + whatever the pod happened to have served" and it climbed for days:
+// 87Mi at startup, 667Mi at 1h, 1868-2408Mi at ~5d. The giveaway was that the
+// spread across SAME-AGE pods tracked distinct functions served, not uptime and
+// not request count — four 25-minute-old pods sat at 210/336/398/486Mi holding
+// 2/3/3/4 functions. The ceiling is the whole bundle (`[bundle] done: 55 eszips,
+// 2.2G total`, see the Dockerfile), and 2.2G of cache plus 8 admitted isolates
+// at 256Mi each does not fit in the 4Gi container limit. That is the OOMKill:
+// the limit was never a backstop, it was a deadline.
+//
+// Three structures now, because the three cases have genuinely different
+// lifetimes and conflating them is what made the leak invisible:
+//   * `inflight` preserves the ORIGINAL coalescing property this cache existed
+//     for: concurrent first-requests for one function share a single disk read
+//     instead of each allocating its own ~40MB buffer. Entries are dropped on
+//     settle, so it holds at most `--max-parallelism` promises.
+//   * `missing` is the negative cache. No eszip on disk means fall back to raw
+//     servicePath; remembering that costs a string and saves a stat per
+//     request, so it is kept for the pod's life. Note it is now populated ONLY
+//     on NotFound — the old code cached the null from ANY read error, so one
+//     transient EIO downgraded a function to raw servicePath permanently.
+//   * `resident` is the positive cache: an LRU bounded by BYTES, not by entry
+//     count. Entries run 19-59MB and averaging them is how you get surprised.
+// Eviction is always safe: an in-progress worker creation already holds its own
+// reference to the Uint8Array, so evicting only drops OURS.
+const ESZIP_CACHE_MAX_BYTES = Number(
+  Deno.env.get("EDGE_ESZIP_CACHE_MAX_BYTES") ?? 512 * 1024 * 1024
+);
+const inflight = new Map<string, Promise<Uint8Array | null>>();
+const missing = new Set<string>();
+const resident = new Map<string, Uint8Array>();
+let residentBytes = 0;
+
+const mb = (n: number) => (n / 1048576).toFixed(1);
+
+// Mark `name` most-recently-used. Map iterates in insertion order, so
+// delete + re-set is the entire LRU.
+function touch(name: string, bytes: Uint8Array): void {
+  resident.delete(name);
+  resident.set(name, bytes);
+}
+
+function admit(name: string, bytes: Uint8Array): void {
+  // A single eszip larger than the whole budget is served but never cached;
+  // admitting it would evict everything else to hold one entry.
+  if (bytes.byteLength > ESZIP_CACHE_MAX_BYTES) return;
+  // Re-admission shouldn't happen (`inflight` coalesces, and a hit returns
+  // early), but double-counting here would silently raise the bound this whole
+  // structure exists to enforce, so account for it rather than assume.
+  const existing = resident.get(name);
+  if (existing) residentBytes -= existing.byteLength;
+  touch(name, bytes);
+  residentBytes += bytes.byteLength;
+  // Evict oldest-first until back inside budget. The entry just admitted is
+  // newest, so it cannot be evicted out from under this request.
+  for (const victim of resident.keys()) {
+    if (residentBytes <= ESZIP_CACHE_MAX_BYTES) break;
+    const evicted = resident.get(victim)!;
+    resident.delete(victim);
+    residentBytes -= evicted.byteLength;
+    console.log(
+      `[eszip] evicted ${victim} (${mb(evicted.byteLength)}MB), resident ` +
+        `${mb(residentBytes)}MB / ${mb(ESZIP_CACHE_MAX_BYTES)}MB, ${resident.size} functions`
+    );
+  }
+}
 
 // Snapshot the process env ONCE at startup. It's static for the lifetime of the
 // pod, and this runs on the gateway hot path — recomputing it per request would
@@ -85,15 +148,33 @@ const eszipCache = new Map<string, Promise<Uint8Array | null>>();
 const envVars = Object.entries(Deno.env.toObject()) as [string, string][];
 
 function loadEszip(name: string): Promise<Uint8Array | null> {
-  let pending = eszipCache.get(name);
+  const hit = resident.get(name);
+  if (hit) {
+    touch(name, hit);
+    return Promise.resolve(hit);
+  }
+  if (missing.has(name)) return Promise.resolve(null);
+
+  let pending = inflight.get(name);
   if (!pending) {
-    pending = Deno.readFile(`${ESZIP_DIR}/${name}.eszip`).catch((e) => {
-      if (!(e instanceof Deno.errors.NotFound)) {
-        console.error(`failed to read eszip for ${name}:`, (e as Error)?.message ?? e);
-      }
-      return null;
-    });
-    eszipCache.set(name, pending);
+    pending = Deno.readFile(`${ESZIP_DIR}/${name}.eszip`)
+      .then((bytes): Uint8Array | null => {
+        admit(name, bytes);
+        return bytes;
+      })
+      .catch((e) => {
+        if (e instanceof Deno.errors.NotFound) {
+          missing.add(name);
+        } else {
+          // Transient — deliberately NOT remembered, so the next request retries.
+          console.error(`failed to read eszip for ${name}:`, (e as Error)?.message ?? e);
+        }
+        return null;
+      })
+      .finally(() => {
+        inflight.delete(name);
+      });
+    inflight.set(name, pending);
   }
   return pending;
 }

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -137,28 +137,56 @@ let residentBytes = 0;
 
 const mb = (n: number) => (n / 1048576).toFixed(1);
 
-// --- cold-load byte semaphore -------------------------------------------------
+// --- cold-load byte semaphore (FIFO) ---------------------------------------
 // Held from before the read until userWorkers.create() has returned, because the
-// buffer is referenced for that whole span. Waiters are woken on every release
-// and re-check their own condition, so a large request cannot be starved by a
-// stream of small ones slipping under the budget.
+// buffer is referenced for that whole span.
+//
+// Strict FIFO, and the full byte size is charged:
+//   * FIFO because waking every waiter does NOT prevent starvation. A large
+//     request that still cannot fit re-queues, and a stream of small releases
+//     lets younger small requests take the capacity ahead of it indefinitely.
+//     Only the head of the queue may acquire, so nothing overtakes a blocked
+//     older request.
+//   * Full size, never clamped to the allowance, because Deno.readFile allocates
+//     the whole bundle regardless of what the allowance says. Charging a clamped
+//     value would let an oversized bundle through while accounting for less than
+//     it actually costs, which is precisely the gap this semaphore exists to close.
+//     A bundle larger than the entire allowance therefore runs ALONE (see
+//     canAdmitCold), and eszipColdLoadHeadroomMb is required by the chart to be
+//     large enough to cover the biggest bundle in the image.
 let coldBytes = 0;
-const coldWaiters: Array<() => void> = [];
+const coldQueue: Array<{ need: number; resolve: () => void }> = [];
+
+function canAdmitCold(need: number): boolean {
+  // A request bigger than the whole allowance could never satisfy the normal
+  // condition, so it is allowed through when nothing else holds any bytes.
+  if (need > COLD_LOAD_MAX_BYTES) return coldBytes === 0;
+  return coldBytes + need <= COLD_LOAD_MAX_BYTES;
+}
+
+function pumpColdQueue(): void {
+  while (coldQueue.length > 0 && canAdmitCold(coldQueue[0].need)) {
+    const waiter = coldQueue.shift()!;
+    coldBytes += waiter.need;
+    waiter.resolve();
+  }
+}
 
 async function acquireCold(size: number): Promise<void> {
-  // A bundle bigger than the entire allowance would never fit, so it runs alone
-  // rather than deadlocking: wait for the budget to drain, then proceed.
-  const need = Math.min(size, COLD_LOAD_MAX_BYTES);
-  while (coldBytes > 0 && coldBytes + need > COLD_LOAD_MAX_BYTES) {
-    await new Promise<void>((resolve) => coldWaiters.push(resolve));
+  // Fast path only when nobody is queued — otherwise this would overtake them.
+  if (coldQueue.length === 0 && canAdmitCold(size)) {
+    coldBytes += size;
+    return;
   }
-  coldBytes += need;
+  await new Promise<void>((resolve) => {
+    coldQueue.push({ need: size, resolve });
+    pumpColdQueue();
+  });
 }
 
 function releaseCold(size: number): void {
-  coldBytes -= Math.min(size, COLD_LOAD_MAX_BYTES);
-  // Wake all waiters; each re-tests the budget itself.
-  while (coldWaiters.length > 0) coldWaiters.shift()!();
+  coldBytes -= size;
+  pumpColdQueue();
 }
 
 // --- eviction pins -----------------------------------------------------------
@@ -176,6 +204,8 @@ function unpin(name: string): void {
   const n = (pinned.get(name) ?? 0) - 1;
   if (n > 0) pinned.set(name, n);
   else pinned.delete(name);
+  // Reclaim anything that could not be evicted while this entry was in use.
+  enforceBudget();
 }
 
 // Mark `name` most-recently-used. Map iterates in insertion order, so
@@ -196,12 +226,28 @@ function admit(name: string, bytes: Uint8Array): void {
   if (existing) residentBytes -= existing.byteLength;
   touch(name, bytes);
   residentBytes += bytes.byteLength;
-  // Evict oldest-first until back inside budget. The entry just admitted is
-  // newest, so it cannot be evicted out from under this request.
+  enforceBudget();
+}
+
+/**
+ * Evict least-recently-used until residentBytes is back inside the budget.
+ *
+ * Pinned entries are skipped, which is what makes the pin safe — but it also
+ * means a pass can end still over budget if every viable victim is in use. The
+ * newly admitted entry is the most-recently-used, so it is the LAST thing this
+ * loop considers: when pins leave no other room, the new entry is what gets
+ * dropped, i.e. admission is refused rather than the bound being exceeded.
+ * Serving is unaffected, since the caller already holds its own reference.
+ *
+ * unpin() calls this again, so bytes that could not be reclaimed while an entry
+ * was in use are reclaimed as soon as it is released rather than staying resident
+ * forever. Without that retry the "bounded" cache could ratchet upward, one
+ * pinned admission at a time, past the total the chart's assertion certifies.
+ */
+function enforceBudget(): void {
   for (const victim of [...resident.keys()]) {
-    if (residentBytes <= ESZIP_CACHE_MAX_BYTES) break;
-    // Never evict a bundle a worker creation is currently holding (see `pinned`).
-    if (victim === name || pinned.has(victim)) continue;
+    if (residentBytes <= ESZIP_CACHE_MAX_BYTES) return;
+    if (pinned.has(victim)) continue;
     const evicted = resident.get(victim)!;
     resident.delete(victim);
     residentBytes -= evicted.byteLength;
@@ -226,16 +272,19 @@ const envVars = Object.entries(Deno.env.toObject()) as [string, string][];
  *     reservation is taken. The entry is pinned instead, so eviction cannot
  *     subtract its bytes while the reference is still held.
  *   * Cache MISS — the bytes are not in the cache budget (and may never be, if
- *     admit() refuses them as oversized or evicts them again), so they are
+ *     admit() refuses them as oversized or eviction drops them again), so they are
  *     reserved against COLD_LOAD_MAX_BYTES for the whole span. `stat` gives the
- *     size before the allocation happens, which is the only way to reserve
- *     BEFORE the memory is spent rather than after.
+ *     size before the allocation happens, which is the only way to reserve BEFORE
+ *     the memory is spent rather than after.
  *
  * Concurrent misses for the same name each reserve, which over-reserves for one
- * shared buffer. That errs toward waiting rather than toward exceeding the
- * budget, which is the direction to err in.
+ * shared buffer. That errs toward waiting rather than toward exceeding the budget,
+ * which is the direction to err in.
  */
-async function withEszip<T>(name: string, use: (eszip: Uint8Array | null) => Promise<T>): Promise<T> {
+async function withEszip<T>(
+  name: string,
+  use: (eszip: Uint8Array | null) => Promise<T>
+): Promise<T> {
   if (resident.has(name)) {
     pin(name);
     try {

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -100,15 +100,83 @@ const ACCESS_LOG = (Deno.env.get("EDGE_ACCESS_LOG") ?? "1") !== "0";
 //     count. Entries run 19-59MB and averaging them is how you get surprised.
 // Eviction is always safe: an in-progress worker creation already holds its own
 // reference to the Uint8Array, so evicting only drops OURS.
-const ESZIP_CACHE_MAX_BYTES = Number(
-  Deno.env.get("EDGE_ESZIP_CACHE_MAX_BYTES") ?? 512 * 1024 * 1024
-);
+// A budget that isn't a finite positive number isn't a budget. `Number("Infinity")`
+// is Infinity, which makes the eviction condition unsatisfiable and quietly
+// restores the unbounded cache this whole mechanism exists to remove; `Number("")`
+// and `Number("abc")` are 0 and NaN, which break it the other way (NaN comparisons
+// are false, so the evict loop empties the cache on every admit). Anything not
+// finite and positive falls back to the default and says so.
+function byteBudget(envName: string, fallback: number): number {
+  const raw = Deno.env.get(envName);
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(
+      `${envName}=${JSON.stringify(raw)} is not a finite positive byte count; using ${fallback}`
+    );
+    return fallback;
+  }
+  return Math.floor(parsed);
+}
+
+const ESZIP_CACHE_MAX_BYTES = byteBudget("EDGE_ESZIP_CACHE_MAX_BYTES", 512 * 1024 * 1024);
+
+// Aggregate ceiling on bundle bytes held OUTSIDE the resident cache: a bundle
+// being read on a cache miss, and that same buffer while it is being handed to
+// userWorkers.create(). `inflight` only coalesces requests for the SAME function,
+// so without this, N simultaneous cold requests for N DISTINCT functions each
+// allocate their own 19-59MB buffer and nothing bounds the sum — five of the
+// largest bundle in the image already exceed a 256Mi allowance. This makes
+// eszipCacheMaxMb + eszipColdLoadHeadroomMb an enforced total rather than a
+// documented hope, which is what the chart's budget assertion claims it is.
+const COLD_LOAD_MAX_BYTES = byteBudget("EDGE_ESZIP_COLD_LOAD_MAX_BYTES", 256 * 1024 * 1024);
 const inflight = new Map<string, Promise<Uint8Array | null>>();
 const missing = new Set<string>();
 const resident = new Map<string, Uint8Array>();
 let residentBytes = 0;
 
 const mb = (n: number) => (n / 1048576).toFixed(1);
+
+// --- cold-load byte semaphore -------------------------------------------------
+// Held from before the read until userWorkers.create() has returned, because the
+// buffer is referenced for that whole span. Waiters are woken on every release
+// and re-check their own condition, so a large request cannot be starved by a
+// stream of small ones slipping under the budget.
+let coldBytes = 0;
+const coldWaiters: Array<() => void> = [];
+
+async function acquireCold(size: number): Promise<void> {
+  // A bundle bigger than the entire allowance would never fit, so it runs alone
+  // rather than deadlocking: wait for the budget to drain, then proceed.
+  const need = Math.min(size, COLD_LOAD_MAX_BYTES);
+  while (coldBytes > 0 && coldBytes + need > COLD_LOAD_MAX_BYTES) {
+    await new Promise<void>((resolve) => coldWaiters.push(resolve));
+  }
+  coldBytes += need;
+}
+
+function releaseCold(size: number): void {
+  coldBytes -= Math.min(size, COLD_LOAD_MAX_BYTES);
+  // Wake all waiters; each re-tests the budget itself.
+  while (coldWaiters.length > 0) coldWaiters.shift()!();
+}
+
+// --- eviction pins -----------------------------------------------------------
+// A resident buffer being handed to create() must not be evicted out from under
+// that call: dropping it from `resident` would subtract its bytes from
+// residentBytes while the reference is still live, so the accounting would claim
+// memory that is still held. Pinned entries are skipped by eviction instead.
+const pinned = new Map<string, number>();
+
+function pin(name: string): void {
+  pinned.set(name, (pinned.get(name) ?? 0) + 1);
+}
+
+function unpin(name: string): void {
+  const n = (pinned.get(name) ?? 0) - 1;
+  if (n > 0) pinned.set(name, n);
+  else pinned.delete(name);
+}
 
 // Mark `name` most-recently-used. Map iterates in insertion order, so
 // delete + re-set is the entire LRU.
@@ -130,8 +198,10 @@ function admit(name: string, bytes: Uint8Array): void {
   residentBytes += bytes.byteLength;
   // Evict oldest-first until back inside budget. The entry just admitted is
   // newest, so it cannot be evicted out from under this request.
-  for (const victim of resident.keys()) {
+  for (const victim of [...resident.keys()]) {
     if (residentBytes <= ESZIP_CACHE_MAX_BYTES) break;
+    // Never evict a bundle a worker creation is currently holding (see `pinned`).
+    if (victim === name || pinned.has(victim)) continue;
     const evicted = resident.get(victim)!;
     resident.delete(victim);
     residentBytes -= evicted.byteLength;
@@ -146,6 +216,53 @@ function admit(name: string, bytes: Uint8Array): void {
 // pod, and this runs on the gateway hot path — recomputing it per request would
 // churn allocations needlessly. Workers created below all receive this same array.
 const envVars = Object.entries(Deno.env.toObject()) as [string, string][];
+
+/**
+ * Run `use` with this function's bundle, holding the bundle's bytes against a
+ * budget for exactly as long as the reference is live.
+ *
+ * Two cases, deliberately different:
+ *   * Cache HIT — the bytes are already counted in residentBytes, so no extra
+ *     reservation is taken. The entry is pinned instead, so eviction cannot
+ *     subtract its bytes while the reference is still held.
+ *   * Cache MISS — the bytes are not in the cache budget (and may never be, if
+ *     admit() refuses them as oversized or evicts them again), so they are
+ *     reserved against COLD_LOAD_MAX_BYTES for the whole span. `stat` gives the
+ *     size before the allocation happens, which is the only way to reserve
+ *     BEFORE the memory is spent rather than after.
+ *
+ * Concurrent misses for the same name each reserve, which over-reserves for one
+ * shared buffer. That errs toward waiting rather than toward exceeding the
+ * budget, which is the direction to err in.
+ */
+async function withEszip<T>(name: string, use: (eszip: Uint8Array | null) => Promise<T>): Promise<T> {
+  if (resident.has(name)) {
+    pin(name);
+    try {
+      return await use(await loadEszip(name));
+    } finally {
+      unpin(name);
+    }
+  }
+
+  if (missing.has(name)) return await use(null);
+
+  let size = 0;
+  try {
+    size = (await Deno.stat(`${ESZIP_DIR}/${name}.eszip`)).size;
+  } catch {
+    // No bundle (or unreadable): loadEszip records the negative result and the
+    // caller falls back to the raw servicePath. Nothing to reserve.
+    return await use(await loadEszip(name));
+  }
+
+  await acquireCold(size);
+  try {
+    return await use(await loadEszip(name));
+  } finally {
+    releaseCold(size);
+  }
+}
 
 function loadEszip(name: string): Promise<Uint8Array | null> {
   const hit = resident.get(name);
@@ -204,22 +321,18 @@ Deno.serve(async (req: Request) => {
 
   const servicePath = `/home/deno/functions/${serviceName}`;
 
-  const createWorker = async () => {
-    // Loaded HERE rather than once per request, so this reference lives only for
-    // the duration of create() instead of for the whole request.
-    //
-    // It used to be hoisted above callWorker, which meant the closure held a
-    // 19-59MB buffer for as long as worker.fetch() ran — up to the 400s worker
-    // lifetime. Bundles the LRU has evicted, or that were too big to admit, are
-    // not counted by residentBytes, so a cold burst could hold well over
-    // eszipCacheMaxMb in buffers the budget knew nothing about. Narrowing the
-    // window to create() does not make that term zero, but it takes it from
-    // "the length of a request" to "the length of an admission", and the
-    // remainder is covered by eszipColdLoadHeadroomMb in the chart's budget
-    // assertion. A cache hit returns the already-counted buffer, so the steady
-    // state after warmup costs nothing extra.
-    const eszip = await loadEszip(serviceName);
-    const opts: Record<string, unknown> = {
+  const createWorker = () =>
+    withEszip(serviceName, async (eszip) => {
+      // The bundle is obtained and accounted for by withEszip, which holds it
+      // against a budget for exactly as long as this reference is live and
+      // releases it when create() returns.
+      //
+      // It used to be loaded once per request above callWorker, so the closure
+      // held a 19-59MB buffer for as long as worker.fetch() ran — up to the 400s
+      // worker lifetime. Narrowing it to create() shrank that window; withEszip
+      // is what actually bounds the sum across concurrent cold loads for
+      // DIFFERENT functions, which coalescing on `inflight` never could.
+      const opts: Record<string, unknown> = {
       servicePath,
       memoryLimitMb: MEMORY_LIMIT_MB,
       lowMemoryMultiplier: LOW_MEMORY_MULTIPLIER,
@@ -244,9 +357,9 @@ Deno.serve(async (req: Request) => {
       opts.maybeEszip = eszip;
       opts.maybeEntrypoint = `file:///home/deno/functions/${serviceName}/index.ts`;
     }
-    // @ts-ignore EdgeRuntime is provided by supabase/edge-runtime
-    return EdgeRuntime.userWorkers.create(opts);
-  };
+      // @ts-ignore EdgeRuntime is provided by supabase/edge-runtime
+      return await EdgeRuntime.userWorkers.create(opts);
+    });
 
   // Reuse the pooled worker for this function; on retirement, route to a fresh
   // one (create() won't hand back a retired worker). Mirrors the stock

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -38,11 +38,14 @@ worker creation still holds it. main.ts narrows that window to the duration of
 create(), but it cannot be zero, and a burst of cold requests for distinct
 functions is exactly when it is largest.
 
-Two deliberate gaps. When maxParallelism is unset the runtime derives it from
-CPU count, so the isolate term is unknowable here and only cache + host are
-checked. And a limit that is not an integer number of Gi/Mi is skipped rather
-than mis-parsed -- a guardrail that silently computes the wrong number is worse
-than one that admits it cannot.
+maxParallelism is REQUIRED rather than defaulted-to-zero. Left unset the runtime
+derives it from CPU count, which cannot be known at render time; treating that as
+zero made this assertion accept the very combinations the values documentation
+says it rejects, which is worse than not having it.
+
+One deliberate gap remains: a limit that is not an integer number of Gi/Mi is
+skipped rather than mis-parsed -- a guardrail that silently computes the wrong
+number is worse than one that admits it cannot.
 */}}
 {{- define "pawtograder.edgeFunctions.assertMemoryBudget" -}}
 {{- $ef := .Values.edgeFunctions -}}
@@ -61,10 +64,10 @@ than one that admits it cannot.
 {{- $cacheMi := $ef.eszipCacheMaxMb | int -}}
 {{- $perIsolateMi := $ef.worker.memoryLimitMb | int -}}
 {{- $par := $ef.maxParallelism | toString -}}
-{{- $isolatesMi := 0 -}}
-{{- if and (ne $par "") (gt ($par | int) 0) -}}
-{{- $isolatesMi = mul ($par | int) $perIsolateMi -}}
+{{- if or (eq $par "") (le ($par | int) 0) -}}
+{{- fail (printf "edgeFunctions.maxParallelism must be set to a positive integer (got %q). Left unset the runtime derives it from CPU count, which cannot be known at render time -- so the isolate term of the memory budget could not be checked and this assertion would pass configurations it documents as rejected. Set it explicitly; 8 is the chart default and what production runs." $par) -}}
 {{- end -}}
+{{- $isolatesMi := mul ($par | int) $perIsolateMi -}}
 {{- $hostMi := 90 -}}
 {{- $coldMi := $ef.eszipColdLoadHeadroomMb | int -}}
 {{- $needMi := add $cacheMi $coldMi $isolatesMi $hostMi -}}
@@ -227,6 +230,10 @@ spec:
             # maxParallelism x worker.memoryLimitMb — see values.yaml.
             - name: EDGE_ESZIP_CACHE_MAX_BYTES
               value: {{ mul $ctx.Values.edgeFunctions.eszipCacheMaxMb 1048576 | quote }}
+            # Enforced at runtime by main.ts, not just budgeted here: a semaphore
+            # holds these bytes from before a cold read until create() returns.
+            - name: EDGE_ESZIP_COLD_LOAD_MAX_BYTES
+              value: {{ mul $ctx.Values.edgeFunctions.eszipColdLoadHeadroomMb 1048576 | quote }}
             # JWT_SECRET here is NOT the deployment's HS256 shared secret. The
             # only consumer inside the edge runtime is _shared/MCPAuth.ts, which
             # mints short-lived per-user RLS JWTs for MCP and the CLI — with

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -16,8 +16,58 @@ Args:
 All other config is shared from .Values.edgeFunctions; channels differ only by
 name, labels, image, and replicas, and target the same Postgres/auth/storage.
 */}}
+{{/*
+Guardrail: the edge-function container memory budget has THREE terms, and every
+production incident on this tier has come from reconciling fewer than three of
+them. 2026-08-11 counted only the isolates (maxParallelism x per-isolate limit)
+and OOM-killed 21 of 24 pods. 2026-08-19 counted isolates + host but not the
+demuxer's eszip cache, which grows to eszipCacheMaxMb, and OOM-killed pods again.
+
+So the sum is asserted at render time rather than documented and hoped for:
+
+    eszipCacheMaxMb + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
+      <= resources.limits.memory
+
+The host term is measured, not guessed: a freshly started pod with an empty
+cache sits at ~87Mi.
+
+Two deliberate gaps. When maxParallelism is unset the runtime derives it from
+CPU count, so the isolate term is unknowable here and only cache + host are
+checked. And a limit that is not an integer number of Gi/Mi is skipped rather
+than mis-parsed -- a guardrail that silently computes the wrong number is worse
+than one that admits it cannot.
+*/}}
+{{- define "pawtograder.edgeFunctions.assertMemoryBudget" -}}
+{{- $ef := .Values.edgeFunctions -}}
+{{- $limit := "" -}}
+{{- if $ef.resources -}}
+{{- if $ef.resources.limits -}}
+{{- $limit = $ef.resources.limits.memory | default "" | toString -}}
+{{- end -}}
+{{- end -}}
+{{- $limitMi := 0 -}}
+{{- if hasSuffix "Gi" $limit -}}
+{{- $limitMi = mul (trimSuffix "Gi" $limit | int) 1024 -}}
+{{- else if hasSuffix "Mi" $limit -}}
+{{- $limitMi = trimSuffix "Mi" $limit | int -}}
+{{- end -}}
+{{- $cacheMi := $ef.eszipCacheMaxMb | int -}}
+{{- $perIsolateMi := $ef.worker.memoryLimitMb | int -}}
+{{- $par := $ef.maxParallelism | toString -}}
+{{- $isolatesMi := 0 -}}
+{{- if and (ne $par "") (gt ($par | int) 0) -}}
+{{- $isolatesMi = mul ($par | int) $perIsolateMi -}}
+{{- end -}}
+{{- $hostMi := 90 -}}
+{{- $needMi := add $cacheMi $isolatesMi $hostMi -}}
+{{- if and (gt $limitMi 0) (gt $needMi $limitMi) -}}
+{{- fail (printf "edgeFunctions memory budget does not fit inside resources.limits.memory (%s = %dMi): eszipCacheMaxMb %dMi + isolates %dMi (maxParallelism %s x worker.memoryLimitMb %dMi) + ~%dMi Deno host = %dMi. Raise the limit, or lower eszipCacheMaxMb / maxParallelism. This exact sum is what OOM-killed production on 2026-08-11 and again on 2026-08-19; see the notes above these values." $limit $limitMi $cacheMi $isolatesMi (or $par "unset") $perIsolateMi $hostMi $needMi) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "pawtograder.edgeFunctions.workload" -}}
 {{- $ctx := .ctx -}}
+{{- include "pawtograder.edgeFunctions.assertMemoryBudget" $ctx -}}
 {{- $component := .component -}}
 {{- $image := .image -}}
 {{- $name := include "pawtograder.componentName" (dict "ctx" $ctx "component" $component) -}}

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -65,6 +65,21 @@ number is worse than one that admits it cannot.
 {{- if le $cacheMi 0 -}}
 {{- fail (printf "edgeFunctions.eszipCacheMaxMb must be a positive number of MiB (got %v). Zero or negative would be counted as-is by this assertion while main.ts substitutes its own 512Mi default, so the process would reserve memory the budget never accounted for." $ef.eszipCacheMaxMb) -}}
 {{- end -}}
+{{/* Every one of these is rendered into the environment AND has a fallback in
+     main.ts of the shape `Number(env) || default`. A zero, negative or
+     non-numeric value therefore renders as configured, is counted as configured
+     (or as nothing) here, and is then silently replaced by the runtime with its
+     own default -- so the process runs on a number this assertion never saw.
+     worker.memoryLimitMb is the one that breaks the memory budget directly: at
+     0 the isolate term vanishes from the sum while eight workers still reserve
+     8 x 256Mi. The other four are not budget terms, but the same divergence
+     makes them worth rejecting in the same place rather than leaving one
+     validated knob beside four unvalidated ones. */}}
+{{- range $knob, $value := dict "worker.memoryLimitMb" $ef.worker.memoryLimitMb "worker.timeoutMs" $ef.worker.timeoutMs "worker.cpuSoftMs" $ef.worker.cpuSoftMs "worker.cpuHardMs" $ef.worker.cpuHardMs "worker.lowMemoryMultiplier" $ef.worker.lowMemoryMultiplier -}}
+{{- if le ($value | int) 0 -}}
+{{- fail (printf "edgeFunctions.%s must be a positive number (got %v). main.ts falls back to its own default for anything non-positive, so the container would run on a value this budget assertion never counted." $knob $value) -}}
+{{- end -}}
+{{- end -}}
 {{- $perIsolateMi := $ef.worker.memoryLimitMb | int -}}
 {{- $par := $ef.maxParallelism | toString -}}
 {{- if or (eq $par "") (le ($par | int) 0) -}}

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -164,6 +164,11 @@ spec:
               value: {{ $ctx.Values.edgeFunctions.worker.cpuHardMs | quote }}
             - name: EDGE_WORKER_LOW_MEMORY_MULTIPLIER
               value: {{ $ctx.Values.edgeFunctions.worker.lowMemoryMultiplier | quote }}
+            # Byte budget for the demuxer's resident eszip cache. This is the
+            # THIRD term in the container's memory budget, alongside
+            # maxParallelism x worker.memoryLimitMb — see values.yaml.
+            - name: EDGE_ESZIP_CACHE_MAX_BYTES
+              value: {{ mul $ctx.Values.edgeFunctions.eszipCacheMaxMb 1048576 | quote }}
             # JWT_SECRET here is NOT the deployment's HS256 shared secret. The
             # only consumer inside the edge runtime is _shared/MCPAuth.ts, which
             # mints short-lived per-user RLS JWTs for MCP and the CLI — with

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -17,7 +17,7 @@ All other config is shared from .Values.edgeFunctions; channels differ only by
 name, labels, image, and replicas, and target the same Postgres/auth/storage.
 */}}
 {{/*
-Guardrail: the edge-function container memory budget has THREE terms, and every
+Guardrail: the edge-function container memory budget is a SUM, and every
 production incident on this tier has come from reconciling fewer than three of
 them. 2026-08-11 counted only the isolates (maxParallelism x per-isolate limit)
 and OOM-killed 21 of 24 pods. 2026-08-19 counted isolates + host but not the
@@ -25,11 +25,18 @@ demuxer's eszip cache, which grows to eszipCacheMaxMb, and OOM-killed pods again
 
 So the sum is asserted at render time rather than documented and hoped for:
 
-    eszipCacheMaxMb + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
+    eszipCacheMaxMb + eszipColdLoadHeadroomMb
+      + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
       <= resources.limits.memory
 
 The host term is measured, not guessed: a freshly started pod with an empty
 cache sits at ~87Mi.
+
+The cold-load term covers bundle buffers that residentBytes does NOT count: a
+bundle being read for a cache miss, and one the LRU evicted or refused while a
+worker creation still holds it. main.ts narrows that window to the duration of
+create(), but it cannot be zero, and a burst of cold requests for distinct
+functions is exactly when it is largest.
 
 Two deliberate gaps. When maxParallelism is unset the runtime derives it from
 CPU count, so the isolate term is unknowable here and only cache + host are
@@ -59,9 +66,10 @@ than one that admits it cannot.
 {{- $isolatesMi = mul ($par | int) $perIsolateMi -}}
 {{- end -}}
 {{- $hostMi := 90 -}}
-{{- $needMi := add $cacheMi $isolatesMi $hostMi -}}
+{{- $coldMi := $ef.eszipColdLoadHeadroomMb | int -}}
+{{- $needMi := add $cacheMi $coldMi $isolatesMi $hostMi -}}
 {{- if and (gt $limitMi 0) (gt $needMi $limitMi) -}}
-{{- fail (printf "edgeFunctions memory budget does not fit inside resources.limits.memory (%s = %dMi): eszipCacheMaxMb %dMi + isolates %dMi (maxParallelism %s x worker.memoryLimitMb %dMi) + ~%dMi Deno host = %dMi. Raise the limit, or lower eszipCacheMaxMb / maxParallelism. This exact sum is what OOM-killed production on 2026-08-11 and again on 2026-08-19; see the notes above these values." $limit $limitMi $cacheMi $isolatesMi (or $par "unset") $perIsolateMi $hostMi $needMi) -}}
+{{- fail (printf "edgeFunctions memory budget does not fit inside resources.limits.memory (%s = %dMi): eszipCacheMaxMb %dMi + eszipColdLoadHeadroomMb %dMi + isolates %dMi (maxParallelism %s x worker.memoryLimitMb %dMi) + ~%dMi Deno host = %dMi. Raise the limit, or lower eszipCacheMaxMb / maxParallelism. This exact sum is what OOM-killed production on 2026-08-11 and again on 2026-08-19; see the notes above these values." $limit $limitMi $cacheMi $coldMi $isolatesMi (or $par "unset") $perIsolateMi $hostMi $needMi) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -62,6 +62,9 @@ number is worse than one that admits it cannot.
 {{- $limitMi = trimSuffix "Mi" $limit | int -}}
 {{- end -}}
 {{- $cacheMi := $ef.eszipCacheMaxMb | int -}}
+{{- if le $cacheMi 0 -}}
+{{- fail (printf "edgeFunctions.eszipCacheMaxMb must be a positive number of MiB (got %v). Zero or negative would be counted as-is by this assertion while main.ts substitutes its own 512Mi default, so the process would reserve memory the budget never accounted for." $ef.eszipCacheMaxMb) -}}
+{{- end -}}
 {{- $perIsolateMi := $ef.worker.memoryLimitMb | int -}}
 {{- $par := $ef.maxParallelism | toString -}}
 {{- if or (eq $par "") (le ($par | int) 0) -}}
@@ -70,6 +73,18 @@ number is worse than one that admits it cannot.
 {{- $isolatesMi := mul ($par | int) $perIsolateMi -}}
 {{- $hostMi := 90 -}}
 {{- $coldMi := $ef.eszipColdLoadHeadroomMb | int -}}
+{{- if le $coldMi 0 -}}
+{{- fail (printf "edgeFunctions.eszipColdLoadHeadroomMb must be a positive number of MiB (got %v). Same reason as eszipCacheMaxMb: main.ts would substitute its own 256Mi default and the process would reserve memory this assertion did not count." $ef.eszipColdLoadHeadroomMb) -}}
+{{- end -}}
+{{/* The cold-load semaphore charges a bundle's FULL size, so an allowance smaller
+     than the largest bundle in the image cannot bound it -- an oversized bundle is
+     admitted alone and overshoots by (size - allowance). 64Mi covers the largest
+     bundle measured in this image (58.4MiB); if the bundles grow past that, this
+     minimum and the sizing note in values.yaml both need revisiting. */}}
+{{- $minColdMi := 64 -}}
+{{- if lt $coldMi $minColdMi -}}
+{{- fail (printf "edgeFunctions.eszipColdLoadHeadroomMb is %dMi, below the %dMi needed to cover the largest bundle in the image (58.4MiB measured). Below that the cold-load semaphore cannot enforce the ceiling this assertion certifies: the read allocates the whole bundle regardless of the allowance." $coldMi $minColdMi) -}}
+{{- end -}}
 {{- $needMi := add $cacheMi $coldMi $isolatesMi $hostMi -}}
 {{- if and (gt $limitMi 0) (gt $needMi $limitMi) -}}
 {{- fail (printf "edgeFunctions memory budget does not fit inside resources.limits.memory (%s = %dMi): eszipCacheMaxMb %dMi + eszipColdLoadHeadroomMb %dMi + isolates %dMi (maxParallelism %s x worker.memoryLimitMb %dMi) + ~%dMi Deno host = %dMi. Raise the limit, or lower eszipCacheMaxMb / maxParallelism. This exact sum is what OOM-killed production on 2026-08-11 and again on 2026-08-19; see the notes above these values." $limit $limitMi $cacheMi $coldMi $isolatesMi (or $par "unset") $perIsolateMi $hostMi $needMi) -}}

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -428,8 +428,9 @@ spec:
             description: >-
               {{`{{ $labels.pod }}`}} in {{ $ns }} restarted more than
               {{ .Values.monitoring.prometheusRules.edgeFunctionRestarts30m | default 2 }} times in 30m.
-              If the last termination reason is OOMKilled, check that maxParallelism x
-              EDGE_WORKER_MEMORY_LIMIT_MB fits inside the container memory limit.
+              If the last termination reason is OOMKilled, check that eszipCacheMaxMb +
+              (maxParallelism x EDGE_WORKER_MEMORY_LIMIT_MB) + ~90Mi fits inside the container
+              memory limit.
         # Gated on a RECENT restart, not on the reason alone. kube_pod_container_status_last_terminated_reason
         # reflects the container's lastState, so it keeps reporting OOMKilled=1 for the rest of that
         # container's life -- a single 03:00 kill would hold a critical alert firing for days after
@@ -452,8 +453,41 @@ spec:
             summary: "Pawtograder edge-function pod was OOM-killed ({{`{{ $labels.pod }}`}})"
             description: >-
               {{`{{ $labels.pod }}`}} in {{ $ns }} was terminated with OOMKilled. Every request in
-              flight on that pod failed. The admission budget (maxParallelism x per-isolate memory
-              limit) must fit inside the container memory limit, with headroom for a burst.
+              flight on that pod failed. Check the NODE first: a node-level SystemOOM kills the
+              biggest process on the box and is reported here identically to a cgroup kill, but the
+              fix is different (see PawtograderEdgeFunctionsNodeMemoryHigh). If the node was fine,
+              the pod budget has THREE terms that must fit inside the container memory limit with
+              headroom for a burst: eszipCacheMaxMb + (maxParallelism x EDGE_WORKER_MEMORY_LIMIT_MB)
+              + ~90Mi of Deno host. The cache term is the one that is easy to forget — it grows with
+              the number of DISTINCT FUNCTIONS a pod has served, not with load.
+        # The axis the two rules above CANNOT see. Every alert in this group is per-pod and compares
+        # a pod against its own limit, so all of them stay green while the node underneath runs out
+        # of memory -- which is exactly how 2026-08-18 went: worker-1 hit a kernel SystemOOM, the
+        # kernel picked edge-runtime as the victim, and the pod-level rules had nothing to say
+        # because no pod was near its own 4Gi limit.
+        #
+        # Measured against ALLOCATABLE, and deliberately not against requests: these pods run well
+        # over their memory request, so the scheduler packs by a number that understates reality and
+        # request-based headroom looks fine right up to the kill.
+        - alert: PawtograderEdgeFunctionsNodeMemoryHigh
+          expr: |
+            max by (node) (
+              1 - (
+                node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
+              )
+            ) > {{ .Values.monitoring.prometheusRules.nodeMemoryRatio | default 0.85 }}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Node memory is near capacity ({{`{{ $labels.node }}`}})"
+            description: >-
+              {{`{{ $labels.node }}`}} is above
+              {{ .Values.monitoring.prometheusRules.nodeMemoryRatio | default 0.85 }} of total
+              memory. Pods on this node can be OOM-killed by the kernel while every pod-level
+              memory alert stays green, because those compare each pod against its OWN limit.
+              Check which workloads are co-located here -- Postgres and the edge tier landing on
+              one node is the combination that has bitten before.
         # Leading indicator for the above. Memory that climbs with UPTIME rather than load is the
         # signature of long-lived isolates accumulating, and it is visible well before the kill.
         - alert: PawtograderEdgeFunctionsMemoryHigh

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -456,9 +456,11 @@ spec:
               flight on that pod failed. Check the NODE first: a node-level SystemOOM kills the
               biggest process on the box and is reported here identically to a cgroup kill, but the
               fix is different (see PawtograderEdgeFunctionsNodeMemoryHigh). If the node was fine,
-              the pod budget has THREE terms that must fit inside the container memory limit with
-              headroom for a burst: eszipCacheMaxMb + (maxParallelism x EDGE_WORKER_MEMORY_LIMIT_MB)
-              + ~90Mi of Deno host. The cache term is the one that is easy to forget: it fills with
+              the pod budget is a sum that must fit inside the container memory limit:
+              eszipCacheMaxMb + eszipColdLoadHeadroomMb
+              + (maxParallelism x EDGE_WORKER_MEMORY_LIMIT_MB) + ~90Mi of Deno host. The chart
+              asserts it at render time, so a pod that OOMs despite fitting means one of the
+              measured constants has drifted -- re-measure before raising the limit. The cache term is the one that is easy to forget: it fills with
               the DISTINCT FUNCTIONS a pod has served rather than with load, up to eszipCacheMaxMb,
               and evicts least-recently-used past that. So it is bounded, but the bound is a term in
               this budget and raising it without raising the limit is how you get back here.

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -458,36 +458,58 @@ spec:
               fix is different (see PawtograderEdgeFunctionsNodeMemoryHigh). If the node was fine,
               the pod budget has THREE terms that must fit inside the container memory limit with
               headroom for a burst: eszipCacheMaxMb + (maxParallelism x EDGE_WORKER_MEMORY_LIMIT_MB)
-              + ~90Mi of Deno host. The cache term is the one that is easy to forget — it grows with
-              the number of DISTINCT FUNCTIONS a pod has served, not with load.
+              + ~90Mi of Deno host. The cache term is the one that is easy to forget: it fills with
+              the DISTINCT FUNCTIONS a pod has served rather than with load, up to eszipCacheMaxMb,
+              and evicts least-recently-used past that. So it is bounded, but the bound is a term in
+              this budget and raising it without raising the limit is how you get back here.
         # The axis the two rules above CANNOT see. Every alert in this group is per-pod and compares
         # a pod against its own limit, so all of them stay green while the node underneath runs out
         # of memory -- which is exactly how 2026-08-18 went: worker-1 hit a kernel SystemOOM, the
         # kernel picked edge-runtime as the victim, and the pod-level rules had nothing to say
         # because no pod was near its own 4Gi limit.
         #
-        # Measured against ALLOCATABLE, and deliberately not against requests: these pods run well
-        # over their memory request, so the scheduler packs by a number that understates reality and
+        # Scoped by CONSTRUCTION to nodes that run this release's pods: the numerator only produces
+        # a series for a node once a pod from {{ $ns }} lands on it, so an unrelated node filling up
+        # in a shared cluster cannot fire an alert named after our edge functions, and two releases
+        # cannot emit the same cluster-wide series.
+        #
+        # What it therefore measures is THIS RELEASE'S FOOTPRINT against the node's allocatable
+        # memory, not total node usage. That is the honest trade: a node filled by some other
+        # tenant's workload will not fire this. It would have caught 2026-08-18 with room to spare
+        # (27.5Gi of pawtograder pods against 30.8Gi allocatable on worker-1 = 89%), and it is the
+        # part we can both see and act on.
+        #
+        # Against ALLOCATABLE, deliberately not against requests: these pods run well over their
+        # memory request, so the scheduler packs by a number that understates reality and
         # request-based headroom looks fine right up to the kill.
+        #
+        # Uses kube-state-metrics + cadvisor rather than node-exporter, so it depends only on the
+        # same exporters the rest of this group already relies on. `max by (namespace, pod, node)`
+        # on kube_pod_info guards the join against duplicate series for one pod.
         - alert: PawtograderEdgeFunctionsNodeMemoryHigh
           expr: |
-            max by (node) (
-              1 - (
-                node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
+            (
+              sum by (node) (
+                container_memory_working_set_bytes{namespace="{{ $ns }}", container!="", image!=""}
+                  * on (namespace, pod) group_left (node)
+                max by (namespace, pod, node) (kube_pod_info{namespace="{{ $ns }}"})
               )
+                / on (node)
+              max by (node) (kube_node_status_allocatable{resource="memory", unit="byte"})
             ) > {{ .Values.monitoring.prometheusRules.nodeMemoryRatio | default 0.85 }}
           for: 10m
           labels:
             severity: warning
           annotations:
-            summary: "Node memory is near capacity ({{`{{ $labels.node }}`}})"
+            summary: "Pawtograder pods are filling a node ({{`{{ $labels.node }}`}})"
             description: >-
-              {{`{{ $labels.node }}`}} is above
-              {{ .Values.monitoring.prometheusRules.nodeMemoryRatio | default 0.85 }} of total
-              memory. Pods on this node can be OOM-killed by the kernel while every pod-level
-              memory alert stays green, because those compare each pod against its OWN limit.
-              Check which workloads are co-located here -- Postgres and the edge tier landing on
-              one node is the combination that has bitten before.
+              Pods from {{ $ns }} are using more than
+              {{ .Values.monitoring.prometheusRules.nodeMemoryRatio | default 0.85 }} of
+              {{`{{ $labels.node }}`}}'s allocatable memory. At this point the kernel can OOM-kill a
+              pod on this node while every pod-level memory alert stays green, because those compare
+              each pod against its OWN limit. Check what is co-located here -- Postgres and the edge
+              tier landing on one node is the combination that has bitten before. Note this counts
+              only {{ $ns }}'s own usage, so the node may be fuller than this figure shows.
         # Leading indicator for the above. Memory that climbs with UPTIME rather than load is the
         # signature of long-lived isolates accumulating, and it is visible well before the kill.
         - alert: PawtograderEdgeFunctionsMemoryHigh

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1133,6 +1133,23 @@ edgeFunctions:
   # accumulates toward the 256MB cap. cpuHardMs keeps headroom above soft so an
   # in-flight request that crosses 2s can finish rather than being force-cancelled
   # (CPU time excludes async I/O, so 2s of real compute is ample here).
+  # Byte budget for the eszip cache the main.ts demuxer keeps of the bundles it
+  # has served. This is a real term in the container memory budget and it is the
+  # one that is easy to forget: a pod holds one bundle per DISTINCT FUNCTION it
+  # has ever been asked for, bundles run 19-59MB, and the image ships 55 of them
+  # (~2.2GB total). Unbounded, that alone exceeded the container limit and
+  # OOM-killed pods after a few days' uptime (2026-08-19).
+  #
+  # The container budget is now three terms that must be reconciled together:
+  #   eszipCacheMaxBytes + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
+  # At the defaults: 512Mi + (8 x 256Mi) + 90Mi = ~2.6Gi, which is why the
+  # edge tier wants a limit at or above 4Gi. Raise this only alongside that sum.
+  #
+  # 512Mi holds ~13 average bundles — comfortably more than the handful of
+  # functions a pod serves repeatedly — so the LRU only churns on rare ones.
+  # In MiB, matching worker.memoryLimitMb below. (Kept in MiB rather than bytes
+  # because YAML renders a bare 536870912 as 5.36870912e+08 through Helm.)
+  eszipCacheMaxMb: 512
   worker:
     memoryLimitMb: 256
     timeoutMs: 400000 # 400s worker lifetime (hosted paid-plan default)
@@ -1545,6 +1562,16 @@ monitoring:
     edgeFunctionRestarts30m: 2
     # Fraction of the container memory limit above which PawtograderEdgeFunctionsMemoryHigh fires.
     edgeFunctionMemoryRatio: 0.85
+    # Fraction of a node's total memory above which PawtograderEdgeFunctionsNodeMemoryHigh fires.
+    # Covers the axis every other rule here misses: the kernel can OOM-kill a pod that is nowhere
+    # near its own limit, because the NODE is full.
+    #
+    # NOTE: this rule reads node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes, i.e. it
+    # needs node-exporter scraped into the same Prometheus. If those series are absent the rule sits
+    # Inactive forever and looks shipped while being dead on arrival -- the same trap the
+    # container-label comment in prometheus-rules.yaml documents. Confirm the series exists before
+    # relying on this.
+    nodeMemoryRatio: 0.85
     # Postgres connection-budget saturation (used/max_connections), percent.
     connectionUsagePercentWarning: 80   # PawtograderPostgresConnectionsHigh fires above this
     connectionUsagePercentCritical: 90  # PawtograderPostgresConnectionsSaturated fires above this

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1140,8 +1140,9 @@ edgeFunctions:
   # (~2.2GB total). Unbounded, that alone exceeded the container limit and
   # OOM-killed pods after a few days' uptime (2026-08-19).
   #
-  # The container budget is now three terms that must be reconciled together:
-  #   eszipCacheMaxBytes + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
+  # The container budget is four terms that must be reconciled together:
+  #   eszipCacheMaxMb + eszipColdLoadHeadroomMb
+  #     + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
   # At the defaults: 512Mi + (8 x 256Mi) + 90Mi = ~2.6Gi, which is why the
   # edge tier wants a limit at or above 4Gi. Raise this only alongside that sum.
   #
@@ -1150,6 +1151,18 @@ edgeFunctions:
   # In MiB, matching worker.memoryLimitMb below. (Kept in MiB rather than bytes
   # because YAML renders a bare 536870912 as 5.36870912e+08 through Helm.)
   eszipCacheMaxMb: 512
+  # Headroom for bundle bytes the cache accounting does NOT see: a bundle being
+  # read on a cache miss, and one the LRU evicted (or refused as oversized) while
+  # a worker creation still holds a reference to it. Those buffers are real and
+  # concurrent with the cache, so the container budget has to carry them.
+  #
+  # main.ts holds such a reference only for the duration of
+  # EdgeRuntime.userWorkers.create() rather than for the whole request, which is
+  # what keeps this term small — but it is not zero, and a burst of cold requests
+  # for DISTINCT functions right after a pod starts is when it peaks. 256Mi is
+  # roughly four of the largest bundle in the image (58.4MiB measured); after
+  # warmup the working set is resident and this is not touched at all.
+  eszipColdLoadHeadroomMb: 256
   worker:
     memoryLimitMb: 256
     timeoutMs: 400000 # 400s worker lifetime (hosted paid-plan default)
@@ -1160,7 +1173,7 @@ edgeFunctions:
     # hosted "50% of any resource" rule (~128MB at 256MB). This lets a memory-heavy
     # request finish + return instead of being force-killed at the hard cap.
     lowMemoryMultiplier: 2
-  # The memory LIMIT has to hold the whole three-term budget documented above
+  # The memory LIMIT has to hold the whole budget documented above
   # (eszipCacheMaxMb + maxParallelism x worker.memoryLimitMb + ~90Mi host), which
   # is asserted at render time by pawtograder.edgeFunctions.assertMemoryBudget.
   # 4Gi rather than 2Gi because the documented working configuration -- the 512Mi

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1160,9 +1160,21 @@ edgeFunctions:
     # hosted "50% of any resource" rule (~128MB at 256MB). This lets a memory-heavy
     # request finish + return instead of being force-killed at the hard cap.
     lowMemoryMultiplier: 2
+  # The memory LIMIT has to hold the whole three-term budget documented above
+  # (eszipCacheMaxMb + maxParallelism x worker.memoryLimitMb + ~90Mi host), which
+  # is asserted at render time by pawtograder.edgeFunctions.assertMemoryBudget.
+  # 4Gi rather than 2Gi because the documented working configuration -- the 512Mi
+  # cache default with maxParallelism 8 -- comes to ~2.6Gi and did not fit 2Gi, so
+  # the old default was a combination the guardrail now rejects outright.
+  #
+  # This is a backstop, not a target: with the cache bounded, a pod's steady state
+  # is the cache plus admitted isolates, and the headroom exists so the runtime
+  # retires an isolate rather than the kernel killing PID 1 and every request on
+  # it. Limits are not scheduled (requests are), so raising it does not change
+  # placement.
   resources:
     requests: { cpu: "200m", memory: "512Mi" }
-    limits: { cpu: "2", memory: "2Gi" }
+    limits: { cpu: "2", memory: "4Gi" }
   # Horizontal autoscaling. When enabled, a HorizontalPodAutoscaler manages the
   # replica count (and the Deployment's static `replicas` is omitted so the two
   # don't fight). minReplicas should be high enough that a sudden burst spreads
@@ -1562,15 +1574,14 @@ monitoring:
     edgeFunctionRestarts30m: 2
     # Fraction of the container memory limit above which PawtograderEdgeFunctionsMemoryHigh fires.
     edgeFunctionMemoryRatio: 0.85
-    # Fraction of a node's total memory above which PawtograderEdgeFunctionsNodeMemoryHigh fires.
-    # Covers the axis every other rule here misses: the kernel can OOM-kill a pod that is nowhere
-    # near its own limit, because the NODE is full.
+    # Fraction of a node's ALLOCATABLE memory, used by this release's own pods, above which
+    # PawtograderEdgeFunctionsNodeMemoryHigh fires. Covers the axis every other rule here misses:
+    # the kernel can OOM-kill a pod that is nowhere near its own limit, because the NODE is full.
     #
-    # NOTE: this rule reads node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes, i.e. it
-    # needs node-exporter scraped into the same Prometheus. If those series are absent the rule sits
-    # Inactive forever and looks shipped while being dead on arrival -- the same trap the
-    # container-label comment in prometheus-rules.yaml documents. Confirm the series exists before
-    # relying on this.
+    # Counts only this namespace's usage, so it is a floor on how full the node is, not the whole
+    # picture -- a node filled by another tenant will not fire it. In exchange the rule is scoped to
+    # nodes we actually run on, and depends only on kube-state-metrics + cadvisor, the same
+    # exporters the rest of this rule group already needs.
     nodeMemoryRatio: 0.85
     # Postgres connection-budget saturation (used/max_connections), percent.
     connectionUsagePercentWarning: 80   # PawtograderPostgresConnectionsHigh fires above this

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1105,10 +1105,10 @@ edgeFunctions:
   #     work waits for the next cron tick instead. Safer, slower.
   # Raising maxParallelism does not substitute for either: an unbounded loop consumes
   # whatever you give it.
-  # Cap on simultaneous worker isolates (--max-parallelism). Unset, the runtime
-  # derives it from CPU cores, which is low on small pods and forces co-location.
-  # Under per_request this is effectively the max concurrent requests per pod
-  # (excess queue up to request-wait-timeout). Empty = runtime default.
+  # Cap on simultaneous worker isolates (--max-parallelism). Under per_request this
+  # is effectively the max concurrent requests per pod (excess queue up to
+  # request-wait-timeout).
+  #
   # REQUIRED, and validated by pawtograder.edgeFunctions.assertMemoryBudget: this
   # is a term in the container memory budget, and unset means "whatever the runtime
   # infers from CPU count", which cannot be checked at render time. 8 is what
@@ -1179,8 +1179,9 @@ edgeFunctions:
     # request finish + return instead of being force-killed at the hard cap.
     lowMemoryMultiplier: 2
   # The memory LIMIT has to hold the whole budget documented above
-  # (eszipCacheMaxMb + maxParallelism x worker.memoryLimitMb + ~90Mi host), which
-  # is asserted at render time by pawtograder.edgeFunctions.assertMemoryBudget.
+  # (eszipCacheMaxMb + eszipColdLoadHeadroomMb
+  #   + maxParallelism x worker.memoryLimitMb + ~90Mi host), which is asserted at
+  # render time by pawtograder.edgeFunctions.assertMemoryBudget.
   # 4Gi rather than 2Gi because the documented working configuration -- the 512Mi
   # cache and 256Mi cold-load defaults with maxParallelism 8 -- comes to 2906Mi
   # (~2.8Gi) and did not fit 2Gi, so the old default was a combination the

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1109,7 +1109,11 @@ edgeFunctions:
   # derives it from CPU cores, which is low on small pods and forces co-location.
   # Under per_request this is effectively the max concurrent requests per pod
   # (excess queue up to request-wait-timeout). Empty = runtime default.
-  maxParallelism: ""
+  # REQUIRED, and validated by pawtograder.edgeFunctions.assertMemoryBudget: this
+  # is a term in the container memory budget, and unset means "whatever the runtime
+  # infers from CPU count", which cannot be checked at render time. 8 is what
+  # production runs; 8 x worker.memoryLimitMb is the isolate half of the budget.
+  maxParallelism: 8
   verifyJwt: false # all functions in pawtograder set this; auth handled in-function
   # "beforeunload" / EarlyDrop thresholds (% of each per-worker resource limit).
   # When a per_worker isolate crosses the ratio the runtime tells it to finish
@@ -1143,8 +1147,9 @@ edgeFunctions:
   # The container budget is four terms that must be reconciled together:
   #   eszipCacheMaxMb + eszipColdLoadHeadroomMb
   #     + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
-  # At the defaults: 512Mi + (8 x 256Mi) + 90Mi = ~2.6Gi, which is why the
-  # edge tier wants a limit at or above 4Gi. Raise this only alongside that sum.
+  # At the defaults: 512Mi + 256Mi + (8 x 256Mi) + 90Mi = 2906Mi (~2.8Gi), which
+  # is why the edge tier wants a limit at or above 4Gi. Raise this only alongside
+  # that sum.
   #
   # 512Mi holds ~13 average bundles — comfortably more than the handful of
   # functions a pod serves repeatedly — so the LRU only churns on rare ones.
@@ -1177,8 +1182,9 @@ edgeFunctions:
   # (eszipCacheMaxMb + maxParallelism x worker.memoryLimitMb + ~90Mi host), which
   # is asserted at render time by pawtograder.edgeFunctions.assertMemoryBudget.
   # 4Gi rather than 2Gi because the documented working configuration -- the 512Mi
-  # cache default with maxParallelism 8 -- comes to ~2.6Gi and did not fit 2Gi, so
-  # the old default was a combination the guardrail now rejects outright.
+  # cache and 256Mi cold-load defaults with maxParallelism 8 -- comes to 2906Mi
+  # (~2.8Gi) and did not fit 2Gi, so the old default was a combination the
+  # guardrail now rejects outright.
   #
   # This is a backstop, not a target: with the cache bounded, a pod's steady state
   # is the cache plus admitted isolates, and the headroom exists so the runtime

--- a/supabase/functions/_shared/CanvasWrapper.ts
+++ b/supabase/functions/_shared/CanvasWrapper.ts
@@ -1,6 +1,6 @@
 import { CanvasApi } from "npm:@kth/canvas-api";
 import { Course, Enrollment, UserProfile } from "../_shared/CanvasTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 function getCanvas(id: number) {
   const canvas_api_url = Deno.env.get(`CANVAS_API_URL_${id}`) || Deno.env.get("CANVAS_API_URL");

--- a/supabase/functions/_shared/ChimeWrapper.ts
+++ b/supabase/functions/_shared/ChimeWrapper.ts
@@ -3,7 +3,7 @@ import { Database } from "./SupabaseTypes.d.ts";
 // import { jwtDecode } from "npm:jwt-decode"; // Currently unused
 import { UserVisibleError } from "./HandlerUtils.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type { SupabaseClient } from "jsr:@supabase/supabase-js@2";
 
 function uuid() {

--- a/supabase/functions/_shared/DiscordWrapper.ts
+++ b/supabase/functions/_shared/DiscordWrapper.ts
@@ -1,6 +1,6 @@
 import Bottleneck from "https://esm.sh/bottleneck?target=deno";
 import { bottleneckRedisOptions } from "./Redis.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type {
   SendMessageArgs,
   UpdateMessageArgs,

--- a/supabase/functions/_shared/GitHubSyncHelpers.ts
+++ b/supabase/functions/_shared/GitHubSyncHelpers.ts
@@ -9,7 +9,7 @@ import { createRedis, bottleneckRedisOptions, type RedisClient } from "./Redis.t
 import { SYNC_COMMIT_MESSAGE_PREFIX } from "./handoutSyncPush.ts";
 import { SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import Bottleneck from "https://esm.sh/bottleneck?target=deno";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { applyPatch } from "https://esm.sh/diff@5.1.0";
 import { encodeBase64 } from "https://deno.land/std@0.221.0/encoding/base64.ts";
 import * as github from "./GitHubWrapper.ts";

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -5,7 +5,7 @@ import { throttling } from "npm:@octokit/plugin-throttling";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import Bottleneck from "https://esm.sh/bottleneck?target=deno";
 import { App, Endpoints, Octokit, RequestError } from "npm:octokit";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { SecurityError } from "./HandlerUtils.ts";
 
 // Structured error used to signal Octokit secondary rate limit back to callers

--- a/supabase/functions/_shared/HandlerUtils.ts
+++ b/supabase/functions/_shared/HandlerUtils.ts
@@ -1,6 +1,6 @@
 import { PostgrestFilterBuilder } from "https://esm.sh/@supabase/postgrest-js@1.19.2";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "./SupabaseTypes.d.ts";
 // Import for side effect. Module evaluation order guarantees this runs to completion before any
 // code in this file, so the ~50 functions that rely on importing HandlerUtils to get Sentry keep
@@ -427,6 +427,19 @@ export async function wrapRequestHandler(
         status: 500
       }
     );
+  } finally {
+    // Under `policy: per_request` the isolate is torn down as soon as this
+    // response is returned, taking Sentry's in-memory transport queue with it.
+    // Without an explicit flush, everything captured above — and every
+    // captureException/captureMessage a handler made — is silently discarded.
+    // Before this, `Sentry.flush()` was called in exactly one function of 55,
+    // so error reporting from the edge tier was mostly fiction.
+    //
+    // Flushed unconditionally rather than only on the error path: handlers
+    // capture directly too, and with an empty queue this resolves immediately.
+    // The 2s ceiling bounds the worst case — losing an event is better than
+    // holding an isolate (and one of `maxParallelism` admission slots) open.
+    await Sentry.flush(2000);
   }
 }
 export class SecurityError extends Error {

--- a/supabase/functions/_shared/InvitationUtils.ts
+++ b/supabase/functions/_shared/InvitationUtils.ts
@@ -1,7 +1,7 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import type { Database } from "./SupabaseTypes.d.ts";
 import { UserVisibleError } from "./HandlerUtils.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import Bottleneck from "npm:bottleneck@2.19.5";
 import { normalizeEventFingerprint } from "./SentryFingerprint.ts";
 import { sentryIdentity } from "./SentryContext.ts";

--- a/supabase/functions/_shared/MCPAuth.ts
+++ b/supabase/functions/_shared/MCPAuth.ts
@@ -11,6 +11,7 @@
 import { create, verify, getNumericDate } from "https://deno.land/x/djwt@v3.0.2/mod.ts";
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Database } from "./SupabaseTypes.d.ts";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 // Environment variable names.
 //
@@ -428,8 +429,23 @@ export async function updateTokenLastUsed(tokenId: string): Promise<void> {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
     );
 
-    await adminSupabase.from("api_tokens").update({ last_used_at: new Date().toISOString() }).eq("token_id", tokenId);
-  } catch {
-    // Non-critical, silently ignore
+    const { error } = await adminSupabase
+      .from("api_tokens")
+      .update({ last_used_at: new Date().toISOString() })
+      .eq("token_id", tokenId);
+    // supabase-js RESOLVES with an { error } instead of throwing, so the previous
+    // bare await could not fail and the catch below could not fire. Callers had a
+    // `.catch()` that captured to Sentry and was therefore dead code: a token
+    // whose last_used_at silently stopped updating looked identical to one that
+    // was never used, which is exactly the signal this column exists to provide.
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { operation: "update_token_last_used", tokenId }
+      });
+    }
+  } catch (e) {
+    // Still non-fatal for the request — the caller has already responded — but no
+    // longer invisible.
+    Sentry.captureException(e, { tags: { operation: "update_token_last_used", tokenId } });
   }
 }

--- a/supabase/functions/_shared/PrSubmissionFiles.ts
+++ b/supabase/functions/_shared/PrSubmissionFiles.ts
@@ -23,7 +23,7 @@
  * Idempotent: if the submission already has files (webhook re-delivery, or
  * ingest_pr_submission returned an existing version), this is a no-op.
  */
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type { SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { END_TO_END_REPO_PREFIX } from "./GitHubWrapper.ts";
 import { ingestSubmissionFilesFromRepo } from "./SubmissionIngestion.ts";

--- a/supabase/functions/_shared/Redis.ts
+++ b/supabase/functions/_shared/Redis.ts
@@ -1,6 +1,6 @@
 import { Redis as UpstashRedis } from "https://esm.sh/@upstash/redis";
 import IORedisDefault, { type Redis as IORedisInstance } from "npm:ioredis";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import Bottleneck from "https://esm.sh/bottleneck?target=deno";
 
 // npm:ioredis ships as a CJS default export; the named import above is

--- a/supabase/functions/_shared/SentryInit.ts
+++ b/supabase/functions/_shared/SentryInit.ts
@@ -13,7 +13,7 @@
 // reason logic gets extracted out of HandlerUtils in the first place. This module depends only on
 // @sentry/deno plus two pure helpers.
 
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { normalizeEventFingerprint } from "./SentryFingerprint.ts";
 import { sentryIdentity } from "./SentryContext.ts";
 

--- a/supabase/functions/_shared/SentryInit.ts
+++ b/supabase/functions/_shared/SentryInit.ts
@@ -71,3 +71,34 @@ export function serveWithSentryFlush(handler: Deno.ServeHandler): void {
     }
   });
 }
+
+/**
+ * `EdgeRuntime.waitUntil` plus a flush that happens when the BACKGROUND work
+ * settles, not when the response was returned.
+ *
+ * `serveWithSentryFlush` and `wrapRequestHandler` both flush in a `finally` on
+ * the request, which is the right moment for anything the handler did inline —
+ * and the wrong one for work handed to `waitUntil`. Those handlers return
+ * immediately, so the flush runs while the background promise is still going,
+ * and everything it captures afterwards dies with the isolate exactly as before.
+ * The batch workers are the case that matters: their capture sites are all in
+ * the loop or its startup `.catch`, i.e. entirely after the response.
+ *
+ * Flushing here does not remove the need to flush on the request — a handler
+ * can capture inline and in the background — and a second flush with an empty
+ * queue is close to free.
+ */
+export function waitUntilWithSentryFlush(promise: Promise<unknown>): void {
+  const runtime = (globalThis as { EdgeRuntime?: { waitUntil(p: Promise<unknown>): void } }).EdgeRuntime;
+  const flushed = promise.finally(async () => {
+    await Sentry.flush(2000);
+  });
+  if (runtime?.waitUntil) {
+    runtime.waitUntil(flushed);
+  } else {
+    // No runtime to hand it to (local `deno run`, tests): keep the original
+    // fire-and-forget shape rather than changing behaviour, but do not let a
+    // rejection surface as an unhandled one.
+    void flushed.catch(() => {});
+  }
+}

--- a/supabase/functions/_shared/SentryInit.ts
+++ b/supabase/functions/_shared/SentryInit.ts
@@ -46,3 +46,28 @@ export function initSentry(): void {
 }
 
 initSentry();
+
+/**
+ * `Deno.serve` plus the flush that `policy: per_request` makes mandatory.
+ *
+ * Under per_request the isolate is destroyed as soon as the response is
+ * returned, taking Sentry's in-memory transport queue with it. Anything
+ * captured but not yet delivered is lost. `wrapRequestHandler` flushes for the
+ * 43 functions routed through it; the ~10 functions that own their `Deno.serve`
+ * boundary need this instead — including the three heaviest reporters in the
+ * tree (github-repo-webhook, github-async-worker, discord-async-worker), which
+ * between them capture 180 exceptions and flushed none of them.
+ *
+ * The flush is in a `finally`, so it covers the throwing path too, and its 2s
+ * ceiling bounds the worst case: losing an event beats holding an isolate (and
+ * one of `maxParallelism` admission slots) open indefinitely.
+ */
+export function serveWithSentryFlush(handler: Deno.ServeHandler): void {
+  Deno.serve(async (req, info) => {
+    try {
+      return await handler(req, info);
+    } finally {
+      await Sentry.flush(2000);
+    }
+  });
+}

--- a/supabase/functions/_shared/SubmissionIngestion.ts
+++ b/supabase/functions/_shared/SubmissionIngestion.ts
@@ -38,7 +38,7 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { Open as openZip } from "npm:unzipper";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type { SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { cloneRepository, END_TO_END_REPO_PREFIX, getRepoToCloneConsideringE2E } from "./GitHubWrapper.ts";
 import type { Database } from "./SupabaseTypes.d.ts";

--- a/supabase/functions/_shared/handoutFileHashes.ts
+++ b/supabase/functions/_shared/handoutFileHashes.ts
@@ -14,7 +14,7 @@ import { createHash } from "node:crypto";
 import { Buffer } from "node:buffer";
 import micromatch from "npm:micromatch";
 import { SupabaseClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { getOctoKit } from "./GitHubWrapper.ts";
 import { Database } from "./SupabaseTypes.d.ts";
 import { PawtograderConfig } from "./PawtograderYml.d.ts";

--- a/supabase/functions/_shared/workerRun.ts
+++ b/supabase/functions/_shared/workerRun.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { createRedis, type RedisClient } from "./Redis.ts";
 import { type EnvReader } from "./SentryContext.ts";
 

--- a/supabase/functions/assignment-create-all-repos/fix.ts
+++ b/supabase/functions/assignment-create-all-repos/fix.ts
@@ -1,5 +1,5 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { createAllRepos } from "./index.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";

--- a/supabase/functions/assignment-create-all-repos/index.ts
+++ b/supabase/functions/assignment-create-all-repos/index.ts
@@ -23,6 +23,7 @@ import {
   summarizeSettled,
   type SettledSummary
 } from "../_shared/settledSummary.ts";
+import { waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Declare EdgeRuntime for type safety
 declare const EdgeRuntime: {
@@ -601,7 +602,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         Sentry.captureException(error, scope);
       }
     };
-    EdgeRuntime.waitUntil(handler());
+    waitUntilWithSentryFlush(handler());
 
     return new Response(
       JSON.stringify({

--- a/supabase/functions/assignment-create-all-repos/index.ts
+++ b/supabase/functions/assignment-create-all-repos/index.ts
@@ -8,7 +8,7 @@ import { assertUserIsInstructor, UserVisibleError, wrapRequestHandler } from "..
 import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import {
   resolveRepoCreationStrategy,
   type AssignmentForRepoCreation,

--- a/supabase/functions/assignment-create-handout-repo/index.ts
+++ b/supabase/functions/assignment-create-handout-repo/index.ts
@@ -1,6 +1,6 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AssignmentCreateHandoutRepoRequest } from "../_shared/FunctionTypes.d.ts";
 import {
   createRepo,

--- a/supabase/functions/assignment-create-solution-repo/index.ts
+++ b/supabase/functions/assignment-create-solution-repo/index.ts
@@ -8,7 +8,7 @@ import { resolveTemplateRepos } from "../_shared/GitHubSyncHelpers.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
 import { parse } from "jsr:@std/yaml";
 import { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { describeHandoutSeedResult, seedHandoutFileHashes } from "../_shared/handoutFileHashes.ts";
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {

--- a/supabase/functions/assignment-delete/index.ts
+++ b/supabase/functions/assignment-delete/index.ts
@@ -8,7 +8,7 @@ import {
 } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { enqueueGithubArchiveRepo, getOctoKit, listCommits } from "../_shared/GitHubWrapper.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import {
   buildAssignmentDeleteArchiveDebugId,
   collectGitHubRepoTargets,

--- a/supabase/functions/assignment-group-approve-request/index.ts
+++ b/supabase/functions/assignment-group-approve-request/index.ts
@@ -4,7 +4,7 @@ import { TZDate } from "npm:@date-fns/tz";
 import { enqueueSyncRepoPermissions } from "../_shared/GitHubWrapper.ts";
 import { SecurityError, assertUserIsInCourse, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function handleAssignmentGroupApproveRequest(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
   const { join_request_id, course_id } = (await req.json()) as { join_request_id: number; course_id: number };

--- a/supabase/functions/assignment-group-copy-groups-from-assignment/index.ts
+++ b/supabase/functions/assignment-group-copy-groups-from-assignment/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AssignmentGroupCopyGroupsFromAssignmentRequest } from "../_shared/FunctionTypes.d.ts";
 import { IllegalArgumentError, assertUserIsInstructor, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";

--- a/supabase/functions/assignment-group-create/index.ts
+++ b/supabase/functions/assignment-group-create/index.ts
@@ -4,7 +4,7 @@ import { TZDate } from "npm:@date-fns/tz";
 import { AssignmentGroupCreateRequest } from "../_shared/FunctionTypes.d.ts";
 import { IllegalArgumentError, SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function createAutograderGroup(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
   //Get the user

--- a/supabase/functions/assignment-group-instructor-create/index.ts
+++ b/supabase/functions/assignment-group-instructor-create/index.ts
@@ -13,7 +13,7 @@ import {
   IllegalArgumentError,
   assertUserIsInstructor
 } from "../_shared/HandlerUtils.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function instructorCreateAutograderGroup(
   req: Request,
   scope: Sentry.Scope

--- a/supabase/functions/assignment-group-instructor-move-student/index.ts
+++ b/supabase/functions/assignment-group-instructor-move-student/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AssignmentGroupInstructorMoveStudentRequest } from "../_shared/FunctionTypes.d.ts";
 import { IllegalArgumentError, assertUserIsInstructor, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";

--- a/supabase/functions/assignment-group-join/index.ts
+++ b/supabase/functions/assignment-group-join/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { TZDate } from "npm:@date-fns/tz";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AssignmentGroupJoinRequest } from "../_shared/FunctionTypes.d.ts";
 import { enqueueSyncRepoPermissions } from "../_shared/GitHubWrapper.ts";
 import {

--- a/supabase/functions/assignment-group-leave/index.ts
+++ b/supabase/functions/assignment-group-leave/index.ts
@@ -14,7 +14,7 @@ import {
   wrapRequestHandler
 } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleAssignmentGroupLeave(req: Request, scope: Sentry.Scope): Promise<{ message: string }> {
   const { assignment_id } = (await req.json()) as { assignment_id: number };
   scope?.setTag("function", "assignment-group-leave");

--- a/supabase/functions/assignment-sync-autograder-workflow/index.ts
+++ b/supabase/functions/assignment-sync-autograder-workflow/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AssignmentSyncAutograderWorkflowRequest } from "../_shared/FunctionTypes.d.ts";
 import { RequestError } from "npm:octokit";
 import {

--- a/supabase/functions/autograder-create-regression-test-run/index.ts
+++ b/supabase/functions/autograder-create-regression-test-run/index.ts
@@ -10,7 +10,7 @@ import { getRepoTarballURL, validateOIDCToken } from "../_shared/GitHubWrapper.t
 import { SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   scope?.setTag("function", "autograder-create-regression-test-run");
   const url = req.url;

--- a/supabase/functions/autograder-create-repos-for-student/index.ts
+++ b/supabase/functions/autograder-create-repos-for-student/index.ts
@@ -13,7 +13,7 @@ import { isServiceRoleRequest, SecurityError, UserVisibleError, wrapRequestHandl
 import { sanitizeRepoNameComponent } from "../_shared/repoNames.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import {
   resolveRepoCreationStrategy,
   type AssignmentForRepoCreation,

--- a/supabase/functions/autograder-create-submission/index.ts
+++ b/supabase/functions/autograder-create-submission/index.ts
@@ -33,7 +33,7 @@ import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { indexSubmission } from "../_shared/CodeSymbolIndexer.ts";
 import { Buffer } from "node:buffer";
 import { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 const GRADE_WORKFLOW_PATH = ".github/workflows/grade.yml";
 const STAFF_ROLES = new Set(["admin", "instructor", "grader"]);

--- a/supabase/functions/autograder-reinvite-to-class-org/index.ts
+++ b/supabase/functions/autograder-reinvite-to-class-org/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { reinviteToOrgTeam } from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInCourse, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { course_id, user_id } = (await req.json()) as { course_id: number; user_id: string };
   scope?.setTag("function", "autograder-reinvite-to-class-org");

--- a/supabase/functions/autograder-retrieve-autograder-regression-tests/index.ts
+++ b/supabase/functions/autograder-retrieve-autograder-regression-tests/index.ts
@@ -4,7 +4,7 @@ import { validateOIDCToken } from "../_shared/GitHubWrapper.ts";
 import { UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { attachWorkflowRunLink } from "../_shared/workflowRunUrl.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   scope?.setTag("function", "autograder-retrieve-autograder-regression-tests");
   const token = req.headers.get("Authorization");

--- a/supabase/functions/autograder-submit-feedback/index.ts
+++ b/supabase/functions/autograder-submit-feedback/index.ts
@@ -26,7 +26,7 @@ import {
   fetchRubricCheckIdsRequiringTargetStudentProfileId
 } from "../_shared/rubricCommentTargetStudentProfileId.ts";
 import { hasGradeableContent, resolveGraderResultConflictVerdict } from "../_shared/graderResultVerdict.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { graderResultErrorsIndicateFailure } from "../_shared/graderResultStatus.ts";
 
 type GraderResultErrors = Database["public"]["Tables"]["grader_results"]["Row"]["errors"];

--- a/supabase/functions/autograder-sync-staff-team/index.ts
+++ b/supabase/functions/autograder-sync-staff-team/index.ts
@@ -3,7 +3,7 @@ import { syncStaffTeam } from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInstructor, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 //See also autograder-sync-student-team
 async function handleRequest(req: Request, scope: Sentry.Scope) {

--- a/supabase/functions/autograder-sync-student-team/index.ts
+++ b/supabase/functions/autograder-sync-student-team/index.ts
@@ -8,7 +8,7 @@ import {
   fetchAllPages
 } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 //See also autograder-sync-staff-team
 async function handleRequest(req: Request, scope: Sentry.Scope) {

--- a/supabase/functions/autograder-trigger-grading-workflow/index.ts
+++ b/supabase/functions/autograder-trigger-grading-workflow/index.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { AutograderTriggerGradingWorkflowRequest, CheckRunStatus } from "../_shared/FunctionTypes.d.ts";
 import { GetCommitResponse, getCommit, repoHasFileAtRef, triggerWorkflow } from "../_shared/GitHubWrapper.ts";
 import {

--- a/supabase/functions/calendar-sync/index.ts
+++ b/supabase/functions/calendar-sync/index.ts
@@ -3,7 +3,7 @@ import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
-import "../_shared/SentryInit.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import type { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
 
@@ -1338,7 +1338,7 @@ async function runSync(): Promise<void> {
 }
 
 // HTTP handler
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   console.log(`[calendar-sync] Received request: ${req.method}`);
 
   // Verify request is from cron or has proper auth

--- a/supabase/functions/calendar-sync/index.ts
+++ b/supabase/functions/calendar-sync/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
 import "../_shared/SentryInit.ts";

--- a/supabase/functions/cli/index.ts
+++ b/supabase/functions/cli/index.ts
@@ -48,7 +48,7 @@
 
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { authenticateMCPRequest, MCPAuthError, updateTokenLastUsed } from "../_shared/MCPAuth.ts";
 import { dispatch, dispatchStream, getCommand, UnknownCommandError } from "./router.ts";
 import { isStreamCommand } from "./commands/base.ts";

--- a/supabase/functions/cli/index.ts
+++ b/supabase/functions/cli/index.ts
@@ -71,7 +71,7 @@ import "./commands/helpRequests.ts";
 import "./commands/reviews.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
-import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
+import { serveWithSentryFlush, waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 if (Deno.env.get("SENTRY_DSN")) {
   Sentry.init({
@@ -97,7 +97,13 @@ serveWithSentryFlush(async (req) => {
     const authHeader = req.headers.get("Authorization");
     const authContext = await authenticateMCPRequest(authHeader);
 
-    updateTokenLastUsed(authContext.tokenId).catch(() => {});
+    // Detached on purpose: the CLI response must not wait on a last-used
+    // timestamp write. Routed through the background helper so the capture
+    // updateTokenLastUsed now makes on failure is actually delivered — the
+    // request-boundary flush has already run by the time this settles — and so
+    // the isolate is kept alive until the write completes. The old empty
+    // `.catch(() => {})` swallowed the outcome entirely.
+    waitUntilWithSentryFlush(updateTokenLastUsed(authContext.tokenId));
 
     const body: CLIRequest = await req.json();
 

--- a/supabase/functions/cli/index.ts
+++ b/supabase/functions/cli/index.ts
@@ -71,6 +71,7 @@ import "./commands/helpRequests.ts";
 import "./commands/reviews.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 
 if (Deno.env.get("SENTRY_DSN")) {
   Sentry.init({
@@ -80,7 +81,7 @@ if (Deno.env.get("SENTRY_DSN")) {
   });
 }
 
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }

--- a/supabase/functions/cli/utils/ndjson.ts
+++ b/supabase/functions/cli/utils/ndjson.ts
@@ -11,7 +11,7 @@
  * discriminator in each record.
  */
 
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { CLICommandError } from "../errors.ts";
 import { corsHeaders } from "./supabase.ts";
 

--- a/supabase/functions/cli/utils/ndjson.ts
+++ b/supabase/functions/cli/utils/ndjson.ts
@@ -69,22 +69,30 @@ export function streamNdjson(handler: (writer: NdjsonWriter) => Promise<void>): 
   // edge runtime (broken pipe is exactly when we most want a quiet death).
   (async () => {
     try {
-      await handler(writer);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      // The Response left before the handler ran, so cli/index.ts's catch can
-      // never see this: without reporting here, every server fault inside a
-      // streaming export (statement timeouts on large courses, storage errors)
-      // is an HTTP 200 with an error line in the body and nothing in Sentry.
-      // Client errors thrown before the stream opened are still handled by the
-      // dispatcher; anything reaching here is mid-stream and ours.
-      if (!(err instanceof CLICommandError) || err.status >= 500) {
-        Sentry.captureException(err, { tags: { endpoint: "cli", phase: "ndjson_stream" } });
+      try {
+        await handler(writer);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // The Response left before the handler ran, so cli/index.ts's catch can
+        // never see this: without reporting here, every server fault inside a
+        // streaming export (statement timeouts on large courses, storage errors)
+        // is an HTTP 200 with an error line in the body and nothing in Sentry.
+        // Client errors thrown before the stream opened are still handled by the
+        // dispatcher; anything reaching here is mid-stream and ours.
+        if (!(err instanceof CLICommandError) || err.status >= 500) {
+          Sentry.captureException(err, { tags: { endpoint: "cli", phase: "ndjson_stream" } });
+        }
+        await writer.abort(message).catch(() => {});
+        return;
       }
-      await writer.abort(message).catch(() => {});
-      return;
+      await writer.close().catch(() => {});
+    } finally {
+      // The Response left before any of this ran, so the flush that
+      // serveWithSentryFlush does on the request has already happened. This is
+      // the only point at which a mid-stream capture above can still be
+      // delivered before the per_request isolate is torn down.
+      await Sentry.flush(2000);
     }
-    await writer.close().catch(() => {});
   })();
 
   return new Response(stream.readable, {

--- a/supabase/functions/course-import-sis/deno.json
+++ b/supabase/functions/course-import-sis/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "sentry": "npm:@sentry/deno"
+    "sentry": "npm:@sentry/deno@10.10.0"
   }
 }

--- a/supabase/functions/course-import-sis/index.ts
+++ b/supabase/functions/course-import-sis/index.ts
@@ -8,6 +8,7 @@ declare const EdgeRuntime: {
 };
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
+import { waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 type SISSycEnrollmentResult = {
   success: boolean;
@@ -971,7 +972,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<CourseI
     };
 
     // Run in background for cron jobs
-    EdgeRuntime.waitUntil(syncHandler());
+    waitUntilWithSentryFlush(syncHandler());
 
     return {
       message: "SIS sync started in background"
@@ -1291,7 +1292,7 @@ async function routeRequest(req: Request, scope: Sentry.Scope) {
     };
 
     // Run in background for cron jobs
-    EdgeRuntime.waitUntil(syncHandler());
+    waitUntilWithSentryFlush(syncHandler());
 
     return {
       message: "SIS sync started in background",

--- a/supabase/functions/course-import-sis/index.ts
+++ b/supabase/functions/course-import-sis/index.ts
@@ -7,7 +7,7 @@ declare const EdgeRuntime: {
   waitUntil(promise: Promise<unknown>): void;
 };
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 type SISSycEnrollmentResult = {
   success: boolean;

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@sentry/deno": "npm:@sentry/deno@^10.1.0",
+    "@sentry/deno": "npm:@sentry/deno@10.10.0",
     "@supabase/functions-js": "jsr:@supabase/functions-js@^2.4.5",
     "@supabase/postgrest-js": "https://esm.sh/@supabase/postgrest-js@1.19.2",
     "mathjs": "npm:mathjs@14.5.2",

--- a/supabase/functions/discord-async-worker/debug.ts
+++ b/supabase/functions/discord-async-worker/debug.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import type { DiscordAsyncEnvelope } from "../_shared/DiscordAsyncTypes.ts";
 

--- a/supabase/functions/discord-async-worker/index.ts
+++ b/supabase/functions/discord-async-worker/index.ts
@@ -1,7 +1,7 @@
 import type { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
 import "../_shared/SentryInit.ts";

--- a/supabase/functions/discord-async-worker/index.ts
+++ b/supabase/functions/discord-async-worker/index.ts
@@ -4,7 +4,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
-import "../_shared/SentryInit.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 import type {
   DiscordAsyncEnvelope,
   SendMessageArgs,
@@ -2512,7 +2512,7 @@ export async function runBatchHandler() {
   }
 }
 
-Deno.serve((req) => {
+serveWithSentryFlush((req) => {
   console.log(`[serve] Received request, method: ${req.method}, url: ${req.url}`);
   const secret = req.headers.get("x-edge-function-secret");
   const expectedSecret = Deno.env.get("EDGE_FUNCTION_SECRET");

--- a/supabase/functions/discord-async-worker/index.ts
+++ b/supabase/functions/discord-async-worker/index.ts
@@ -27,6 +27,7 @@ import {
   DISCORD_UNKNOWN_GUILD
 } from "../_shared/DiscordErrorClassification.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
+import { waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Declare EdgeRuntime for type safety
 declare const EdgeRuntime: {
@@ -2552,7 +2553,7 @@ serveWithSentryFlush((req) => {
     // missing-environment-variable check. `.catch` is what makes that throw visible: nothing
     // consumes the promise handed to waitUntil, so without it the one error that can actually end
     // this worker is an unhandled rejection and never reaches Sentry.
-    EdgeRuntime.waitUntil(
+    waitUntilWithSentryFlush(
       runBatchHandler()
         .catch((e) => {
           console.error(`[serve] Batch handler exited with an error:`, e);

--- a/supabase/functions/discord-discussion-stats-update/index.ts
+++ b/supabase/functions/discord-discussion-stats-update/index.ts
@@ -3,7 +3,7 @@ import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
-import "../_shared/SentryInit.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import type { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
 
@@ -330,7 +330,7 @@ async function runStatsUpdate(
 }
 
 // HTTP handler
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   console.log(`[discord-discussion-stats-update] Received request: ${req.method}`);
 
   const scope = new Sentry.Scope();

--- a/supabase/functions/discord-discussion-stats-update/index.ts
+++ b/supabase/functions/discord-discussion-stats-update/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
 import "../_shared/SentryInit.ts";

--- a/supabase/functions/enrollments-add/index.ts
+++ b/supabase/functions/enrollments-add/index.ts
@@ -5,7 +5,7 @@ import { createUserInClass } from "../_shared/EnrollmentUtils.ts";
 import type { AddEnrollmentRequest } from "../_shared/FunctionTypes.d.ts";
 import { assertUserIsInstructor, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { email, name, role, courseId, notify } = (await req.json()) as AddEnrollmentRequest;

--- a/supabase/functions/enrollments-sync-canvas/index.ts
+++ b/supabase/functions/enrollments-sync-canvas/index.ts
@@ -7,7 +7,7 @@ import { createClient } from "jsr:@supabase/supabase-js@2";
 
 import { assertUserIsInstructor } from "../_shared/HandlerUtils.ts";
 import { createUserInClass } from "../_shared/EnrollmentUtils.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { course_id } = (await req.json()) as { course_id: number };
   if (!course_id) {

--- a/supabase/functions/get-pr-base-files/index.ts
+++ b/supabase/functions/get-pr-base-files/index.ts
@@ -28,7 +28,7 @@ import { cloneRepository, END_TO_END_REPO_PREFIX, getRepoToCloneConsideringE2E }
 import { assertUserIsInCourse, SecurityError, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { collectTextFilesFromZipBuffer } from "../_shared/SubmissionIngestion.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 type RequestBody = { submission_id: number };
 

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -26,7 +26,7 @@ import { beginWorkerRun } from "../_shared/workerRun.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { syncRepositoryToHandout, getFirstCommit } from "../_shared/GitHubSyncHelpers.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
-import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
+import { serveWithSentryFlush, waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 // Declare EdgeRuntime for type safety
 declare const EdgeRuntime: {
   waitUntil(promise: Promise<unknown>): void;
@@ -2667,7 +2667,7 @@ if (import.meta.main) {
       // captured, delayed 5s, and retried indefinitely. `.catch` is what makes an exit visible --
       // nothing consumes the promise handed to waitUntil, so a rejection here would otherwise be
       // an unhandled rejection that never reaches Sentry.
-      EdgeRuntime.waitUntil(
+      waitUntilWithSentryFlush(
         runBatchHandler()
           .catch((e) => {
             const scope = new Sentry.Scope();

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -158,12 +158,16 @@ function recordMetric(
       p_status_code: params.status_code,
       p_latency_ms: latency_ms
     });
-    log_result.then((result) => {
-      if (result.error) {
-        console.error(result.error);
-        Sentry.captureException(result.error, scope);
-      }
-    });
+    // Detached: gateway-call logging must not add latency to the call it logs.
+    // Flushed after it settles, since nothing else will be alive to do it.
+    waitUntilWithSentryFlush(
+      log_result.then((result) => {
+        if (result.error) {
+          console.error(result.error);
+          Sentry.captureException(result.error, scope);
+        }
+      })
+    );
   } else {
     // Create new log record (fallback for backward compatibility)
     const log_result = adminSupabase.schema("public").rpc("log_api_gateway_call", {
@@ -174,12 +178,16 @@ function recordMetric(
       p_message_processed_at: new Date().toISOString(),
       p_latency_ms: latency_ms
     });
-    log_result.then((result) => {
-      if (result.error) {
-        console.error(result.error);
-        Sentry.captureException(result.error, scope);
-      }
-    });
+    // Detached: gateway-call logging must not add latency to the call it logs.
+    // Flushed after it settles, since nothing else will be alive to do it.
+    waitUntilWithSentryFlush(
+      log_result.then((result) => {
+        if (result.error) {
+          console.error(result.error);
+          Sentry.captureException(result.error, scope);
+        }
+      })
+    );
   }
 }
 

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -1,7 +1,7 @@
 import type { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.js";
 import { createClient, SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type {
   ArchiveRepoAndLockArgs,
   CreateRepoArgs,

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -26,6 +26,7 @@ import { beginWorkerRun } from "../_shared/workerRun.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { syncRepositoryToHandout, getFirstCommit } from "../_shared/GitHubSyncHelpers.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 // Declare EdgeRuntime for type safety
 declare const EdgeRuntime: {
   waitUntil(promise: Promise<unknown>): void;
@@ -2634,7 +2635,7 @@ export async function runBatchHandler() {
 }
 
 if (import.meta.main) {
-  Deno.serve((req) => {
+  serveWithSentryFlush((req) => {
     const secret = req.headers.get("x-edge-function-secret");
     const expectedSecret = Deno.env.get("EDGE_FUNCTION_SECRET");
 

--- a/supabase/functions/github-check-app-installation/index.ts
+++ b/supabase/functions/github-check-app-installation/index.ts
@@ -15,7 +15,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { getOctoKit, getRepo, getAppSlug, getOrgId } from "../_shared/GitHubWrapper.ts";
 import { UserVisibleError, SecurityError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 type RequestBody = {
   repo: string;

--- a/supabase/functions/github-repo-configure-webhook/index.ts
+++ b/supabase/functions/github-repo-configure-webhook/index.ts
@@ -9,7 +9,7 @@ import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { parse } from "jsr:@std/yaml";
 import { PawtograderConfig } from "../_shared/PawtograderYml.d.ts";
 import { Json } from "https://esm.sh/@supabase/postgrest-js@1.19.2/dist/cjs/select-query-parser/types.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import {
   describeHandoutSeedResult,
   seedHandoutFileHashes,

--- a/supabase/functions/github-repo-reconciler/index.ts
+++ b/supabase/functions/github-repo-reconciler/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";

--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -47,7 +47,7 @@ import {
   MAX_FILE_SIZE_MB
 } from "../_shared/SubmissionIngestion.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { createRedis, type RedisClient } from "../_shared/Redis.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";

--- a/supabase/functions/github-repo-webhook/index.ts
+++ b/supabase/functions/github-repo-webhook/index.ts
@@ -51,6 +51,7 @@ import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { createRedis, type RedisClient } from "../_shared/Redis.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 const eventHandler = createEventHandler({
   secret: Deno.env.get("GITHUB_WEBHOOK_SECRET") || "secret"
 });
@@ -3961,7 +3962,7 @@ export function isRegularTestUnit(unit: GradedUnit): unit is RegularTestUnit {
   return "tests" in unit && "testCount" in unit;
 }
 
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   console.log("[ENTRY] Received webhook request");
   if (req.headers.get("Authorization") !== Deno.env.get("EVENTBRIDGE_SECRET")) {
     return Response.json(

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { TZDate } from "npm:@date-fns/tz";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import {
   createRepo,
   getOctoKit,

--- a/supabase/functions/gradebook-column-recalculate/BatchProcessor.ts
+++ b/supabase/functions/gradebook-column-recalculate/BatchProcessor.ts
@@ -1,6 +1,6 @@
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { processBatch } from "./index.ts";
 export async function runHandler() {

--- a/supabase/functions/gradebook-column-recalculate/DebugOneRow.ts
+++ b/supabase/functions/gradebook-column-recalculate/DebugOneRow.ts
@@ -23,7 +23,7 @@
 /* eslint-disable no-console */
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { processGradebookRowsCalculation } from "./GradebookProcessor.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";

--- a/supabase/functions/gradebook-column-recalculate/GradebookProcessor.ts
+++ b/supabase/functions/gradebook-column-recalculate/GradebookProcessor.ts
@@ -11,7 +11,7 @@ import {
   setRowOverrideValues,
   clearRowOverrideValues
 } from "./expression/DependencySource.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 const DEBUG_LOG = Boolean(Deno.env.get("DEBUG_GRADEBOOK_CALCULATION")) || false;
 

--- a/supabase/functions/gradebook-column-recalculate/expression/DependencySource.ts
+++ b/supabase/functions/gradebook-column-recalculate/expression/DependencySource.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { isDenseMatrix, MathJsInstance, Matrix } from "mathjs";
 import { minimatch } from "minimatch";
 import type { Database } from "../../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import type {
   Assignment,
   GradebookColumn,

--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { processGradebookRowsCalculation } from "./GradebookProcessor.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { beginWorkerRun } from "../_shared/workerRun.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";

--- a/supabase/functions/gradebook-column-recalculate/index.ts
+++ b/supabase/functions/gradebook-column-recalculate/index.ts
@@ -14,6 +14,7 @@ import {
   versionMismatchRowKey,
   type GradebookRowBatchResult
 } from "../_shared/gradebookVersionMismatch.ts";
+import { serveWithSentryFlush, waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Declare EdgeRuntime for type safety
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1002,7 +1003,7 @@ export async function runBatchHandler() {
   console.log("Batch handler stopped");
 }
 
-Deno.serve((req) => {
+serveWithSentryFlush((req) => {
   const headers = req.headers;
   const secret = headers.get("x-edge-function-secret");
   const expectedSecret = Deno.env.get("EDGE_FUNCTION_SECRET") || "some-secret-value";
@@ -1036,7 +1037,7 @@ Deno.serve((req) => {
     // Reset on exit: runBatchHandler breaks out of its loop after maxConsecutiveErrors, and without
     // this the flag would stay true forever and the worker would never restart even once the
     // underlying fault cleared.
-    EdgeRuntime.waitUntil(
+    waitUntilWithSentryFlush(
       runBatchHandler().finally(() => {
         started = false;
       })

--- a/supabase/functions/index-submission/index.ts
+++ b/supabase/functions/index-submission/index.ts
@@ -1,6 +1,6 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 import { indexSubmission } from "../_shared/CodeSymbolIndexer.ts";
 import type { IndexSubmissionRequest, IndexSubmissionResponse } from "../_shared/FunctionTypes.d.ts";

--- a/supabase/functions/invitation-create/deno.json
+++ b/supabase/functions/invitation-create/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "sentry": "npm:@sentry/deno"
+    "sentry": "npm:@sentry/deno@10.10.0"
   }
 }

--- a/supabase/functions/invitation-create/index.ts
+++ b/supabase/functions/invitation-create/index.ts
@@ -1,5 +1,5 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { assertUserIsInstructor, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { createInvitationsBulk, type InvitationRequest } from "../_shared/InvitationUtils.ts";
 

--- a/supabase/functions/list-github-orgs/index.ts
+++ b/supabase/functions/list-github-orgs/index.ts
@@ -3,7 +3,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { listAppInstallations } from "../_shared/GitHubWrapper.ts";
 import type { ListGitHubOrgsResponse } from "../_shared/FunctionTypes.d.ts";
 import { assertUserIsAdmin, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function handleRequest(req: Request, scope: Sentry.Scope): Promise<ListGitHubOrgsResponse> {
   scope?.setTag("function", "list-github-orgs");

--- a/supabase/functions/live-meeting-callback/index.ts
+++ b/supabase/functions/live-meeting-callback/index.ts
@@ -1,7 +1,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import * as chimeUtils from "../_shared/ChimeWrapper.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const body = await req.json();

--- a/supabase/functions/live-meeting-for-help-request/index.ts
+++ b/supabase/functions/live-meeting-for-help-request/index.ts
@@ -6,7 +6,7 @@ import * as chimeUtils from "../_shared/ChimeWrapper.ts";
 import { assertUserIsInCourse, NotFoundError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { LiveMeetingForHelpRequestRequest } from "../_shared/FunctionTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { courseId, helpRequestId } = (await req.json()) as LiveMeetingForHelpRequestRequest;

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -31,6 +31,7 @@ import {
 } from "../_shared/MCPAuth.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Initialize Sentry if configured
 if (Deno.env.get("SENTRY_DSN")) {
@@ -2047,7 +2048,7 @@ function getEndpointUrl(_req: Request): string | null {
 // Main Handler
 // =============================================================================
 
-Deno.serve(async (req: Request): Promise<Response> => {
+serveWithSentryFlush(async (req: Request): Promise<Response> => {
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -2084,13 +2084,11 @@ serveWithSentryFlush(async (req: Request): Promise<Response> => {
       // last-used timestamp write. Routed through the background-work helper
       // so a late failure still gets flushed -- the request-boundary flush has
       // already run by the time this settles.
-      waitUntilWithSentryFlush(
-        updateTokenLastUsed(context.tokenId).catch((err) => {
-          Sentry.captureException(err, {
-            tags: { operation: "update_token_last_used", tokenId: context.tokenId }
-          });
-        })
-      );
+      // Detached on purpose: the response must not wait on a last-used timestamp
+      // write. updateTokenLastUsed reports its own failures, so there is nothing to
+      // catch here — but it reports them AFTER this response, so the flush has to
+      // come from the background helper rather than the request boundary.
+      waitUntilWithSentryFlush(updateTokenLastUsed(context.tokenId));
 
       // Create SSE stream
       const { stream, sse } = createSSEStream();
@@ -2150,13 +2148,11 @@ serveWithSentryFlush(async (req: Request): Promise<Response> => {
     // last-used timestamp write. Routed through the background-work helper
     // so a late failure still gets flushed -- the request-boundary flush has
     // already run by the time this settles.
-    waitUntilWithSentryFlush(
-      updateTokenLastUsed(context.tokenId).catch((err) => {
-        Sentry.captureException(err, {
-          tags: { operation: "update_token_last_used", tokenId: context.tokenId }
-        });
-      })
-    );
+    // Detached on purpose: the response must not wait on a last-used timestamp
+    // write. updateTokenLastUsed reports its own failures, so there is nothing to
+    // catch here — but it reports them AFTER this response, so the flush has to
+    // come from the background helper rather than the request boundary.
+    waitUntilWithSentryFlush(updateTokenLastUsed(context.tokenId));
 
     // Parse the MCP request (can be single or batch)
     const body = await req.json();

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -18,7 +18,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
 import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { minimatch } from "npm:minimatch@9";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import * as github from "../_shared/GitHubWrapper.ts";

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -31,7 +31,7 @@ import {
 } from "../_shared/MCPAuth.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
-import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
+import { serveWithSentryFlush, waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Initialize Sentry if configured
 if (Deno.env.get("SENTRY_DSN")) {
@@ -2080,11 +2080,17 @@ serveWithSentryFlush(async (req: Request): Promise<Response> => {
       const context = await authenticateMCPRequest(authHeader);
 
       // Update last used timestamp asynchronously
-      updateTokenLastUsed(context.tokenId).catch((err) => {
-        Sentry.captureException(err, {
-          tags: { operation: "update_token_last_used", tokenId: context.tokenId }
-        });
-      });
+      // Detached on purpose: the SSE/JSON response must not wait on a
+      // last-used timestamp write. Routed through the background-work helper
+      // so a late failure still gets flushed -- the request-boundary flush has
+      // already run by the time this settles.
+      waitUntilWithSentryFlush(
+        updateTokenLastUsed(context.tokenId).catch((err) => {
+          Sentry.captureException(err, {
+            tags: { operation: "update_token_last_used", tokenId: context.tokenId }
+          });
+        })
+      );
 
       // Create SSE stream
       const { stream, sse } = createSSEStream();
@@ -2140,11 +2146,17 @@ serveWithSentryFlush(async (req: Request): Promise<Response> => {
     const context = await authenticateMCPRequest(authHeader);
 
     // Update last used timestamp asynchronously
-    updateTokenLastUsed(context.tokenId).catch((err) => {
-      Sentry.captureException(err, {
-        tags: { operation: "update_token_last_used", tokenId: context.tokenId }
-      });
-    });
+    // Detached on purpose: the SSE/JSON response must not wait on a
+    // last-used timestamp write. Routed through the background-work helper
+    // so a late failure still gets flushed -- the request-boundary flush has
+    // already run by the time this settles.
+    waitUntilWithSentryFlush(
+      updateTokenLastUsed(context.tokenId).catch((err) => {
+        Sentry.captureException(err, {
+          tags: { operation: "update_token_last_used", tokenId: context.tokenId }
+        });
+      })
+    );
 
     // Parse the MCP request (can be single or batch)
     const body = await req.json();

--- a/supabase/functions/mcp-tokens/index.ts
+++ b/supabase/functions/mcp-tokens/index.ts
@@ -22,6 +22,7 @@ import { createApiToken, MCPScope, VALID_SCOPES } from "../_shared/MCPAuth.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { describeCause, isDuplicateKey } from "../_shared/ErrorDetail.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Initialize Sentry if configured
 if (Deno.env.get("SENTRY_DSN")) {
@@ -319,7 +320,7 @@ async function handleDelete(authHeader: string | null, body: DeleteTokenRequest)
 /**
  * Main handler
  */
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });

--- a/supabase/functions/mcp-tokens/index.ts
+++ b/supabase/functions/mcp-tokens/index.ts
@@ -16,7 +16,7 @@
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { createApiToken, MCPScope, VALID_SCOPES } from "../_shared/MCPAuth.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";

--- a/supabase/functions/metrics/index.ts
+++ b/supabase/functions/metrics/index.ts
@@ -4,7 +4,7 @@ import { BottleneckLimiterSnapshot, collectBottleneckRedisSnapshots } from "../_
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
-import "../_shared/SentryInit.ts";
+import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 /** Best-effort cap for vacuum/RAM RPCs so a slow DB cannot stall the scrape. */
@@ -328,7 +328,7 @@ async function authenticateRequest(req: Request): Promise<boolean> {
   }
 }
 
-Deno.serve(async (req) => {
+serveWithSentryFlush(async (req) => {
   // Only allow GET requests
   if (req.method !== "GET") {
     return new Response("Method not allowed", { status: 405 });

--- a/supabase/functions/metrics/index.ts
+++ b/supabase/functions/metrics/index.ts
@@ -5,7 +5,7 @@ import { Database } from "../_shared/SupabaseTypes.d.ts";
 // Import for side effect: this function makes Sentry calls but does not import HandlerUtils, so
 // without this Sentry.init never ran and every capture was a silent no-op.
 import "../_shared/SentryInit.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 /** Best-effort cap for vacuum/RAM RPCs so a slow DB cannot stall the scrape. */
 const VACUUM_RAM_RPC_TIMEOUT_MS = 3000;

--- a/supabase/functions/notification-queue-processor/index.ts
+++ b/supabase/functions/notification-queue-processor/index.ts
@@ -4,7 +4,7 @@ import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { emailTemplates } from "./emailTemplates.ts";
 import type { DiscussionThreadNotification, Notification, NotificationEnvelope } from "../_shared/FunctionTypes.d.ts";
 import nodemailer from "npm:nodemailer";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { beginWorkerRun } from "../_shared/workerRun.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";

--- a/supabase/functions/notification-queue-processor/index.ts
+++ b/supabase/functions/notification-queue-processor/index.ts
@@ -9,6 +9,7 @@ import { beginWorkerRun } from "../_shared/workerRun.ts";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
 import { resolveEmailTransport, type EmailTransportDecision } from "../_shared/emailTransportConfig.ts";
+import { serveWithSentryFlush, waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
 
 // Declare EdgeRuntime for type safety
 declare const EdgeRuntime: {
@@ -1691,7 +1692,7 @@ export async function runBatchHandler() {
   console.log("Email batch handler stopped");
 }
 
-Deno.serve((req) => {
+serveWithSentryFlush((req) => {
   const headers = req.headers;
   const secret = headers.get("x-edge-function-secret");
   const expectedSecret = Deno.env.get("EDGE_FUNCTION_SECRET") || "some-secret-value";
@@ -1725,7 +1726,7 @@ Deno.serve((req) => {
     // Reset on exit. runBatchHandler breaks out of its loop after maxConsecutiveErrors, and
     // without this the flag would stay true forever and the worker would never restart even once
     // the underlying fault cleared. That matters much more now that misconfigured SMTP throws.
-    EdgeRuntime.waitUntil(
+    waitUntilWithSentryFlush(
       runBatchHandler().finally(() => {
         started = false;
       })

--- a/supabase/functions/pr-link-confirm/index.ts
+++ b/supabase/functions/pr-link-confirm/index.ts
@@ -22,7 +22,7 @@ import { assertUserIsInCourse, SecurityError, UserVisibleError, wrapRequestHandl
 import { ingestPrSubmissionFiles } from "../_shared/PrSubmissionFiles.ts";
 import { prStateFromPullRequest } from "../_shared/PrState.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 type RequestBody = { link_id: number };
 

--- a/supabase/functions/repositories-list/index.ts
+++ b/supabase/functions/repositories-list/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import * as github from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInstructor, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { ListReposRequest } from "../_shared/FunctionTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { courseId, template_only } = (await req.json()) as ListReposRequest;
   scope?.setTag("function", "repositories-list");

--- a/supabase/functions/repository-get-file/index.ts
+++ b/supabase/functions/repository-get-file/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import * as github from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInstructor, NotFoundError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import * as FunctionTypes from "../_shared/FunctionTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 // Rate limiting storage: Map<fileKey, timestamp[]>
 const rateLimitStore = new Map<string, number[]>();
 const RATE_LIMIT_MAX_REQUESTS = 3;

--- a/supabase/functions/repository-list-commits/index.ts
+++ b/supabase/functions/repository-list-commits/index.ts
@@ -3,7 +3,7 @@ import { RepositoryListCommitsRequest } from "../_shared/FunctionTypes.d.ts";
 import { listCommits } from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInCourse, SecurityError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { ListCommitsResponse } from "../_shared/GitHubWrapper.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 export type RepositoryListCommitsResponse = {
   commits: ListCommitsResponse["data"];

--- a/supabase/functions/repository-list-files/index.ts
+++ b/supabase/functions/repository-list-files/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { ListFilesRequest } from "../_shared/FunctionTypes.d.ts";
 import { assertUserIsInstructor, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import * as github from "../_shared/GitHubWrapper.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { courseId, orgName, repoName } = (await req.json()) as ListFilesRequest;
   scope?.setTag("function", "repository-list-files");

--- a/supabase/functions/repository-write-file/index.ts
+++ b/supabase/functions/repository-write-file/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import * as github from "../_shared/GitHubWrapper.ts";
 import { assertUserIsInstructor, UserVisibleError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import * as FunctionTypes from "../_shared/FunctionTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 
 /**
  * Allowlist of file paths that instructors may edit via this function.

--- a/supabase/functions/scripts/CheckBranchProtection.ts
+++ b/supabase/functions/scripts/CheckBranchProtection.ts
@@ -29,7 +29,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { getOctoKit, createBranchProtectionRuleset } from "../_shared/GitHubWrapper.ts";
 import { RequestError } from "https://esm.sh/octokit?dts";

--- a/supabase/functions/scripts/ClearCaches.ts
+++ b/supabase/functions/scripts/ClearCaches.ts
@@ -1,7 +1,7 @@
 import { getOctoKit } from "../_shared/GitHubWrapper.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import Bottleneck from "https://esm.sh/bottleneck?target=deno";
 
 interface Cache {

--- a/supabase/functions/scripts/PushChangesToRepoFromHandout.ts
+++ b/supabase/functions/scripts/PushChangesToRepoFromHandout.ts
@@ -11,7 +11,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { getOctoKit } from "../_shared/GitHubWrapper.ts";
 import { syncRepositoryToHandout, getFirstCommit } from "../_shared/GitHubSyncHelpers.ts";

--- a/supabase/functions/user-fetch-azure-profile/deno.json
+++ b/supabase/functions/user-fetch-azure-profile/deno.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "sentry": "npm:@sentry/deno"
+    "sentry": "npm:@sentry/deno@10.10.0"
   }
 }

--- a/supabase/functions/user-fetch-azure-profile/index.ts
+++ b/supabase/functions/user-fetch-azure-profile/index.ts
@@ -2,7 +2,7 @@ import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { wrapRequestHandler, UserVisibleError } from "../_shared/HandlerUtils.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
-import * as Sentry from "npm:@sentry/deno";
+import * as Sentry from "npm:@sentry/deno@10.10.0";
 import { normalizeEventFingerprint } from "../_shared/SentryFingerprint.ts";
 import { sentryIdentity } from "../_shared/SentryContext.ts";
 


### PR DESCRIPTION
Prod edge-function pods have been OOM-killed repeatedly. This fixes the cause, the thing that made it twice as expensive as it needed to be, and the observability that missed it.

## The cause

`eszipCache` in the main.ts demuxer (`charts/pawtograder/images/edge-functions/main.ts:80`) was an unbounded `Map` holding the bundle bytes of every function a pod had ever served, in the main isolate — which lives as long as the pod. Nothing evicted it.

Evidence from prod, four independent angles:

| observation | value |
|---|---|
| build log of the deployed image | `[bundle] done: 55 eszips, 2.2G total` |
| independent rebuild with the same base image | 2,281,147,601 B, mean 37.7 MiB, range 18.6–58.4 MiB |
| four **same-age** pods, identical scrape counts | 210 / 336 / 398 / 486 Mi holding **2 / 3 / 3 / 4** distinct functions |
| growth curve | 87 Mi at startup → 667 Mi at 1h → 1868–2408 Mi at ~5d |

Memory tracked **distinct functions served**, not uptime and not request count. So the 4Gi limit was never a backstop — it was a deadline: warm cache (~2.2Gi) + 8 admitted isolates × 256Mi = 4.2Gi. The budget comment in `values-prod.yaml` assumed a "~320Mi Deno host baseline" measured on a pod 0.3h old and omitted this term entirely.

## What changed

**1. Bounded cache** — one conflated map becomes three with honest lifetimes: `inflight` (preserves the read-coalescing the cache was added for, drops on settle), `missing` (negative cache, kept), `resident` (LRU bounded by **bytes**, not entry count — bundles run 19–59MB and averaging them is how you get surprised). Also fixes a latent bug: the old code cached the `null` from *any* read error, so one transient EIO downgraded a function to raw servicePath permanently.

The budget is now stated as three terms, in `values.yaml` and in the alert text: `eszipCacheMaxMb + (maxParallelism × EDGE_WORKER_MEMORY_LIMIT_MB) + ~90Mi host` = 512Mi + 2Gi + 90Mi ≈ **2.6Gi** under a 4Gi limit. Tunable via `edgeFunctions.eszipCacheMaxMb` without a rebuild.

**2. Pinned `@sentry/deno` (separate commit, 78 mechanical files)** — the specifier was unversioned at all 75 sites; the import-map alias `@sentry/deno` doesn't match the `npm:` specifier so its `^10.1.0` never applied, and `deno.lock` is gitignored *and* deleted by the Dockerfile. Nothing pinned this. It drifted into a Node APM stack that can't run in an isolate and that `SentryInit.ts` already disables. Measured A/B, same machine, `metrics/index.ts` via the image's own bundler:

```
floating:  30,534,275 B
10.10.0:   14,565,215 B   (-15,969,060 B, -52%)
```

54 functions carry it → **~822 MiB off a 2.12 GiB corpus**, which is exactly what the cache holds resident.

**3. `Sentry.flush()` in `wrapRequestHandler`** — under `per_request` the isolate dies the moment the response returns, taking the in-memory transport queue with it. `flush()` was called in **1 function of 55**, so error reporting from this tier was largely fiction.

**4. Alerts** — `PawtograderEdgeFunctionsOOMKilled` described a two-term budget that was never the whole story, and *every* rule in that group is per-pod, comparing a pod to its own limit. They all stayed green while the node underneath ran out of memory — which is how 2026-08-18 went: a kernel `SystemOOM` on `pawtograder-worker-1` picked `edge-runtime` as its victim while no pod was near 4Gi. Adds `PawtograderEdgeFunctionsNodeMemoryHigh` and corrects the two annotations that pointed at the wrong knob.

## Verification

- Cache behaviour asserted against the **real code sliced out of `main.ts`**: LRU eviction order, recency-on-touch, byte accounting never drifting or exceeding budget, negative caching, concurrent-read coalescing (same buffer identity, no double-count), `inflight` retaining nothing after settle.
- `helm lint` and `helm template` pass; all four rules render.
- `main.ts` type-checks identically to before (the file isn't type-checked in CI); `HandlerUtils.ts` checks clean — the one error is pre-existing in the generated `SupabaseTypes.d.ts`.
- Sentry saving measured, not estimated (numbers above).

## Reviewer notes

- **The new node alert is unverified against your Prometheus.** It reads `node_memory_MemAvailable_bytes` / `node_memory_MemTotal_bytes`, i.e. it needs node-exporter in the same Prometheus. I could not confirm those series exist. If they don't, the rule sits Inactive forever and looks shipped — the same trap the container-label comment in `prometheus-rules.yaml` already documents. Please confirm before trusting it.
- **PromQL is not statically validated** — `promtool` isn't available here.
- **The Sentry pin may be a downgrade.** What prod resolved to on 2026-08-13 is unknowable after the fact; 10.10.0 is what the lockfile and the `^10.1.0` range always intended, and `SentryInit.ts` uses only long-stable APIs.
- Branch is based on the local `origin/staging` ref (`f9f89311`) because `git fetch` couldn't reach the remote from where this was prepared. `main.ts` was verified byte-identical to the deployed `54b63eef`.
- **Not included:** the `npm:octokit` barrel import costs another ~275 MiB across 33 functions. Deliberately left out — it changes GitHub auth plumbing and deserves its own review.

Deploying this needs an image build; the running fleet still has the old code. Pods were rolled on 2026-08-19 so the cache is reset, which buys roughly 5 days before the plateau returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bounded bundle caching with LRU eviction and controlled concurrent loading.
  - Added configurable cold-load memory headroom and stricter deployment-time budget validation.
  - Added improved namespace-scoped memory monitoring and OOM alerts.

- **Bug Fixes**
  - Improved reliability when loading and evicting bundles under memory pressure.
  - Improved monitoring event delivery during request and background-task shutdown.

- **Reliability**
  - Standardized monitoring SDK versions across edge functions.
  - Increased the edge-function memory limit to 4 GiB by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->