### PR TITLE
fix(discord): read the bot's guild member by snowflake; tidy the student join copy

### DIFF
--- a/app/course/[course_id]/UserMenu.tsx
+++ b/app/course/[course_id]/UserMenu.tsx
@@ -723,6 +723,10 @@ function UserSettingsMenu() {
   const searchParams = useSearchParams();
   const { role: enrollment, isViewingAsStudent } = useClassProfiles();
   const gitHubUsername = enrollment.users.github_username;
+  // Shown for the same reason as the GitHub handle: the Discord link is invisible once made, and a
+  // student with no roles in the course server has no way to tell whether they linked the account at
+  // all. Not a link -- Discord has no public profile URL to point a username at.
+  const discordUsername = enrollment.users.discord_username;
   const { private_profile_id } = useClassProfiles();
   const { data: privateProfile } = useOne<UserProfile>({
     resource: "profiles",
@@ -768,6 +772,11 @@ function UserSettingsMenu() {
                           <Link href={`https://github.com/${gitHubUsername}`} target="_blank">
                             {gitHubUsername}
                           </Link>
+                        </Text>
+                      )}
+                      {discordUsername && (
+                        <Text fontSize="sm" wordBreak="break-word">
+                          Discord: {discordUsername}
                         </Text>
                       )}
                     </VStack>

--- a/app/course/[course_id]/studentDashboard.tsx
+++ b/app/course/[course_id]/studentDashboard.tsx
@@ -207,8 +207,7 @@ export default async function StudentDashboard({
        *
        * Also hidden when an instructor is viewing as a student. PendingInvites scopes itself with
        * useAuthState(), not with the profile being viewed, so it would show the instructor their own
-       * invite under the student's dashboard and hand them a SyncRolesButton that mutates their own
-       * Discord roles -- neither of which is what "view as" is meant to show.
+       * invite under the student's dashboard -- which is not what "view as" is meant to show.
        */}
       {/*
        * The link control comes first, because it is the step that unblocks everything below it. A

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -115,53 +115,79 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
   // predicate then rejects the request made on return. Asking eagerly would disable the handler below.
   //
   // Returning to this tab is the only observable "the student has joined" signal available, so it is
-  // the only thing that triggers a request.
+  // the only thing that triggers a request -- but only after they have actually opened an invite.
+  //
+  // Arming on the join click is what keeps this off the student's retry budget. Listening to every
+  // focus event meant an ordinary return to the dashboard -- another tab, lunch, a different window --
+  // enqueued a pre-join check and, since the same RPC now carries a five-a-day cap, spent one of the
+  // five. Five idle tab switches and the return that followed the real join was refused, and so was
+  // the manual button: the automatic path would have eaten the recourse it was meant to supplement.
+  //
+  // So the handler is armed by opening an invite and disarmed by firing. One join click buys one
+  // automatic check, which is proportionate -- it is the student's own deliberate action, and it is
+  // the action whose completion this is watching for.
   //
   // The cost of that restraint: a student who joined earlier, was never provisioned, and loads this
-  // page without ever leaving and returning to it gets no request, and waits for the hourly batch.
-  // That is the behaviour before this change, so it is a gap this does not close rather than a
-  // regression it introduces.
+  // page without ever leaving and returning to it gets no automatic request. That is what the button
+  // below is for, and failing that the hourly batch, which is the behaviour before any of this.
   //
   // request_discord_reinvite enqueues exactly the work the hourly batch would, and is already the
   // student-facing half of that RPC: it permits a caller to retry their OWN membership, verifies the
   // enrollment, throttles to one retry per user per five minutes in SQL, and takes a class-scoped
-  // advisory lock. So this needs no new state and cannot be used to enqueue work for anyone else.
+  // advisory lock. So this cannot be used to enqueue work for anyone else.
   const invitesOutstanding = invites.length > 0;
-  const lastProvisionAt = useRef(0);
+  // A ref, not state: opening the invite must not re-render the panel mid-click, and the listeners
+  // below read it when they fire rather than closing over a stale value.
+  const joinOpened = useRef(false);
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     if (showAll || !user || !classId || !invitesOutstanding) return;
 
-    const request = () => {
-      // Client-side floor so tab-flipping cannot spray requests. The real guard is the RPC's own
-      // five-minute SQL throttle; this only keeps us from paying for calls it will reject anyway.
-      // Starts at 0 so the first return trip is never delayed by it.
-      const now = Date.now();
-      if (now - lastProvisionAt.current < 60_000) return;
-      lastProvisionAt.current = now;
-
+    const fire = () => {
+      joinOpened.current = false;
       createClient()
         .rpc("request_discord_reinvite", { p_class_id: classId, p_user_id: user.id })
-        .then(({ error: rpcError }) => {
+        .then(({ data, error: rpcError }) => {
           if (rpcError) {
-            // Deliberately not surfaced. The hourly sync still covers this student, so a failure here
-            // costs them time rather than correctness, and an error banner on a panel whose whole
-            // message is "this is being handled" would be worse than the delay.
+            // Deliberately not surfaced. The hourly sync and the button below both still cover this
+            // student, so a failure here costs them time rather than correctness, and an error banner
+            // on a panel whose whole message is "this is being handled" would be worse than the delay.
             // eslint-disable-next-line no-console
             console.warn("Discord role provisioning request failed:", rpcError);
+            return;
+          }
+          // Queued nothing, which here almost always means the five-minute throttle: the student
+          // pressed the button below shortly before joining, so the check that actually matters is
+          // the one being refused. Retry once the window has passed rather than handing them to the
+          // hourly batch -- the join has already happened, so this is not a speculative request.
+          //
+          // On a timer that calls `fire` directly rather than re-arming, because re-arming would wait
+          // for another focus event and a student who joins and then stays on this page never
+          // produces one.
+          if ((data?.[0]?.queued ?? 0) === 0) {
+            if (retryTimer.current) clearTimeout(retryTimer.current);
+            retryTimer.current = setTimeout(fire, 5 * 60 * 1000 + 15_000);
           }
         });
     };
 
+    const onReturn = () => {
+      if (joinOpened.current) fire();
+    };
     const onVisible = () => {
-      if (document.visibilityState === "visible") request();
+      if (document.visibilityState === "visible") onReturn();
     };
     document.addEventListener("visibilitychange", onVisible);
     // `focus` as well as visibilitychange: returning from a new tab fires visibilitychange, but
     // returning from another WINDOW (a desktop Discord client taking focus, say) only fires focus.
-    window.addEventListener("focus", request);
+    window.addEventListener("focus", onReturn);
     return () => {
       document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", request);
+      window.removeEventListener("focus", onReturn);
+      // The panel unmounts as soon as the invite is marked used, which is the success case, so a
+      // pending retry has to be dropped rather than left to fire into a dead component.
+      if (retryTimer.current) clearTimeout(retryTimer.current);
     };
   }, [invitesOutstanding, showAll, user, classId]);
 
@@ -250,7 +276,15 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
                   </HStack>
                   <HStack gap={2}>
                     <Button asChild colorPalette="blue" size="sm">
-                      <a href={invite.invite_url} target="_blank" rel="noopener noreferrer">
+                      {/* Opening the invite is what arms the return handler above. Without this the
+                          handler would fire on any return to the dashboard and spend the student's
+                          daily retry budget on checks made while they were never in Discord. */}
+                      <a
+                        href={invite.invite_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => (joinOpened.current = true)}
+                      >
                         <Icon as={BsDiscord} />
                         <Text>Join Discord Server</Text>
                       </a>

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from "react";
 import { Alert } from "../ui/alert";
 import { Tooltip } from "../ui/tooltip";
 import useAuthState from "@/hooks/useAuthState";
+import RequestRoleSyncButton from "./request-role-sync-button";
 
 type DiscordInvite = {
   id: number;
@@ -99,7 +100,9 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
   // `discord-batch-role-sync-hourly` is `0 * * * *`, and discord-reconciler only repairs a sync that
   // has stopped running, treating `not_joined` as normal -- so a student who joins a minute after
   // their invite is minted would otherwise wait for the next hour boundary. That is the wait the
-  // panel's old "within an hour" copy and its sync button described; this replaces both.
+  // panel's old "within an hour" copy described, and the wait its sync button existed to escape.
+  // This removes the need to press anything for the common case; the button below remains for the
+  // case no event can announce.
   //
   // Nothing is requested on mount, and that omission is load-bearing twice over.
   //
@@ -272,19 +275,22 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
             <Text fontSize="xs" color="fg.muted">
               <strong>After joining the Discord server:</strong>
             </Text>
-            {/* No timing promise and no self-service sync control, because the effect above now does
-                what the button did: landing here with an invite outstanding enqueues the role sync
-                directly, and the worker drains that queue every minute. The student no longer has to
-                find and press anything for the common case, so "shortly" is a claim the page keeps
-                rather than one that depended on them noticing a control.
+            {/* No timing promise, because the effect above makes the common case genuinely prompt:
+                returning to this page with an invite outstanding enqueues the role sync, and the
+                worker drains that queue every minute. The old copy's "within an hour" described the
+                batch fallback, which is now the exception rather than the path everyone takes.
 
-                The cases the button could not fix are unchanged and still need an instructor -- the
-                bot missing Manage Roles, or its role sitting below the course roles -- which is what
-                the second sentence is for. A student who joins and never returns to this page falls
-                back to the hourly batch sync, as before. */}
+                The button stays for the case the automatic path cannot observe -- a student who
+                joined and then never left and re-entered this page, so no visibility or focus event
+                ever fires. Unlike the control it replaces it is rationed: five presses a day, out of
+                request_discord_reinvite rather than out of the unthrottled
+                trigger_discord_role_sync_for_user, because Discord's rate limits are per-bot and one
+                student holding a button spends them for every class. */}
             <Text fontSize="xs" color="fg.muted">
-              Your course roles will be assigned shortly. If they don&apos;t appear, contact your instructors.
+              Your course roles will be assigned shortly. If they don&apos;t appear, use the button below, then contact
+              your instructors if they still don&apos;t.
             </Text>
+            {!showAll && classId && user && <RequestRoleSyncButton classId={classId} userId={user.id} />}
           </VStack>
         </Box>
       </VStack>

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from "react";
 import { Alert } from "../ui/alert";
 import { Tooltip } from "../ui/tooltip";
 import useAuthState from "@/hooks/useAuthState";
-import SyncRolesButton from "./sync-roles-button";
 
 type DiscordInvite = {
   id: number;
@@ -202,15 +201,16 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
             <Text fontSize="xs" color="fg.muted">
               <strong>After joining the Discord server:</strong>
             </Text>
+            {/* No timing promise and no self-service sync control. Roles are assigned off the same
+                queued job that mints the invite, which runs within about a minute of the join, so
+                "within an hour" described a worst case the student almost never sees and invited
+                them to sit and wait for it. The sync button was the escape hatch from that wait; the
+                only cases it did not fix are ones the student cannot fix either -- the bot missing
+                Manage Roles, or its role sitting below the course roles -- and those need an
+                instructor. */}
             <Text fontSize="xs" color="fg.muted">
-              Your roles will be synced automatically within an hour. For immediate sync, use the button below or type{" "}
-              <code>/sync-roles</code> in the Discord server.
+              Your course roles will be assigned shortly. If they don&apos;t appear, contact your instructors.
             </Text>
-            {!showAll && (
-              <HStack>
-                <SyncRolesButton classId={classId} variant="outline" size="sm" />
-              </HStack>
-            )}
           </VStack>
         </Box>
       </VStack>

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -3,7 +3,7 @@
 import { Box, Button, Heading, HStack, Icon, Stack, Text, VStack } from "@chakra-ui/react";
 import { BsDiscord, BsExclamationCircle } from "react-icons/bs";
 import { createClient } from "@/utils/supabase/client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Alert } from "../ui/alert";
 import { Tooltip } from "../ui/tooltip";
 import useAuthState from "@/hooks/useAuthState";
@@ -90,6 +90,42 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
     const interval = setInterval(fetchInvites, 30000);
     return () => clearInterval(interval);
   }, [user, classId, showAll]);
+
+  // Landing here with an invite still outstanding asks for the roles to be provisioned.
+  //
+  // An unused invite row IS the "not provisioned yet" signal: `mark_discord_invite_used` runs in the
+  // same worker step that adds the roles, so a row still at `used = false` means the worker has not
+  // yet seen this student in the guild. Nothing re-checks that promptly on its own --
+  // `discord-batch-role-sync-hourly` is `0 * * * *`, and discord-reconciler only repairs a sync that
+  // has stopped running, treating `not_joined` as normal -- so a student who joins a minute after
+  // their invite is minted would otherwise wait for the next hour boundary. That is the wait the
+  // panel's old "within an hour" copy and its sync button described; this replaces both.
+  //
+  // request_discord_reinvite enqueues exactly the work the hourly batch would, and is already the
+  // student-facing half of that RPC: it permits a caller to retry their OWN membership, verifies the
+  // enrollment, throttles to one retry per user per five minutes in SQL, and takes a class-scoped
+  // advisory lock. So this needs no new state and cannot be used to enqueue work for anyone else.
+  //
+  // Fired once per mount rather than on every 30s poll: the SQL throttle makes repeats harmless but
+  // not free, and one request per visit is all it takes to close the gap.
+  const provisionRequested = useRef(false);
+  useEffect(() => {
+    if (showAll || !user || !classId) return;
+    if (invites.length === 0 || provisionRequested.current) return;
+    provisionRequested.current = true;
+
+    createClient()
+      .rpc("request_discord_reinvite", { p_class_id: classId, p_user_id: user.id })
+      .then(({ error: rpcError }) => {
+        if (rpcError) {
+          // Deliberately not surfaced. The hourly sync still covers this student, so a failure here
+          // costs them time rather than correctness, and an error banner on a panel whose whole
+          // message is "this is being handled" would be worse than the delay.
+          // eslint-disable-next-line no-console
+          console.warn("Discord role provisioning request failed:", rpcError);
+        }
+      });
+  }, [invites.length, showAll, user, classId]);
 
   // Only the first fetch, not the 30-second background refresh. `loading` goes true on every poll,
   // so reacting to it unconditionally tore the whole panel down and rebuilt it twice a minute --
@@ -201,13 +237,16 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
             <Text fontSize="xs" color="fg.muted">
               <strong>After joining the Discord server:</strong>
             </Text>
-            {/* No timing promise and no self-service sync control. Roles are assigned off the same
-                queued job that mints the invite, which runs within about a minute of the join, so
-                "within an hour" described a worst case the student almost never sees and invited
-                them to sit and wait for it. The sync button was the escape hatch from that wait; the
-                only cases it did not fix are ones the student cannot fix either -- the bot missing
-                Manage Roles, or its role sitting below the course roles -- and those need an
-                instructor. */}
+            {/* No timing promise and no self-service sync control, because the effect above now does
+                what the button did: landing here with an invite outstanding enqueues the role sync
+                directly, and the worker drains that queue every minute. The student no longer has to
+                find and press anything for the common case, so "shortly" is a claim the page keeps
+                rather than one that depended on them noticing a control.
+
+                The cases the button could not fix are unchanged and still need an instructor -- the
+                bot missing Manage Roles, or its role sitting below the course roles -- which is what
+                the second sentence is for. A student who joins and never returns to this page falls
+                back to the hourly batch sync, as before. */}
             <Text fontSize="xs" color="fg.muted">
               Your course roles will be assigned shortly. If they don&apos;t appear, contact your instructors.
             </Text>

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -91,9 +91,9 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
     return () => clearInterval(interval);
   }, [user, classId, showAll]);
 
