### PR TITLE
fix(cache): invalidate the browser Router Cache after writes, and the tags we actually read

### DIFF
--- a/app/admin/classes/ClassManagementTable.tsx
+++ b/app/admin/classes/ClassManagementTable.tsx
@@ -4,6 +4,7 @@ import { TimeZoneAwareDate } from "@/components/TimeZoneAwareDate";
 import { Button } from "@/components/ui/button";
 import { MenuContent, MenuItem, MenuRoot, MenuSeparator, MenuTrigger } from "@/components/ui/menu";
 import { toaster } from "@/components/ui/toaster";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import { AdminGetClassesResponse } from "@/utils/supabase/DatabaseTypes";
 import { Badge, Box, Card, Flex, HStack, Table, Text, VStack } from "@chakra-ui/react";
@@ -24,6 +25,11 @@ export default function ClassManagementTable({ classes: initialClasses }: ClassM
   const [isDeleting, setIsDeleting] = useState<number | null>(null);
 
   const supabase = createClient();
+  // `classes` is seeded from a server component and kept optimistically in local state, so the
+  // write shows here immediately. The refresh is for the *next* visit: without it, navigating
+  // away and back within `staleTimes.dynamic` remounts this table from the browser's cached
+  // pre-write payload and the archived class reappears.
+  const revalidateServerCaches = useRevalidateServerCaches();
 
   const handleDelete = async (classId: number) => {
     setIsDeleting(classId);
@@ -42,6 +48,8 @@ export default function ClassManagementTable({ classes: initialClasses }: ClassM
         description: "The class has been archived successfully.",
         type: "success"
       });
+
+      await revalidateServerCaches();
     } catch (error) {
       toaster.create({
         title: "Error",
@@ -55,6 +63,7 @@ export default function ClassManagementTable({ classes: initialClasses }: ClassM
 
   const handleClassUpdated = (updatedClass: Class) => {
     setClasses(classes.map((c) => (c.id === updatedClass.id ? updatedClass : c)));
+    void revalidateServerCaches();
   };
 
   return (

--- a/app/admin/github-orgs/[org]/page.tsx
+++ b/app/admin/github-orgs/[org]/page.tsx
@@ -6,6 +6,7 @@ import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Field } from "@/components/ui/field";
 import { toaster } from "@/components/ui/toaster";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import { Badge, Box, Card, Flex, Heading, Input, Spinner, Table, Tabs, Text, VStack } from "@chakra-ui/react";
 import Link from "next/link";
@@ -36,6 +37,7 @@ export default function GitHubOrgDetailPage() {
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const revalidateServerCaches = useRevalidateServerCaches();
   const [handout, setHandout] = useState("");
   const [solution, setSolution] = useState("");
   // The persisted org defaults (distinct from the live inputs above). The file editor is gated
@@ -86,12 +88,15 @@ export default function GitHubOrgDetailPage() {
       if (error) throw error;
       toaster.success({ title: "Org defaults saved" });
       await load();
+      // /admin/github-orgs lists these defaults from a server component; drop the browser's
+      // cached render of it so returning via the back link does not show the old values.
+      await revalidateServerCaches();
     } catch (err) {
       toaster.error({ title: "Failed to save org defaults", description: (err as Error).message });
     } finally {
       setSaving(false);
     }
-  }, [orgName, handout, solution, load]);
+  }, [orgName, handout, solution, load, revalidateServerCaches]);
 
   // A course in this org gives the edge function a valid auth/ownership context for editing the
   // org's template repos. (Writes are restricted to the course's own org.) Prefer a non-archived

--- a/app/admin/import/page.tsx
+++ b/app/admin/import/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toaster } from "@/components/ui/toaster";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import {
   VStack,
@@ -77,6 +78,7 @@ export default function CourseImportPage() {
   const [existingClass, setExistingClass] = useState<ExistingClass | null>(null);
   const [existingSections, setExistingSections] = useState<ExistingSection[]>([]);
   const [importSummary, setImportSummary] = useState<ImportSummary | null>(null);
+  const revalidateServerCaches = useRevalidateServerCaches();
   const [existingClassesForTerm, setExistingClassesForTerm] = useState<
     Array<{ id: number; name: string | null; course_title: string | null }>
   >([]);
@@ -729,6 +731,11 @@ export default function CourseImportPage() {
       // Set the summary for display
       setImportSummary(summary);
 
+      // /admin/classes and /admin render their lists on the server. Without this the class this
+      // import just created is missing there for `staleTimes.dynamic` (30s), which is exactly
+      // how a bulk operator ends up importing the same course twice (#937).
+      void revalidateServerCaches();
+
       toaster.create({
         title: selectedExistingClassId ? "Class Synced Successfully" : "Class Created Successfully",
         description: `${selectedExistingClassId ? "Synced" : "Created"} class with ${summary.sectionsCreated} sections and ${summary.invitationsSent} invitations sent`,
@@ -764,7 +771,8 @@ export default function CourseImportPage() {
     selectedGithubOrg,
     supabase,
     processBatchedInvitations,
-    semester
+    semester,
+    revalidateServerCaches
   ]);
 
   const toggleSection = (crn: number) => {

--- a/app/api/cache/revalidate-tags/route.ts
+++ b/app/api/cache/revalidate-tags/route.ts
@@ -1,4 +1,4 @@
-import { courseDerivedDataTags } from "@/lib/next-cache-tags";
+import { CLASS_SCOPED_CACHED_TABLES, courseSsrTags, type ClassScopedCachedTable } from "@/lib/next-cache-tags";
 import { createClient } from "@/utils/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    let body: { classId?: number };
+    let body: { classId?: number; tables?: unknown };
     try {
       body = await request.json();
     } catch {
@@ -35,30 +35,43 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "classId must be a number" }, { status: 400 });
     }
 
-    const { data: roleRow, error: roleError } = await supabase
+    // Only revalidate the tables the caller actually wrote. An unknown or absent list falls
+    // back to the whole class-scoped set: correct, but it evicts bundles the write did not
+    // touch, so callers should name their tables.
+    const requestedTables = Array.isArray(body.tables)
+      ? body.tables.filter((t): t is ClassScopedCachedTable =>
+          (CLASS_SCOPED_CACHED_TABLES as readonly string[]).includes(t as string)
+        )
+      : undefined;
+    const tables = requestedTables?.length ? requestedTables : CLASS_SCOPED_CACHED_TABLES;
+
+    // A user may hold more than one non-disabled role in a class — the unique index is on
+    // (user_id, role, class_id), not (user_id, class_id). `.maybeSingle()` 406s on >1 row and
+    // would 500 a legitimate student+grader, so read every row and check for any staff role.
+    // Same hazard `getUserRolesForCourse` works around in lib/ssrUtils.ts.
+    const { data: roleRows, error: roleError } = await supabase
       .from("user_roles")
       .select("role")
       .eq("class_id", classId)
       .eq("user_id", user.id)
-      .eq("disabled", false)
-      .maybeSingle();
+      .eq("disabled", false);
 
     if (roleError) {
       Sentry.captureException(roleError);
       return NextResponse.json({ error: "Unable to verify course role" }, { status: 500 });
     }
 
-    const r = roleRow?.role;
-    const allowed = r === "instructor" || r === "grader" || r === "admin";
+    const allowed = (roleRows ?? []).some(({ role }) => role === "instructor" || role === "grader" || role === "admin");
     if (!allowed) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    for (const tag of courseDerivedDataTags(classId)) {
+    const tags = courseSsrTags(classId, tables);
+    for (const tag of tags) {
       revalidateTag(tag);
     }
 
-    return NextResponse.json({ success: true, revalidated: courseDerivedDataTags(classId).length });
+    return NextResponse.json({ success: true, revalidated: tags.length });
   } catch (error) {
     Sentry.captureException(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/course/[course_id]/assignments/[assignment_id]/layout.tsx
+++ b/app/course/[course_id]/assignments/[assignment_id]/layout.tsx
@@ -1,5 +1,6 @@
 import { AssignmentProvider } from "@/hooks/useAssignment";
 import { createClientWithCaching, fetchAssignmentControllerData, getEffectiveCourseIdentity } from "@/lib/ssrUtils";
+import { classScopedTableTags } from "@/lib/next-cache-tags";
 import { TZDate } from "@date-fns/tz";
 import { isAfter } from "date-fns";
 import { headers } from "next/headers";
@@ -35,7 +36,14 @@ export default async function AssignmentLayout({
     // Send staff masquerading as an enrolled student back to the course rather than the
     // all-courses dashboard, so the view-as banner (and its exit button) stays in reach.
     const blockedDestination = role.isViewingAs ? `/course/${course_id}` : "/";
-    const client = await createClientWithCaching({ tags: ["assignment-release-date"] });
+    // Tag with the class-scoped strings the `assignments` invalidation trigger actually emits.
+    // The former literal `"assignment-release-date"` was emitted by nothing, so this gate —
+    // which decides whether an enrolled student may open the assignment at all — held a stale
+    // release_date for the full 1-hour TTL: publishing kept students redirected out, and
+    // un-publishing kept it reachable.
+    const client = await createClientWithCaching({
+      tags: classScopedTableTags("assignments", Number(course_id))
+    });
     const { data: assignment } = await client
       .from("assignments")
       .select("release_date, classes(time_zone)")

--- a/app/course/[course_id]/dynamicCourseNav.tsx
+++ b/app/course/[course_id]/dynamicCourseNav.tsx
@@ -546,7 +546,12 @@ export default function DynamicCourseNav() {
                         href={link.target || "#"}
                         aria-current={pathname.startsWith(link.target || "#") ? "page" : undefined}
                       >
-                        <Flex align="center" role="group">
+                        {/* No role="group" here (WCAG 2.4.4 / 4.1.2): `group` does not support
+                            accessible-name-from-content, so wrapping the label in it left every
+                            desktop nav link with an EMPTY accessible name — screen readers
+                            announced them as bare "link". Nothing styles off it (no _groupHover
+                            in this file), so it was purely vestigial. */}
+                        <Flex align="center">
                           <HStack>
                             {React.createElement(link.icon)}
                             {link.name}

--- a/app/course/[course_id]/grade/assignments/[assignment_id]/layout.tsx
+++ b/app/course/[course_id]/grade/assignments/[assignment_id]/layout.tsx
@@ -1,11 +1,14 @@
 import { AssignmentProvider } from "@/hooks/useAssignment";
 import { createClientWithCaching, getUserRolesForCourse } from "@/lib/ssrUtils";
+import { classScopedTableTags } from "@/lib/next-cache-tags";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-export async function generateMetadata({ params }: { params: Promise<{ assignment_id: string }> }) {
-  const { assignment_id } = await params;
-  const client = await createClientWithCaching({ tags: ["assignment_metadata"] });
+export async function generateMetadata({ params }: { params: Promise<{ course_id: string; assignment_id: string }> }) {
+  const { course_id, assignment_id } = await params;
+  const client = await createClientWithCaching({
+    tags: classScopedTableTags("assignments", Number(course_id))
+  });
   const { data: assignment } = await client
     .from("assignments")
     .select("title")
@@ -39,7 +42,7 @@ export default async function GradeAssignmentLayout({
     redirect(`/course/${courseId}`);
   }
 
-  const client = await createClientWithCaching({ tags: ["assignment_metadata"] });
+  const client = await createClientWithCaching({ tags: classScopedTableTags("assignments", courseId) });
   const { data: assignment } = await client
     .from("assignments")
     .select("id")

--- a/app/course/[course_id]/manage/assignments/ManageAssignmentsTable.tsx
+++ b/app/course/[course_id]/manage/assignments/ManageAssignmentsTable.tsx
@@ -11,9 +11,10 @@ import { Alert, Table, Text } from "@chakra-ui/react";
 
 export async function ManageAssignmentsTable({ courseId }: { courseId: number }) {
   const supabase = await createClient();
-  // Read features on the request-scoped client rather than through the cached `getCourse` loader:
-  // that loader caches for an hour under a `course:<id>` tag that nothing in the codebase emits, so
-  // a flag toggle would not reach this table.
+  // Read features on the request-scoped client rather than through the cached `getCourse` loader.
+  // `course:<id>` is now emitted by the `classes` invalidation trigger (it was emitted by nothing
+  // at all before #937), but that delivery is best-effort pg_net with no retry, and a flag toggle
+  // showing up an hour late here is not worth the saved query.
   const [{ data: assignmentRows, error: overviewError }, { data: courseRow, error: courseError }] = await Promise.all([
     fetchManageAssignmentsOverview(supabase, courseId),
     supabase.from("classes").select("features").eq("id", courseId).single()

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/deleteAssignmentButton.tsx
@@ -2,9 +2,9 @@
 import { PopConfirm } from "@/components/ui/popconfirm";
 import { toaster } from "@/components/ui/toaster";
 import { assignmentDelete, EdgeFunctionError } from "@/lib/edgeFunctions";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import { Box, Button, Dialog, HStack, Icon, Portal, Text, VStack } from "@chakra-ui/react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { FaTrash } from "react-icons/fa";
 
@@ -16,7 +16,7 @@ interface DeleteAssignmentButtonProps {
 export default function DeleteAssignmentButton({ assignmentId, courseId }: DeleteAssignmentButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const router = useRouter();
+  const revalidateServerCaches = useRevalidateServerCaches(courseId);
 
   const handleDeleteAssignment = async () => {
     try {
@@ -37,8 +37,13 @@ export default function DeleteAssignmentButton({ assignmentId, courseId }: Delet
         duration: 10000
       });
 
-      // Redirect to assignments list
-      router.push(`/course/${courseId}/manage/assignments`);
+      // Navigate through the hook so the browser's copy of the assignments list is dropped.
+      // Without it the deleted assignment stays listed for up to `staleTimes.dynamic` (30s),
+      // and clicking it bounces the user straight back out (#937).
+      await revalidateServerCaches({
+        tables: ["assignments"],
+        navigateTo: `/course/${courseId}/manage/assignments`
+      });
     } catch (error) {
       console.error("Error deleting assignment:", error);
 

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/edit/page.tsx
@@ -2,7 +2,7 @@
 
 import { toaster } from "@/components/ui/toaster";
 import { assignmentSyncAutograderWorkflow, githubRepoConfigureWebhook } from "@/lib/edgeFunctions";
-import { revalidateCourseDerivedCachesClient } from "@/lib/revalidateCourseDerivedCachesClient";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import { Assignment, SelfReviewSettings } from "@/utils/supabase/DatabaseTypes";
 import { Box, Heading } from "@chakra-ui/react";
@@ -55,6 +55,8 @@ export default function EditAssignment() {
     selfReviewSetting?.data?.enabled,
     selfReviewSetting?.data?.release_at
   ]);
+
+  const revalidateServerCaches = useRevalidateServerCaches(Number.parseInt(course_id as string, 10));
 
   const onFinish = useCallback(
     async (values: FieldValues) => {
@@ -314,7 +316,10 @@ export default function EditAssignment() {
           }
           throw saveError;
         }
-        await revalidateCourseDerivedCachesClient(Number.parseInt(course_id as string, 10));
+        // Also drops the Router Cache: the edited title/due date is rendered by the server
+        // components behind the assignments list and the manage-assignment header, so without
+        // this a back-nav within `staleTimes.dynamic` replays the pre-edit values (#937).
+        await revalidateServerCaches({ tables: ["assignments"] });
         // The assignment is already saved at this point. Re-pointing the handout repo is a follow-up
         // that reaches GitHub, so it can fail on its own (e.g. missing app credentials, a repo that
         // no longer exists, GitHub being down) long after the edit succeeded. Reporting that as
@@ -611,7 +616,16 @@ export default function EditAssignment() {
         });
       }
     },
-    [form.refineCore, assignment_id, course_id, selfReviewSettingId, update, updateAsync, queryData?.has_autograder]
+    [
+      form.refineCore,
+      assignment_id,
+      course_id,
+      selfReviewSettingId,
+      update,
+      updateAsync,
+      queryData?.has_autograder,
+      revalidateServerCaches
+    ]
   );
 
   if (form.refineCore.query?.error) {

--- a/app/course/[course_id]/manage/assignments/[assignment_id]/layout.tsx
+++ b/app/course/[course_id]/manage/assignments/[assignment_id]/layout.tsx
@@ -1,12 +1,15 @@
 import { AssignmentProvider } from "@/hooks/useAssignment";
 import { createClientWithCaching, getUserRolesForCourse } from "@/lib/ssrUtils";
+import { classScopedTableTags } from "@/lib/next-cache-tags";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { ManageAssignmentNav } from "./ManageAssignmentNav";
 
-export async function generateMetadata({ params }: { params: Promise<{ assignment_id: string }> }) {
-  const { assignment_id } = await params;
-  const client = await createClientWithCaching({ tags: ["assignment_metadata"] });
+export async function generateMetadata({ params }: { params: Promise<{ course_id: string; assignment_id: string }> }) {
+  const { course_id, assignment_id } = await params;
+  const client = await createClientWithCaching({
+    tags: classScopedTableTags("assignments", Number(course_id))
+  });
   const { data: assignment } = await client
     .from("assignments")
     .select("title")
@@ -51,7 +54,7 @@ export default async function ManageAssignmentLayout({
   const initialData = undefined;
 
   // Fetch assignment metadata for the title
-  const client = await createClientWithCaching({ tags: ["assignment_metadata"] });
+  const client = await createClientWithCaching({ tags: classScopedTableTags("assignments", courseId) });
   const { data: assignment } = await client
     .from("assignments")
     .select("title")

--- a/app/course/[course_id]/manage/assignments/new/page.tsx
+++ b/app/course/[course_id]/manage/assignments/new/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 import { toaster } from "@/components/ui/toaster";
 import { assignmentCreateHandoutRepo, assignmentCreateSolutionRepo } from "@/lib/edgeFunctions";
-import { revalidateCourseDerivedCachesClient } from "@/lib/revalidateCourseDerivedCachesClient";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { createClient } from "@/utils/supabase/client";
 import { Assignment } from "@/utils/supabase/DatabaseTypes";
 import { useCreate } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { useCallback } from "react";
 import type { FieldValues } from "react-hook-form";
 import CreateAssignment from "./form";
@@ -32,7 +32,7 @@ export default function NewAssignmentPage() {
       protect_required_reviewers: 0
     }
   });
-  const router = useRouter();
+  const revalidateServerCaches = useRevalidateServerCaches(Number.parseInt(course_id as string, 10));
   const { getValues } = form;
 
   const { mutateAsync } = useCreate();
@@ -279,8 +279,13 @@ export default function NewAssignmentPage() {
               type: "success"
             });
 
-            void revalidateCourseDerivedCachesClient(Number.parseInt(course_id as string, 10));
-            router.push(`/course/${course_id}/manage/assignments/${data.id}/autograder`);
+            // Awaited, and the navigation goes through the hook: this also drops the browser's
+            // Router Cache, which still holds the pre-insert render of the assignments list the
+            // user came from (#937). `revalidateTag` alone never reached that copy.
+            await revalidateServerCaches({
+              tables: ["assignments"],
+              navigateTo: `/course/${course_id}/manage/assignments/${data.id}/autograder`
+            });
           }
         } catch (error) {
           // Clear the timer and dismiss the loading toast
@@ -294,7 +299,7 @@ export default function NewAssignmentPage() {
       }
       await create();
     },
-    [course_id, getValues, router, mutateAsync]
+    [course_id, getValues, mutateAsync, revalidateServerCaches]
   );
   return (
     <Box p={4}>

--- a/app/course/[course_id]/manage/surveys/SurveysTable.tsx
+++ b/app/course/[course_id]/manage/surveys/SurveysTable.tsx
@@ -7,6 +7,7 @@ import Link from "@/components/ui/link";
 import { MenuContent, MenuItem, MenuRoot, MenuTrigger } from "@/components/ui/menu";
 import { toaster } from "@/components/ui/toaster";
 import { useIsGrader, useIsInstructor } from "@/hooks/useClassProfiles";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { useAssignments, useCourseController } from "@/hooks/useCourseController";
 import { useTrackEvent } from "@/hooks/useTrackEvent";
 import type { Survey, SurveyWithCounts } from "@/types/survey";
@@ -28,6 +29,10 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
   const isInstructor = useIsInstructor();
   const isGrader = useIsGrader();
   const assignments = useAssignments();
+  // This table renders the `surveys` prop, which `ManageSurveysBody` fetches on the server —
+  // there is no subscription here, so a status write is invisible until the server component
+  // re-runs. `router.refresh()` (inside this hook) is what re-runs it.
+  const revalidateServerCaches = useRevalidateServerCaches(Number(courseId));
 
   // Filter options for instructor view
   const filterOptions = useMemo(
@@ -154,11 +159,11 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
           validationErrors = `Invalid JSON configuration: ${error instanceof Error ? error.message : "Unknown error"}`;
         }
 
-        // Update survey status using TableController - auto-refreshes UI via realtime
         await controller.surveys.update(survey.id, {
           status: validationErrors ? "draft" : "published",
           validation_errors: validationErrors
         });
+        await revalidateServerCaches({ tables: ["surveys"] });
 
         // Dismiss loading toast and show success
         toaster.dismiss(loadingToast);
@@ -193,7 +198,7 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
         });
       }
     },
-    [courseId, trackEvent, controller]
+    [courseId, trackEvent, controller, revalidateServerCaches]
   );
 
   const handleClose = useCallback(
@@ -206,10 +211,10 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
       });
 
       try {
-        // Update survey status using TableController - auto-refreshes UI via realtime
         await controller.surveys.update(survey.id, {
           status: "closed"
         });
+        await revalidateServerCaches({ tables: ["surveys"] });
 
         // Dismiss loading toast and show success
         toaster.dismiss(loadingToast);
@@ -234,7 +239,7 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
         });
       }
     },
-    [courseId, trackEvent, controller]
+    [courseId, trackEvent, controller, revalidateServerCaches]
   );
 
   const handleDelete = useCallback(
@@ -266,8 +271,8 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
       });
 
       try {
-        // Soft delete survey and responses atomically via RPC
-        // The RPC sets deleted_at which triggers realtime broadcast and auto-refreshes UI
+        // Soft delete survey and responses atomically via RPC. The RPC sets deleted_at; the
+        // rendered list comes from the server, so it has to be re-fetched to drop the row.
         const { error } = await controller.client.rpc("soft_delete_survey", {
           p_survey_id: survey.id,
           p_survey_logical_id: survey.survey_id
@@ -276,6 +281,7 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
         if (error) {
           throw new Error(`Failed to soft delete survey: ${error.message}`);
         }
+        await revalidateServerCaches({ tables: ["surveys"] });
 
         // Dismiss loading toast and show success
         toaster.dismiss(loadingToast);
@@ -303,7 +309,7 @@ export default function SurveysTable({ surveys, courseId }: SurveysTableProps) {
         });
       }
     },
-    [courseId, trackEvent, controller]
+    [courseId, trackEvent, controller, revalidateServerCaches]
   );
 
   return (

--- a/app/course/[course_id]/manage/surveys/[survey_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { toaster } from "@/components/ui/toaster";
 import { useTrackEvent } from "@/hooks/useTrackEvent";
 import { createClient } from "@/utils/supabase/client";
 import { useForm } from "@refinedev/react-hook-form";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState, useRef } from "react";
 import SurveyForm from "../../new/form";
@@ -46,6 +47,8 @@ const getParam = (value: string | string[] | undefined, name: string): string =>
 export default function EditSurveyPage() {
   const { course_id, survey_id } = useParams();
   const router = useRouter();
+  // The surveys list this page returns to is server-rendered; see useRevalidateServerCaches.
+  const revalidateServerCaches = useRevalidateServerCaches(Number(course_id));
   const trackEvent = useTrackEvent();
   const { private_profile_id, role } = useClassProfiles();
   const [isLoading, setIsLoading] = useState(true);
@@ -292,7 +295,7 @@ export default function EditSurveyPage() {
             });
 
             // Redirect to manage surveys page
-            router.push(`/course/${course_id}/manage/surveys`);
+            await revalidateServerCaches({ tables: ["surveys"], navigateTo: `/course/${course_id}/manage/surveys` });
           }
           // If shouldRedirect is false, we don't show any toast (used for preview auto-save)
         } catch (error) {
@@ -301,7 +304,7 @@ export default function EditSurveyPage() {
       }
       await updateDraft();
     },
