### PR TITLE
fix(chart): recreate pg_net after the preview drift reset (+ capture hook-job logs)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -521,6 +521,66 @@ jobs:
               ;;
           esac
 
+      - name: Start hook-job log capture
+        # `kubectl logs job/x` after the fact only works while a pod still
+        # exists, and a failed hook job's pod does not survive: once the Job
+        # hits its backoff limit the Job controller deletes the pod, typically
+        # a couple of seconds after the container exits. So the failure
+        # snapshot below reliably lost exactly the output we needed — a seed
+        # failure showed up as nothing but `error: timed out waiting for the
+        # condition`, and diagnosing it meant re-running the job by hand
+        # against the live preview.
+        #
+        # Follow every batch job pod from the moment it appears instead, and
+        # spool it to disk. `--pod-running-timeout` makes each follower wait
+        # out ContainerCreating rather than erroring on a not-yet-started
+        # container, and `-f` returns on its own when the pod ends or is
+        # deleted, so the followers wind themselves up.
+        env:
+          NS: ${{ needs.meta.outputs.namespace }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/hook-logs"
+          cat > "$RUNNER_TEMP/follow-hook-logs.sh" <<'EOS'
+          #!/usr/bin/env bash
+          # usage: follow-hook-logs.sh <namespace> <output-dir>
+          ns="$1"; dir="$2"
+
+          follow_pod() {
+            local pod="$1" out="$2" phase i
+            for i in $(seq 1 900); do
+              phase=$(kubectl -n "$ns" get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+              # Pod is gone (deleted, or never observed) — nothing left to read.
+              [ -z "$phase" ] && return 0
+              # `kubectl logs -f <pod>` does NOT wait out ContainerCreating: it
+              # errors immediately with "is waiting to start", and
+              # --pod-running-timeout only applies to selector/controller
+              # lookups, not a named pod. So poll until the container exists.
+              if [ "$phase" = "Pending" ]; then sleep 1; continue; fi
+              # Succeeded/Failed pods that still exist return their full log and
+              # exit 0 immediately; Running pods stream until the pod ends.
+              kubectl -n "$ns" logs -f --all-containers --timestamps "$pod" >>"$out" 2>/dev/null && return 0
+              sleep 1
+            done
+          }
+
+          while :; do
+            for pod in $(kubectl -n "$ns" get pods -l batch.kubernetes.io/job-name \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+              marker="$dir/.$pod.following"
+              [ -e "$marker" ] && continue
+              : > "$marker"
+              follow_pod "$pod" "$dir/$pod.log" &
+            done
+            sleep 2
+          done
+          EOS
+          chmod +x "$RUNNER_TEMP/follow-hook-logs.sh"
+          nohup "$RUNNER_TEMP/follow-hook-logs.sh" "$NS" "$RUNNER_TEMP/hook-logs" \
+            > "$RUNNER_TEMP/hook-logs/.watcher.out" 2>&1 &
+          echo "$!" > "$RUNNER_TEMP/hook-logs/.watcher.pid"
+          echo "following batch job pods in $NS (pid $(cat "$RUNNER_TEMP/hook-logs/.watcher.pid"))"
+
       - name: helm upgrade --install
         env:
           RELEASE: ${{ needs.meta.outputs.release }}
@@ -566,16 +626,48 @@ jobs:
           NS: ${{ needs.meta.outputs.namespace }}
         run: |
           kubectl -n "$NS" get pods,jobs 2>&1 | head -50
-          for j in $(kubectl -n "$NS" get jobs -o name); do
-            echo "=== $j ==="
-            kubectl -n "$NS" logs "$j" --all-containers --tail=200 2>&1 | tail -200 || true
+
+          # Captured live by the follower above, so this survives the Job
+          # controller deleting a failed pod. Print the tail of every hook pod
+          # we managed to follow, failures last-and-loudest.
+          shopt -s nullglob
+          for f in "$RUNNER_TEMP"/hook-logs/*.log; do
+            echo "=== $(basename "$f" .log) (captured live) ==="
+            tail -200 "$f"
           done
+
+          # Best-effort fallback for anything the follower missed (a pod that
+          # came and went inside one poll interval, or a job whose pod is
+          # somehow still around).
+          for j in $(kubectl -n "$NS" get jobs -o name); do
+            pod_logs=$(kubectl -n "$NS" logs "$j" --all-containers --tail=200 2>/dev/null || true)
+            [ -z "$pod_logs" ] && continue
+            echo "=== $j (live pod) ==="
+            printf '%s\n' "$pod_logs" | tail -200
+          done
+
+          # Whatever the seed/migration containers printed, the Job's own
+          # failure reason (BackoffLimitExceeded, DeadlineExceeded, an image
+          # pull that never resolved) is only on the Job object and its events.
+          for j in $(kubectl -n "$NS" get jobs -o name); do
+            echo "=== $j conditions ==="
+            kubectl -n "$NS" get "$j" -o jsonpath='{range .status.conditions[*]}{.type}: {.reason} — {.message}{"\n"}{end}' 2>&1 || true
+          done
+          echo "=== recent events ==="
+          kubectl -n "$NS" get events --sort-by=.lastTimestamp 2>&1 | tail -30
 
       - name: Status snapshot
         if: always()
         env:
           NS: ${{ needs.meta.outputs.namespace }}
         run: |
+          # Wind up the log follower before the runner does it for us — an
+          # `kubectl logs -f` left attached keeps the job alive to its cleanup
+          # phase and shows up as "Cleaning up orphan processes".
+          if [ -f "$RUNNER_TEMP/hook-logs/.watcher.pid" ]; then
+            pkill -P "$(cat "$RUNNER_TEMP/hook-logs/.watcher.pid")" 2>/dev/null || true
+            kill "$(cat "$RUNNER_TEMP/hook-logs/.watcher.pid")" 2>/dev/null || true
+          fi
           kubectl -n "$NS" get pods,svc,ingress 2>&1 | head -50
 
       - name: Comment URL on PR

--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.14
+version: 0.3.15
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/images/migrations/migrate.sh
+++ b/charts/pawtograder/images/migrations/migrate.sh
@@ -227,6 +227,17 @@ $reset_storage$;
 -- create uses `IF NOT EXISTS` and is safe to leave in place.
 DROP EXTENSION IF EXISTS pg_cron CASCADE;
 
+-- pg_net, unlike pg_cron, is NOT created by any migration: the chart installs it
+-- once at initdb (postgres-config.yaml), and `CREATE EXTENSION pg_net` registers
+-- the extension in `public` even though its functions live in schema `net`. So
+-- the DROP SCHEMA above cascades it away ("drop cascades to extension pg_net")
+-- and nothing brings it back — every later `net.http_post` call fails with
+-- `schema "net" does not exist`. That bites immediately: phase 4 re-seeds the
+-- vercel_host / cache_invalidation_secret vault entries, which is exactly what
+-- makes call_cache_invalidate stop short-circuiting, so the first class INSERT
+-- of the re-seed dies on the cache-invalidation trigger and the seed job fails.
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
 -- Our migrations seed vault.secrets (e.g. supabase_project_url,
 -- edge-function-secret, vercel_host, cache_invalidation_secret) via
 -- vault.create_secret, which is unique on name and errors on replay. A fresh


### PR DESCRIPTION
## What broke

Deploy-preview runs started failing tonight on unrelated PRs (#939, #940) with:

```
Error: UPGRADE FAILED: post-upgrade hooks failed: 1 error occurred:
	* job pawtograder-seed-N failed: BackoffLimitExceeded
```

The seed job's real error — invisible in CI, see the second commit:

```
❌ Error seeding database: Error: Failed to create class: schema "net" does not exist
```

## Root cause

1. The preview migrations job detects drift and runs its destructive replay: `DROP SCHEMA IF EXISTS public CASCADE` (`migrate.sh`). The chart installs pg_net at initdb with a bare `CREATE EXTENSION IF NOT EXISTS pg_net`, which registers the extension **in `public`** even though its functions live in schema `net`. So the reset cascades it away — the migrations-2 log says so literally:

   ```
   [migrate] MIGRATIONS_RESET_ON_DRIFT=true (tier=preview) — wiping application data and replaying.
   DETAIL:  drop cascades to extension pg_net
   ```

2. The reset block explicitly recreates `pg_cron` but nothing recreates `pg_net`, and initdb never runs again on an existing volume. The database is now permanently without `net.*`.

3. Phase 4 re-seeds the `vercel_host` / `cache_invalidation_secret` vault entries (added in #873), which is exactly the condition that makes `public.call_cache_invalidate` stop short-circuiting and actually call `net.http_post`.

4. The seed inserts a class → `invalidate_classes_admin_stats_insert` fires → `schema "net" does not exist` → seed exits 1 → `helm upgrade --wait-for-jobs` fails.

Not branch-specific: any PR whose migrations trigger a drift reset poisons its preview DB, which is why two unrelated PRs started failing within 15 minutes. Cluster survey matched exactly — every preview namespace with `pg_net=0` **and** `vercel_host` present was broken (pr-876, pr-898, pr-939, pr-940); every one with `pg_net=1` was healthy (pr-917, pr-919, pr-938, pr-941).

**Production is unaffected** — the drift reset is gated to ephemeral tiers.

## Changes

**1. `fix(chart)`: recreate `pg_net` in the reset block** (chart 0.3.14 → 0.3.15), next to the `pg_cron` recreate that exists for exactly the same reason.

**2. `ci(preview)`: capture hook-job logs live.** This bug was undiagnosable from CI output. The failure snapshot runs `kubectl logs job/x` *after* helm gives up, but the Job controller deletes a failed job's pod a couple of seconds after the container exits, so the step printed only `error: timed out waiting for the condition`. Finding the actual error required re-running the seed job by hand against the live preview.

A follower now spools every batch job pod's output to disk from the moment the pod appears, and the failure snapshot reads that instead of racing the controller. Note `kubectl logs -f <pod>` does *not* wait out ContainerCreating — `--pod-running-timeout` only applies to selector lookups, not a named pod, and attaching too early returns `is waiting to start` instead of logs — so the follower polls for the container first. The snapshot also now prints each Job's failure conditions and recent namespace events, since the *reason* a job failed lives on the Job object, not in any container log.

## Verification

Both changes verified against live preview namespaces, not just reasoned about:

- **The bug**: re-ran pr-940's seed job as a bare pod (bare, because the Job controller reaps the real one in ~2s) → failed in 2s with `schema "net" does not exist`.
- **The fix**: ran `CREATE EXTENSION IF NOT EXISTS pg_net` in that database → schema `net` and its 12 functions returned; re-ran the identical seed pod → `🎉 Database seeding completed successfully!`, exit 0.
- **The log capture**: ran the new follower step verbatim (extracted from the YAML) against a live namespace, then created a job that prints two lines and exits 1 with `backoffLimit: 0` — the pod-reaped case that lost the seed output. Both lines now appear in the failure snapshot under `(captured live)`, along with `Failed: BackoffLimitExceeded`.

Already applied `CREATE EXTENSION pg_net` by hand to the four poisoned previews (pr-876, pr-898, pr-939, pr-940) to unblock them; pr-939's deploy was re-run and pr-940 has since re-seeded cleanly.

## Follow-up (not in this PR)

`call_cache_invalidate` hard-fails when pg_net is missing. It already short-circuits with a `RAISE WARNING` when the vault secrets are absent; a `to_regnamespace('net') IS NULL` guard would degrade the same way instead of failing the caller's transaction. Arguable both ways — failing loud may be what you want in prod — so left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