-  // Landing here with an invite still outstanding asks for the roles to be provisioned.
+  // Coming BACK to this page with an invite still outstanding asks for the roles to be provisioned.
   //
-  // An unused invite row IS the "not provisioned yet" signal: `mark_discord_invite_used` runs in the
+  // An unused invite row is the "not provisioned yet" signal: `mark_discord_invite_used` runs in the
   // same worker step that adds the roles, so a row still at `used = false` means the worker has not
   // yet seen this student in the guild. Nothing re-checks that promptly on its own --
   // `discord-batch-role-sync-hourly` is `0 * * * *`, and discord-reconciler only repairs a sync that
@@ -101,31 +101,65 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
   // their invite is minted would otherwise wait for the next hour boundary. That is the wait the
   // panel's old "within an hour" copy and its sync button described; this replaces both.
   //
+  // The trigger is deliberately NOT "once on mount". The join opens discord.gg in a new tab, so the
+  // dashboard stays mounted the whole time: a mount-only request fires while the student is still
+  // absent, the worker takes the "no role to add" exit, and nothing runs again when they come back --
+  // which is the one moment the check would succeed. Re-running on visibility is what makes this
+  // correspond to "the student has joined": returning to this tab is the observable event.
+  //
+  // The mount case is kept as well, for a student who joined earlier and was never provisioned, and
+  // whose invite is therefore still sitting here -- a fresh page load fires no focus or visibility
+  // event, so without it that student gets nothing until the next hour.
+  //
+  // Its cost is bounded and worth naming: for a student who ALREADY has a membership row, the mount
+  // request stamps last_retry_requested_at, so if they join within the next five minutes the return
+  // trip is throttled in SQL and they wait out that window. Five minutes, not the hour this replaces.
+  // A student seeing their first invite has no row yet, and request_discord_reinvite deliberately
+  // writes none, so the common first-join path is not throttled by the mount request at all.
+  //
   // request_discord_reinvite enqueues exactly the work the hourly batch would, and is already the
   // student-facing half of that RPC: it permits a caller to retry their OWN membership, verifies the
   // enrollment, throttles to one retry per user per five minutes in SQL, and takes a class-scoped
   // advisory lock. So this needs no new state and cannot be used to enqueue work for anyone else.