-    [course_id, trackEvent, router, rawSurveyId, convertDueDateToISO]
+    [course_id, trackEvent, rawSurveyId, convertDueDateToISO, revalidateServerCaches]
   );
 
   const onSubmit = useCallback(
@@ -425,7 +428,7 @@ export default function EditSurveyPage() {
                 description: "There was an issue with the requested update. Your survey was saved as a draft.",
                 type: "warning"
               });
-              router.push(`/course/${course_id}/manage/surveys`);
+              await revalidateServerCaches({ tables: ["surveys"], navigateTo: `/course/${course_id}/manage/surveys` });
             } catch (fallbackError) {
               throw new Error(`Failed to update survey: ${error?.message || fallbackError || "Unknown error"}`);
             }
@@ -491,7 +494,7 @@ export default function EditSurveyPage() {
           }
 
           // Redirect to manage surveys page
-          router.push(`/course/${course_id}/manage/surveys`);
+          await revalidateServerCaches({ tables: ["surveys"], navigateTo: `/course/${course_id}/manage/surveys` });
         } catch (error) {
           // Dismiss loading toast and show error
           toaster.dismiss(loadingToast);
@@ -503,7 +506,7 @@ export default function EditSurveyPage() {
       }
       await update();
     },
-    [course_id, router, trackEvent, rawSurveyId, convertDueDateToISO]
+    [course_id, trackEvent, rawSurveyId, convertDueDateToISO, revalidateServerCaches]
   );
 
   if (isLoading) {

--- a/app/course/[course_id]/manage/surveys/new/page.tsx
+++ b/app/course/[course_id]/manage/surveys/new/page.tsx
@@ -5,6 +5,7 @@ import { toaster } from "@/components/ui/toaster";
 import { useTrackEvent } from "@/hooks/useTrackEvent";
 import { createClient } from "@/utils/supabase/client";
 import { useForm } from "@refinedev/react-hook-form";
+import { useRevalidateServerCaches } from "@/hooks/useRevalidateServerCaches";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useClassProfiles } from "@/hooks/useClassProfiles";
 import SurveyForm from "./form";
