### PR TITLE
fix(submissions): classify extensionless binaries by content, not just extension

### DIFF
--- a/supabase/functions/_shared/SubmissionIngestion.test.ts
+++ b/supabase/functions/_shared/SubmissionIngestion.test.ts
@@ -9,7 +9,9 @@
  *     expected submission-scoped key, and its submission_files row references it,
  *   - the combined empty-hash matches an independent recomputation,
  *   - the fileFilter restricts ingestion,
- *   - empty detection flips isEmpty when the handout-hash table matches.
+ *   - empty detection flips isEmpty when the handout-hash table matches,
+ *   - a file whose name carries no extension is classified by its bytes: a
+ *     compiled executable goes to storage, a Makefile stays inline.
  *
  * Run from supabase/functions:  deno test _shared/SubmissionIngestion.test.ts
  * (it pulls npm:jszip + npm:unzipper from the global deno cache; no DB needed).
@@ -38,7 +40,7 @@ async function generateDummyPkcs8Pem(): Promise<string> {
 Deno.env.set("GITHUB_PRIVATE_KEY_STRING", await generateDummyPkcs8Pem());
 Deno.env.set("GITHUB_APP_ID", "1");
 
-const { ingestSubmissionFilesFromZip } = await import("./SubmissionIngestion.ts");
+const { ingestSubmissionFilesFromZip, collectTextFilesFromZipBuffer } = await import("./SubmissionIngestion.ts");
 
 // ---- helpers -------------------------------------------------------------
 
@@ -429,4 +431,135 @@ Deno.test("ingestSubmissionFilesFromZip: an emptyHashFilter that matches nothing
 
   assertEquals(insertedFiles.length, 2);
   assertEquals(result.isEmpty, false);
+});
+
+// Regression (prod): a student compiled `mystery.c` and committed the resulting
+// executable next to it. `mystery` has no extension, so extension-only detection
+// called it text and the ingester sent NUL-laden bytes to
+// `submission_files.contents`; Postgres rejected the JSON escape ("unsupported
+// Unicode escape sequence"), the rollback tore the submission down, and every
+// later push to that repo failed identically.
+const ELF_BYTES = new Uint8Array([
+  0x7f,
+  0x45,
+  0x4c,
+  0x46, // \x7fELF
+  0x02,
+  0x01,
+  0x01,
+  0x00, // 64-bit, little-endian, ELF v1, System V ABI
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00, // padding — the NUL run that breaks the text insert
+  0x02,
+  0x00,
+  0x3e,
+  0x00 // ET_EXEC, EM_X86_64
+]);
+
+Deno.test("ingestSubmissionFilesFromZip: an extensionless binary goes to storage, not contents", async () => {
+  const zipBuffer = await buildZip({
+    "module-01/mystery.c": "int main(void) { return 0; }\n",
+    "module-01/mystery": ELF_BYTES
+  });
+  const { client, insertedFiles, storageUploads } = makeFakeSupabase();
+
+  const result = await ingestSubmissionFilesFromZip({
+    // deno-lint-ignore no-explicit-any
+    adminSupabase: client as any,
+    zipBuffer,
+    submissionId: 42,
+    classId: 7,
+    profileId: "profile-abc",
+    groupId: null
+  });
+
+  assertEquals(insertedFiles.length, 2);
+
+  const binRow = insertedFiles.find((r) => r.name === "module-01/mystery");
+  assert(binRow, "the executable should still be ingested, as a binary");
+  assertEquals(binRow!.is_binary, true);
+  assertEquals(binRow!.contents, null);
+  // No extension to map, so the generic type.
+  assertEquals(binRow!.mime_type, "application/octet-stream");
+  assertEquals(binRow!.storage_key, "classes/7/profiles/profile-abc/submissions/42/files/module-01/mystery");
+  assertEquals(binRow!.file_size, ELF_BYTES.length);
+
+  assertEquals(storageUploads.length, 1);
+  assertEquals(storageUploads[0].key, "classes/7/profiles/profile-abc/submissions/42/files/module-01/mystery");
+  assertEquals(storageUploads[0].size, ELF_BYTES.length);
+
+  // The source next to it is unaffected.
+  const srcRow = insertedFiles.find((r) => r.name === "module-01/mystery.c");
+  assertEquals(srcRow!.is_binary, false);
+  assertEquals(srcRow!.contents, "int main(void) { return 0; }\n");
+
+  // The actual failure condition: nothing carrying a NUL reaches `contents`.
+  // PostgREST would serialize it as a NUL escape, which Postgres refuses to
+  // convert to text.
+  for (const row of insertedFiles) {
+    assert(!row.contents?.includes("\0"), `row ${row.name} must not carry a NUL in contents`);
+  }
+
+  // Hashing is over raw bytes and so is unchanged by the classification.
+  assertEquals(
+    result.combinedHash,
+    combinedHash({
+      "module-01/mystery.c": sha256Hex(Buffer.from("int main(void) { return 0; }\n", "utf-8")),
+      "module-01/mystery": sha256Hex(Buffer.from(ELF_BYTES))
+    })
+  );
+});
+
+// The other half of the contract: plenty of legitimate source files carry no
+// extension, and misrouting them to storage would drop them out of the code
+// viewer entirely. Only the bytes decide.
+Deno.test("ingestSubmissionFilesFromZip: extensionless TEXT files stay inline", async () => {
+  const makefile = "all:\n\tgcc -o mystery mystery.c\n";
+  const zipBuffer = await buildZip({ Makefile: makefile, LICENSE: "MIT\n" });
+  const { client, insertedFiles, storageUploads } = makeFakeSupabase();
+
+  await ingestSubmissionFilesFromZip({
+    // deno-lint-ignore no-explicit-any
+    adminSupabase: client as any,
+    zipBuffer,
+    submissionId: 1,
+    classId: 1,
+    profileId: "p",
+    groupId: null
+  });
+
+  assertEquals(storageUploads.length, 0);
+  assertEquals(insertedFiles.length, 2);
+  for (const row of insertedFiles) {
+    assertEquals(row.is_binary, false);
+    assertEquals(row.storage_key, undefined);
+  }
+  assertEquals(insertedFiles.find((r) => r.name === "Makefile")!.contents, makefile);
+});
+
+// The PR base-tree side of the same classification. Its output is written to the
+// jsonb `pr_base_tree_cache.files`, which rejects a NUL exactly as
+// `submission_files.contents` does — and the head side now routes these to
+// storage, so keeping one here as pseudo-text would render as a whole-file
+// deletion in the diff.
+Deno.test("collectTextFilesFromZipBuffer: skips extensionless binaries, keeps extensionless text", async () => {
+  const zipBuffer = await buildZip({
+    "module-01/mystery.c": "int main(void) { return 0; }\n",
+    "module-01/mystery": ELF_BYTES,
+    Makefile: "all:\n",
+    "assets/logo.png": PNG_BYTES
+  });
+
+  const files = await collectTextFilesFromZipBuffer(zipBuffer);
+
+  assertEquals(Object.keys(files).sort(), ["Makefile", "module-01/mystery.c"]);
+  for (const [name, contents] of Object.entries(files)) {
+    assert(!contents.includes("\0"), `${name} must not carry a NUL`);
+  }
 });

