### PR TITLE
Tighten survey/poll RLS and remove app secrets from the E2E lane

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -455,9 +455,11 @@ jobs:
           # mildest thing in the old set: scoped to one visual-testing project,
           # with no reach into GitHub, Redis, or any student repo.
           #
-          # playwright.config.ts still gates uploads on the token being present,
-          # so a lane without it (local, or a future no-secrets variant) records
-          # results and passes rather than failing on an empty credential.
+          # It has to be passed explicitly here. Argos can authenticate
+          # tokenlessly on GitHub Actions via OIDC -- which is how
+          # playwright-standalone.yml uploads without a token -- but that needs
+          # `id-token: write`, and this job deliberately holds only
+          # `contents: read`.
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
         run: npx playwright test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,11 +19,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide whether this ref may run on the self-hosted pool at all.
+  #
+  # e2e-local checks out the PR head and executes it: `npm ci` runs lockfile
+  # install scripts, and the build, the config files and the test sources are
+  # all attacker-controlled on a fork PR. The app secrets are gone from that job
+  # (see the .env.local step below) and ARGOS_TOKEN is all that remains, so the
+  # main exposure is now the runner itself — an untrusted PR gets arbitrary code
+  # execution in a pod on the cluster, with only a container boundary between it
+  # and everything else. That is a low-probability, high-cost failure, and it is
+  # not worth carrying for drive-by PRs.
+  #
+  # This is also why the trigger stays `pull_request_target` even though the
+  # job no longer wants secrets: under `pull_request`, GitHub runs the workflow
+  # file from the PR head, so a fork could simply delete this gate. Under
+  # `pull_request_target` the workflow — and therefore this check — always comes
+  # from the base branch.
+  #
+  # An untrusted PR gets no E2E run. To run one, a maintainer reviews the diff
+  # and pushes the branch into this repo, which makes it a same-repo PR; that is
+  # the same manual path canvas-e2e.yml documents.
+  check-trust:
+    runs-on: ubuntu-latest
+    outputs:
+      trusted: ${{ steps.check.outputs.trusted }}
+    steps:
+      - id: check
+        # Read the event through env rather than interpolating into the script:
+        # these are GitHub-controlled enums today, but the habit is what keeps a
+        # future field from becoming an injection.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" != "pull_request_target" ]]; then
+            # push to main/staging, or a maintainer's manual dispatch
+            trusted=true
+          elif [[ "${IS_FORK}" != "true" ]]; then
+            # a branch in this repo: pushing it already required write access
+            trusted=true
+          elif [[ "${AUTHOR_ASSOCIATION}" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+            # a fork, but by someone who already has standing in the org/repo
+            trusted=true
+          else
+            trusted=false
+          fi
+          echo "trusted=${trusted}" >> "$GITHUB_OUTPUT"
+          if [[ "${trusted}" != "true" ]]; then
+            echo "::notice title=E2E skipped::This PR comes from a fork by an outside contributor, so it does not run on the self-hosted E2E pool. A maintainer can run the suite by pushing the branch into this repo after reviewing the diff."
+          fi
+
   # Local-Supabase E2E. Spins up a clean dev environment on the runner and runs
   # the Playwright suite against it. The Coolify branch-preview job that used to
   # run alongside this one is gone — it'll come back once the deployment target
   # moves into the same k8s cluster as this runner.
   e2e-local:
+    needs: check-trust
+    if: needs.check-trust.outputs.trusted == 'true'
     runs-on: pawtograder-e2e
     timeout-minutes: 75
     permissions:
@@ -81,24 +135,38 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # No repo secrets go into .env.local — every value below is a literal or
+      # is generated on the runner. The suite does not need the real ones:
+      #
+      #   * GitHub App key / OAuth creds — E2E_MOCK_GITHUB below short-circuits
+      #     the ingestion paths before they reach cloneRepository, so nothing
+      #     authenticates to GitHub, and _shared/GitHubWrapper.ts only builds a
+      #     JWT lazily, so a throwaway PEM satisfies the App constructor at
+      #     module load. This is what AGENTS.md means by "GitHub App credentials
+      #     are not required locally".
+      #   * UPSTASH_REDIS_REST_* — omitted entirely. _shared/Redis.ts returns
+      #     null when neither REDIS_URL nor the Upstash pair is set, and callers
+      #     take the "Redis disabled" path.
+      #   * SENTRY_DSN — omitted. _shared/SentryInit.ts no-ops without a DSN, so
+      #     CI edge-function events no longer reach the Bugsink "Dev" project.
+      #     Re-add the secret here if that reporting is wanted back.
+      #
+      # The remaining tokens (END_TO_END_SECRET, EDGE_FUNCTION_SECRET,
+      # EVENTBRIDGE_SECRET) were already literals — they authenticate the suite
+      # to a Supabase stack that lives and dies with this job.
       - name: Write .env.local
         env:
-          GITHUB_APP_ID: ${{ secrets.PAWTOGRADER_GITHUB_APP_ID }}
-          GITHUB_PRIVATE_KEY_STRING: ${{ secrets.PAWTOGRADER_GITHUB_PRIVATE_KEY_STRING }}
-          GITHUB_OAUTH_CLIENT_ID: ${{ secrets.PAWTOGRADER_GITHUB_OAUTH_CLIENT_ID }}
-          GITHUB_OAUTH_CLIENT_SECRET: ${{ secrets.PAWTOGRADER_GITHUB_OAUTH_CLIENT_SECRET }}
-          UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
-          UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          # Sentry identity for this run. Without these, edge-function events in the Bugsink "Dev"
-          # project carry no release, no branch and no PR — the CI run was only recoverable by reading
-          # the compose project name out of the `URL` tag, and only on events from functions that set
-          # it. Consumed by _shared/SentryContext.ts. Quoted through env: rather than interpolated into
-          # the heredoc so a branch name cannot inject shell.
+          # Identity for this run. Inert while SENTRY_DSN is unset, but cheap to
+          # keep so re-adding a DSN gives usable events immediately. Quoted
+          # through env: rather than interpolated into the heredoc so a branch
+          # name cannot inject shell.
           DEPLOY_BRANCH: ${{ github.head_ref || github.ref_name }}
           DEPLOY_PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          GITHUB_APP_ID=1
+          GITHUB_OAUTH_CLIENT_ID=not-a-real-oauth-client-id
+          GITHUB_OAUTH_CLIENT_SECRET=not-a-real-oauth-client-secret
           cat > .env.local <<EOF
           NEXT_PUBLIC_SUPABASE_URL=${LOCAL_SUPABASE_URL}
           NEXT_PUBLIC_SUPABASE_ANON_KEY=${LOCAL_SUPABASE_ANON_KEY}
@@ -108,18 +176,23 @@ jobs:
           ENABLE_SIGNUPS=true
           NEXT_PUBLIC_PAWTOGRADER_WEB_URL=http://localhost:3001
           E2E_ENABLE=true
+          # E2E_ENABLE only opens the edge functions' auth bypass. The GitHub
+          # bypass is a separate flag: without it, isE2ERun still falls through
+          # to cloneRepository -> getOctoKit and issues a real GitHub request,
+          # which the dummy App credentials below cannot satisfy. The suites
+          # that ingest submissions or webhooks (push-no-autograder,
+          # pr-webhook-ingest, pr-base-tree-cache) are written for this path and
+          # assert against the canned file it inserts.
+          E2E_MOCK_GITHUB=true
           END_TO_END_SECRET=not-a-secret
           EDGE_FUNCTION_SECRET=some-secret-value
           # Auth gate for the github-repo-webhook EventBridge envelope. Lets the
           # webhook-direct e2e (push-no-autograder, pr-webhook-ingest) authenticate
-          # and run in CI; no real GitHub (E2E repos resolve via getRepoToCloneConsideringE2E).
+          # and run in CI; no real GitHub (see E2E_MOCK_GITHUB above).
           EVENTBRIDGE_SECRET=some-eventbridge-secret
           GITHUB_APP_ID=${GITHUB_APP_ID}
           GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID}
           GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET}