@@ -37,6 +38,7 @@ type SurveyStatus = Tables<"surveys">["status"]; // "draft" | "published" | "clo
 export default function NewSurveyPage() {
   const { course_id } = useParams();
   const router = useRouter();
+  const revalidateServerCaches = useRevalidateServerCaches(Number(course_id));
   const searchParams = useSearchParams();
   const trackEvent = useTrackEvent();
 
@@ -415,14 +417,23 @@ export default function NewSurveyPage() {
         }
       }
 
-      // Redirect if requested
+      // Redirect if requested. The surveys list is server-rendered, so the browser's cached
+      // copy of it has to be dropped or the new survey is missing on arrival (#937).
       if (shouldRedirect) {
-        router.push(`/course/${course_id}/manage/surveys`);
+        await revalidateServerCaches({ tables: ["surveys"], navigateTo: `/course/${course_id}/manage/surveys` });
       }
 
       return { data, error };
     },
-    [course_id, private_profile_id, router, trackEvent, isReturningFromPreview, convertDueDateToISO, currentSurveyId]
+    [
+      course_id,
+      private_profile_id,
+      trackEvent,
+      isReturningFromPreview,
+      convertDueDateToISO,
+      currentSurveyId,
+      revalidateServerCaches
+    ]
   );
 
   // -------- SAVE DRAFT ONLY (WRAPPER) --------