--- a/supabase/functions/_shared/SubmissionIngestion.ts
+++ b/supabase/functions/_shared/SubmissionIngestion.ts
@@ -20,7 +20,8 @@
  * Behavior is preserved exactly from the autograder path:
  *   - identical path sanitization (getSafeRelativePath / normalizeFilenameWhitespace
  *     / sanitizeSegmentForSupabaseStorage / sanitizePathForSupabaseStorageObjectKey),
- *   - identical BINARY_EXTENSIONS / MIME_TYPES sets,
+ *   - identical BINARY_EXTENSIONS / MIME_TYPES sets, plus a content check
+ *     (`hasNulByte`) for files the extension set cannot classify,
  *   - identical per-file 50 MB cap and the two pre-unzip guards
  *     (MAX_SUBMISSION_ZIP_* / MAX_SUBMISSION_UNZIPPED_*),
  *   - identical binary storage-key shape and de-dup suffixing,
@@ -145,6 +146,35 @@ function getFileExtension(name: string): string {
 
 function isBinaryFile(name: string): boolean {
   return BINARY_EXTENSIONS.has(getFileExtension(name));
+}
+
+/**
+ * A NUL byte anywhere in the file means the contents cannot be stored inline.
+ * PostgREST sends `submission_files.contents` as a JSON string, and Postgres
+ * refuses to convert a NUL escape in that JSON to `text` ("unsupported Unicode
+ * escape sequence", SQLSTATE 22P05) — which fails the insert and, via the
+ * rollback below, the entire submission.
+ *
+ * It is also the standard content heuristic for "not source code" (git uses the
+ * same signal), and it is the only classification we have for a file whose name
+ * carries no extension: a compiled `a.out` committed next to its `.c` is the
+ * case that motivated this. Such files now route to storage like any other
+ * binary instead of crashing ingestion.
+ *
+ * Scanning the whole buffer rather than git's 8000-byte prefix window costs one
+ * memchr and leaves no tail past which a NUL could still reach the insert.
+ */
+function hasNulByte(contents: Buffer): boolean {
+  return contents.indexOf(0) !== -1;
+}
+
+/**
+ * Full binary classification: known-binary extension, or NUL-bearing content.
+ * Callers that must decide before reading a file still use `isBinaryFile` alone
+ * (name-only), then apply this once the buffer is in hand.
+ */
+function isBinaryContent(name: string, contents: Buffer): boolean {
+  return isBinaryFile(name) || hasNulByte(contents);
 }
 
 function sha256Hex(buf: Uint8Array): string {
@@ -349,6 +379,13 @@ export function collectTextFilesFromZipBuffer(zipBuffer: Buffer): Promise<Record
       if (contents.length > MAX_FILE_SIZE) {
         throw new SubmissionFileTooLargeError(name, contents.length);
       }
+      // Extensionless binaries survive the name-only filter above, so re-check
+      // once the bytes are in hand. Two reasons to drop them here: `files` is
+      // written to the jsonb `pr_base_tree_cache.files`, which rejects a NUL for
+      // the same reason `submission_files.contents` does; and the head side of
+      // the diff now sends these to storage, so keeping one as pseudo-text would
+      // render the pair as a whole-file deletion.
+      if (hasNulByte(contents)) continue;
       out[name] = contents.toString("utf-8");
     }
     return out;
@@ -425,7 +462,7 @@ export async function ingestSubmissionFilesFromZip(params: IngestFromZipParams):
 
       file_hashes[name] = sha256Hex(contents);
 
-      if (isBinaryFile(name)) {
+      if (isBinaryContent(name, contents)) {
         const logicalPath = normalizeFilenameWhitespace(getSafeRelativePath(name));
         let storageRelPath = sanitizePathForSupabaseStorageObjectKey(logicalPath);
         if (usedBinaryStorageRelPaths.has(storageRelPath)) {


### PR DESCRIPTION
## The bug

A student in a fall course compiled `module-01/mystery.c` and committed the resulting executable, `module-01/mystery`, next to it. Every push to that repo has failed since (Sentry `48a4154c45744f36bf0be72f56bfd206`):

```
Failed to insert text submission file "module-01/mystery": unsupported Unicode escape sequence
```

Binary detection in `SubmissionIngestion.ts` was extension-only:

```ts
function isBinaryFile(name: string): boolean {
  return BINARY_EXTENSIONS.has(getFileExtension(name));
}
```

A Unix executable has no extension, so the file fell to the text branch and its bytes went to `submission_files.contents`. PostgREST sends that column as a JSON string, and Postgres refuses to convert a NUL escape in JSON to `text`:

```
ERROR:  unsupported Unicode escape sequence
DETAIL:  \u0000 cannot be converted to text.
```

The insert 400'd, the ingest rollback removed the storage objects and rows written so far, `cleanupPushDirectSubmission` deleted the submission, and the previous submission was re-activated. The rollback did its job — but the student's push produced no submission, and the failure is deterministic: the webhook redelivery (`attempt_count: 2`) failed identically, and so would every later push while that file is tracked.

## The fix

Classify by content as well as by name. A NUL byte anywhere in the file routes it to the storage bucket like any other binary:

```ts
function isBinaryContent(name: string, contents: Buffer): boolean {
  return isBinaryFile(name) || hasNulByte(contents);
}
```

All three ingest paths — push-direct, autograder Actions, and PR submissions — go through this one writer, so a single check covers them. Files with no extension that really are text (`Makefile`, `LICENSE`) still land inline; only the bytes decide. Scanning the whole buffer rather than git's 8000-byte prefix window costs one memchr and leaves no tail past which a NUL could still reach the insert.

`collectTextFilesFromZipBuffer` gets the same check, applied after buffering so the existing name-only pre-filter still avoids reading known binaries. Two reasons it belongs there too: its output is written to the jsonb `pr_base_tree_cache.files`, which rejects a NUL for the same reason `contents` does; and now that the head side routes these to storage, keeping one on the base side as pseudo-text would render the pair as a whole-file deletion in the diff.

## Scope notes

- Extensionless binaries get `application/octet-stream`, which is not a new case for the UI — `.class`, `.jar`, `.o` and friends already land there, and `isTextLikeFile` sends them all down the download path.
- A UTF-16 source file also carries NULs, so it fails to insert today. After this change it is stored as a binary rather than crashing the submission. Still not rendered as source — a separate, much smaller problem.
- Not addressed: a Latin-1 or otherwise non-UTF-8 text file still goes inline and gets mangled into U+FFFD by `toString("utf-8")`. Lossy, but it inserts, so it is not part of this failure class.

## Testing

`supabase/functions/_shared/SubmissionIngestion.test.ts` gains three cases: an extensionless ELF goes to storage with its contents null and nothing NUL-bearing reaching `contents`; extensionless *text* files stay inline; and `collectTextFilesFromZipBuffer` drops the binary while keeping `Makefile` and the `.c`.

- 331 `_shared` Deno tests pass; prettier 3.5.3 clean.
- A-B control: reverting only `SubmissionIngestion.ts` while keeping the new tests fails exactly the two binary-classification cases and no others, so they are not passing for an unrelated reason.
- `deno check` on both files reports 7 errors, all pre-existing in `GitHubWrapper.ts` and `SupabaseTypes.d.ts`, none in the changed code.
- The Postgres error was reproduced directly against local Supabase to confirm the mechanism, not inferred from the message.

## Immediate unblock

This stops the crash for future pushes. The student still has a compiled binary in their repo; removing it from tracking and gitignoring it is the tidier end state, but no longer required for their submissions to go through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