-          UPSTASH_REDIS_REST_URL=${UPSTASH_REDIS_REST_URL}
-          UPSTASH_REDIS_REST_TOKEN=${UPSTASH_REDIS_REST_TOKEN}
-          SENTRY_DSN=${SENTRY_DSN}
           DEPLOY_KIND=e2e-local
           DEPLOY_BRANCH=${DEPLOY_BRANCH}
           DEPLOY_PR=${DEPLOY_PR}
@@ -127,10 +200,17 @@ jobs:
           DEPLOY_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT}
           GIT_COMMIT_SHA=${GITHUB_SHA}
           EOF
+          # Throwaway App key, generated per run and never leaving the runner.
+          # @octokit/auth-app parses it lazily, so it only has to be a
+          # well-formed PKCS#8 RSA key for `new App(...)` in GitHubWrapper.ts to
+          # construct; nothing in the suite signs a JWT that GitHub will see.
+          mkdir -p "$RUN_TMP"
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+            -out "$RUN_TMP/dummy-app-key.pem" 2>/dev/null
           # Single-line escaped PEM — supabase functions serve --env-file does
           # not support multi-line quoted values; .env.local.staging uses the
           # same shape. The Octokit / GitHub-App SDK unescapes \n at runtime.
-          KEY_ESCAPED=$(printf '%s' "${GITHUB_PRIVATE_KEY_STRING}" | awk 'BEGIN{ORS=""} {printf "%s\\n", $0}')
+          KEY_ESCAPED=$(awk 'BEGIN{ORS=""} {printf "%s\\n", $0}' "$RUN_TMP/dummy-app-key.pem")
           printf 'GITHUB_PRIVATE_KEY_STRING="%s"\n' "$KEY_ESCAPED" >> .env.local
 
       # Make supabase/config.toml's project_id unique per run so the supabase