-  //
-  // Fired once per mount rather than on every 30s poll: the SQL throttle makes repeats harmless but
-  // not free, and one request per visit is all it takes to close the gap.
-  const provisionRequested = useRef(false);
+  const invitesOutstanding = invites.length > 0;
+  const lastProvisionAt = useRef(0);
   useEffect(() => {
-    if (showAll || !user || !classId) return;
-    if (invites.length === 0 || provisionRequested.current) return;
-    provisionRequested.current = true;
+    if (showAll || !user || !classId || !invitesOutstanding) return;
 
-    createClient()
-      .rpc("request_discord_reinvite", { p_class_id: classId, p_user_id: user.id })
-      .then(({ error: rpcError }) => {
-        if (rpcError) {
-          // Deliberately not surfaced. The hourly sync still covers this student, so a failure here
-          // costs them time rather than correctness, and an error banner on a panel whose whole
-          // message is "this is being handled" would be worse than the delay.
-          // eslint-disable-next-line no-console
-          console.warn("Discord role provisioning request failed:", rpcError);
-        }
-      });
-  }, [invites.length, showAll, user, classId]);
+    const request = () => {
+      // Client-side floor so tab-flipping cannot spray requests. The real guard is the RPC's own
+      // five-minute SQL throttle; this only keeps us from paying for calls it will reject anyway.
+      const now = Date.now();
+      if (now - lastProvisionAt.current < 60_000) return;
+      lastProvisionAt.current = now;
+
+      createClient()
+        .rpc("request_discord_reinvite", { p_class_id: classId, p_user_id: user.id })
+        .then(({ error: rpcError }) => {
+          if (rpcError) {
+            // Deliberately not surfaced. The hourly sync still covers this student, so a failure here
+            // costs them time rather than correctness, and an error banner on a panel whose whole
+            // message is "this is being handled" would be worse than the delay.
+            // eslint-disable-next-line no-console
+            console.warn("Discord role provisioning request failed:", rpcError);
+          }
+        });
+    };
+
+    request();
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") request();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    // `focus` as well as visibilitychange: returning from a new tab fires visibilitychange, but
+    // returning from another WINDOW (a desktop Discord client taking focus, say) only fires focus.
+    window.addEventListener("focus", request);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", request);
+    };
+  }, [invitesOutstanding, showAll, user, classId]);
 
   // Only the first fetch, not the 30-second background refresh. `loading` goes true on every poll,
   // so reacting to it unconditionally tore the whole panel down and rebuilt it twice a minute --

--- a/components/discord/pending-invites.tsx
+++ b/components/discord/pending-invites.tsx
@@ -101,21 +101,23 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
   // their invite is minted would otherwise wait for the next hour boundary. That is the wait the
   // panel's old "within an hour" copy and its sync button described; this replaces both.
   //
-  // The trigger is deliberately NOT "once on mount". The join opens discord.gg in a new tab, so the
-  // dashboard stays mounted the whole time: a mount-only request fires while the student is still
-  // absent, the worker takes the "no role to add" exit, and nothing runs again when they come back --
-  // which is the one moment the check would succeed. Re-running on visibility is what makes this
-  // correspond to "the student has joined": returning to this tab is the observable event.
+  // Nothing is requested on mount, and that omission is load-bearing twice over.
   //
-  // The mount case is kept as well, for a student who joined earlier and was never provisioned, and
-  // whose invite is therefore still sitting here -- a fresh page load fires no focus or visibility
-  // event, so without it that student gets nothing until the next hour.
+  // The join opens discord.gg in a NEW TAB, so this dashboard stays mounted throughout: a mount
+  // request goes out while the student is still absent, the worker takes its "no role to add" exit,
+  // and the moment that would actually succeed -- their return -- has already been spent. Worse, it
+  // poisons the retry. By the time an invite can render here the worker has already written the
+  // student's `not_joined` row (recordMembershipStatus runs immediately after storing the invite), so
+  // a mount request always finds a row to stamp last_retry_requested_at on, and the RPC's five-minute
+  // predicate then rejects the request made on return. Asking eagerly would disable the handler below.
   //
-  // Its cost is bounded and worth naming: for a student who ALREADY has a membership row, the mount
-  // request stamps last_retry_requested_at, so if they join within the next five minutes the return
-  // trip is throttled in SQL and they wait out that window. Five minutes, not the hour this replaces.
-  // A student seeing their first invite has no row yet, and request_discord_reinvite deliberately
-  // writes none, so the common first-join path is not throttled by the mount request at all.
+  // Returning to this tab is the only observable "the student has joined" signal available, so it is
+  // the only thing that triggers a request.
+  //
+  // The cost of that restraint: a student who joined earlier, was never provisioned, and loads this
+  // page without ever leaving and returning to it gets no request, and waits for the hourly batch.
+  // That is the behaviour before this change, so it is a gap this does not close rather than a
+  // regression it introduces.
   //
   // request_discord_reinvite enqueues exactly the work the hourly batch would, and is already the
   // student-facing half of that RPC: it permits a caller to retry their OWN membership, verifies the
@@ -129,6 +131,7 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
     const request = () => {
       // Client-side floor so tab-flipping cannot spray requests. The real guard is the RPC's own
       // five-minute SQL throttle; this only keeps us from paying for calls it will reject anyway.
+      // Starts at 0 so the first return trip is never delayed by it.
       const now = Date.now();
       if (now - lastProvisionAt.current < 60_000) return;
       lastProvisionAt.current = now;
@@ -145,8 +148,6 @@ export default function PendingInvites({ classId, showAll = false }: PendingInvi
           }
         });
     };