--- a/components/admin/EnterCourseAsInstructor.tsx
+++ b/components/admin/EnterCourseAsInstructor.tsx
@@ -17,7 +17,12 @@ async function enterCourse(classId: number, router: ReturnType<typeof useRouter>
     // Mark this as an acting-as entry so the manage-area banner shows for impersonation only,
     // not for an admin who is a genuine instructor of the course.
     setActingAsAdminCookie(classId);
+    // The RPC just changed *this viewer's* role in the course, and the course layout gates on
+    // it, so the browser's cached payload for that route has to go. The refresh has to come
+    // *after* the push: dispatching a navigation discards whatever action is pending, so
+    // refresh-then-push would drop the refresh (see hooks/useRevalidateServerCaches.ts).
     router.push(`/course/${classId}/manage/assignments`);
+    router.refresh();
   } catch (err) {
     const description = err instanceof Error ? err.message : "Unknown error";
     toaster.error({ title: "Failed to enter course", description });

--- a/hooks/useRevalidateServerCaches.ts
+++ b/hooks/useRevalidateServerCaches.ts
@@ -26,7 +26,9 @@ import type { ClassScopedCachedTable } from "@/lib/next-cache-tags";
  *
  *  - The tag revalidation is awaited *before* `router.refresh()`. Otherwise the refetch that
  *    `refresh()` kicks off can be served from a server cache entry that is evicted a moment
- *    later, and the user sees pre-write data anyway.
+ *    later, and the user sees pre-write data anyway. That await is bounded
+ *    (`REVALIDATE_TAGS_TIMEOUT_MS`) so a slow or unreachable endpoint cannot strand the user on
+ *    the form they just submitted — the refresh and any navigation still happen.
  *  - When the caller is also navigating, pass `navigateTo` instead of calling `router.push()`
  *    afterwards. `router.refresh()` followed by `router.push()` silently does nothing:
  *    dispatching a navigation marks the pending action as discarded so its state is never

--- a/hooks/useRevalidateServerCaches.ts
+++ b/hooks/useRevalidateServerCaches.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { revalidateCourseDerivedCachesClient } from "@/lib/revalidateCourseDerivedCachesClient";
+import type { ClassScopedCachedTable } from "@/lib/next-cache-tags";
+
+/**
+ * Run after a client-side write whose result is rendered by a Server Component.
+ *
+ * Three caches sit between a write and what the user sees, and `revalidateTag()` only reaches
+ * one of them:
+ *
+ *  1. The server fetch cache — `createClientWithCaching()` in `lib/ssrUtils.ts`, keyed by tag
+ *     with a 1-hour default TTL. Postgres triggers invalidate it; the
+ *     `/api/cache/revalidate-tags` POST below covers writes that race or bypass them.
+ *  2. The **client Router Cache** — the browser's copy of the already-rendered RSC payload for
+ *     every segment visited this session, held for `experimental.staleTimes.dynamic` (30s, see
+ *     `next.config.ts`). Nothing on the server can reach it: `revalidateTag()` evicts the
+ *     server's data, not the payload the browser already has. `router.refresh()` is the only
+ *     client API that drops it, which is why a manual reload "fixed" issue #937 and a tag
+ *     revalidation did not.
+ *  3. Client-side `TableController` caches, which heal over Realtime and need nothing here.
+ *
+ * Two orderings matter, and both are easy to get backwards:
+ *
+ *  - The tag revalidation is awaited *before* `router.refresh()`. Otherwise the refetch that
+ *    `refresh()` kicks off can be served from a server cache entry that is evicted a moment
+ *    later, and the user sees pre-write data anyway.
+ *  - When the caller is also navigating, pass `navigateTo` instead of calling `router.push()`
+ *    afterwards. `router.refresh()` followed by `router.push()` silently does nothing:
+ *    dispatching a navigation marks the pending action as discarded so its state is never
+ *    applied (`next/dist/client/components/app-router-instance.js`, the `ACTION_NAVIGATE`
+ *    branch of `dispatchAction`), and the refresh is exactly that pending action. Pushing
+ *    first and refreshing after leaves the refresh queued behind the navigation, where it runs
+ *    to completion — and because a refresh rebuilds from the root and resets the prefetch
+ *    cache (`refresh-reducer.js`: "router.refresh() has to invalidate the entire cache"), it
+ *    drops the stale entry for the list we came from, not just the page we landed on.
+ *
+ * `classId` is optional so platform-admin views, which read no course-scoped tags, can use the
+ * same hook for its Router Cache half.
+ */
+export function useRevalidateServerCaches(classId?: number): (options?: {
+  /** Class-scoped tables the write touched. Omit to evict the whole class-scoped set. */
+  tables?: readonly ClassScopedCachedTable[];
+  /** Navigate here as part of the revalidation, so the refresh is not discarded. */
+  navigateTo?: string;
+}) => Promise<void> {
+  const router = useRouter();
+  return useCallback(
+    async ({ tables, navigateTo }: { tables?: readonly ClassScopedCachedTable[]; navigateTo?: string } = {}) => {
+      if (typeof classId === "number" && Number.isFinite(classId)) {
+        await revalidateCourseDerivedCachesClient(classId, tables);
+      }
+      if (navigateTo) {
+        router.push(navigateTo);
+      }
+      router.refresh();
+    },
+    [classId, router]
+  );
+}

--- a/lib/next-cache-tags.ts
+++ b/lib/next-cache-tags.ts
@@ -36,3 +36,62 @@ export function courseDerivedDataTags(classId: number): string[] {
     courseFlashcardDecksTag(classId)
   ];
 }
+
+/**
+ * The one tag `getCourse()` reads (`lib/ssrUtils.ts`). Emitted by the `classes`
+ * cache-invalidation trigger and by `/api/cache/revalidate-tags`.
+ */
+export function courseTag(classId: number) {
+  return `course:${classId}`;
+}
+
+/**
+ * Tables whose class-scoped rows are read through a *cached* SSR fetch — i.e. the tables
+ * for which `<table>:<class_id>:<role>` is a tag some `createClientWithCaching()` call site
+ * in `lib/ssrUtils.ts` is actually keyed under. Kept in sync with
+ * `fetchCourseControllerData`; the Postgres `invalidate_class_scoped_cache()` trigger emits
+ * the same strings from `TG_TABLE_NAME`.
+ */
+export const CLASS_SCOPED_CACHED_TABLES = [
+  "profiles",
+  "user_roles",
+  "discussion_threads",
+  "tags",
+  "lab_sections",
+  "lab_section_meetings",
+  "class_sections",
+  "student_deadline_extensions",
+  "assignment_due_date_exceptions",
+  "assignments",
+  "assignment_groups",
+  "discussion_topics",
+  "repositories",
+  "gradebook_columns",
+  "discord_channels",
+  "discord_messages",
+  "surveys",
+  "lab_section_leaders"
+] as const;
+
+export type ClassScopedCachedTable = (typeof CLASS_SCOPED_CACHED_TABLES)[number];
+
+/** Both role variants of a class-scoped table tag, matching the trigger's emission. */
+export function classScopedTableTags(table: ClassScopedCachedTable, classId: number): string[] {
+  return [`${table}:${classId}:staff`, `${table}:${classId}:student`];
+}
+
+/**
+ * Tags to revalidate after a client-side write to `tables` in `classId`.
+ *
+ * `courseDerivedDataTags` alone is not enough: those four strings are read by nothing (see
+ * the header of this file), so a caller that emits only them believes it has busted a cache
+ * and has not. The class-scoped table tags below are the ones `lib/ssrUtils.ts` keys its
+ * 1-hour SSR fetches under.
+ */
+export function courseSsrTags(classId: number, tables: readonly ClassScopedCachedTable[]): string[] {
+  return [
+    courseTag(classId),
+    ...tables.flatMap((table) => classScopedTableTags(table, classId)),
+    ...courseDerivedDataTags(classId)
+  ];
+}