@@ -350,9 +430,22 @@ jobs:
           # EDGE_FUNCTION_SECRET / END_TO_END_SECRET are sourced from .env.local
           # (written above) via the test-runner's dotenv load — single source
           # of truth so the two values can't drift.
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          #
+          # TEST_PASSWORD is gone: every call site already falls back to
+          # "change-it", which is what the seeder writes, so the secret was only
+          # ever restating the default.
+          #
+          # ARGOS_TOKEN is the one secret this job still takes. Visual
+          # regression is worth keeping, and check-trust above means only a
+          # trusted ref ever reaches this step, so the token is not exposed to
+          # fork-supplied code the way the GitHub App key was. It is also the
+          # mildest thing in the old set: scoped to one visual-testing project,
+          # with no reach into GitHub, Redis, or any student repo.
+          #
+          # playwright.config.ts still gates uploads on the token being present,
+          # so a lane without it (local, or a future no-secrets variant) records
+          # results and passes rather than failing on an empty credential.
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx playwright test
 
       - name: Tail server logs on failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,26 @@ jobs:
   # `pull_request_target` the workflow — and therefore this check — always comes
   # from the base branch.
   #
+  # Trust is decided on where the head branch lives, and nothing else. A branch
+  # in this repo can only have been pushed by someone who already has write
+  # access, so whoever supplied the latest commit is someone we already trust.
+  #
+  # Deliberately NOT author_association: that field describes the PR's author
+  # and their standing in *this* repo, not whoever pushed the head commit that
+  # is about to be checked out. Anyone with push access to the head branch can
+  # update a PR and fire `synchronize`, and for a fork that set is controlled by
+  # the fork's owner -- a personal fork's collaborators, or, for an org-owned
+  # fork, every member with write there. Trusting a fork PR because its author
+  # is a MEMBER would let any of them land code on this runner under that
+  # member's standing. Current head-repo permission is not answerable from the
+  # event payload either, and the API call it would need is not something a
+  # fork-triggered token can be relied on to make.
+  #
   # An untrusted PR gets no E2E run. To run one, a maintainer reviews the diff
   # and pushes the branch into this repo, which makes it a same-repo PR; that is
-  # the same manual path canvas-e2e.yml documents.
+  # the same manual path canvas-e2e.yml documents. Everyone whose fork PR this
+  # used to wave through -- owners, org members, collaborators -- already has
+  # write access here, so that is a branch push rather than a favour to ask.
   check-trust:
     runs-on: ubuntu-latest
     outputs:
@@ -51,7 +68,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
           set -euo pipefail
           if [[ "${EVENT_NAME}" != "pull_request_target" ]]; then