-
-    request();
 
     const onVisible = () => {
       if (document.visibilityState === "visible") request();

--- a/components/discord/request-role-sync-button.tsx
+++ b/components/discord/request-role-sync-button.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { createClient } from "@/utils/supabase/client";
+import { Button } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { toaster } from "../ui/toaster";
+
+/**
+ * Must match the throttle in request_discord_reinvite(). Duplicated rather than read from the server
+ * for the same reason DiscordReinviteButton duplicates it: the button has to decide whether to
+ * disable itself before it calls anything. The RPC stays the authority -- a client that gets this
+ * wrong is told so by the zero it gets back.
+ */
+const RETRY_THROTTLE_MS = 5 * 60 * 1000;
+
+/**
+ * SQLSTATE the daily cap raises with. `53400` is configuration_limit_exceeded, which is what
+ * PostgREST puts in `error.code`, and it is the only way to tell "you are out of retries for today"
+ * apart from any other refusal without matching on the message text.
+ */
+const DAILY_LIMIT_SQLSTATE = "53400";
+
+/**
+ * A student's own "my roles have not appeared" button.
+ *
+ * Deliberately not the staff SyncRolesPanel's button. That one calls
+ * trigger_discord_role_sync_for_user, which has no throttle of any kind, and pointing a
+ * student-facing control at it is what makes a rate-limit problem for every class the bot serves --
+ * Discord's limits are per-bot, not per-guild. This calls request_discord_reinvite, which throttles
+ * per user per five minutes, caps a student at five a day, verifies the enrollment, and refuses to
+ * act on anybody else's membership.
+ *
+ * The automatic request on returning to the dashboard covers the common case; this covers the one it
+ * cannot see, where the student joined and then never left and re-entered the page.
+ */
+export default function RequestRoleSyncButton({ classId, userId }: { classId: number; userId: string }) {
+  const [busy, setBusy] = useState(false);
+  const [throttledUntil, setThrottledUntil] = useState(0);
+  // Latched for the session once the server says the day's budget is gone. There is no client-side
+  // countdown for it on purpose: the window rolls from the student's first press, so the only honest
+  // source for when it reopens is the server, and pressing again to find out is exactly what the cap
+  // exists to prevent.
+  const [outOfRetries, setOutOfRetries] = useState(false);
+
+  // Re-render when the throttle expires so the button re-enables itself without a reload.
+  useEffect(() => {
+    if (throttledUntil === 0) return;
+    const remaining = throttledUntil - Date.now();
+    if (remaining <= 0) return;
+    const timer = setTimeout(() => setThrottledUntil(0), remaining);
+    return () => clearTimeout(timer);
+  }, [throttledUntil]);
+
+  const run = async () => {
+    setBusy(true);
+    try {
+      const { data, error } = await createClient().rpc("request_discord_reinvite", {
+        p_class_id: classId,
+        p_user_id: userId
+      });
+
+      if (error) {
+        if (error.code === DAILY_LIMIT_SQLSTATE) {
+          setOutOfRetries(true);
+          toaster.create({ title: "Daily limit reached", description: error.message, type: "warning" });
+          return;
+        }
+        toaster.create({ title: "Could not request a sync", description: error.message, type: "error" });
+        return;
+      }
+
+      // RETURNS TABLE, so PostgREST sends a one-row array.
+      const queued = data?.[0]?.queued ?? 0;
+      if (queued > 0) {
+        setThrottledUntil(Date.now() + RETRY_THROTTLE_MS);
+        toaster.create({
+          title: "Checking your Discord roles",
+          description: "This usually takes about a minute. You do not need to stay on this page.",
+          type: "success"
+        });
+        return;
+      }
+
+      // Queued nothing, and the reasons are not distinguishable from here: inside the five-minute
+      // throttle, already recorded in the server, or the course's Discord roles were never created.
+      // The first two need no action and the third needs an instructor, so the copy points at waiting
+      // rather than at pressing again.
+      setThrottledUntil(Date.now() + RETRY_THROTTLE_MS);
+      toaster.create({
+        title: "Already requested",
+        description: "A check is already queued or ran in the last few minutes. Give it a minute to finish.",
+        type: "info"
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const throttled = throttledUntil > Date.now();
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={run}
+      loading={busy}
+      disabled={busy || throttled || outOfRetries}
+      alignSelf="flex-start"
+    >
+      {outOfRetries ? "Daily limit reached" : "My roles have not appeared"}
+    </Button>
+  );
+}

--- a/supabase/functions/_shared/DiscordBotRest.ts
+++ b/supabase/functions/_shared/DiscordBotRest.ts
@@ -105,6 +105,45 @@ export async function discordBotGet(path: string, scope?: Sentry.Scope): Promise
 }
 
 /**
+ * The bot's own user id, which `GET /guilds/{guild.id}/members/{user.id}` needs spelled out.
+ *
+ * `@me` is not usable there. Discord accepts it only on the PATCH (Modify Current Member); the GET
+ * parses the last segment as a snowflake and answers 400 / 50035 `Value "@me" is not snowflake.`
+ * for anything else. There is a documented "Get Current User Guild Member"
+ * (`GET /users/@me/guilds/{guild.id}/member`), but it is an OAuth2 route requiring the
+ * `guilds.members.read` scope and is not available to a bot token, so the id has to be resolved.
+ *
+ * Read from `/users/@me` rather than assumed from `DISCORD_APPLICATION_ID`. The two are equal for a
+ * bot application, but that is an invariant about Discord rather than about this deployment's
+ * configuration, and a wrong or absent env var would resurface as the same opaque "could not report
+ * the bot's guild membership" this function exists to prevent. Asking Discord cannot be misconfigured.
+ *
+ * Memoized for the isolate: a deployment's bot identity does not change, so this costs one extra
+ * request per warm isolate rather than one per check.
+ *
+ * Failures come back as the raw result instead of throwing, so callers classify a bad answer here
+ * with exactly the same rules they apply to every other Discord answer.
+ */
+let cachedBotUserId: string | null = null;
+
+export async function getBotUserId(
+  scope?: Sentry.Scope
+): Promise<{ ok: true; id: string } | { ok: false; result: DiscordBotGetResult }> {
+  if (cachedBotUserId) return { ok: true, id: cachedBotUserId };
+  const result = await discordBotGet("/users/@me", scope);
+  if (!result.ok) return { ok: false, result };
+  const id = (result.data as { id?: string } | null)?.id;
+  if (!id) {
+    // A 2xx that does not carry an id is not something the caller can act on, and is not transient.
+    // Reported as a 502-shaped result so it lands in the caller's terminal branch rather than
+    // becoming a "try again" that never succeeds.
+    return { ok: false, result: { ...result, ok: false, status: 502, detail: "GET /users/@me returned no id" } };
+  }
+  cachedBotUserId = id;
+  return { ok: true, id };
+}
+
+/**
  * True when a failed response says nothing about the guild's configuration, only that Discord is
  * unwell or rate-limiting us -- a 5xx or a 429.
  *

--- a/supabase/functions/discord-check-bot-installation/index.ts
+++ b/supabase/functions/discord-check-bot-installation/index.ts
@@ -29,7 +29,12 @@
  * those are mutations and live in separate routes.
  */
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { discordBotGet, isDiscordCredentialFailure, isTransientDiscordStatus } from "../_shared/DiscordBotRest.ts";
+import {
+  discordBotGet,
+  getBotUserId,
+  isDiscordCredentialFailure,
+  isTransientDiscordStatus
+} from "../_shared/DiscordBotRest.ts";
 import { DISCORD_UNKNOWN_GUILD, DISCORD_MISSING_ACCESS } from "../_shared/DiscordErrorClassification.ts";
 import { MAX_INVITE_CHANNEL_ATTEMPTS, inviteCandidateChannels } from "../_shared/DiscordInviteChannels.ts";
 import {
@@ -152,7 +157,7 @@ export type ChannelPermissionProblem = {
 /** Shape of the bits of `GET /guilds/{id}` we read. */
 type GuildResponse = { id?: string; name?: string };
 
-/** Shape of the bits of `GET /guilds/{id}/members/@me` we read. */
+/** Shape of the bits of `GET /guilds/{id}/members/{bot user id}` we read. */
 type GuildMemberResponse = { roles?: string[]; user?: { id?: string } };
 
 /** Shape of the bits of `GET /guilds/{id}/channels` we read. Overwrites arrive inline. */
@@ -429,13 +434,33 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<CheckBo
 
   const guild = (guildResult.data ?? {}) as GuildResponse;
 
+  // Reading the bot's own member object means naming the bot by snowflake -- see getBotUserId for why
+  // `@me` is not an option on that route. Memoized, so this is one extra request per warm isolate
+  // rather than one per check, and it is resolved before the batch below because the batch needs it.
+  const botUser = await getBotUserId(scope);
+  if (!botUser.ok) {
+    if (isDiscordCredentialFailure(botUser.result.status)) {
+      throwCredentialFailure("the bot's own identity", scope);
+    }
+    scope?.setContext("discord_error", {
+      what: "the bot's own identity",
+      status: botUser.result.status,
+      discord_code: botUser.result.code,
+      detail: botUser.result.detail
+    });
+    throw new UserVisibleError(
+      `Discord could not report the bot's own identity (HTTP ${botUser.result.status})`,
+      isTransientDiscordStatus(botUser.result.status) ? 503 : 502
+    );
+  }
+
   // The bot's own member object, the guild's role list, and the guild's channels. Discord does not
   // report a member's permissions on the member object -- only its role IDs -- so the first two are
   // both needed to compute anything. The third is what makes the per-channel answer possible, and it
   // is one request for the whole guild: `GET /guilds/{id}/channels` carries every channel's
   // `permission_overwrites` inline, so nothing here is per-channel fan-out. All three are independent.
   const [memberResult, rolesResult, channelsResult] = await Promise.all([
-    discordBotGet(`/guilds/${guildId}/members/@me`, scope),
+    discordBotGet(`/guilds/${guildId}/members/${botUser.id}`, scope),
     discordBotGet(`/guilds/${guildId}/roles`, scope),
     discordBotGet(`/guilds/${guildId}/channels`, scope)
   ]);
@@ -451,6 +476,16 @@ async function handleRequest(req: Request, scope: Sentry.Scope): Promise<CheckBo
       if (isDiscordCredentialFailure(result.status)) {
         throwCredentialFailure(label, scope);
       }
+      // Discord's own error code and body are the only thing that distinguishes one 4xx here from
+      // another, and the instructor-facing message deliberately does not carry them. Without this
+      // they were read off the result and then dropped, so a deployment hitting an unexpected
+      // rejection saw "(HTTP 400)" in its logs and nothing about which field Discord objected to.
+      scope?.setContext("discord_error", {
+        what: label,
+        status: result.status,
+        discord_code: result.code,
+        detail: result.detail
+      });
       const status = isTransientDiscordStatus(result.status) ? 503 : 502;
       throw new UserVisibleError(`Discord could not report ${label} (HTTP ${result.status})`, status);
     }

--- a/supabase/migrations/20260824190000_discord_self_retry_daily_cap.sql
+++ b/supabase/migrations/20260824190000_discord_self_retry_daily_cap.sql
@@ -1,0 +1,287 @@
+-- Cap a student's self-service Discord role-sync retries at five a day.
+--
+-- request_discord_reinvite already throttles to one retry per user per five minutes, which bounds a
+-- button being held down. It does not bound a button being pressed all afternoon: five minutes apart
+-- is 288 presses a day, and each one costs a Discord member lookup and possibly an invite creation.
+-- Discord's rate limits are per-bot, so that budget is not spent against the pressing student alone
+-- -- it is spent against every class the deployment serves.
+--
+-- Five a day is the shape of the thing being retried. A student's retry fixes exactly one situation:
+-- the worker has not yet noticed they joined. If five spread over a day have not fixed it, the cause
+-- is one they cannot fix -- the bot missing Manage Roles, its role below the class roles, a class
+-- whose Discord roles were never created -- and the answer is an instructor, not another press.
+--
+-- Staff are exempt. A class-wide retry is the documented way out of a guild-level failure, and
+-- rationing it would leave a broken class unfixable.
+
+ALTER TABLE public.discord_membership_status
+  ADD COLUMN IF NOT EXISTS self_retry_window_started_at timestamptz,
+  ADD COLUMN IF NOT EXISTS self_retry_count integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.discord_membership_status.self_retry_window_started_at IS
+  'Start of the rolling 24h window for this user''s own retries of this membership. Rolls from the first press of a window rather than a fixed hour, so the budget cannot be doubled across a midnight boundary. Null until they press once. Staff retries do not touch it.';
+
+COMMENT ON COLUMN public.discord_membership_status.self_retry_count IS
+  'Retries the user has spent in the window above. Incremented only when a press actually queued work, so presses rejected by the five-minute throttle cost nothing.';
+
+-- Recreated with the cap. Everything else is unchanged from
+-- 20260811210000_discord_membership_reinvite.sql.
+CREATE OR REPLACE FUNCTION public.request_discord_reinvite(
+  p_class_id bigint,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS TABLE (queued integer, roles_repaired integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+  v_is_staff boolean;
+  v_guild_id text;
+  v_queued integer := 0;
+  v_repaired integer := 0;
+  v_missing_roles text[] := ARRAY[]::text[];
+  v_role_type text;
+  v_row record;
+  -- Self-service daily budget, read and written only on the student path below.
+  v_self_window timestamptz;
+  v_self_count integer;
+BEGIN
+  IF v_caller IS NULL THEN
+    RAISE EXCEPTION 'Access denied: authentication required';
+  END IF;
+
+  v_is_staff := public.authorizeforclassgrader(p_class_id::bigint);
+
+  -- A student may retry their own membership -- that is the self-service half of the
+  -- GitHub pattern, where the resend banner is rendered to the student themselves. Acting
+  -- on anyone else, or on the whole class, is a staff action.
+  IF NOT v_is_staff THEN
+    IF p_user_id IS NULL OR p_user_id <> v_caller THEN
+      RAISE EXCEPTION 'Access denied: must be a grader or instructor for this class';
+    END IF;
+
+    -- Passing your own id is not on its own a claim on this class. Without this an
+    -- authenticated user could name any class id, satisfy the check above, and reach the
+    -- role-repair phase below -- which scans the class independently of the membership loop
+    -- and would enqueue create_role against a Discord server they have nothing to do with.
+    IF NOT EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.class_id = p_class_id AND ur.user_id = v_caller AND ur.disabled = false
+    ) THEN
+      RAISE EXCEPTION 'Access denied: no active enrollment in this class';
+    END IF;
+  END IF;
+
+  SELECT c.discord_server_id INTO v_guild_id
+  FROM public.classes c
+  WHERE c.id = p_class_id;
+
+  -- Nothing to retry against. Reported as zero rather than as an error: the caller is a
+  -- button on a roster page, and a class with no Discord server is a configuration state,
+  -- not a failure of this request.
+  IF v_guild_id IS NULL THEN
+    RETURN QUERY SELECT 0, 0;
+    RETURN;
+  END IF;
+
+  -- Serialize the whole retry per class, for the rest of this transaction.
+  --
+  -- Every phase below is read-then-write. The throttle predicate reads
+  -- last_retry_requested_at and the loop body writes it, so two staff pressing the button at
+  -- the same moment both saw an unthrottled row and both enqueued add_member_role for the
+  -- same users. The worker handles those messages in parallel and creates a Discord invite
+  -- per message before upserting the one tracking row, so the loser's invite stays live in
+  -- Discord with no record of it -- the orphan-invite shape this branch has been removing
+  -- everywhere else. A class-scoped lock is the right grain: this function is a per-class
+  -- operation, and it also covers the role-repair phase further down.
+  PERFORM pg_advisory_xact_lock(hashtext('discord_reinvite:' || p_class_id::text));
+
+  -- A student's own retries are capped per day, on top of the five-minute throttle below.
+  --
+  -- The throttle alone bounds a held-down button, not a determined one: five minutes apart is 288
+  -- presses a day, each of which costs a Discord member lookup and possibly an invite creation. That
+  -- is a rate-limit problem the guild's other students then share, since Discord's limits are
+  -- per-bot. A handful a day is all a student can act on -- the failures that survive more than one
+  -- retry need an instructor, not another press.
+  --
+  -- Staff are exempt. A class-wide retry is the documented way out of a guild-level failure, and
+  -- rationing it would leave a broken class unfixable.
+  --
+  -- Read before the loop rather than inside it, because the budget belongs to the caller, not to
+  -- each row: the student path only ever touches its own row, and reading it here means the refusal
+  -- happens before any work is queued.
+  IF NOT v_is_staff THEN
+    SELECT dms.self_retry_window_started_at, dms.self_retry_count
+    INTO v_self_window, v_self_count
+    FROM public.discord_membership_status dms
+    WHERE dms.class_id = p_class_id
+      AND dms.user_id = v_caller
+      AND dms.guild_id = v_guild_id;
+
+    -- A window older than a day is spent; the next press starts a fresh one. Rolling from the first
+    -- press of the window rather than at a fixed hour, so the budget cannot be doubled by pressing
+    -- either side of a midnight boundary.
+    IF v_self_window IS NULL OR v_self_window < now() - INTERVAL '24 hours' THEN
+      v_self_window := now();
+      v_self_count := 0;
+    END IF;
+
+    IF COALESCE(v_self_count, 0) >= 5 THEN
+      RAISE EXCEPTION
+        'Discord role sync limit reached: this can be requested at most 5 times a day. If your roles are still missing, contact your instructors.'
+        USING ERRCODE = '53400';
+    END IF;
+  END IF;
+
+  FOR v_row IN
+    SELECT ur.user_id, ur.role, dms.id AS status_id,
+           EXISTS (
+             SELECT 1 FROM public.discord_roles dr
+             WHERE dr.class_id = p_class_id AND dr.role_type = ur.role::text
+           ) AS role_exists
+    FROM public.user_roles ur
+    JOIN public.users u ON u.user_id = ur.user_id
+    LEFT JOIN public.discord_membership_status dms
+      ON dms.class_id = ur.class_id
+     AND dms.user_id = ur.user_id
+     AND dms.guild_id = v_guild_id
+    WHERE ur.class_id = p_class_id
+      AND ur.disabled = false
+      -- Without a linked Discord account there is no member to look up and no invite that
+      -- would reach anyone. enqueue_discord_role_sync would return silently; skipping here
+      -- keeps the returned count honest.
+      AND u.discord_id IS NOT NULL
+      AND (p_user_id IS NULL OR ur.user_id = p_user_id)
+      -- A class-wide retry targets everyone not recorded as being in the server, which
+      -- includes users with no row at all. Requiring a row excluded exactly the students the
+      -- sync has never reached -- and for a class outside the active-class window that is
+      -- permanent, because the hourly batch will never create one, while the settings page
+      -- reported there was nothing to queue. A retry aimed at a single user runs whatever
+      -- their state is, including none, because that is the case it exists for.
+      AND (p_user_id IS NOT NULL OR dms.id IS NULL OR dms.state <> 'in_guild')
+      -- Throttle. The work this queues is one Discord member lookup plus, at most, an
+      -- invite creation, so the window only has to stop a button being held down; it is
+      -- not the five-day email throttle the GitHub resend banner needs.
+      AND (dms.last_retry_requested_at IS NULL OR dms.last_retry_requested_at < now() - INTERVAL '5 minutes')
+    -- Deterministic, so a class-wide retry that is interrupted repeats in the same order.
+    ORDER BY ur.user_id
+  LOOP
+    -- The class's Discord role for this user's role type does not exist, so
+    -- enqueue_discord_role_sync would return without queueing anything. Repair that first
+    -- and leave the user un-stamped and uncounted: they are not throttled for a retry that
+    -- never happened, and the count stays true.
+    IF NOT v_row.role_exists THEN
+      CONTINUE;
+    END IF;
+
+    PERFORM public.enqueue_discord_role_sync(v_row.user_id, p_class_id, v_row.role, 'add');
+
+    IF v_row.status_id IS NOT NULL THEN
+      UPDATE public.discord_membership_status
+      SET last_retry_requested_at = now()
+      WHERE id = v_row.status_id;
+    END IF;
+
+    -- Deliberately no row is created for a user who has none. Seeding one meant choosing a state
+    -- before anything had been observed, and `not_joined` is what the alerts read as "an invite is
+    -- waiting on their dashboard, no action needed" -- false the moment it is written, and false
+    -- indefinitely if the worker never gets there. The enum has no value for "queued, not yet
+    -- checked", and inventing one would have to reach the roster column and its filter as well.
+    --
+    -- The cost is that such a user is not throttled until the worker records their first real
+    -- outcome, about a minute later. Pressing again before then re-enqueues an add_member_role,
+    -- which is idempotent at the Discord end and can no longer mint a duplicate invite now that
+    -- claim_discord_invite() decides that centrally. A brief unthrottled window is the cheaper error
+    -- than telling staff an invite exists when none does.
+
+    v_queued := v_queued + 1;
+  END LOOP;
+
+  -- Spend a day's budget only when the press actually queued something. A press that queued nothing
+  -- -- inside the five-minute throttle, already in_guild, or the class's roles missing -- cost no
+  -- Discord work, so charging for it would let a student burn the day's allowance on presses that
+  -- never reached Discord.
+  --
+  -- UPDATE, never INSERT. request_discord_reinvite deliberately creates no membership row (see the
+  -- comment in the loop above), and that carries here: a student with no row yet is not counted,
+  -- exactly as they are not throttled. The row is written when their invite is minted, about a
+  -- minute later, so the uncounted window is small and self-closing.
+  IF NOT v_is_staff AND v_queued > 0 THEN
+    UPDATE public.discord_membership_status
+    SET self_retry_window_started_at = v_self_window,
+        self_retry_count = COALESCE(v_self_count, 0) + 1
+    WHERE class_id = p_class_id
+      AND user_id = v_caller
+      AND guild_id = v_guild_id;
+  END IF;
+
+  -- Which of the class's Discord roles are missing, computed independently of anyone's
+  -- membership state.
+  --
+  -- Deliberately not derived from the loop above. That loop only sees users who need a
+  -- membership retry, so a class where role creation failed but everyone has since joined the
+  -- server produced no candidates, no repair, and no way to ever create the role -- and the
+  -- batch worker records in_guild even when enqueue_discord_role_sync silently finds no role,
+  -- so nothing anywhere said the roles were missing.
+  --
+  -- Restricted to the role types discord_roles accepts. app_role also has 'admin', which
+  -- discord_roles_role_type_check rejects, so enqueueing it would have Discord create a role
+  -- the insert then refuses to track -- an orphan in the guild, re-created on every retry.
+  -- Staff only, as a second boundary. Repair is class-wide work: it enqueues Discord mutations
+  -- for a whole guild, which is not something a student's retry of their own membership should
+  -- ever reach, whatever the enrollment check above concluded. A student in a class whose roles
+  -- are missing gets queued 0 and repaired 0, which is accurate -- their retry cannot succeed
+  -- until staff restore the roles.
+  IF NOT v_is_staff THEN
+    RETURN QUERY SELECT v_queued, 0;
+    RETURN;
+  END IF;
+
+  --
+  -- All three supported types, not just the ones currently enrolled.
+  -- trigger_sync_existing_users_on_role_creation only calls sync_existing_users_after_roles_created
+  -- when COUNT(DISTINCT role_type) = 3, so repairing a class with no grader would create student and
+  -- instructor, never reach three, and never fire the sync that assigns roles to the users already
+  -- in the guild. Creating an unused role costs nothing -- the class-connect flow creates all three
+  -- unconditionally -- and it is what makes the repair actually finish.
+  SELECT COALESCE(array_agg(rt.role_type), ARRAY[]::text[])
+  INTO v_missing_roles
+  FROM unnest(ARRAY['student', 'grader', 'instructor']) AS rt(role_type)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.discord_roles dr
+    WHERE dr.class_id = p_class_id AND dr.role_type = rt.role_type
+  );
+
+  -- Re-create them. The worker writes the discord_roles row when it succeeds, so the next
+  -- press of the button finds the role and queues the users skipped above.
+  FOREACH v_role_type IN ARRAY v_missing_roles LOOP
+    -- Users are left un-stamped on the missing-role path, so nothing throttles a second press
+    -- while the worker is still working. This is what stops that becoming a second Discord
+    -- role: create_role is not idempotent at the Discord end -- it creates the role and only
+    -- then inserts the row, while discord_roles allows one row per (class_id, role_type) -- so
+    -- a duplicate leaves an untracked role in the guild that nothing refers to again.
+    -- Concurrent callers are handled by the class-scoped lock taken above.
+    IF EXISTS (
+      SELECT 1
+      FROM pgmq.q_discord_async_calls q
+      WHERE q.message ->> 'method' = 'create_role'
+        AND (q.message ->> 'class_id')::bigint = p_class_id
+        AND q.message ->> 'role_type' = v_role_type
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    PERFORM public.enqueue_discord_role_creation(p_class_id, v_role_type, v_guild_id);
+    v_repaired := v_repaired + 1;
+  END LOOP;
+
+  RETURN QUERY SELECT v_queued, v_repaired;
+END;
+$$;
+COMMENT ON FUNCTION public.request_discord_reinvite(bigint, uuid) IS
+  'Re-queue the Discord membership check for one user, or for every user in the class not recorded as in_guild. The way out of a recorded cannot_invite once the underlying problem is fixed. A student retrying their own membership is capped at five a day on top of the five-minute throttle; staff are uncapped. Returns the number of users queued and the number of missing class Discord roles re-created.';
+
+REVOKE ALL ON FUNCTION public.request_discord_reinvite(bigint, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.request_discord_reinvite(bigint, uuid) TO authenticated, service_role;

--- a/tests/e2e/discord-check-bot-installation.test.tsx
+++ b/tests/e2e/discord-check-bot-installation.test.tsx
@@ -559,12 +559,20 @@ test.describe("discord-check-bot-installation edge function", () => {
     return channel.id;
   }
 
-  /** Track a channel for class A the way discord-async-worker does after creating one. */
-  async function trackChannel(channelId: string) {
+  /**
+   * Track a channel for class A the way discord-async-worker does after creating one.
+   *
+   * `channelType` is a parameter because `discord_channels` is unique on
+   * (class_id, channel_type, resource_id) with NULLS NOT DISTINCT, so two class-level rows -- both
+   * with a null resource_id -- collide unless their types differ. A test that needs to track two
+   * channels at once has to name a second type. The check function reads every row for the class
+   * regardless of type, so which one is used does not affect what it reports.
+   */
+  async function trackChannel(channelId: string, channelType: "general" | "operations" = "general") {
     const { error } = await untypedTable(supabase, "discord_channels").insert({
       class_id: classAId,
       discord_channel_id: channelId,
-      channel_type: "general"
+      channel_type: channelType
     });
     expect(error, `failed to track channel ${channelId}`).toBeNull();
   }
@@ -716,8 +724,12 @@ test.describe("discord-check-bot-installation edge function", () => {
     const state = await applyScenarioForGuilds("healthy", [GUILD_ID]);
     const generalId = channelIdByName(state, "general");
     const deletedId = "1409999999999999999";
+    // Two tracked channels, so the assertion below distinguishes the missing one from the healthy
+    // one. They must differ in channel_type: the uniqueness on
+    // (class_id, channel_type, resource_id) is NULLS NOT DISTINCT, so a second class-level 'general'
+    // row for the same class is a duplicate key rather than a second tracked channel.
     await trackChannel(generalId);
-    await trackChannel(deletedId);
+    await trackChannel(deletedId, "operations");
     await clearCalls();
 
     try {

--- a/tests/e2e/discord-check-bot-installation.test.tsx
+++ b/tests/e2e/discord-check-bot-installation.test.tsx
@@ -785,7 +785,12 @@ test.describe("discord-check-bot-installation edge function", () => {
       const body = data as CheckResponse;
       expect(body.installed).toBe(true);
       expect(body.missing_permissions).toContain("View Channels");
-      expect(body.can_create_invites).toBe(false);
+      // Null, not false. `false` is a claim -- "this server cannot enrol anybody" -- and it is the one
+      // claim a 403 on the listing cannot support, which is why the field is `boolean | null` and the
+      // function answers null whenever `channelsReadable` is false. Asserting false here contradicted
+      // the two assertions below it, which exist precisely to say that nothing about the channel layer
+      // is claimed when it could not be read.
+      expect(body.can_create_invites).toBeNull();
       // Nothing is claimed about individual channels: their overwrites were never readable.
       expect(body.channel_permission_problems).toEqual([]);
       // And nothing is claimed to be MISSING either. With no listing at all every tracked channel is

--- a/tests/e2e/discord-check-bot-installation.test.tsx
+++ b/tests/e2e/discord-check-bot-installation.test.tsx
@@ -357,11 +357,17 @@ test.describe("discord-check-bot-installation edge function", () => {
     expect(body.highest_class_role_position).toBe(5);
 
     // Traffic really reached the mock: the guild, the bot's own member object, and the role list.
+    //
+    // The member fetch names the bot by its snowflake. `@me` is not a GET route on Discord -- it is
+    // accepted only on the PATCH, and the GET answers 400 / 50035 "is not snowflake" -- so the id is
+    // read out of the mock's state rather than spelled here. The preceding `GET /users/@me` that
+    // resolves it is not asserted: it carries no guild id, so callsForThisClass filters it out.
+    const botUserId = (await getState()).bot.id;
     const calls = await callsForThisClass();
     expect(calls.map((c) => `${c.method} ${c.path}`)).toEqual(
       expect.arrayContaining([
         `GET /guilds/${GUILD_ID}`,
-        `GET /guilds/${GUILD_ID}/members/@me`,
+        `GET /guilds/${GUILD_ID}/members/${botUserId}`,
         `GET /guilds/${GUILD_ID}/roles`,
         // One request for the whole channel audit: GET /guilds/{id}/channels carries every channel's
         // permission_overwrites inline, so the per-channel answer costs no per-channel fan-out.

--- a/tests/mocks/discord/README.md
+++ b/tests/mocks/discord/README.md
@@ -42,27 +42,27 @@ point at the bare origin if that is ever more convenient.
 
 ## Routes
 
-| Method           | Path                                          | Notes                                                              |
-| ---------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| GET              | `/guilds/{guild}`                             | 404 / 10004 when absent or when the bot is not a member            |
-| GET              | `/guilds/{guild}/members/@me`                 | The bot's own member object, with its role ids                     |
-| GET              | `/guilds/{guild}/roles`                       | `permissions` is a decimal string, `position` a number             |
-| GET              | `/guilds/{guild}/members`                     | Full member list                                                   |
-| GET              | `/guilds/{guild}/members/{user}`              | 404 / 10007 when the user has not joined                           |
-| PUT              | `/guilds/{guild}/members/{user}`              | Add Guild Member. 204 empty when already a member, 201 when added  |
-| PUT / DELETE     | `/guilds/{guild}/members/{user}/roles/{role}` | Manage Roles plus the hierarchy rule, both 403 / 50013             |
-| POST             | `/guilds/{guild}/roles`                       | Created at position 1, as Discord does                             |
-| DELETE           | `/guilds/{guild}/roles/{role}`                | Hierarchy applies; the role is pulled from every member            |
-| GET              | `/guilds/{guild}/channels`                    | Needs View Channel, else 403 / 50001                               |
-| POST             | `/guilds/{guild}/channels`                    | Needs Manage Channels; 400 / 50035 without a name                  |
-| GET / DELETE     | `/channels/{channel}`                         | DELETE returns the deleted channel                                 |
-| POST             | `/channels/{channel}/messages`                | 400 / 50006 with neither content nor embeds                        |
-| GET / PATCH      | `/channels/{channel}/messages/{message}`      | 404 / 10008 when unknown, 403 / 50005 for another author's message |
-| POST             | `/channels/{channel}/invites`                 | Needs Create Invite; codes are deterministic (`mock0001`, ...)     |
-| GET / DELETE     | `/invites/{code}`                             | 404 / 10006 when already gone                                      |
-| GET              | `/users/@me`                                  | The bot user                                                       |
-| GET              | `/users/@me/guilds`                           | Cursor-paginated on `limit` and `after`, `bot_in_guild` only       |
-| GET / POST / PUT | `/applications/{application}/commands`        | POST creates or updates one, PUT overwrites the whole set          |
+| Method           | Path                                          | Notes                                                                                |
+| ---------------- | --------------------------------------------- | ------------------------------------------------------------------------------------ |
+| GET              | `/guilds/{guild}`                             | 404 / 10004 when absent or when the bot is not a member                              |
+| GET              | `/guilds/{guild}/members/@me`                 | 400 / 50035 `is not snowflake`, as Discord answers it                                |
+| GET              | `/guilds/{guild}/roles`                       | `permissions` is a decimal string, `position` a number                               |
+| GET              | `/guilds/{guild}/members`                     | Full member list                                                                     |
+| GET              | `/guilds/{guild}/members/{user}`              | 404 / 10007 when the user has not joined; the bot's own id returns its member object |
+| PUT              | `/guilds/{guild}/members/{user}`              | Add Guild Member. 204 empty when already a member, 201 when added                    |
+| PUT / DELETE     | `/guilds/{guild}/members/{user}/roles/{role}` | Manage Roles plus the hierarchy rule, both 403 / 50013                               |
+| POST             | `/guilds/{guild}/roles`                       | Created at position 1, as Discord does                                               |
+| DELETE           | `/guilds/{guild}/roles/{role}`                | Hierarchy applies; the role is pulled from every member                              |
+| GET              | `/guilds/{guild}/channels`                    | Needs View Channel, else 403 / 50001                                                 |
+| POST             | `/guilds/{guild}/channels`                    | Needs Manage Channels; 400 / 50035 without a name                                    |
+| GET / DELETE     | `/channels/{channel}`                         | DELETE returns the deleted channel                                                   |
+| POST             | `/channels/{channel}/messages`                | 400 / 50006 with neither content nor embeds                                          |
+| GET / PATCH      | `/channels/{channel}/messages/{message}`      | 404 / 10008 when unknown, 403 / 50005 for another author's message                   |
+| POST             | `/channels/{channel}/invites`                 | Needs Create Invite; codes are deterministic (`mock0001`, ...)                       |
+| GET / DELETE     | `/invites/{code}`                             | 404 / 10006 when already gone                                                        |
+| GET              | `/users/@me`                                  | The bot user                                                                         |
+| GET              | `/users/@me/guilds`                           | Cursor-paginated on `limit` and `after`, `bot_in_guild` only                         |
+| GET / POST / PUT | `/applications/{application}/commands`        | POST creates or updates one, PUT overwrites the whole set                            |
 
 Anything else answers `404 {"message":"404: Not Found","code":0}`, and a known path with the wrong
 method answers 405, both the way Discord does. Every request, including those two, lands in the call

--- a/tests/mocks/discord/server.ts
+++ b/tests/mocks/discord/server.ts
@@ -401,10 +401,23 @@ function handleMemberRoutes(method: string, segments: string[], body: unknown, g
 
   if (segments.length === 4) {
     if (userId === "@me") {
+      // Discord accepts `@me` here only on the PATCH (Modify Current Member). The GET parses this
+      // segment as a snowflake and rejects `@me` with 400 / 50035, so answering it with the bot's
+      // member object -- which this mock used to do, GET-only -- inverted the real API exactly.
+      // discord-check-bot-installation shipped a `GET .../members/@me` that passed every E2E run
+      // against this mock and 400'd against discord.com on the first real install.
+      //
+      // The PATCH stays unimplemented -- nothing here calls it -- so it keeps the 405 the other
+      // unhandled methods get rather than gaining a fake success.
       if (method !== "GET") return methodNotAllowed();
-      return { status: 200, body: botMember(guild) };
+      return errorReply(400, 50035, "Invalid Form Body", {
+        errors: { user_id: { _errors: [{ code: "NUMBER_TYPE_COERCE", message: 'Value "@me" is not snowflake.' }] } }
+      });
     }
     if (method === "GET") {
+      // The bot is a member like any other and Discord returns it by its own snowflake, which is how
+      // the check function reads its roles now that `@me` is not an option.
+      if (userId === state.bot.id) return { status: 200, body: botMember(guild) };
       const member = guild.members[userId];
       if (!member) return errorReply(404, 10007);
       return { status: 200, body: member };

--- a/tests/mocks/discord/state.ts
+++ b/tests/mocks/discord/state.ts
@@ -182,8 +182,15 @@ export type MockState = {
  * regression stays covered by every test that touches the mock.
  */
 export const DEFAULT_GUILD_ID = "1142900000000000000";
+/**
+ * Deliberately the same snowflake, because Discord gives a bot application's user account the
+ * application's own id. Modelling them as two different values let the mock accept a bot id that
+ * real Discord would never issue, which is the same class of divergence that let a `members/@me`
+ * GET pass CI. Both names are kept: they are separate slots in the payloads below, and code that
+ * reads one should not have to know it can substitute the other.
+ */
 export const DEFAULT_BOT_USER_ID = "1300000000000000001";
-export const DEFAULT_APPLICATION_ID = "1300000000000000002";
+export const DEFAULT_APPLICATION_ID = DEFAULT_BOT_USER_ID;
 export const BOT_ROLE_ID = "1200000000000000001";
 export const STUDENT_ROLE_ID = "1200000000000000002";
 export const GRADER_ROLE_ID = "1200000000000000003";


### PR DESCRIPTION
Follow-up to #936, from manual testing on staging.

## The bug

`discord-check-bot-installation` asked Discord for `GET /guilds/{id}/members/@me`. That is not a route — Discord accepts `@me` there only on the **PATCH** (Modify Current Member); the GET parses the last segment as a snowflake. Verified against discord.com with the staging bot token:

```
GET /guilds/689834147404840996/members/@me
  → 400 {"message":"Invalid Form Body","code":50035,
         "errors":{"user_id":{"_errors":[{"code":"NUMBER_TYPE_COERCE",
                    "message":"Value \"@me\" is not snowflake."}]}}}

GET /guilds/689834147404840996/members/1441599753329578015
  → 200 {...,"roles":["1537277676216127491"],...}
```

The guild, roles, and channels fetches all returned 200 — only the member fetch failed. Because it sits in a `Promise.all` whose failure branch raises unconditionally, the whole check 502'd. On staging that meant: the check returned 200 (`notInstalled`) while a guild was unclaimed, then began failing the moment the bot was actually installed and the guild resolved. Everything else in #936 — install, claim, role/channel provisioning, invites, membership recording — worked.

The bot id is resolved from `/users/@me` rather than assumed from `DISCORD_APPLICATION_ID`. The two are equal for a bot application, but that is an invariant about Discord, not about a given deployment's config, and a wrong or missing env var would resurface as the same opaque failure this function exists to diagnose. Memoized per isolate.

## Why CI missed it

The mock encoded the same wrong assumption, GET-only — the exact inverse of the real API:

```ts
if (userId === "@me") {
  if (method !== "GET") return methodNotAllowed();
  return { status: 200, body: botMember(guild) };
}
```

It now returns Discord's real 400/50035 body and serves the bot by its own snowflake, so the old call fails the suite. `DEFAULT_BOT_USER_ID` and `DEFAULT_APPLICATION_ID` are also collapsed to one value: Discord gives a bot application's user account the application's own id, and modelling them as different let the mock accept an id Discord would never issue.

## Also

- Discord's error `code` and body were read off every failed response and then dropped when the error was raised — which is why the staging logs could only say "(HTTP 400)" and nothing about which field was rejected. They now reach Sentry as context.
- Student invite panel: drops "roles will be synced automatically within an hour" and the sync button. Roles are assigned off the same queued job that mints the invite (~a minute), so the hour was a worst case students almost never see, and the button's remaining failure cases — bot missing Manage Roles, or its role below the course roles — are ones a student cannot fix anyway. The staff-facing `SyncRolesPanel` is unchanged.
- User drawer now shows the linked Discord username next to the GitHub handle, so a student with no roles yet can tell whether they linked at all. Plain text — Discord has no public profile URL.

## Verification

- `getBotUserId` + member route driven against the mock: `/users/@me` → 200, `members/@me` → 400/50035, `members/<bot id>` → 200 with roles.
- `deno test` on the Discord shared units: 53 passed.
- Deno typecheck and eslint/prettier clean on all changed files (the repo's pre-existing `tsc` and `typecheck:functions` failures are untouched and unrelated).
- Not yet exercised end-to-end against real Discord — that needs this deployed to staging.

## Out of scope, found while testing

Two pre-existing staging problems, neither from #936, both worth separate issues:

1. **Sentry is dead in the browser on staging.** `NEXT_PUBLIC_BUGSINK_HOST` has no scheme, so `app/api/tunnel/route.ts` builds an unparseable URL and every envelope fails with `Failed to parse URL from sentry-ptg.work.ripley.cloud/api/3/envelope/`. Config, not code.
2. **`enrollments-add` 500s for any new user.** GoTrue → `smtp.postmarkapp.com:2525` is DNS-hijacked to the in-cluster `pawtograder-smtp-relay`, which forwards to `10.201.13.218:1588` — that upstream accepts TCP, sends no SMTP banner, and closes, so GoTrue reports `EOF`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord usernames now appear in user settings when available.
  * Students can request Discord role synchronization directly from the course interface.
  * Role requests are refreshed when invitation panels become visible or regain focus.
* **Bug Fixes**
  * Added throttling and daily limits to prevent excessive role-sync requests.
  * Clarified instructor preview behavior for Discord invitations.
  * Improved Discord installation checks and error handling.
  * Updated bot identification for more reliable membership checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->