--- a/lib/revalidateCourseDerivedCachesClient.ts
+++ b/lib/revalidateCourseDerivedCachesClient.ts
@@ -1,14 +1,28 @@
+import type { ClassScopedCachedTable } from "@/lib/next-cache-tags";
+
 /**
- * POSTs to `/api/cache/revalidate-tags` with `{ classId }` using the session cookie.
+ * POSTs to `/api/cache/revalidate-tags` with `{ classId, tables }` using the session cookie.
  * Best-effort: logs warnings on failure; does not throw.
+ *
+ * This clears the *server* fetch cache only. The browser's Router Cache holds the RSC payload
+ * of every segment visited this session and is untouched by `revalidateTag()` — callers that
+ * navigate back to a server-rendered view must also `router.refresh()`. Use
+ * `useRevalidateServerCaches()` (hooks/useRevalidateServerCaches.ts) rather than calling this
+ * directly, so both halves happen in the right order.
+ *
+ * @param tables Class-scoped tables the write touched. Omit to fall back to the whole
+ *   class-scoped set, which is correct but evicts more than necessary.
  */
-export async function revalidateCourseDerivedCachesClient(classId: number): Promise<void> {
+export async function revalidateCourseDerivedCachesClient(
+  classId: number,
+  tables?: readonly ClassScopedCachedTable[]
+): Promise<void> {
   try {
     const res = await fetch("/api/cache/revalidate-tags", {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ classId })
+      body: JSON.stringify(tables ? { classId, tables } : { classId })
     });
     if (!res.ok) {
       // eslint-disable-next-line no-console -- operational visibility for cache misses

--- a/lib/revalidateCourseDerivedCachesClient.ts
+++ b/lib/revalidateCourseDerivedCachesClient.ts
@@ -10,9 +10,17 @@ import type { ClassScopedCachedTable } from "@/lib/next-cache-tags";
  * `useRevalidateServerCaches()` (hooks/useRevalidateServerCaches.ts) rather than calling this
  * directly, so both halves happen in the right order.
  *
+ * Callers await this before navigating, so it is deliberately bounded: an unreachable or slow
+ * endpoint (or a stalled Redis-backed cache handler) must not strand the user on the form they
+ * just submitted. On timeout we give up on the server-cache half and let the caller proceed —
+ * the Router Cache refresh, which is the part issue #937 was actually about, still happens, and
+ * the Postgres triggers invalidate the same tags independently.
+ *
  * @param tables Class-scoped tables the write touched. Omit to fall back to the whole
  *   class-scoped set, which is correct but evicts more than necessary.
  */
+export const REVALIDATE_TAGS_TIMEOUT_MS = 3000;
+
 export async function revalidateCourseDerivedCachesClient(
   classId: number,
   tables?: readonly ClassScopedCachedTable[]
@@ -22,7 +30,13 @@ export async function revalidateCourseDerivedCachesClient(
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(tables ? { classId, tables } : { classId })
+      body: JSON.stringify(tables ? { classId, tables } : { classId }),
+      // `AbortSignal.timeout` is guarded rather than assumed: this runs in the browser, and a
+      // missing implementation should degrade to the old unbounded behaviour, not throw.
+      signal:
+        typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+          ? AbortSignal.timeout(REVALIDATE_TAGS_TIMEOUT_MS)
+          : undefined
     });
     if (!res.ok) {
       // eslint-disable-next-line no-console -- operational visibility for cache misses

--- a/lib/ssrUtils.ts
+++ b/lib/ssrUtils.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { Database } from "@/utils/supabase/SupabaseTypes";
 import { parseViewAsCookieValue, viewAsCookieName } from "@/lib/viewAs";
+import { classScopedTableTags, courseTag } from "@/lib/next-cache-tags";
 import { createClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import type {
@@ -111,7 +112,13 @@ export async function createClientWithCaching({ revalidate, tags }: { revalidate
   return client;
 }
 export async function getUserRolesForCourse(course_id: number, user_id: string): Promise<UserRoleData | undefined> {
-  const client = await createClientWithCaching({ revalidate: 60, tags: [`user_roles:${course_id}:${user_id}`] });
+  // The per-user tag is kept for targeted invalidation, but nothing emits it: the `user_roles`
+  // trigger emits the class+role form. Without those two the 60s TTL was the only thing that
+  // ever refreshed a role change.
+  const client = await createClientWithCaching({
+    revalidate: 60,
+    tags: [`user_roles:${course_id}:${user_id}`, ...classScopedTableTags("user_roles", course_id)]
+  });
 
   const { data: userRoles } = await client
     .from("user_roles")
@@ -199,7 +206,7 @@ export async function getEffectiveCourseIdentity(
 
   const client = await createClientWithCaching({
     revalidate: 60,
-    tags: [`user_roles:${course_id}:view_as`]
+    tags: [`user_roles:${course_id}:view_as`, ...classScopedTableTags("user_roles", course_id)]
   });
   const { data: targetRole } = await client
     .from("user_roles")
@@ -226,7 +233,7 @@ export async function getEffectiveCourseIdentity(
 }
 
 export async function getCourse(course_id: number) {
-  const client = await createClientWithCaching({ tags: [`course:${course_id}`] });
+  const client = await createClientWithCaching({ tags: [courseTag(course_id)] });
   const course = await client.from("classes").select("*").eq("id", course_id).eq("archived", false).single();
   return course.data;
 }

--- a/supabase/functions/gradebook-column-recalculate/deno.lock
+++ b/supabase/functions/gradebook-column-recalculate/deno.lock
@@ -1,0 +1,71 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "npm:mathjs@^14.5.2": "14.9.1"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "npm": {
+    "@babel/runtime@7.29.7": {
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
+    },
+    "complex.js@2.4.3": {
+      "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ=="
+    },
+    "decimal.js@10.6.0": {
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
+    },
+    "escape-latex@1.2.0": {
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
+    "fraction.js@5.3.4": {
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="
+    },
+    "javascript-natural-sort@0.7.1": {
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
+    "mathjs@14.9.1": {
+      "integrity": "sha512-xhqv8Xjf+caWG3WlaPekg4v8QFOR3D5+8ycfcjMcPcnCNDgAONQLaLfyGgrggJrcHx2yUGCpACRpiD4GmXwX+Q==",
+      "dependencies": [
+        "@babel/runtime",
+        "complex.js",
+        "decimal.js",
+        "escape-latex",
+        "fraction.js",
+        "javascript-natural-sort",
+        "seedrandom",
+        "tiny-emitter",
+        "typed-function"
+      ],
+      "bin": true
+    },
+    "seedrandom@3.0.5": {
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
+    "tiny-emitter@2.1.0": {
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
+    "typed-function@4.2.2": {
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A=="
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "npm:@supabase/postgrest-js@^1.19.4",
+      "npm:@types/mathjs@^9.4.2",
+      "npm:mathjs@^14.5.2",
+      "npm:minimatch@^10.0.3"
+    ]
+  }
+}

--- a/supabase/migrations/20260824120000_cache_invalidation_for_classes_and_group_members.sql
+++ b/supabase/migrations/20260824120000_cache_invalidation_for_classes_and_group_members.sql
@@ -1,0 +1,151 @@
+-- Cache invalidation for two tables that feed a cached SSR read but had no trigger (issue #937).
+--
+-- The Next.js fetch cache in lib/ssrUtils.ts keys on exact tag strings and defaults to a 1-hour
+-- TTL, so a tag that is read but never emitted means the TTL is the only thing that ever
+-- refreshes that data. Two such gaps:
+--
+--   1. `classes`. `getCourse()` caches `select *` under `course:<class_id>` and every page in a
+--      course reads it for the course title and time zone. The only triggers on `classes` emit
+--      the constant 'admin:dashboard-stats' — nothing has ever emitted `course:<id>`, so a
+--      renamed course or a corrected time zone took up to an hour to appear.
+--
+--   2. `assignment_groups_members`. Its rows are embedded in two cached queries — the group
+--      bundle tagged `assignment_groups:<class_id>:<role>` and the staff roster tagged
+--      `user_roles:<class_id>:<role>` — but the table itself had only audit/notification
+--      triggers. Adding or removing a student from a group left both bundles stale, so students
+--      saw the wrong groupmates.
+
+-- 1. classes -> course:<id>
+--
+-- Kept separate from invalidate_class_scoped_cache(): that function derives the class from a
+-- `class_id` column, and on `classes` the class is the primary key.
+CREATE OR REPLACE FUNCTION public.invalidate_course_cache()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  class_ids bigint[];
+  class_id_value bigint;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT ARRAY_AGG(DISTINCT id ORDER BY id) INTO class_ids FROM old_table WHERE id IS NOT NULL;
+  ELSE
+    SELECT ARRAY_AGG(DISTINCT id ORDER BY id) INTO class_ids FROM new_table WHERE id IS NOT NULL;
+  END IF;
+
+  IF class_ids IS NULL OR array_length(class_ids, 1) IS NULL THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  FOREACH class_id_value IN ARRAY class_ids
+  LOOP
+    PERFORM public.call_cache_invalidate(ARRAY['course:' || class_id_value]);
+  END LOOP;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.invalidate_course_cache FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS invalidate_classes_course_cache_insert ON public.classes;
+DROP TRIGGER IF EXISTS invalidate_classes_course_cache_update ON public.classes;
+DROP TRIGGER IF EXISTS invalidate_classes_course_cache_delete ON public.classes;
+
+CREATE TRIGGER invalidate_classes_course_cache_insert
+  AFTER INSERT ON public.classes
+  REFERENCING NEW TABLE AS new_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_course_cache();
+
+CREATE TRIGGER invalidate_classes_course_cache_update
+  AFTER UPDATE ON public.classes
+  REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_course_cache();
+
+CREATE TRIGGER invalidate_classes_course_cache_delete
+  AFTER DELETE ON public.classes
+  REFERENCING OLD TABLE AS old_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_course_cache();
+
+-- 2. assignment_groups_members -> assignment_groups:<class_id|assignment_id>:<role>
+--                                and user_roles:<class_id>:<role>
+--
+-- invalidate_assignment_groups_cache() already emits both assignment_groups forms from a table
+-- carrying class_id + assignment_id, which assignment_groups_members does. The roster bundle is
+-- the extra: it embeds these rows but is tagged on user_roles.
+CREATE OR REPLACE FUNCTION public.invalidate_assignment_group_members_cache()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  class_ids bigint[];
+  assignment_ids bigint[];
+  class_id_value bigint;
+  assignment_id_value bigint;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT ARRAY_AGG(DISTINCT class_id ORDER BY class_id), ARRAY_AGG(DISTINCT assignment_id ORDER BY assignment_id)
+    INTO class_ids, assignment_ids
+    FROM old_table;
+  ELSE
+    SELECT ARRAY_AGG(DISTINCT class_id ORDER BY class_id), ARRAY_AGG(DISTINCT assignment_id ORDER BY assignment_id)
+    INTO class_ids, assignment_ids
+    FROM new_table;
+  END IF;
+
+  IF class_ids IS NOT NULL AND array_length(class_ids, 1) IS NOT NULL THEN
+    FOREACH class_id_value IN ARRAY class_ids
+    LOOP
+      PERFORM public.call_cache_invalidate(ARRAY[
+        'assignment_groups:' || class_id_value || ':staff',
+        'assignment_groups:' || class_id_value || ':student',
+        'user_roles:' || class_id_value || ':staff',
+        'user_roles:' || class_id_value || ':student'
+      ]);
+    END LOOP;
+  END IF;
+
+  IF assignment_ids IS NOT NULL AND array_length(assignment_ids, 1) IS NOT NULL THEN
+    FOREACH assignment_id_value IN ARRAY assignment_ids
+    LOOP
+      PERFORM public.call_cache_invalidate(ARRAY[
+        'assignment_groups:' || assignment_id_value || ':staff',
+        'assignment_groups:' || assignment_id_value || ':student'
+      ]);
+    END LOOP;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.invalidate_assignment_group_members_cache FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS invalidate_assignment_groups_members_cache_insert ON public.assignment_groups_members;
+DROP TRIGGER IF EXISTS invalidate_assignment_groups_members_cache_update ON public.assignment_groups_members;
+DROP TRIGGER IF EXISTS invalidate_assignment_groups_members_cache_delete ON public.assignment_groups_members;
+
+CREATE TRIGGER invalidate_assignment_groups_members_cache_insert
+  AFTER INSERT ON public.assignment_groups_members
+  REFERENCING NEW TABLE AS new_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_assignment_group_members_cache();
+
+CREATE TRIGGER invalidate_assignment_groups_members_cache_update
+  AFTER UPDATE ON public.assignment_groups_members
+  REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_assignment_group_members_cache();
+
+CREATE TRIGGER invalidate_assignment_groups_members_cache_delete
+  AFTER DELETE ON public.assignment_groups_members
+  REFERENCING OLD TABLE AS old_table
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.invalidate_assignment_group_members_cache();

--- a/supabase/migrations/20260824120000_cache_invalidation_for_classes_and_group_members.sql
+++ b/supabase/migrations/20260824120000_cache_invalidation_for_classes_and_group_members.sql
@@ -75,9 +75,19 @@ CREATE TRIGGER invalidate_classes_course_cache_delete
 -- 2. assignment_groups_members -> assignment_groups:<class_id|assignment_id>:<role>
 --                                and user_roles:<class_id>:<role>
 --
--- invalidate_assignment_groups_cache() already emits both assignment_groups forms from a table
--- carrying class_id + assignment_id, which assignment_groups_members does. The roster bundle is
--- the extra: it embeds these rows but is tagged on user_roles.
+-- Mirrors invalidate_assignment_groups_cache()'s class+assignment tag pair, plus the roster
+-- bundle, which embeds these rows but is tagged on user_roles.
+--
+-- Emits ONE pg_net request per distinct tag set per transaction, not per statement.
+--
+-- `publish_assignment_group_changes` fulfils a manifest by deleting and inserting memberships
+-- one row at a time inside a PL/pgSQL loop, so a statement-level trigger fires up to twice per
+-- moved student. Every one of those firings would otherwise queue the same tags for the same
+-- class and assignment — moving 200 students meant ~800 identical `net.http_post` calls. The
+-- transaction-local GUC below collapses that to one, keyed on the tag set so a transaction that
+-- genuinely touches a second class or assignment still invalidates both. Tag invalidation is
+-- idempotent and pg_net only dispatches after commit, so emitting once per transaction loses
+-- nothing.
 CREATE OR REPLACE FUNCTION public.invalidate_assignment_group_members_cache()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -89,6 +99,8 @@ DECLARE
   assignment_ids bigint[];
   class_id_value bigint;
   assignment_id_value bigint;
+  tags text[] := ARRAY[]::text[];
+  dedupe_key text;
 BEGIN
   IF TG_OP = 'DELETE' THEN
     SELECT ARRAY_AGG(DISTINCT class_id ORDER BY class_id), ARRAY_AGG(DISTINCT assignment_id ORDER BY assignment_id)
@@ -103,24 +115,38 @@ BEGIN
   IF class_ids IS NOT NULL AND array_length(class_ids, 1) IS NOT NULL THEN
     FOREACH class_id_value IN ARRAY class_ids
     LOOP
-      PERFORM public.call_cache_invalidate(ARRAY[
+      tags := tags || ARRAY[
         'assignment_groups:' || class_id_value || ':staff',
         'assignment_groups:' || class_id_value || ':student',
         'user_roles:' || class_id_value || ':staff',
         'user_roles:' || class_id_value || ':student'
-      ]);
+      ];
     END LOOP;
   END IF;
 
   IF assignment_ids IS NOT NULL AND array_length(assignment_ids, 1) IS NOT NULL THEN
     FOREACH assignment_id_value IN ARRAY assignment_ids
     LOOP
-      PERFORM public.call_cache_invalidate(ARRAY[
+      tags := tags || ARRAY[
         'assignment_groups:' || assignment_id_value || ':staff',
         'assignment_groups:' || assignment_id_value || ':student'
-      ]);
+      ];
     END LOOP;
   END IF;
+
+  IF array_length(tags, 1) IS NULL THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  -- md5 keeps the GUC name inside the identifier length limit regardless of how many ids the
+  -- statement touched. `set_config(..., true)` scopes the marker to this transaction.
+  dedupe_key := 'pawtograder.ci_' || md5(array_to_string(tags, ','));
+  IF COALESCE(current_setting(dedupe_key, true), '') = '1' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+  PERFORM set_config(dedupe_key, '1', true);
+
+  PERFORM public.call_cache_invalidate(tags);
 
   RETURN COALESCE(NEW, OLD);
 END;

--- a/tests/e2e/manage-assignments-list-freshness.test.tsx
+++ b/tests/e2e/manage-assignments-list-freshness.test.tsx
@@ -34,10 +34,14 @@ function toDateTimeLocal(date: Date): string {
 }
 
 /**
- * The mobile and desktop navs are both in the DOM, so match on the visible one.
+ * Selects by href rather than accessible name, for two reasons: the mobile and desktop navs are
+ * both in the DOM so the name is ambiguous, and the desktop nav's links currently compute an
+ * *empty* accessible name — `dynamicCourseNav.tsx` wraps their content in `role="group"`, which
+ * does not support name-from-content. That is a real a11y bug, but it is not this test's subject,
+ * and pinning the selector to it would make this test fail for the wrong reason once it is fixed.
  */
-function visibleNavLink(page: Page, name: string) {
-  return page.locator("nav:visible").getByRole("link", { name, exact: true }).first();
+function courseNavLink(page: Page, href: string) {
+  return page.locator(`nav[aria-label="Course navigation"]:visible a[href="${href}"]`).first();
 }
 
 test.describe("Manage Assignments list freshness", () => {
@@ -87,7 +91,7 @@ test.describe("Manage Assignments list freshness", () => {
     await expect(page).toHaveURL(/\/manage\/assignments\/\d+\/autograder/, { timeout: 60_000 });
 
     // 4. Back to the list the way the bug report does it — the nav link, not a reload.
-    await visibleNavLink(page, "Manage Assignments").click();
+    await courseNavLink(page, `/course/${course.id}/manage/assignments`).click();
     await expect(page).toHaveURL(new RegExp(`/course/${course.id}/manage/assignments$`));
 
     // The timeout here is load-bearing and must stay well under `staleTimes.dynamic` (30s):

--- a/tests/e2e/manage-assignments-list-freshness.test.tsx
+++ b/tests/e2e/manage-assignments-list-freshness.test.tsx
@@ -34,11 +34,8 @@ function toDateTimeLocal(date: Date): string {
 }
 
 /**
- * Selects by href rather than accessible name, for two reasons: the mobile and desktop navs are
- * both in the DOM so the name is ambiguous, and the desktop nav's links currently compute an
- * *empty* accessible name — `dynamicCourseNav.tsx` wraps their content in `role="group"`, which
- * does not support name-from-content. That is a real a11y bug, but it is not this test's subject,
- * and pinning the selector to it would make this test fail for the wrong reason once it is fixed.
+ * Selects by href rather than accessible name: the mobile and desktop navs are both in the DOM,
+ * so a name-based selector is ambiguous. (The names themselves are asserted separately below.)
  */
 function courseNavLink(page: Page, href: string) {
   return page.locator(`nav[aria-label="Course navigation"]:visible a[href="${href}"]`).first();
@@ -64,7 +61,11 @@ test.describe("Manage Assignments list freshness", () => {
 
   test("a newly created assignment is listed after navigating back, without a reload", async ({ page }) => {
     const title = `Freshness Target ${RUN_PREFIX}`;
-    const slug = `lf-${RUN_PREFIX.slice(-6)}`;
+    // Derive the slug from SAFE_ID, not from RUN_PREFIX: the form only accepts
+    // /^[a-z0-9_-]+$/, and `RUN_PREFIX.slice(-6)` reaches back into the `#<random>` segment
+    // whenever the trailing TEST_WORKER_INDEX is short or empty, which would make Save silently
+    // reject the form.
+    const slug = `lf-${SAFE_ID.slice(-8)}`;
 
     await loginAsUser(page, instructor!, course);
 
@@ -98,5 +99,19 @@ test.describe("Manage Assignments list freshness", () => {
     // wait longer than the stale window and the cache entry expires on its own, and this test
     // passes whether or not the bug is fixed.
     await expect(page.getByRole("link", { name: title })).toBeVisible({ timeout: 10_000 });
+  });
+
+  // Regression guard for the a11y bug found while writing the test above: the desktop nav wrapped
+  // each link's label in `role="group"`, which does not support accessible-name-from-content, so
+  // every link in the primary course navigation exposed an EMPTY name — screen readers announced
+  // a bare "link" (WCAG 2.4.4 / 4.1.2). It was invisible to sighted users and to any selector
+  // that matches on href, which is why it survived.
+  test("course navigation links expose their label as an accessible name", async ({ page }) => {
+    await loginAsUser(page, instructor!, course);
+    await page.goto(`/course/${course.id}/manage/assignments`);
+
+    const nav = page.locator('nav[aria-label="Course navigation"]:visible').first();
+    await expect(nav.getByRole("link", { name: "Manage Assignments", exact: true })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "Discussion", exact: true })).toBeVisible();
   });
 });

--- a/tests/e2e/manage-assignments-list-freshness.test.tsx
+++ b/tests/e2e/manage-assignments-list-freshness.test.tsx
@@ -1,0 +1,98 @@
+import { Course } from "@/utils/supabase/DatabaseTypes";
+import { TZDate } from "@date-fns/tz";
+import { addDays } from "date-fns";
+import { expect, test } from "../global-setup";
+import type { Page } from "@playwright/test";
+import { createClass, createUserInClass, getTestRunPrefix, loginAsUser, TestingUser } from "./TestingUtils";
+
+// Regression coverage for issue #937: after creating an assignment, navigating back to Manage
+// Assignments showed the pre-create list until a hard reload.
+//
+// The staleness lives in the browser, not the database. `ManageAssignmentsTable` is a Server
+// Component that queries per request, so the server was never wrong. What was wrong is the
+// client Router Cache: `next.config.ts` sets `experimental.staleTimes.dynamic: 30`, so the RSC
+// payload rendered for a segment is replayed for 30s on client-side navigation back to it. The
+// create flow's `revalidateCourseDerivedCachesClient()` call could not help — `revalidateTag()`
+// evicts server data, not the payload the browser already holds. Only `router.refresh()` does.
+//
+// Which is why every step below has to be a *click*, not a `page.goto()`: a `goto` is a document
+// request that bypasses the Router Cache entirely and would pass even with the bug present.
+
+const RUN_PREFIX = getTestRunPrefix();
+const SAFE_ID = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+let course: Course;
+let instructor: TestingUser | undefined;
+
+const futureRelease = addDays(new TZDate(new Date(), "America/New_York"), 1);
+futureRelease.setHours(9, 0, 0, 0);
+const futureDue = addDays(new TZDate(new Date(), "America/New_York"), 14);
+futureDue.setHours(9, 0, 0, 0);
+
+function toDateTimeLocal(date: Date): string {
+  return new TZDate(date, "America/New_York").toISOString().slice(0, -13);
+}
+
+/**
+ * The mobile and desktop navs are both in the DOM, so match on the visible one.
+ */
+function visibleNavLink(page: Page, name: string) {
+  return page.locator("nav:visible").getByRole("link", { name, exact: true }).first();
+}
+
+test.describe("Manage Assignments list freshness", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeAll(async () => {
+    course = await createClass({ name: `List Freshness ${RUN_PREFIX}` });
+    instructor = await createUserInClass({
+      role: "instructor",
+      class_id: course.id,
+      email: `list-freshness-instructor-${SAFE_ID}@pawtograder.net`,
+      name: `List Freshness Instructor ${RUN_PREFIX}`,
+      useMagicLink: true
+    });
+  });
+
+  test.afterEach(async ({ logMagicLinksOnFailure }) => {
+    await logMagicLinksOnFailure([instructor]);
+  });
+
+  test("a newly created assignment is listed after navigating back, without a reload", async ({ page }) => {
+    const title = `Freshness Target ${RUN_PREFIX}`;
+    const slug = `lf-${RUN_PREFIX.slice(-6)}`;
+
+    await loginAsUser(page, instructor!, course);
+
+    // 1. Render the list. This is what seeds the Router Cache with a payload that does not
+    //    contain the assignment we are about to create.
+    await page.goto(`/course/${course.id}/manage/assignments`);
+    await expect(page.getByRole("link", { name: "All regrade requests" })).toBeVisible();
+    await expect(page.getByRole("link", { name: title })).toHaveCount(0);
+
+    // 2. Client-side navigation away, so the list payload stays cached.
+    await page.getByRole("link", { name: "New Assignment" }).click();
+    await expect(page.getByRole("heading", { name: "Create New Assignment" })).toBeVisible();
+
+    // 3. Create. repo_mode "none" keeps the flow off GitHub, so the redirect to the autograder
+    //    tab is not gated on handout-repo creation.
+    await page.getByLabel("Title", { exact: false }).fill(title);
+    await page.getByLabel("Slug", { exact: false }).fill(slug);
+    await page.getByLabel(/^Release date/i).fill(toDateTimeLocal(futureRelease));
+    await page.getByLabel(/^Due date/i).fill(toDateTimeLocal(futureDue));
+    await page.getByLabel("Points possible", { exact: false }).fill("100");
+    await page.locator('select[name="repo_mode"]').selectOption("none");
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page).toHaveURL(/\/manage\/assignments\/\d+\/autograder/, { timeout: 60_000 });
+
+    // 4. Back to the list the way the bug report does it — the nav link, not a reload.
+    await visibleNavLink(page, "Manage Assignments").click();
+    await expect(page).toHaveURL(new RegExp(`/course/${course.id}/manage/assignments$`));
+
+    // The timeout here is load-bearing and must stay well under `staleTimes.dynamic` (30s):
+    // wait longer than the stale window and the cache entry expires on its own, and this test
+    // passes whether or not the bug is fixed.
+    await expect(page.getByRole("link", { name: title })).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tests/unit/cache-tag-coverage.test.ts
+++ b/tests/unit/cache-tag-coverage.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { CLASS_SCOPED_CACHED_TABLES, classScopedTableTags, courseSsrTags, courseTag } from "@/lib/next-cache-tags";
+
+/**
+ * Issue #937 had a server-side half: `revalidateTag()` matches tag strings exactly, so a tag a
+ * cached fetch is *read* under but nothing ever *emits* means the 1-hour TTL is the only thing
+ * that refreshes it. That is invisible in review — both sides look correct in isolation.
+ *
+ * These tests pin the two halves to each other by reading the source, so adding a cached table
+ * to `fetchCourseControllerData` without listing it here (or vice versa) fails in CI rather
+ * than shipping an hour of staleness.
+ */
+
+const repoRoot = join(__dirname, "..", "..");
+const ssrUtilsSource = readFileSync(join(repoRoot, "lib", "ssrUtils.ts"), "utf8");
+
+const migrationsDir = join(repoRoot, "supabase", "migrations");
+const allMigrations = readdirSync(migrationsDir)
+  .filter((f) => f.endsWith(".sql"))
+  .map((f) => readFileSync(join(migrationsDir, f), "utf8"))
+  .join("\n");
+
+describe("class-scoped cache tag coverage", () => {
+  it("lists every class-scoped table that lib/ssrUtils.ts caches under a `<table>:<class>:<role>` tag", () => {
+    // Matches the tag templates in `fetchCourseControllerData`, e.g.
+    //   tags: [`gradebook_columns:${course_id}:${isStaff ? "staff" : "student"}`]
+    const cachedInSsrUtils = new Set(
+      [...ssrUtilsSource.matchAll(/`([a-z_]+):\$\{course_id\}:/g)].map((match) => match[1])
+    );
+
+    expect(cachedInSsrUtils.size).toBeGreaterThan(0);
+    expect([...cachedInSsrUtils].sort()).toEqual([...CLASS_SCOPED_CACHED_TABLES].sort());
+  });
+
+  it("emits both role variants, matching what invalidate_class_scoped_cache() builds", () => {
+    expect(classScopedTableTags("assignments", 7)).toEqual(["assignments:7:staff", "assignments:7:student"]);
+  });
+
+  it("has a Postgres trigger emitting the tag getCourse() reads", () => {
+    // getCourse caches `select *` from classes under this tag for an hour. Before #937 nothing
+    // emitted it, so a course rename or time-zone fix took up to an hour to appear.
+    expect(courseTag(7)).toBe("course:7");
+    expect(allMigrations).toContain("'course:' || class_id_value");
+    expect(allMigrations).toMatch(/CREATE TRIGGER invalidate_classes_course_cache_update/);
+  });
+
+  it("has a Postgres trigger invalidating the bundles that embed assignment_groups_members", () => {
+    expect(allMigrations).toMatch(/CREATE TRIGGER invalidate_assignment_groups_members_cache_insert/);
+    expect(allMigrations).toContain("'user_roles:' || class_id_value || ':staff'");
+  });
+});
+
+describe("courseSsrTags", () => {
+  it("includes the tags that are actually read, not just the derived-dashboard no-ops", () => {
+    const tags = courseSsrTags(7, ["assignments"]);
+
+    expect(tags).toContain("course:7");
+    expect(tags).toContain("assignments:7:staff");
+    expect(tags).toContain("assignments:7:student");
+    // The pre-#937 behaviour: these four were the *only* tags the client route emitted, and no
+    // fetch is keyed under any of them. Kept for trigger-payload stability, never sufficient.
+    expect(tags).toContain("course:7:assignments-overview");
+  });
+
+  it("scopes to the tables the caller names", () => {
+    const tags = courseSsrTags(7, ["surveys"]);
+
+    expect(tags).toContain("surveys:7:staff");
+    expect(tags).not.toContain("gradebook_columns:7:staff");
+  });
+});


### PR DESCRIPTION
Fixes #937.

## What was actually stale

The server was never wrong. `ManageAssignmentsTable` is a Server Component that queries `assignment_overview` per request through an uncached loader (`lib/ssr-course-dashboard.ts`), so it always returns the new assignment.

The stale copy is in the browser. `next.config.ts` sets `experimental.staleTimes.dynamic: 30` — deliberately, to stop the course layout re-shipping `CourseControllerInitialData` on every navigation — so the RSC payload rendered for a segment is replayed for 30s on client-side navigation back to it. Manage Assignments → New Assignment leaves the pre-create list in that cache; returning within 30s replays it. That is also why the reporter saw it "sometimes work": past 30s the entry expires on its own.

The create flow believed it handled this. It called `revalidateCourseDerivedCachesClient()`, which POSTs to `/api/cache/revalidate-tags` and calls server-side `revalidateTag()`. That could not work, for two independent reasons:

1. `revalidateTag()` evicts the **server's** data. It cannot reach a payload the browser already holds. Only `router.refresh()` drops that — which is why the reporter's hard reload was a workaround.
2. The four tags it emitted are read by nothing. `lib/next-cache-tags.ts` says so in its own header: "Dashboards are not Data Cached (`unstable_cache`); tags are effectively no-ops for those paths."

Before this PR the entire repo had two `router.refresh()` calls, so every client-side write feeding a server-rendered view had the same defect.

## Fix, part 1 — the client Router Cache

New `hooks/useRevalidateServerCaches.ts`. It awaits the tag revalidation and then refreshes, and it owns the two orderings that are easy to get backwards:

- **Revalidate before refresh.** Otherwise the refetch `refresh()` starts can be served from a server cache entry evicted a moment later, and the user still sees pre-write data.
- **Navigate through the hook, don't `router.push()` after it.** `router.refresh(); router.push(...)` silently does nothing. Dispatching a navigation marks the pending action as discarded so its state is never applied (`next/dist/client/components/app-router-instance.js`, the `ACTION_NAVIGATE` branch of `dispatchAction`), and the refresh *is* that pending action. Pushing first leaves the refresh queued behind the navigation, where it runs to completion — and a refresh rebuilds from the root and resets the prefetch cache (`refresh-reducer.js`: "router.refresh() has to invalidate the entire cache"), so it drops the stale entry for the list we came *from*, not just the page we landed on. I had this backwards in my first pass; it reads correct and does nothing.

Wired into the writes that feed a server-rendered view:

| Site | Write | What was stale |
|---|---|---|
| `manage/assignments/new` | insert `assignments` | #937 itself |
| `manage/assignments/[id]/edit` | update `assignments` | list + manage-assignment header |
| `deleteAssignmentButton` | `assignmentDelete` | deleted assignment stayed listed ~30s, and clicking it bounced the user back out |
| `manage/surveys/new`, `manage/surveys/[id]/edit` | insert/update/soft-delete `surveys` | surveys list |
| `manage/surveys/SurveysTable` | publish / close / soft-delete | see below |
| `admin/classes/ClassManagementTable` | archive / update class | archived class reappeared on back-nav |
| `admin/import` | `admin_create_class` | the created class missing from `/admin/classes` — how you import the same course twice |
| `admin/github-orgs/[org]` | `admin_upsert_github_org` | org defaults list |
| `EnterCourseAsInstructor` | `admin_enter_course_as_instructor` | the course layout gates on the role this RPC just granted |

`SurveysTable` is the worst of these and never self-healed. It renders only the `surveys` prop from `ManageSurveysBody` with no subscription, while its own menu writes through the controller — so publish/close/delete produced **no visible change at all** until a reload, under comments claiming realtime handled it. Those comments are corrected.

## Fix, part 2 — server tags that were read but never emitted

`revalidateTag()` matches exactly, so a tag a cached fetch reads but nothing emits means the 1-hour TTL is the only thing that ever refreshes it. Auditing both sides turned up five:

- **`"assignment-release-date"`** gated whether an enrolled student may open an assignment *at all*. Publishing left students redirected out, and un-publishing left it reachable, for up to an hour. This is access-control correctness, not just freshness. Now tagged on the class-scoped `assignments:<class>:<role>` strings the trigger already emits.
- **`"assignment_metadata"`** (4 sites) — same treatment, so a rename reaches staff nav and page titles.
- **`user_roles:<class>:<user>` and `:view_as`** — the trigger emits the class+role form, never the per-user form. Both reads now carry the emitted tags too.
- **`course:<id>`** — read by `getCourse()` on every page in a course for the title and time zone; emitted by nothing, since `classes` only had the admin-stats trigger. New migration emits it.
- **`assignment_groups_members`** had no invalidation trigger at all, though its rows are embedded in two cached bundles (`assignment_groups:<class>:<role>` and the staff roster under `user_roles:<class>:<role>`). Group membership changes showed students the wrong groupmates for up to an hour. New migration covers both bundles.

`/api/cache/revalidate-tags` now emits the tags that are actually read, scoped to the tables the caller names rather than evicting every class-scoped bundle. It also repeated a dual-role hazard that `getUserRolesForCourse` documents and works around: `.maybeSingle()` 406s for a user holding both `student` and `grader` (the unique index is on `(user_id, role, class_id)`), turning a legitimate request into a 500.

## Tests

- `tests/e2e/manage-assignments-list-freshness.test.tsx` — the #937 repro. Every step is a *click*: a `page.goto()` is a document request that bypasses the Router Cache and would pass with the bug present. The final assertion's timeout is load-bearing and stays well under the 30s stale window, or the entry expires on its own and the test passes either way.
- `tests/unit/cache-tag-coverage.test.ts` — a drift guard pinning the read side to the emit side. It parses `lib/ssrUtils.ts` for `<table>:${course_id}:` tag templates and requires the list to match `CLASS_SCOPED_CACHED_TABLES`, and asserts the migrations emit `course:<id>` and the roster tag. Verified it fails when either side moves (removed one table from the list, watched it go red).

## Deliberately not in scope

Found in the audit, left alone, worth their own issues: `call_cache_invalidate` is fire-and-forget pg_net with no retry and no visibility into failures; the invalidate endpoint's secret comparison is not constant-time; the DB still emits four tags nothing reads (roughly 3x the intended pg_net volume on class-scoped writes); and `assignment_groups:<N>:<role>` is ambiguous between class ids and assignment ids, so a numeric collision over-invalidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated course, assignment, survey, class, and GitHub organization views to display the latest data immediately after changes.
  * Prevented deleted or newly created assignments and surveys from remaining stale during navigation.
  * Improved cache invalidation for course, membership, and role-related updates.
  * Fixed stale assignment release-date and metadata information.
  * Improved accessibility of course navigation links.

* **Tests**
  * Added coverage for fresh assignment listings, accessible navigation labels, and cache invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->