@@ -60,15 +76,12 @@ jobs:
           elif [[ "${IS_FORK}" != "true" ]]; then
             # a branch in this repo: pushing it already required write access
             trusted=true
-          elif [[ "${AUTHOR_ASSOCIATION}" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
-            # a fork, but by someone who already has standing in the org/repo
-            trusted=true
           else
             trusted=false
           fi
           echo "trusted=${trusted}" >> "$GITHUB_OUTPUT"
           if [[ "${trusted}" != "true" ]]; then
-            echo "::notice title=E2E skipped::This PR comes from a fork by an outside contributor, so it does not run on the self-hosted E2E pool. A maintainer can run the suite by pushing the branch into this repo after reviewing the diff."
+            echo "::notice title=E2E skipped::This PR's head branch lives in a fork, so it does not run on the self-hosted E2E pool. A maintainer can run the suite by pushing the branch into this repo after reviewing the diff."
           fi
 
   # Local-Supabase E2E. Spins up a clean dev environment on the runner and runs

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,11 @@ export default defineConfig({
     [
       "@argos-ci/playwright/reporter",
       {
-        // Upload to Argos on CI only.
-        uploadToArgos: !!process.env.CI,
+        // Upload to Argos on CI only, and only when a token is actually
+        // present. The E2E lane deliberately runs without repo secrets, so
+        // without the token check the reporter would fail the run trying to
+        // upload with an empty credential.
+        uploadToArgos: !!process.env.CI && !!process.env.ARGOS_TOKEN,
 
         // Set your Argos token (required if not using GitHub Actions).
         token: process.env.ARGOS_TOKEN || ""

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,11 +41,8 @@ export default defineConfig({
     [
       "@argos-ci/playwright/reporter",
       {
-        // Upload to Argos on CI only, and only when a token is actually
-        // present. The E2E lane deliberately runs without repo secrets, so
-        // without the token check the reporter would fail the run trying to
-        // upload with an empty credential.
-        uploadToArgos: !!process.env.CI && !!process.env.ARGOS_TOKEN,
+        // Upload to Argos on CI only.
+        uploadToArgos: !!process.env.CI,
 
         // Set your Argos token (required if not using GitHub Actions).
         token: process.env.ARGOS_TOKEN || ""

--- a/supabase/migrations/20260817120000_tighten_survey_and_poll_rls.sql
+++ b/supabase/migrations/20260817120000_tighten_survey_and_poll_rls.sql
@@ -1,0 +1,263 @@
+-- Survey and poll RLS: scope response writes to the survey, assignment reads to the assignee,
+-- and unauthenticated poll reads to polls that are actually live.
+--
+-- 20251213200333_surveys_polls.sql shipped three policies that authorize less than their names
+-- suggest. All three are read/write boundaries reachable directly through PostgREST, so the
+-- client-side guards that currently stand in for them are not a control.
+--
+-- 1. `survey_responses_insert_owner` / `_update_owner` test only that `profile_id` is one of the
+--    caller's own profiles. Nothing joins `surveys`, so the row being written is never checked
+--    against the survey it belongs to: a student could write a response to a `draft` survey, a
+--    `closed` survey, a soft-deleted survey, a survey they were never assigned, or a survey in a
+--    class they are not enrolled in — and could edit a response they had already submitted to a
+--    survey with `allow_response_editing = false`. Only the last of those is guarded in the client
+--    (`app/course/[course_id]/surveys/[survey_id]/page.tsx` derives `isReadOnly` from
+--    `allow_response_editing`), and the guard lives entirely in the browser.
+--
+--    `can_respond_to_survey` now carries the whole check, mirroring the predicates that
+--    `surveys_select_students` applies on the read side as of
+--    20260222000000_survey_assignment_grading.sql (class membership, `deleted_at IS NULL`,
+--    `available_at`, assignment) and tightening `status` from "published or closed" to "published"
+--    — a closed survey is readable but must not accept new writes. Without the `available_at` leg
+--    an assigned student could read their own `survey_assignments` row for the id and respond
+--    before the survey was ever visible to them. `SECURITY DEFINER` so the decision
+--    is made against the real `surveys` row rather than whatever `surveys` RLS happens to expose to
+--    the caller.
+--
+--    `due_date` is deliberately NOT enforced here. It has never been enforced anywhere — not in
+--    RLS, not in the client, which only renders it (`app/course/[course_id]/surveys/page.tsx`) —
+--    so surveys have always accepted late responses and instructors have `submitted_at` to judge
+--    them by. Enforcing it in this migration would silently start rejecting late submissions,
+--    which is a course-policy decision, not a security fix. To adopt it later, add
+--    `AND (s.due_date IS NULL OR s.due_date > now())` to `can_respond_to_survey`.
+--
+--    The student write path is an upsert (`onConflict: survey_id,profile_id`), which needs both the
+--    INSERT and the UPDATE policy to pass: the draft autosave inserts, and submit updates the draft
+--    row in place. Both legs are allowed below. Staff have no UPDATE policy on `survey_responses`
+--    today and gain none here.
+--
+-- 2. `survey_assignments_select_class_member` grants SELECT on the whole table to any member of the
+--    class. Responses are protected; the roster of who was assigned what is not — including
+--    `survey_id` values for `draft` surveys that `surveys_select_students` deliberately withholds,
+--    which is how a student would learn the identifiers to aim (1) at. The policy is also pure
+--    surplus: `survey_assignments_select_assignee` already covers a student reading their own
+--    assignments, and `_select_graders` / `_select_instructors` cover staff. Dropping it changes
+--    nothing a client can see today except other people's rows.
+--
+--    `surveys_select_students` subqueries `survey_assignments`, and RLS applies inside a policy
+--    expression, but that subquery only ever matches the caller's own profiles — exactly the rows
+--    `_select_assignee` still returns. Survey visibility is unaffected.
+--
+-- 3. `live_polls_select` is `TO anon, authenticated USING (true)`: every column of every poll in
+--    every course, readable without authenticating. The anonymous `/poll/[course_id]` page is the
+--    reason the `anon` grant exists, but that page asks for exactly one thing —
+--    `class_id = ? AND is_live = true` (`app/poll/[course_id]/page.tsx`) — so `USING (true)` also
+--    hands out the question JSON of drafts and closed polls, i.e. the questions for a poll that has
+--    not been run yet. `USING (true)` was additionally serving every authenticated read, since the
+--    other `live_polls` policies are INSERT/UPDATE/DELETE only and there is no staff SELECT policy;
+--    the manage-side readers are restored by the staff policy below. That policy is scoped to
+--    graders rather than to class members on purpose: permissive policies are ORed, so a
+--    class-member predicate would hand every enrolled student the draft and closed rows this
+--    change exists to withhold. Students need nothing more than the live policy — `useLivePolls`
+--    and `useLivePoll` are both manage-only, and the one student-facing hook
+--    (`useActiveLivePolls`) already filters to `is_live === true`.
+--
+--    The SELECT policy is only half of it; see (4) below for the realtime broadcast that was
+--    handing students the same rows regardless of what the policy said.
+--
+--    A live poll's question stays readable by an unauthenticated visitor who knows the course id.
+--    That is inherent to joining a poll by QR code with no token in the URL, and narrowing it
+--    further is a product change rather than a policy fix.
+
+-- 1. survey_responses: writes must be legal for the survey, not just owned by the caller.
+
+CREATE OR REPLACE FUNCTION public.can_respond_to_survey(p_survey_id uuid, p_profile_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.surveys s
+    JOIN public.user_privileges up
+      ON up.class_id = s.class_id
+     AND up.user_id = auth.uid()
+     AND (up.private_profile_id = p_profile_id OR up.public_profile_id = p_profile_id)
+    WHERE s.id = p_survey_id
+      AND s.deleted_at IS NULL
+      AND s.status = 'published'::survey_status
+      AND (s.available_at IS NULL OR s.available_at <= now())
+      AND (
+        s.assigned_to_all
+        OR EXISTS (
+          SELECT 1
+          FROM public.survey_assignments sa
+          WHERE sa.survey_id = s.id
+            AND (sa.profile_id = up.private_profile_id OR sa.profile_id = up.public_profile_id)
+        )
+      )
+  );
+$$;
+
+COMMENT ON FUNCTION public.can_respond_to_survey(uuid, uuid) IS
+  'True when auth.uid() owns p_profile_id and the survey is one that profile may still write a response to: same class, not soft-deleted, published, past its available_at, and assigned. Used by the survey_responses write policies.';
+
+CREATE OR REPLACE FUNCTION public.survey_allows_response_editing(p_survey_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.surveys s
+    WHERE s.id = p_survey_id AND s.allow_response_editing
+  );
+$$;
+
+COMMENT ON FUNCTION public.survey_allows_response_editing(uuid) IS
+  'True when the survey permits a student to edit a response they have already submitted. Server-side counterpart to the isReadOnly guard in the student survey page.';
+
+DROP POLICY IF EXISTS "survey_responses_insert_owner" ON public.survey_responses;
+
+CREATE POLICY "survey_responses_insert_owner"
+ON public.survey_responses
+AS PERMISSIVE
+FOR INSERT
+TO public
+WITH CHECK (public.can_respond_to_survey(survey_id, profile_id));
+
+DROP POLICY IF EXISTS "survey_responses_update_owner" ON public.survey_responses;
+
+CREATE POLICY "survey_responses_update_owner"
+ON public.survey_responses
+AS PERMISSIVE
+FOR UPDATE
+TO public
+USING (
+  public.can_respond_to_survey(survey_id, profile_id)
+  -- A submitted response is final unless the survey opted into re-editing. The draft leg of the
+  -- upsert (is_submitted still false) is what lets submit itself through.
+  AND (NOT is_submitted OR public.survey_allows_response_editing(survey_id))
+)
+WITH CHECK (public.can_respond_to_survey(survey_id, profile_id));
+
+-- 2. survey_assignments: drop the class-wide roster read. Assignees and staff keep theirs.
+
+DROP POLICY IF EXISTS "survey_assignments_select_class_member" ON public.survey_assignments;
+
+-- 3. live_polls: separate the anonymous reader from the enrolled one.
+
+DROP POLICY IF EXISTS "live_polls_select" ON public.live_polls;
+
+CREATE POLICY "live_polls_select_live"
+ON public.live_polls
+AS PERMISSIVE
+FOR SELECT
+TO anon, authenticated
+USING (is_live = true);
+
+CREATE POLICY "live_polls_select_staff"
+ON public.live_polls
+AS PERMISSIVE
+FOR SELECT
+TO authenticated
+USING (authorizeforclassgrader(class_id));
+
+-- 4. live_polls broadcasts: the students' channel must not carry what RLS withholds.
+--
+-- Narrowing the SELECT policy above is not sufficient on its own. Every write to live_polls also
+-- fires broadcast_live_poll_change(), which is SECURITY DEFINER and sends the same payload to
+-- `class:<id>:staff` and `class:<id>:students`, with `data` set to to_jsonb(NEW) — the whole row,
+-- question JSON included — regardless of is_live. Channel membership is the only authorization on
+-- that path; row policies are never consulted. On the client, TableController takes a payload that
+-- carries `data` straight into its cache (see _handleInsertBatch / _handleUpdate) and only refetches
+-- through RLS when `data` is absent. So any student holding an open session while staff drafted or
+-- edited a poll received the question anyway, and the policy change would have looked effective
+-- while changing nothing for exactly the students most likely to be connected: the ones in class.
+--
+-- Students now get the full row only while the poll is live. Every other transition — a draft being
+-- written, a poll closing, a row being deleted — is announced to them as a bare DELETE carrying
+-- row_id and no data, which _handleDelete applies by dropping the row. A client that already had
+-- the poll loses it the moment it stops being live; a client that never had it learns nothing but
+-- an id it cannot resolve, since the SELECT policy will not return the row on refetch either.
+--
+-- The staff channel is unchanged: authorizeforclassgrader already governs who joins it, and the
+-- manage views need the full row.
+--
+-- The live transition still works in both directions. A poll going live sends a full-data UPDATE,
+-- and _handleUpdate adds the row when it is not already cached, so the student's list picks it up.
+
+CREATE OR REPLACE FUNCTION public.broadcast_live_poll_change()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    target_class_id bigint;
+    staff_payload jsonb;
+    student_payload jsonb;
+    changed_row_id uuid;
+    row_is_live boolean;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        target_class_id := NEW.class_id;
+    ELSIF TG_OP = 'UPDATE' THEN
+        target_class_id := COALESCE(NEW.class_id, OLD.class_id);
+    ELSIF TG_OP = 'DELETE' THEN
+        target_class_id := OLD.class_id;
+    END IF;
+
+    IF target_class_id IS NOT NULL THEN
+        changed_row_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.id ELSE NEW.id END;
+        row_is_live := (TG_OP <> 'DELETE' AND NEW.is_live);
+
+        staff_payload := jsonb_build_object(
+            'type', 'table_change',
+            'operation', TG_OP,
+            'table', TG_TABLE_NAME,
+            'row_id', changed_row_id,
+            'data', CASE WHEN TG_OP = 'DELETE' THEN to_jsonb(OLD) ELSE to_jsonb(NEW) END,
+            'class_id', target_class_id,
+            'timestamp', NOW()
+        );
+
+        PERFORM realtime.send(
+            staff_payload,
+            'broadcast',
+            'class:' || target_class_id || ':staff',
+            true
+        );
+
+        IF row_is_live THEN
+            student_payload := staff_payload;
+        ELSE
+            -- No `data` key: the client drops the row by id and cannot learn its contents.
+            student_payload := jsonb_build_object(
+                'type', 'table_change',
+                'operation', 'DELETE',
+                'table', TG_TABLE_NAME,
+                'row_id', changed_row_id,
+                'class_id', target_class_id,
+                'timestamp', NOW()
+            );
+        END IF;
+
+        PERFORM realtime.send(
+            student_payload,
+            'broadcast',
+            'class:' || target_class_id || ':students',
+            true
+        );
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    ELSE
+        RETURN NEW;
+    END IF;
+END;
+$function$;


### PR DESCRIPTION
Two independent hardening changes, one commit each.

## 1. Survey and poll RLS

Three policies in the surveys/polls schema authorize less than their names suggest. All are reachable directly through PostgREST, so the client-side guards that stood in for them were not a control.

**`survey_responses` writes** tested only that `profile_id` belonged to the caller — nothing joined `surveys`. A response could be written to a draft, closed, soft-deleted, unassigned or not-yet-available survey, or to one in a class the caller is not enrolled in, and a submitted response could be re-edited on a survey with `allow_response_editing = false`. `can_respond_to_survey()` now carries the check, mirroring the predicates `surveys_select_students` applies on the read side (class membership, `deleted_at`, `available_at`, assignment) and tightening `status` to `published` only.

`due_date` is deliberately **not** enforced. It has never been enforced anywhere, in RLS or the client, so surveys have always accepted late responses; adding it here would silently start rejecting them, which is a course-policy decision rather than a security fix. The migration header says how to opt in.

**`survey_assignments_select_class_member`** exposed the full assigned-roster of every survey to any member of the class, including `survey_id` values for drafts that `surveys_select_students` withholds. It was redundant with `survey_assignments_select_assignee`, so it is dropped.

**`live_polls` SELECT** was `to anon, authenticated using (true)` — every poll's question JSON in every course, readable unauthenticated. Split into an anonymous policy scoped to live polls (all the `/poll` page asks for) and a staff policy for the manage views. The staff policy is scoped to graders rather than class members because permissive policies are ORed, and a class-member predicate would hand every enrolled student the draft rows this change exists to withhold.

Narrowing that policy is only half of it. `broadcast_live_poll_change()` is `SECURITY DEFINER` and sent `to_jsonb(NEW)` — question included — to the class student channel on every write regardless of `is_live`, and `TableController` applies a payload carrying `data` without refetching through RLS. Any student with an open session received draft polls anyway. Students now get the full row only while the poll is live; drafts, closures and deletions are announced to them as a bare `DELETE` carrying `row_id` and no data. The staff channel is unchanged, and a poll going live still sends full data, which `TableController` adds when not already cached.

### Verification

Run against a seeded database inside a rolled-back transaction, as real users with `SET ROLE authenticated`:

| | before | after |
|---|---|---|
| outsider (class 1) → class-4 published survey | allowed | blocked |
| student → draft survey | allowed | blocked |
| student → not-yet-available published survey | allowed | blocked |
| student → assigned published survey (legitimate) | allowed | allowed |
| student: `survey_assignments` rows visible | 30 | 1 |
| student: class-4 polls visible | 2 (1 non-live) | 1 (0 non-live) |
| grader: class-4 polls visible | 2 (1 non-live) | 2 (1 non-live) |
| anon: polls visible | 2 (1 non-live) | 1 (0 non-live) |

Broadcast payloads were captured by shadowing `realtime.send` in-transaction. Before, the student channel carried the question on create/close/delete; after, only on the live transition. Staff payloads are byte-identical.

## 2. E2E lane: no app secrets, trusted refs only

`deploy.yml` triggers on `pull_request_target`, checks out `pull_request.head.sha`, and wrote the GitHub App private key, the OAuth client secret, the Upstash token, the Sentry DSN and `TEST_PASSWORD` into `.env.local` before running the checked-out code on a self-hosted runner. Fork PRs reached that path unattended, so an outside contributor could exfiltrate the App key — and with it every installation across every course — through a lockfile install script or an edited config file.

The suite does not need those values, but it does need the GitHub mock enabled to go without them. `E2E_ENABLE` only opens the edge functions' auth bypass; `E2E_MOCK_GITHUB` is the separate flag that short-circuits ingestion before `cloneRepository` reaches `getOctoKit`, so this sets it. Beyond GitHub: `Redis.ts` returns null when neither `REDIS_URL` nor the Upstash pair is set, `SentryInit` no-ops without a DSN, and every `TEST_PASSWORD` call site already falls back to the seeder's default. The App key is now generated per run with `openssl`, which is all the App constructor needs at module load.

`ARGOS_TOKEN` stays — visual regression is worth keeping, it is scoped to one visual-testing project, and the trust gate means only a trusted ref reaches the step that uses it. It is passed explicitly rather than relying on Argos's tokenless GitHub Actions authentication, which needs `id-token: write` while this job holds only `contents: read`. `playwright.config.ts` is unchanged, so `playwright-standalone.yml` keeps uploading tokenlessly as it does today.

`check-trust` denies the self-hosted lane to fork PRs from outside contributors, closing the remaining exposure: arbitrary code execution in a pod on the cluster with only a container boundary around it. It is stricter than GitHub's own approval setting, which auto-approves anyone with a merged PR. A maintainer runs the suite for such a PR by reviewing the diff and pushing the branch into this repo — the manual path `canvas-e2e.yml` already documents.

The trigger stays `pull_request_target` on purpose: under `pull_request`, GitHub runs the workflow file from the PR head, so a fork could delete the gate. Under `pull_request_target` the gate always comes from the base branch.

Trust is decided on where the head branch lives, and nothing else — deliberately **not** `author_association`. That field describes the PR's author and their standing in this repo; it says nothing about who pushed the head commit about to be checked out. Anyone with push access to the head branch can update a PR and fire `synchronize`, and for a fork that set belongs to the fork's owner: a personal fork's collaborators, or — as with the org-owned fork already used against this repo — every member with write access there. The author stays a `MEMBER` throughout, so trusting on association would let a third party land code on the runner under someone else's standing.

A branch in this repo can only have been pushed by someone who already has write access, which makes the head-repo check sufficient on its own. Nothing is lost: every association that might otherwise be trusted already implies write access here, so those authors can push a branch instead.

Gate behaviour, exercised across every event shape:

| | trusted |
|---|---|
| push to `staging`/`main`, manual dispatch | yes |
| same-repo branch PR | yes |
| fork PR — any author, any association | no |

## Notes for review

- **Rotate `PAWTOGRADER_GITHUB_PRIVATE_KEY_STRING`.** It has been reachable from public fork PRs since the branch-preview job was removed in c812235e (Apr 2026). Nothing in CI consumes it after this change, so the rotation is free.
- **Watch the first CI run.** Enabling `E2E_MOCK_GITHUB` changes what the ingestion suites see — the canned path inserts a single `Main.java`. The suites are written for it, but this has not been through a full run.
- `check-trust` is a new status context. It is not required by any ruleset today, so nothing blocks on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUkarXCxYefEcTRG3dhbQy
