### PR TITLE
Postgres availability + monitoring: remove the liveness probes that killed prod twice, move global DB metrics to the exporter (77.7% of DB time)

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.15
+version: 0.3.16
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -526,6 +526,18 @@ data:
             usage: "GAUGE"
             description: "Heap size only (no indexes)"
 ---
+{{- /*
+Both of the following are gated on postgres.enabled: the sidecar they front only
+exists inside the chart-managed Postgres StatefulSet. With postgres.enabled=false
+(externally managed database) this Service would select no pods and the
+ServiceMonitor would sit permanently "down" — masking the real exporter an
+operator supplies for the external DB. validations.yaml refuses that combination
+unless monitoring.externalPostgresExporter=true, and in that mode the operator
+brings their own ServiceMonitor. The queries.yaml ConfigMap above is NOT gated:
+it is still useful to mount into an external exporter to keep the metric names
+the dashboards and alert rules expect.
+*/ -}}
+{{- if .Values.postgres.enabled }}
 # Headless Service that fronts the postgres_exporter sidecar's :9187
 # inside the postgres pod. We can't add the metrics port to the existing
 # pawtograder-postgres Service because that Service is consumed as the
@@ -568,6 +580,7 @@ spec:
       path: /metrics
       interval: {{ .Values.monitoring.scrapeInterval }}
       scrapeTimeout: {{ .Values.monitoring.scrapeTimeout }}
+{{- end }}
 ---
 # ServiceMonitor: storage-api. /metrics on the http port. Toggleable via
 # monitoring.serviceMonitors.storage: storage-api only exposes /metrics on its

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -359,6 +359,10 @@ data:
         GROUP BY queryid
         ORDER BY SUM(total_exec_time) DESC
         LIMIT 20
+      # pg_stat_statements is CLUSTER-wide — one shared hash table covering every
+      # database — so auto-discovery would re-export the same top-20 statements
+      # once per discovered database. See the auto-discovery note below.
+      master: true
       metrics:
         - queryid:
             usage: "LABEL"
@@ -379,12 +383,62 @@ data:
             usage: "COUNTER"
             description: "Total rows touched by the statement"
 
+    # =========================================================================
+    # AUTO-DISCOVERY: why every block in this file sets master: true.
+    #
+    # The sidecar runs with PG_EXPORTER_AUTO_DISCOVER_DATABASES=true
+    # (postgres-statefulset.yaml), which makes the exporter enumerate databases
+    # and run the custom queries against EACH one. Without `master: true` a
+    # block runs once per discovered database.
+    #
+    # That is wrong for every query here: they are either cluster-wide
+    # (pg_stat_statements, pg_buffercache, pg_settings, pg_stat_replication) or
+    # specific to the APPLICATION database (public.classes, public.submissions,
+    # public.help_requests, and the pawtograder_* functions). Re-running them
+    # elsewhere either duplicates the same numbers or errors on a missing
+    # relation.
+    #
+    # Auto-discovery is NOT a no-op here. Its query is
+    #   SELECT datname FROM pg_database
+    #    WHERE datallowconn AND NOT datistemplate AND datname != current_database()
+    # and on a supabase/postgres instance that returns `_supabase` and
+    # `storage_vectors` — verified against supabase/postgres 17.6.
+    #
+    # What has kept it from corrupting the metrics so far is only that these
+    # queries happen to fail or come back empty on those databases:
+    # pg_stat_statements, public.classes, public.submissions and
+    # public.help_requests all raise "relation does not exist" there (the
+    # namespace is skipped and nothing is emitted), and pawtograder_table_sizes
+    # runs but matches no >10 MiB table in the public/auth/storage/realtime
+    # schemas, so it returns 0 rows.
+    #
+    # That is luck, not a design. Two reasons to fix it properly:
+    #
+    # 1. The four erroring blocks set pg_exporter_last_scrape_error on EVERY
+    #    scrape, once per discovered database, and log the failure each time.
+    #    master: true removes that standing error and the log noise.
+    # 2. The `server` label is only host:port — it comes from
+    #    parseFingerprint(dsn), which concatenates host and port and does NOT
+    #    include the database name. Databases discovered on one instance are
+    #    therefore indistinguishable by label. The moment one of these queries
+    #    DOES return a row from a second database (a colliding relation name,
+    #    another application database, a matching schema appearing in
+    #    `_supabase`), the result is not a mis-ranked topk — it is a genuinely
+    #    DUPLICATE label set, and that makes the exporter's registry return HTTP
+    #    500 for the ENTIRE /metrics endpoint (see pg_stat_statements_top
+    #    above), taking down all postgres metrics at once.
+    #
+    # Rule of thumb: a new block here needs master: true unless it genuinely
+    # means something different per database.
+    # =========================================================================
     pawtograder_classes:
       query: |
         SELECT COUNT(*) FILTER (WHERE NOT is_demo)::float AS real_classes,
                COUNT(*) FILTER (WHERE is_demo)::float AS demo_classes,
                COUNT(*)::float AS total_classes
         FROM public.classes
+      # public.classes only exists in the application database.
+      master: true
       metrics:
         - real_classes:
             usage: "GAUGE"
@@ -403,6 +457,8 @@ data:
         FROM public.submissions
         WHERE is_active = true
         GROUP BY class_id
+      # public.submissions only exists in the application database.
+      master: true
       metrics:
         - class_id:
             usage: "LABEL"
@@ -419,6 +475,8 @@ data:
         FROM public.help_requests
         WHERE created_at > NOW() - INTERVAL '24 hours'
         GROUP BY class_id
+      # public.help_requests only exists in the application database.
+      master: true
       metrics:
         - class_id:
             usage: "LABEL"
@@ -448,6 +506,12 @@ data:
           AND pg_total_relation_size(c.oid) > 10485760
         ORDER BY pg_total_relation_size(c.oid) DESC
         LIMIT 30
+      # pg_class is per-database, and the public/auth/storage/realtime schemas
+      # this filters on are the application database's. Without master:true the
+      # top-30 cut would be computed per discovered database, so the dashboard's
+      # unfiltered `topk(30, pawtograder_table_sizes_total_bytes)` could rank
+      # tables from different databases against each other.
+      master: true
       metrics:
         - relation:
             usage: "LABEL"

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -146,6 +146,197 @@ data:
             usage: "GAUGE"
             description: "superuser_reserved_connections — slots reserved for superusers, shrinking the app-usable ceiling"
 
+    # =========================================================================
+    # Global database state, moved here from the `metrics` edge function
+    # (supabase/functions/metrics/index.ts).
+    #
+    # WHY: the edge-functions ServiceMonitor at the bottom of this file selects
+    # the functions *Service*, and Prometheus scrapes EVERY pod endpoint behind
+    # a Service. Prod pins the functions HPA at 32 replicas, so a 30s interval
+    # meant ~1.07 scrapes/sec of that /metrics handler, each one calling
+    # database_ram_metrics() and vacuum_health_check(). Measured over a 42-day
+    # pg_stat_statements window:
+    #
+    #   database_ram_metrics()  3,036,749 calls  360.6 ms mean  77.7% of ALL
+    #                                                           database exec time
+    #   vacuum_health_check()   3,036,995 calls   32.8 ms mean   7.1%
+    #
+    # database_ram_metrics() is that expensive because it scans pg_buffercache:
+    # one row per buffer descriptor, and shared_buffers = 4GB means 524,288
+    # descriptors per call. The data is GLOBAL database state — byte-identical
+    # from every pod — so 31 of every 32 scrapes were pure waste, and they
+    # produced 32 duplicate copies of every series (which is why the dashboard
+    # panels all wrap in max()).
+    #
+    # The exporter sidecar is scraped ONCE (one postgres pod, one endpoint), so
+    # the same series now cost 1/32 as much and arrive un-duplicated.
+    #
+    # Metric AND label names are reproduced exactly: postgres_exporter names
+    # each metric `<block>_<column>`, so the block/column splits below are
+    # chosen to land on the names the Grafana panels already query, not for
+    # elegance. Don't "tidy" a block name without regrading the dashboards.
+    #
+    # Long → wide: database_ram_metrics() returned long format
+    # (metric_name, metric_labels jsonb, metric_value). This exporter needs
+    # WIDE format — one row per label set, each numeric column becoming a
+    # metric — so `SELECT * FROM database_ram_metrics()` cannot work. The
+    # queries below reproduce its semantics against the underlying sources
+    # directly, which is also this file's house style (see
+    # pawtograder_db_connections above).
+    #
+    # The exporter connects as supabase_admin (postgres-statefulset.yaml
+    # DATA_SOURCE_USER), which initdb creates as the bootstrap SUPERUSER, so no
+    # extra grant is needed for pg_buffercache (normally pg_monitor-gated) or
+    # for the SECURITY DEFINER vacuum_health_check().
+    # =========================================================================
+
+    # Buffer-cache bytes per relation. Reproduces database_ram_metrics()'s
+    # 'buffer_cache_bytes' rows: same >1 MiB floor, same top-20 cut, same
+    # unqualified `relname` label. GROUP BY relname (not oid) is what the RPC
+    # did, and it also guarantees one row per label set — duplicate series make
+    # the exporter's registry return HTTP 500 for the ENTIRE /metrics endpoint,
+    # taking down all postgres metrics (see the pg_stat_statements_top note).
+    #
+    # public.pg_buffercache is schema-qualified on purpose: migrations
+    # 20260722000000 / 20260722120000 pin the extension to `public` (relocating
+    # it if a base image put it in `extensions`), so qualify rather than trust
+    # the exporter connection's search_path.
+    #
+    # cache_seconds: the 524,288-descriptor scan is the whole reason this moved,
+    # and buffer-pool composition changes slowly, so serve it from the
+    # exporter's per-namespace cache and re-run the scan at most once every 5
+    # minutes. `cache_seconds` is honoured for user queries by the pinned
+    # exporter (v0.18.0, monitoring.postgresExporter.image.tag) and needs no
+    # flag; cached metrics are re-emitted on every scrape, so Prometheus sees
+    # no staleness gap.
+    #
+    # master: true — pg_buffercache is the CLUSTER's shared buffer pool. With
+    # PG_EXPORTER_AUTO_DISCOVER_DATABASES=true, without this the scan would be
+    # repeated once per discovered database (`_supabase`, ...) and re-exported
+    # under different `server` labels.
+    pawtograder_db_buffer_cache:
+      query: |
+        SELECT c.relname,
+               (count(*) * 8192)::float AS bytes
+        FROM public.pg_buffercache b
+        JOIN pg_class c ON c.relfilenode = b.relfilenode
+        WHERE b.reldatabase = (SELECT oid FROM pg_database WHERE datname = current_database())
+        GROUP BY c.relname
+        HAVING count(*) * 8192 > 1048576
+        ORDER BY count(*) DESC
+        LIMIT 20
+      master: true
+      cache_seconds: 300
+      metrics:
+        - relname:
+            usage: "LABEL"
+            description: "Relation name, unqualified (pg_buffercache joins pg_class by relfilenode)"
+        - bytes:
+            usage: "GAUGE"
+            description: "Bytes of shared buffer cache held by this relation (8 KiB per buffer); relations over 1 MiB only, top 20"
+
+    # Total buffer-cache bytes in use by the current database. Deliberately its
+    # own block rather than a second column above: the per-relation query is
+    # capped (>1 MiB, LIMIT 20) so sum() over it is NOT the total, and folding
+    # the total into that block would stamp a `relname` label onto a series the
+    # dashboards query bare. Block `pawtograder_db_buffer_cache_total` + column
+    # `used_bytes` is what yields pawtograder_db_buffer_cache_total_used_bytes.
+    # Same cache_seconds / master rationale as above.
+    pawtograder_db_buffer_cache_total:
+      query: |
+        SELECT (count(*) * 8192)::float AS used_bytes
+        FROM public.pg_buffercache
+        WHERE reldatabase = (SELECT oid FROM pg_database WHERE datname = current_database())
+      master: true
+      cache_seconds: 300
+      metrics:
+        - used_bytes:
+            usage: "GAUGE"
+            description: "Total bytes of shared buffer cache held by the current database"
+
+    # Dead tuples per table — the input to every vacuum/bloat judgement.
+    # Block `pawtograder_db_dead` + column `tuples` is the only split that
+    # reproduces the existing metric name pawtograder_db_dead_tuples exactly;
+    # the odd word break is deliberate, not a typo.
+    #
+    # sum()/GROUP BY relname: pg_stat_user_tables.relname is unqualified and
+    # the view spans public, auth, storage and realtime, so two same-named
+    # tables in different schemas would emit the same label set twice and 500
+    # the whole endpoint. Summing is also the honest reading of a
+    # `relname`-only label. No cache_seconds — pg_stat_user_tables is an
+    # in-memory stats view, and 30s freshness is what vacuum triage wants.
+    #
+    # master: true — pg_stat_user_tables is per-database; auto-discovery would
+    # otherwise re-export other databases' tables under a `server` label.
+    pawtograder_db_dead:
+      query: |
+        SELECT relname,
+               sum(n_dead_tup)::float AS tuples
+        FROM pg_stat_user_tables
+        WHERE n_dead_tup > 100
+        GROUP BY relname
+        ORDER BY sum(n_dead_tup) DESC
+        LIMIT 20
+      master: true
+      metrics:
+        - relname:
+            usage: "LABEL"
+            description: "Table name, unqualified (summed across schemas when the name repeats)"
+        - tuples:
+            usage: "GAUGE"
+            description: "Dead tuples awaiting vacuum; tables over 100 only, top 20"
+
+    # Vacuum health. Wraps public.vacuum_health_check() (defined in
+    # 20260325000000_autovacuum_tuning.sql): overdue vacuums, XID wraparound
+    # risk, dead-tuple bloat, and large never-vacuumed tables. The function
+    # returns only text columns, so `alert` is a synthetic 1 — the label set is
+    # the payload, exactly as the edge function emitted it.
+    #
+    # Label names are load-bearing (docs/grafana-dashboard-vacuum-health.json
+    # filters on severity): check_name → `check` (quoted, CHECK is a reserved
+    # word and cannot be a bare alias), relname → `table_name`.
+    #
+    # DISTINCT: the xid_wraparound_risk branch scans pg_class across every
+    # schema, so two same-named relations would produce an identical label set
+    # and 500 the whole /metrics endpoint.
+    #
+    # The NOT EXISTS fallback row keeps the series continuously present when the
+    # database is healthy, matching the edge function's
+    # {check="none",severity="ok",table_name="none"} 0 sentinel. MATERIALIZED so
+    # the 32.8 ms function runs once per scrape, not twice.
+    #
+    # No cache_seconds: this is the alerting-relevant signal and it is cheap at
+    # one target (32.8 ms / 30s is a ~0.1% duty cycle, against ~1.07 calls/sec
+    # before).
+    #
+    # master: true — the function exists only in the application database;
+    # auto-discovered databases would raise "function does not exist" on every
+    # scrape and permanently light up pg_exporter_last_scrape_error.
+    pawtograder_vacuum:
+      query: |
+        WITH health AS MATERIALIZED (
+          SELECT DISTINCT check_name AS "check", severity, relname AS table_name, 1::float AS alert
+          FROM public.vacuum_health_check()
+        )
+        SELECT * FROM health
+        UNION ALL
+        SELECT 'none', 'ok', 'none', 0::float
+        WHERE NOT EXISTS (SELECT 1 FROM health)
+      master: true
+      metrics:
+        - check:
+            usage: "LABEL"
+            description: "Which check fired: vacuum_overdue, xid_wraparound_risk, high_dead_tuple_ratio, never_vacuumed_large_table, or none"
+        - severity:
+            usage: "LABEL"
+            description: "warning or critical; ok on the healthy sentinel row"
+        - table_name:
+            usage: "LABEL"
+            description: "Relation the check fired on; none on the healthy sentinel row"
+        - alert:
+            usage: "GAUGE"
+            description: "1 while this vacuum health alert is active, 0 on the healthy sentinel row"
+
     pg_stat_statements_top:
       # Aggregate by queryid. pg_stat_statements holds one row PER
       # (userid, dbid, toplevel, queryid), so selecting queryid + query text

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -128,7 +128,10 @@ data:
     # inflate the ratio and page for saturation that isn't there. Drives the
     # PawtograderPostgresConnections* alerts. master:true so auto-discovered
     # per-database servers (PG_EXPORTER_AUTO_DISCOVER_DATABASES) don't re-export
-    # the cluster-wide count under different `server` labels.
+    # the cluster-wide count. Note the re-exports would NOT be separable: the
+    # `server` label is parseFingerprint(dsn), host:port only, with no database
+    # name, so identical label sets collide and the exporter's registry returns
+    # HTTP 500 for the whole /metrics endpoint. See the AUTO-DISCOVERY note below.
     pawtograder_db_connections:
       query: |
         SELECT (SELECT COUNT(*) FROM pg_stat_activity WHERE backend_type = 'client backend')::float AS used,

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -211,9 +211,10 @@ data:
     # no staleness gap.
     #
     # master: true — pg_buffercache is the CLUSTER's shared buffer pool. With
-    # PG_EXPORTER_AUTO_DISCOVER_DATABASES=true, without this the scan would be
-    # repeated once per discovered database (`_supabase`, ...) and re-exported
-    # under different `server` labels.
+    # PG_EXPORTER_AUTO_DISCOVER_DATABASES=true, without this the expensive scan
+    # would be repeated once per discovered database. See the AUTO-DISCOVERY note
+    # below: the `server` label does NOT distinguish them, so the re-exports
+    # collide rather than separate.
     pawtograder_db_buffer_cache:
       query: |
         SELECT c.relname,
@@ -398,35 +399,34 @@ data:
     # elsewhere either duplicates the same numbers or errors on a missing
     # relation.
     #
-    # Auto-discovery is NOT a no-op here. Its query is
+    # Whether that actually bites depends on the Postgres image. The discovery
+    # query is
     #   SELECT datname FROM pg_database
     #    WHERE datallowconn AND NOT datistemplate AND datname != current_database()
-    # and on a supabase/postgres instance that returns `_supabase` and
-    # `storage_vectors` — verified against supabase/postgres 17.6.
     #
-    # What has kept it from corrupting the metrics so far is only that these
-    # queries happen to fail or come back empty on those databases:
-    # pg_stat_statements, public.classes, public.submissions and
-    # public.help_requests all raise "relation does not exist" there (the
-    # namespace is skipped and nothing is emitted), and pawtograder_table_sizes
-    # runs but matches no >10 MiB table in the public/auth/storage/realtime
-    # schemas, so it returns 0 rows.
+    # On the CURRENTLY DEPLOYED supabase/postgres 17.4.x there is nothing for it
+    # to find: the only databases are `postgres`, `template0` and `template1`,
+    # and templates are excluded — so these blocks only ever run against the
+    # application database and are LATENT. Confirmed on the live prod exporter:
+    # pg_exporter_last_scrape_error is 0 and there is exactly one `server` label
+    # value (127.0.0.1:5432) across the whole scrape.
     #
-    # That is luck, not a design. Two reasons to fix it properly:
+    # On 17.6.x and later, Supabase adds `_supabase` and `storage_vectors`
+    # (verified against 17.6.1.132). At that point pg_stat_statements,
+    # public.classes, public.submissions and public.help_requests would raise
+    # "relation does not exist" once per discovered database on every scrape —
+    # standing pg_exporter_last_scrape_error plus log noise — and
+    # pawtograder_table_sizes would run against the wrong databases.
     #
-    # 1. The four erroring blocks set pg_exporter_last_scrape_error on EVERY
-    #    scrape, once per discovered database, and log the failure each time.
-    #    master: true removes that standing error and the log noise.
-    # 2. The `server` label is only host:port — it comes from
-    #    parseFingerprint(dsn), which concatenates host and port and does NOT
-    #    include the database name. Databases discovered on one instance are
-    #    therefore indistinguishable by label. The moment one of these queries
-    #    DOES return a row from a second database (a colliding relation name,
-    #    another application database, a matching schema appearing in
-    #    `_supabase`), the result is not a mis-ranked topk — it is a genuinely
-    #    DUPLICATE label set, and that makes the exporter's registry return HTTP
-    #    500 for the ENTIRE /metrics endpoint (see pg_stat_statements_top
-    #    above), taking down all postgres metrics at once.
+    # So master: true is a PREREQUISITE FOR THE NEXT POSTGRES IMAGE BUMP, not a
+    # fix for something failing today. The second reason is worse than noise:
+    # the `server` label is only host:port — parseFingerprint(dsn) concatenates
+    # host and port and does NOT include the database name — so databases
+    # discovered on one instance are indistinguishable by label. The first time
+    # one of these queries returns a row from a second database, the result is
+    # not a mis-ranked topk but a genuinely DUPLICATE label set, and that makes
+    # the exporter's registry return HTTP 500 for the ENTIRE /metrics endpoint
+    # (see pg_stat_statements_top above), taking down all postgres metrics.
     #
     # Rule of thumb: a new block here needs master: true unless it genuinely
     # means something different per database.

--- a/charts/pawtograder/templates/postgres-replica.yaml
+++ b/charts/pawtograder/templates/postgres-replica.yaml
@@ -214,12 +214,32 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 5
             timeoutSeconds: 3
-          livenessProbe:
-            exec:
-              command: [pg_isready, -U, supabase_admin, -d, {{ .Values.postgres.database }}]
-            initialDelaySeconds: 45
-            periodSeconds: 10
-            timeoutSeconds: 5
+          # NO livenessProbe — same decision as the primary, for the same reason.
+          # See the long note in postgres-statefulset.yaml.
+          #
+          # This is not a copy of the primary's problem, it is the second half of
+          # the same incident: postgres-replica-0 was killed by its own liveness
+          # probe at 17:18:18 on 2026-08-27, hours after the primary went down at
+          # 14:02:44. Both templates carried their own hardcoded probe with
+          # periodSeconds 10 / timeoutSeconds 5 / failureThreshold unset (default
+          # 3), so both had ~30s of tolerance and both lost the same race against
+          # a transient NetApp NFS stall during network maintenance.
+          #
+          # The recovery argument is STRONGER here than on the primary. A standby
+          # is in continuous recovery by definition, and pg_isready reports
+          # "rejecting connections" (exit 1) whenever it cannot yet accept
+          # queries — which is precisely the state a replica catching up on WAL is
+          # in. A liveness probe on a standby is therefore closest to a timer that
+          # kills it whenever it falls behind, which is the worst possible response
+          # to falling behind.
+          #
+          # readinessProbe above is kept and does the useful work: an unready
+          # replica is removed from Service endpoints, so nothing is routed to a
+          # standby that cannot serve, without destroying the process.
+          #
+          # If you reintroduce a liveness probe, you must also update the
+          # assertion in charts/pawtograder/tests/render-guardrails.sh that pins
+          # its absence.
           resources:
             {{- toYaml .Values.postgres.replica.resources | nindent 12 }}
       volumes:

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -240,13 +240,28 @@ spec:
           #
           # What this trades away: a permanently wedged postmaster is no longer
           # restarted automatically. The pod stays Running and NotReady until
-          # someone intervenes. That is the intended trade — readiness (kept
-          # below) already stops traffic being routed here, which is the useful
-          # half of the signal and is non-destructive, and the wedged case now
-          # surfaces as alerts instead of a blind restart: the pawtograder.app
-          # group pages critical within 1-5m once the app cannot reach the DB, and
-          # PawtograderPostgresExporterQueryFailing / ...ExporterDown fire on the
-          # exporter sidecar in this same pod. Detection without amputation.
+          # someone intervenes. Readiness (kept below) stops traffic being routed
+          # here, which is the useful half of the signal and is non-destructive.
+          #
+          # The other half of the trade is DETECTION, and it had to be built —
+          # an earlier version of this comment claimed the pawtograder.app group
+          # would page critical within 1-5m once the app could not reach the DB.
+          # That was WRONG, and the error mattered because it was the safety
+          # argument for removing the probe. Every critical rule in that group is
+          # `metric > threshold` on a series that DISAPPEARS when the database is
+          # gone (the queue gauges come from the metrics edge function, whose
+          # handler returns HTTP 500 when its first DB RPC fails), and a threshold
+          # against no data returns no data. They fail OPEN. Same for
+          # PawtograderPostgresConnectionsSaturated, which reads the exporter
+          # sidecar in THIS pod. Before the fix a wedged primary was silent for 30
+          # minutes and then only warned (PawtograderPostgresExporterDown).
+          #
+          # PawtograderPostgresUnavailable now covers it: critical, for 5m, keyed
+          # on kube_statefulset_status_replicas_ready from kube-state-metrics —
+          # deliberately OUTSIDE this pod, so it survives both a dead database and
+          # a dead exporter. See templates/prometheus-rules.yaml. Detection
+          # without amputation, but only because that rule exists: do not remove
+          # it and leave this probe removed.
           #
           # If you reintroduce a liveness probe, you must also update the
           # assertion in charts/pawtograder/tests/render-guardrails.sh that pins

--- a/charts/pawtograder/templates/postgres-statefulset.yaml
+++ b/charts/pawtograder/templates/postgres-statefulset.yaml
@@ -186,21 +186,71 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 3
-          livenessProbe:
-            exec:
-              command:
-                - pg_isready
-                # Probe the bootstrap superuser, not `postgres`. The
-                # `postgres` role is created later by migrate.sh; on first
-                # boot it doesn't exist yet, so probing it would keep the
-                # pod NotReady (or trip liveness) until migrations finish.
-                - -U
-                - supabase_admin
-                - -d
-                - {{ .Values.postgres.database }}
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+          # NO livenessProbe. Deliberate, and load-bearing — see the 2026-08-27
+          # incident below before adding one back.
+          #
+          # There was one here: pg_isready with initialDelaySeconds 30,
+          # periodSeconds 10, timeoutSeconds 5 and failureThreshold unset, so it
+          # inherited the Kubernetes default of 3 — about 30 seconds of tolerance.
+          # It took the platform down twice in one day:
+          #
+          #   14:02:19.677  all 7 pg_cron jobs log "job startup timeout"
+          #                 (the postmaster could not fork background workers)
+          #   14:02:44      kubelet: "Container postgres failed liveness probe,
+          #                 will be restarted"
+          #   14:02:45.452  shutdown checkpoint: 1397 buffers, write=0.122s,
+          #                 sync=0.002s  <- storage was already FINE
+          #   14:02:46.169  database system is shut down
+          #   14:02:51      all 3 realtime pods exit 1 (Postgrex admin_shutdown ->
+          #                 Erlang app exit + crash dump)
+          #   17:18:18      the same sequence again, on postgres-replica-0
+          #
+          # The probe was not wrong. pg_cron's "job startup timeout" means the
+          # postmaster genuinely could not fork workers, which is exactly what
+          # pg_isready needs; it really was unresponsive for 25s+. But the
+          # condition was transient and self-resolving: the shutdown checkpoint
+          # one second after the kill flushed 1397 buffers in 0.122s with a 2ms
+          # sync, so storage was healthy again by then. The probe's patience ran
+          # out roughly a second before the problem cleared itself.
+          #
+          # Cause was external: network maintenance that day. PGDATA is NetApp
+          # NFS, and hard mounts BLOCK rather than error, so the fork path stalled
+          # while Postgres logged nothing — the log is empty for the 12 minutes
+          # before the kill.
+          #
+          # Why removed rather than loosened. Restarting a single-writer Postgres
+          # cannot fix external storage, so waiting is strictly better. Liveness
+          # only helps a permanently wedged postmaster, which is rare, warrants a
+          # human, and on this stack means manual failover anyway. Against that,
+          # every misfire costs the 4GB warm buffer pool, every connection, and a
+          # hard exit of all three realtime pods (dropping every WebSocket client
+          # at once). The expected value is negative.
+          #
+          # Loosening to ~90s (timeoutSeconds 10 / periodSeconds 15 /
+          # failureThreshold 6) was the other candidate and is NOT enough, because
+          # of a second failure mode: pg_isready also exits non-zero during crash
+          # recovery, printing "rejecting connections" (observed on the replica
+          # during startup). This database is ~29 GB, so WAL replay after any
+          # unclean stop can exceed 90 seconds — and initialDelaySeconds does not
+          # help, it delays the first probe rather than widening the window once
+          # probing starts. Liveness would then kill the pod MID-RECOVERY, and
+          # each kill is another unclean stop with more WAL to replay than the
+          # last: a self-worsening restart loop at the exact moment the database
+          # can least afford one.
+          #
+          # What this trades away: a permanently wedged postmaster is no longer
+          # restarted automatically. The pod stays Running and NotReady until
+          # someone intervenes. That is the intended trade — readiness (kept
+          # below) already stops traffic being routed here, which is the useful
+          # half of the signal and is non-destructive, and the wedged case now
+          # surfaces as alerts instead of a blind restart: the pawtograder.app
+          # group pages critical within 1-5m once the app cannot reach the DB, and
+          # PawtograderPostgresExporterQueryFailing / ...ExporterDown fire on the
+          # exporter sidecar in this same pod. Detection without amputation.
+          #
+          # If you reintroduce a liveness probe, you must also update the
+          # assertion in charts/pawtograder/tests/render-guardrails.sh that pins
+          # its absence.
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
         {{- if and .Values.postgres.walg.enabled .Values.postgres.walg.baseBackup.enabled }}

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -20,6 +20,7 @@ docs/operations/monitoring-alerting.md.
      have a letter after `<name>-`). Keeps a failing/slow verify or drill from
      masking a stale real backup or paging as a backup outage. */}}
 {{- $backupJob := include "pawtograder.componentName" (dict "ctx" . "component" "backup") }}
+{{- $pgSts := include "pawtograder.componentName" (dict "ctx" . "component" "postgres") }}
 {{- $backupMaxAge := .Values.monitoring.prometheusRules.backupMaxAgeHours | default 36 }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -202,6 +203,66 @@ spec:
     {{- if .Values.postgres.enabled }}
     - name: pawtograder.postgres
       rules:
+        # DATABASE AVAILABILITY — the one rule that actually detects a dead or
+        # wedged primary. Read this before touching any other rule in this group.
+        #
+        # Why it has to exist, and why it is keyed on kube-state-metrics rather
+        # than on anything the platform itself emits: EVERY other critical rule in
+        # this chart fails OPEN when the database is gone. They are all
+        # `metric > threshold` on series that DISAPPEAR in that scenario, and a
+        # threshold comparison against no data returns no data, so the alert
+        # simply never fires:
+        #
+        #   PawtograderPostgresConnectionsSaturated (critical, 5m) reads
+        #     pawtograder_db_connections_*, produced by the postgres_exporter
+        #     SIDECAR — which lives in the postgres pod and dies with it.
+        #   PawtograderRecalcStalled (3m), PawtograderAsyncDLQGrowing (1m),
+        #     PawtograderAsyncQueueBacklog (5m), PawtograderQueueOldestMessageAging
+        #     (10m) — all critical — read pawtograder_*queue* series from the
+        #     `metrics` edge function, whose handler THROWS and returns HTTP 500
+        #     when its first DB RPC fails, so the whole target goes away.
+        #   PawtograderPostgresExporterDown notices, but at warning after 30m.
+        #
+        # So before this rule, a wedged primary was silent for 30 minutes and then
+        # merely warned. That gap became load-bearing when the liveness probes were
+        # removed from postgres-statefulset.yaml / postgres-replica.yaml: nothing
+        # restarts a wedged postmaster automatically now, so the condition MUST
+        # page. Detection is the other half of that trade.
+        #
+        # kube_statefulset_status_replicas_ready is independent of the database,
+        # the exporter and the edge function, and it is precisely the signal the
+        # retained readinessProbe produces. Labels are `statefulset` and
+        # `namespace` (kube-state-metrics, STABLE). max() because kube-state-metrics
+        # may run more than one replica and kube-prometheus-stack adds per-target
+        # labels; we want one alert, not one per KSM pod.
+        #
+        # Known limitation, deliberate and consistent with this file's stated
+        # philosophy: if kube-state-metrics is absent the series is missing and this
+        # rule is silent rather than firing. No absent() arm — that would page every
+        # install without KSM. Do not "simplify" this rule away on the grounds that
+        # the queue alerts look like they cover it. They do not.
+        - alert: PawtograderPostgresUnavailable
+          expr: max(kube_statefulset_status_replicas_ready{namespace="{{ $ns }}", statefulset="{{ $pgSts }}"}) == 0
+          for: {{ .Values.monitoring.prometheusRules.postgresUnavailableFor | default "5m" }}
+          labels:
+            severity: critical
+          annotations:
+            summary: "Pawtograder Postgres has no ready replica — database unavailable"
+            description: >-
+              The {{ $pgSts }} StatefulSet in {{ $ns }} has reported zero ready
+              replicas for
+              {{ .Values.monitoring.prometheusRules.postgresUnavailableFor | default "5m" }}.
+              Every tier is down: PostgREST, GoTrue, realtime, storage and the edge
+              functions all depend on this database. The pod is NOT restarted
+              automatically — the liveness probes were deliberately removed after
+              they killed the primary twice during a transient NFS stall (see
+              templates/postgres-statefulset.yaml), so recovery here is a human
+              decision. Check `kubectl describe pod` and the postgres container
+              logs first: if the postmaster is wedged on storage, restarting will
+              not help and may extend the outage by forcing WAL replay. Do not
+              expect the queue or connection alerts to corroborate this — they read
+              series that vanish when the database is gone. Runbook:
+              docs/operations/monitoring-alerting.md.
         # Connection-budget saturation. pawtograder_db_connections (postgres_exporter
         # query in monitoring.yaml) reports used backends against max_connections;
         # the ratio is compared to a percent threshold. max() not sum(): there is a

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -244,6 +244,97 @@ spec:
               are about to be refused (FATAL: too many clients). Kill leaked/idle
               sessions or scale down connection consumers immediately. Runbook:
               docs/operations/monitoring-alerting.md.
+        # Monitoring blind-spot guard. Added when the vacuum, buffer-cache and
+        # dead-tuple metrics moved off the `metrics` edge function into the
+        # postgres_exporter's queries.yaml (monitoring.yaml).
+        #
+        # postgres_exporter does NOT fail a scrape when one custom query breaks. It
+        # drops that namespace from /metrics entirely and records the failure only
+        # here. Traced in the pinned v0.18.0: a db.Query error becomes
+        # queryNamespaceMapping's fatal (third) return, lands in
+        # queryNamespaceMappings' errMap, and Server.Scrape turns a non-empty errMap
+        # into the error that sets this gauge to 1.
+        #
+        # Without this alert that failure is not just silent, it fails OPEN. The
+        # vacuum dashboard reads
+        # `count(pawtograder_vacuum_alert{severity!="ok"} == 1) OR vector(0)`, so a
+        # dropped namespace renders as 0 active alerts — green. A dropped function, a
+        # revoked grant, or a pg_buffercache extension relocated out of `public`
+        # would look exactly like a healthy database. The edge function used to emit
+        # an explicit pawtograder_vacuum_alert{check="rpc_failed"} 1 on failure; the
+        # exporter has no equivalent, so the signal has to come from here.
+        #
+        # severity: warning, not critical — nothing user-facing is broken. We have
+        # gone blind on vacuum/XID-wraparound and RAM telemetry, which needs fixing
+        # in hours, not a 3am page. `for: 15m` so a single bad scrape (or one query
+        # hitting a transient lock timeout) cannot flap it, matching
+        # PawtograderPostgresConnectionsHigh and PawtograderWALArchiveFailing.
+        #
+        # max() for the same reason as the connection rules above: the ServiceMonitor
+        # attaches pod/instance/endpoint labels, and this should be one alert rather
+        # than one per label set.
+        - alert: PawtograderPostgresExporterQueryFailing
+          expr: max(pg_exporter_last_scrape_error{namespace="{{ $ns }}"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pawtograder postgres_exporter custom queries are failing"
+            description: >-
+              At least one postgres_exporter custom query in {{ $ns }} has failed for
+              15m (pg_exporter_last_scrape_error=1). The exporter silently OMITS the
+              failing query's metrics from /metrics, so affected panels read as empty
+              or — for pawtograder_vacuum_alert, whose dashboard wraps it in
+              `OR vector(0)` — as healthy. Likely causes: a function the queries wrap
+              was dropped or renamed (public.vacuum_health_check), a grant was revoked
+              from the exporter's role (supabase_admin), the pg_buffercache extension
+              moved out of `public`, or a query is timing out under load. Check the
+              postgres-exporter container logs in the postgres pod — it logs the
+              failing namespace and the Postgres error. Runbook:
+              docs/operations/monitoring-alerting.md.
+        # The watcher's watcher. The rule above needs pg_exporter_last_scrape_error to
+        # EXIST. If the exporter sidecar is gone, the postgres-exporter Service or its
+        # ServiceMonitor selector breaks, or Prometheus stops scraping that target,
+        # the gauge disappears and that rule goes quiet along with every signal it was
+        # guarding.
+        #
+        # This matters more than it used to: the vacuum, buffer-cache and dead-tuple
+        # series previously came from 32 edge-function pods, so losing any one changed
+        # nothing. The exporter is a single target, so it is now a single point of
+        # monitoring failure for those signals.
+        #
+        # absent() is deliberately on pg_exporter_last_scrape_error and NOT on the
+        # pawtograder_db_* families themselves. Those are legitimately empty on a
+        # healthy database: pawtograder_db_dead_tuples only has series for tables with
+        # more than 100 dead tuples, and pawtograder_db_buffer_cache_bytes only for
+        # relations over 1 MiB, so absent() on either would page on an idle instance.
+        # This gauge is emitted on every scrape regardless of what the queries return,
+        # so its absence means exactly one thing: the exporter is not being scraped.
+        #
+        # `for: 30m` and severity: warning — rides out a postgres StatefulSet roll or
+        # a Prometheus reload without paging (matching PawtograderBackupMissing's 30m),
+        # and deliberately overlaps kube-prometheus-stack's own TargetDown: this is the
+        # Pawtograder-scoped, self-contained version for installs that have not wired
+        # generic target alerting to a receiver.
+        - alert: PawtograderPostgresExporterDown
+          expr: absent(pg_exporter_last_scrape_error{namespace="{{ $ns }}"})
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pawtograder postgres_exporter is not being scraped"
+            description: >-
+              pg_exporter_last_scrape_error has been absent from {{ $ns }} for 30m, so
+              Prometheus is not scraping the postgres_exporter sidecar at all. Every
+              pawtograder_db_*, pawtograder_table_sizes, pawtograder_vacuum_alert,
+              pawtograder_replication_* and pawtograder_wal_archiving_* series is
+              missing, which also silences PawtograderPostgresConnections*,
+              PawtograderWALArchiveFailing, PawtograderReplica* and
+              PawtograderPostgresExporterQueryFailing. Check that the postgres pod's
+              postgres-exporter container is running, that the postgres-exporter
+              Service still selects it, and that the ServiceMonitor's labels still
+              match your Prometheus ruleSelector/serviceMonitorSelector. Runbook:
+              docs/operations/monitoring-alerting.md.
     {{- end }}
     # App-level KPI alerts. Converted from the Ripley Grafana-managed rules
     # (k8s/apps/monitoring/alerting/rules.yaml — reference only; a SEPARATE

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -30,6 +30,30 @@ keyed off global.environment (dev | preview | staging | production):
 {{- fail "studio.ingressEnabled=true without studio.basicAuth.enabled exposes full database control to anyone with the URL. Enable basic-auth, or set studio.allowUnauthenticatedIngress=true to confirm another auth layer (VPN / oauth2-proxy / IP allowlist) fronts this host." -}}
 {{- end -}}
 
+{{- /*
+Monitoring with an externally managed database. Every DB-derived series the chart
+ships comes from the postgres_exporter SIDECAR in the chart-managed Postgres
+StatefulSet, so postgres.enabled=false leaves no collector at all — and the
+`metrics` edge function no longer gathers them, because scraping it once per
+functions pod (32 replicas in prod) cost 77.7% of all database execution time.
+The PawtograderPostgresExporter* self-health rules are gated on postgres.enabled
+too, so nothing would even report the absence. Fail loudly here rather than
+degrade silently.
+
+Guarded any-environment, not just staging/production: this is a configuration
+that does not WORK, like postgres.replica without walg above, rather than one
+that is merely risky in a durable tier. It also cannot fire by accident — it
+needs monitoring.enabled=true (default false) AND postgres.enabled=false
+(default true), both deliberate.
+
+Acknowledgement rather than a hard fail, following studio.allowUnauthenticatedIngress:
+running your own exporter against the external DB is a legitimate setup the chart
+cannot detect.
+*/ -}}
+{{- if and .Values.monitoring.enabled (not .Values.postgres.enabled) (not .Values.monitoring.externalPostgresExporter) -}}
+{{- fail "monitoring.enabled=true with postgres.enabled=false ships NO database metrics collector. pawtograder_vacuum_alert, pawtograder_db_buffer_cache*, pawtograder_db_dead_tuples, pawtograder_db_connections_*, pawtograder_table_sizes_*, pawtograder_replication_*, pawtograder_wal_archiving_* and pg_stat_statements_top all come from the postgres_exporter sidecar inside the chart-managed Postgres StatefulSet, which this mode does not deploy; the metrics edge function no longer collects them either. The PawtograderPostgresExporterQueryFailing/Down alerts are skipped under the same condition, so the absence would be silent. Point your own postgres_exporter at the external database (the queries.yaml ConfigMap still renders, so you can mount it and keep the same metric names), add a ServiceMonitor for it, then set monitoring.externalPostgresExporter=true to confirm. Set monitoring.enabled=false if you do not want DB metrics." -}}
+{{- end -}}
+
 {{- if and .Values.postgres.replica.enabled (not .Values.postgres.walg.enabled) -}}
 {{- fail "postgres.replica.enabled=true requires postgres.walg.enabled=true — the standby uses `wal-g wal-fetch` as its archive fallback when it falls behind the primary's retained pg_wal, and shares the WAL-G config. Enable postgres.walg first." -}}
 {{- end -}}

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -389,6 +389,60 @@ EOF
 
 assert_exporter_all_master
 
+# assert_no_liveness_probe "<label>" "<template>" <extra --set args...>
+# The postgres primary and its replica must render NO livenessProbe, and must
+# still render a readinessProbe.
+#
+# On 2026-08-27 the hardcoded liveness probes killed BOTH pods during a transient
+# NetApp NFS stall caused by network maintenance — the primary at 14:02:44 and
+# postgres-replica-0 at 17:18:18. Each template carried periodSeconds 10 /
+# timeoutSeconds 5 with failureThreshold unset, so both inherited the Kubernetes
+# default of 3 and had only ~30s of tolerance. The shutdown checkpoint one second
+# after the primary was killed flushed 1397 buffers in 0.122s (sync 0.002s), so
+# storage was already healthy: the probe's patience ran out about a second before
+# the problem cleared itself. Each misfire cost the 4GB warm buffer pool, every
+# connection, and a hard exit of all three realtime pods.
+#
+# Restarting a single-writer Postgres cannot fix external storage, so waiting is
+# strictly better. Loosening was rejected because pg_isready ALSO exits non-zero
+# during crash recovery ("rejecting connections"), and on this ~29 GB database WAL
+# replay can outlast any sane liveness window — the probe would then kill the pod
+# mid-recovery, each kill leaving more WAL to replay than the last.
+#
+# This assertion exists so that cannot be silently undone. Readiness is asserted
+# present in the same breath, because removing THAT would be the opposite mistake:
+# it is the non-destructive half of the signal. Rationale lives in
+# templates/postgres-statefulset.yaml.
+assert_no_liveness_probe() {
+  local label="$1" template="$2"; shift 2
+  if ! helm template t "$CHART" "${BASE[@]}" "$@" --show-only "$template" >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+    return
+  fi
+  local bad=0
+  if grep -qE '^[[:space:]]*livenessProbe:' "$OUTFILE"; then
+    echo "FAIL [$label]: $template renders a livenessProbe — see the note above and in postgres-statefulset.yaml"
+    bad=1
+  fi
+  if ! grep -qE '^[[:space:]]*readinessProbe:' "$OUTFILE"; then
+    echo "FAIL [$label]: $template renders NO readinessProbe — that is the half we must keep"
+    bad=1
+  fi
+  if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label]"; fi
+}
+
+echo "== postgres liveness probes stay removed (2026-08-27 incident) =="
+assert_no_liveness_probe "postgres primary has no livenessProbe, keeps readinessProbe" \
+  templates/postgres-statefulset.yaml
+assert_no_liveness_probe "postgres replica has no livenessProbe, keeps readinessProbe" \
+  templates/postgres-replica.yaml \
+  --set postgres.replica.enabled=true \
+  --set postgres.replica.persistence.storageClass=lp \
+  --set postgres.walg.enabled=true \
+  --set postgres.walg.s3Prefix=s3://b/walg
+
 echo "== rendered hardening (redis securityContext, smtp-relay SA token) =="
 assert_rendered_contains "internal redis pod runs non-root with a securityContext" \
   templates/redis.yaml "runAsNonRoot: true" \

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -307,6 +307,84 @@ assert_exporter_metric pawtograder_db_buffer_cache_total used_bytes
 assert_exporter_metric pawtograder_db_dead tuples relname
 assert_exporter_metric pawtograder_vacuum alert check severity table_name
 
+# assert_exporter_all_master
+# Every custom query block in the exporter's queries.yaml must set `master: true`.
+#
+# The sidecar runs PG_EXPORTER_AUTO_DISCOVER_DATABASES=true, so without it a
+# block runs once per discovered database. Every query in that file is either
+# cluster-wide (pg_stat_statements, pg_buffercache, pg_settings,
+# pg_stat_replication) or specific to the application database (public.classes,
+# public.submissions, public.help_requests, the pawtograder_* functions), so
+# per-database execution is wrong in all of them.
+#
+# Auto-discovery is not a no-op: on supabase/postgres it finds `_supabase` and
+# `storage_vectors`. It has stayed harmless only because these queries error or
+# return empty there — which still sets pg_exporter_last_scrape_error on every
+# scrape. And the `server` label is only host:port (parseFingerprint, no
+# database name), so databases on one instance are indistinguishable by label:
+# the first query that does return a row from a second database yields a
+# duplicate label set, and that makes the exporter return HTTP 500 for the WHOLE
+# /metrics endpoint, taking down all postgres metrics at once.
+#
+# Blanket assertion on purpose. A future block that genuinely means something
+# different per database is fine, but it has to be added to ALLOW_NO_MASTER here
+# with a reason, so the decision is deliberate and reviewable instead of a
+# forgotten default.
+assert_exporter_all_master() {
+  local label="every exporter query block sets master: true"
+  # Blocks legitimately exempt (per-database by design). Space-separated.
+  local ALLOW_NO_MASTER=""
+  if ! helm template t "$CHART" "${BASE[@]}" \
+      --set monitoring.enabled=true --set monitoring.prometheusRules.labels.release=kps \
+      --show-only templates/monitoring.yaml >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+    return
+  fi
+  # Slice out just the queries.yaml literal: starts after `queries.yaml: |` and
+  # ends at the next document separator. Keeps the 4-space block scan below from
+  # straying into the Service/ServiceMonitor manifests further down the file.
+  local queries
+  queries="$(awk '
+    /^  queries\.yaml: \|$/ { inq = 1; next }
+    inq && /^---$/ { exit }
+    inq { print }
+  ' "$OUTFILE")"
+  if [ -z "$queries" ]; then
+    echo "FAIL [$label]: could not find the queries.yaml literal in the rendered ConfigMap"
+    FAILED=1
+    return
+  fi
+  # One line per block: "<name> <has_master>". A 4-space key with no value opens
+  # a block; `master: true` at 6 spaces belongs to the block currently open.
+  local report
+  report="$(printf '%s\n' "$queries" | awk '
+    /^    [a-z_]+:$/ { if (blk != "") print blk, has; blk = substr($1, 1, length($1) - 1); has = 0; next }
+    /^      master: true$/ { has = 1 }
+    END { if (blk != "") print blk, has }
+  ')"
+  local nblocks bad=0 name flag
+  nblocks="$(printf '%s\n' "$report" | grep -c . || true)"
+  if [ "$nblocks" -lt 10 ]; then
+    echo "FAIL [$label]: only parsed $nblocks query blocks — the scan looks broken, not the file"
+    FAILED=1
+    return
+  fi
+  while read -r name flag; do
+    [ -z "$name" ] && continue
+    if [ "$flag" != "1" ] && ! printf ' %s ' "$ALLOW_NO_MASTER" | grep -qF " $name "; then
+      echo "FAIL [$label]: block '$name' does not set master: true (and is not in ALLOW_NO_MASTER)"
+      bad=1
+    fi
+  done <<EOF
+$report
+EOF
+  if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label] ($nblocks blocks)"; fi
+}
+
+assert_exporter_all_master
+
 echo "== rendered hardening (redis securityContext, smtp-relay SA token) =="
 assert_rendered_contains "internal redis pod runs non-root with a securityContext" \
   templates/redis.yaml "runAsNonRoot: true" \

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -245,6 +245,68 @@ assert_renders "prometheus rules with ruleSelector label renders" \
 assert_renders "prometheus rules allowUnselectedRules renders" \
   --set monitoring.enabled=true --set monitoring.prometheusRules.allowUnselectedRules=true
 
+# assert_exporter_metric "<block>" "<column>" [<label>...]
+# postgres_exporter names every custom metric `<block key>_<column name>`, so the
+# queries.yaml block key and the column name TOGETHER are the metric name that
+# Grafana panels and alert rules query — a block rename that looks like tidying
+# silently blanks a dashboard.
+#
+# The four metrics pinned below moved off the `metrics` edge function, which
+# Prometheus scraped once per functions pod (32 replicas in prod, ~1.07
+# scrapes/sec, 77.7% of all database execution time). Their block/column splits
+# were chosen to land on the pre-existing names, not for elegance — hence e.g.
+# block `pawtograder_db_dead` + column `tuples`. Label names are pinned too:
+# panels legend on them and alert rules can match on them.
+assert_exporter_metric() {
+  local block="$1" column="$2"; shift 2
+  local label="exporter metric ${block}_${column}"
+  if ! helm template t "$CHART" "${BASE[@]}" \
+      --set monitoring.enabled=true --set monitoring.prometheusRules.labels.release=kps \
+      --show-only templates/monitoring.yaml >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+    return
+  fi
+  # Slice this block's stanza out of the embedded queries.yaml: queries.yaml is a
+  # YAML literal inside the ConfigMap, so blocks sit at exactly 4 spaces and the
+  # next 4-space key ends the stanza. Anchoring on the exact key keeps
+  # `pawtograder_db_buffer_cache` from matching `pawtograder_db_buffer_cache_total`.
+  local stanza
+  stanza="$(awk -v b="    $block:" '
+    $0 == b { inb = 1; next }
+    inb && /^    [^ ]/ { exit }
+    inb { print }
+  ' "$OUTFILE")"
+  if [ -z "$stanza" ]; then
+    echo "FAIL [$label]: queries.yaml has no block named '$block'"
+    FAILED=1
+    return
+  fi
+  local bad=0
+  if ! printf '%s\n' "$stanza" | grep -qE "^        - $column:$"; then
+    echo "FAIL [$label]: block '$block' declares no column '$column'"
+    bad=1
+  fi
+  local lbl
+  for lbl in "$@"; do
+    # The column key, then the two lines under it (usage, description). A LABEL
+    # column must render usage: "LABEL" so the exporter turns it into a label
+    # rather than a second metric.
+    if ! printf '%s\n' "$stanza" | grep -A2 -E "^        - $lbl:$" | grep -qF 'usage: "LABEL"'; then
+      echo "FAIL [$label]: block '$block' does not expose '$lbl' as a LABEL"
+      bad=1
+    fi
+  done
+  if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label]"; fi
+}
+
+echo "== postgres_exporter metric names moved off the edge function are pinned =="
+assert_exporter_metric pawtograder_db_buffer_cache bytes relname
+assert_exporter_metric pawtograder_db_buffer_cache_total used_bytes
+assert_exporter_metric pawtograder_db_dead tuples relname
+assert_exporter_metric pawtograder_vacuum alert check severity table_name
+
 echo "== rendered hardening (redis securityContext, smtp-relay SA token) =="
 assert_rendered_contains "internal redis pod runs non-root with a securityContext" \
   templates/redis.yaml "runAsNonRoot: true" \

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -317,14 +317,18 @@ assert_exporter_metric pawtograder_vacuum alert check severity table_name
 # public.submissions, public.help_requests, the pawtograder_* functions), so
 # per-database execution is wrong in all of them.
 #
-# Auto-discovery is not a no-op: on supabase/postgres it finds `_supabase` and
-# `storage_vectors`. It has stayed harmless only because these queries error or
-# return empty there — which still sets pg_exporter_last_scrape_error on every
-# scrape. And the `server` label is only host:port (parseFingerprint, no
-# database name), so databases on one instance are indistinguishable by label:
-# the first query that does return a row from a second database yields a
-# duplicate label set, and that makes the exporter return HTTP 500 for the WHOLE
-# /metrics endpoint, taking down all postgres metrics at once.
+# Latent on the currently deployed supabase/postgres 17.4.x: the discovery query
+# excludes templates, and prod has only `postgres`, `template0` and `template1`,
+# so nothing is discovered (prod pg_exporter_last_scrape_error is 0, one `server`
+# label value). On 17.6.x and later Supabase adds `_supabase` and
+# `storage_vectors`, and then four of these blocks error once per discovered
+# database on every scrape and pawtograder_table_sizes runs against the wrong
+# databases — so this is a prerequisite for the next Postgres image bump. It also
+# guards worse than noise: the `server` label is only host:port
+# (parseFingerprint, no database name), so databases on one instance are
+# indistinguishable by label, and the first query that returns a row from a
+# second database yields a duplicate label set — which makes the exporter return
+# HTTP 500 for the WHOLE /metrics endpoint, taking down all postgres metrics.
 #
 # Blanket assertion on purpose. A future block that genuinely means something
 # different per database is fine, but it has to be added to ALLOW_NO_MASTER here

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -85,6 +85,24 @@ assert_rendered_contains() {
   fi
 }
 
+# assert_rendered_lacks "<label>" "<template>" "<forbidden substring>" <extra --set args...>
+# Inverse of assert_rendered_contains: the render must SUCCEED and must NOT contain
+# the substring. Used to prove a manifest is absent in a mode where it would be
+# actively harmful, rather than merely unused.
+assert_rendered_lacks() {
+  local label="$1" template="$2" forbidden="$3"; shift 3
+  if ! helm template t "$CHART" "${BASE[@]}" "$@" --show-only "$template" >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+  elif grep -qF "$forbidden" "$OUTFILE"; then
+    echo "FAIL [$label]: rendered, but still contains: $forbidden"
+    FAILED=1
+  else
+    echo "ok   [$label]"
+  fi
+}
+
 # assert_edge_envfrom_optional "<label>" "<template>" <extra --set args...>
 # Every Secret listed in edgeFunctions.envFromSecrets must render optional: true.
 # envFrom is one-shot and all-or-nothing: a single absent Secret puts the whole
@@ -153,6 +171,37 @@ assert_refused "studio ingress without auth" \
 assert_refused "replica without wal-g" \
   "requires postgres.walg.enabled=true" \
   --set postgres.replica.enabled=true --set postgres.replica.persistence.storageClass=lp
+
+# Monitoring with an externally managed database. Every DB-derived series comes
+# from the postgres_exporter SIDECAR in the chart-managed Postgres StatefulSet, so
+# postgres.enabled=false leaves no collector — and since this PR the `metrics` edge
+# function no longer gathers them (it cost 77.7% of all DB execution time, scraped
+# once per functions pod). The PawtograderPostgresExporter* self-health rules are
+# gated on postgres.enabled too, so nothing would report the absence. The guard
+# must refuse that combination, and the acknowledgement must clear it.
+assert_refused "monitoring without the chart's postgres (no collector)" \
+  "ships NO database metrics collector" \
+  --set monitoring.enabled=true --set postgres.enabled=false \
+  --set monitoring.prometheusRules.labels.release=kps
+assert_renders "monitoring without postgres is allowed once an external exporter is declared" \
+  --set monitoring.enabled=true --set postgres.enabled=false \
+  --set monitoring.externalPostgresExporter=true \
+  --set monitoring.prometheusRules.labels.release=kps
+# ...and in that mode the chart must NOT ship its own exporter Service/ServiceMonitor:
+# they select the sidecar's pod, which does not exist, so they would sit permanently
+# "down" and mask the operator's real exporter. The queries.yaml ConfigMap SHOULD
+# still render — it is worth mounting into an external exporter to keep the metric
+# names the dashboards and alert rules expect.
+assert_rendered_lacks "external-exporter mode ships no dangling exporter Service/ServiceMonitor" \
+  templates/monitoring.yaml "9187" \
+  --set monitoring.enabled=true --set postgres.enabled=false \
+  --set monitoring.externalPostgresExporter=true \
+  --set monitoring.prometheusRules.labels.release=kps
+assert_rendered_contains "external-exporter mode still ships queries.yaml to mount" \
+  templates/monitoring.yaml "queries.yaml: |" \
+  --set monitoring.enabled=true --set postgres.enabled=false \
+  --set monitoring.externalPostgresExporter=true \
+  --set monitoring.prometheusRules.labels.release=kps
 
 echo "== staging + production guards =="
 assert_refused "secrets.create in production" \

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1561,6 +1561,27 @@ monitoring:
   serviceMonitors:
     storage: true
 
+  # Acknowledge that a postgres_exporter you manage is pointed at an externally
+  # managed database. ONLY relevant with postgres.enabled=false.
+  #
+  # Every DB-derived series this chart ships comes from the postgres_exporter
+  # SIDECAR inside the chart-managed Postgres StatefulSet (see
+  # templates/postgres-statefulset.yaml). With postgres.enabled=false that pod
+  # does not exist, so there is no collector — and the `metrics` edge function
+  # no longer gathers them either, because doing so cost 77.7% of all database
+  # execution time when Prometheus scraped it once per functions pod (32 in
+  # prod). templates/validations.yaml therefore REFUSES
+  # monitoring.enabled=true + postgres.enabled=false unless you set this,
+  # rather than letting vacuum/buffer-cache/dead-tuple metrics vanish silently.
+  #
+  # Setting this true asserts you run your own exporter against the external
+  # database. The queries.yaml ConfigMap still renders, so you can mount it into
+  # your exporter and keep the same metric names the dashboards and alert rules
+  # expect. The chart's own postgres-exporter Service and ServiceMonitor are NOT
+  # rendered when postgres.enabled=false (they would select no pods and sit
+  # permanently "down"), so supply your own ServiceMonitor for your exporter.
+  externalPostgresExporter: false
+
   # Alerting rules (Prometheus Operator PrometheusRule) for backup failure /
   # staleness, ExternalSecret sync failure, and TLS cert expiry — the
   # operational alerts PRODUCTION-READINESS deferred to cluster monitoring.

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1626,6 +1626,28 @@ monitoring:
     # 45m and never fired on one. Ten minutes is ten or more consecutive scrapes (so a scrape gap
     # cannot flap it) with 20 minutes of margin left inside the shortest window.
     discordCircuitOpenFor: 10m
+    # How long the chart-managed Postgres StatefulSet may report ZERO ready
+    # replicas before PawtograderPostgresUnavailable pages (critical).
+    #
+    # This is the alert that covers a wedged primary. It exists because the
+    # liveness probes were removed (see postgres-statefulset.yaml): nothing
+    # restarts a wedged postmaster automatically any more, so the condition has to
+    # page instead. It is keyed on kube-state-metrics, NOT on anything produced
+    # inside the postgres pod — the exporter sidecar and the metrics edge function
+    # both die with the database, which is exactly why the pre-existing critical
+    # rules cannot detect this (they are `metric > threshold` on series that
+    # disappear, so they fail OPEN).
+    #
+    # Must outlast a NORMAL rollout or the chart pages on every deploy: the
+    # StatefulSet legitimately goes not-ready on any config change. Budget is
+    # roughly preStop fast shutdown (seconds) + a possible cold image pull of the
+    # supabase/postgres image (1-3 min) + postgres start and readiness
+    # (initialDelay 10s + up to 3x5s) — call it 3-4 min worst case on a cold node.
+    # 5m clears that with margin and matches the 5m used by
+    # PawtograderPostgresConnectionsSaturated and PawtograderAsyncQueueBacklog.
+    # Raise it if your nodes pull images slowly; lower it only if images are always
+    # warm.
+    postgresUnavailableFor: 5m
     # Edge-function pod restarts in 30m above which PawtograderEdgeFunctionsRestarting fires.
     edgeFunctionRestarts30m: 2
     # Fraction of the container memory limit above which PawtograderEdgeFunctionsMemoryHigh fires.

--- a/docs/grafana-dashboard-vacuum-health.json
+++ b/docs/grafana-dashboard-vacuum-health.json
@@ -56,7 +56,7 @@
       },
       "targets": [
         {
-          "expr": "count(pawtograder_vacuum_alert{severity!=\"ok\"} == 1) OR vector(0)",
+          "expr": "count(pawtograder_vacuum_alert{namespace=\"$namespace\", severity!=\"ok\"} == 1) OR vector(0)",
           "legendFormat": "Alerts",
           "refId": "A"
         }
@@ -91,7 +91,7 @@
       },
       "targets": [
         {
-          "expr": "count(pawtograder_vacuum_alert{severity=\"critical\"} == 1) OR vector(0)",
+          "expr": "count(pawtograder_vacuum_alert{namespace=\"$namespace\", severity=\"critical\"} == 1) OR vector(0)",
           "legendFormat": "Critical",
           "refId": "A"
         }
@@ -99,7 +99,7 @@
     },
     {
       "title": "Vacuum Collector Health",
-      "description": "1 = pawtograder_vacuum_alert is absent, i.e. the postgres_exporter's pawtograder_vacuum query is not reporting (function dropped or renamed, permission revoked, query error). Read this ALONGSIDE the two alert-count panels: those use `OR vector(0)`, so if the series vanishes entirely they render 0 and look green. Before this metric moved to the exporter, the metrics edge function emitted an explicit pawtograder_vacuum_alert{check=\"rpc_failed\",severity=\"error\"} 1 on RPC failure, which the count panels picked up. postgres_exporter has no equivalent: a failing custom query is dropped from the output and only sets pg_exporter_last_scrape_error, for which this chart defines no alert rule. This panel restores the fail-loud behaviour.",
+      "description": "1 = pawtograder_vacuum_alert is absent, i.e. the postgres_exporter's pawtograder_vacuum query is not reporting (function dropped or renamed, permission revoked, query error). Read this ALONGSIDE the two alert-count panels: those use `OR vector(0)`, so if the series vanishes entirely they render 0 and look green. Before this metric moved to the exporter, the metrics edge function emitted an explicit pawtograder_vacuum_alert{check=\"rpc_failed\",severity=\"error\"} 1 on RPC failure, which the count panels picked up. postgres_exporter has no equivalent: a failing custom query is dropped from the output and only sets pg_exporter_last_scrape_error, for which this chart defines no alert rule. This panel restores the fail-loud behaviour. The namespace matcher is REQUIRED, not cosmetic: absent() returns empty if ANY matching series exists, so unscoped (or with an All/regex $namespace) a healthy neighbouring release in the shared kube-prometheus-stack would render this deployment as Reporting while its own collector is dead - inverting the exact signal this panel exists to give. The $namespace variable is single-select for that reason.",
       "type": "stat",
       "id": 26,
       "gridPos": { "h": 6, "w": 4, "x": 12, "y": 1 },
@@ -134,7 +134,7 @@
       },
       "targets": [
         {
-          "expr": "absent(pawtograder_vacuum_alert) OR vector(0)",
+          "expr": "absent(pawtograder_vacuum_alert{namespace=\"$namespace\"}) OR vector(0)",
           "legendFormat": "collector absent",
           "refId": "A"
         }
@@ -174,7 +174,7 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_gradebook_row_recalculate_queue_size",
+          "expr": "pawtograder_gradebook_row_recalculate_queue_size{namespace=\"$namespace\"}",
           "legendFormat": "Queue Depth",
           "refId": "A"
         }
@@ -216,7 +216,7 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_vacuum_alert{severity!=\"ok\"} == 1",
+          "expr": "pawtograder_vacuum_alert{namespace=\"$namespace\", severity!=\"ok\"} == 1",
           "legendFormat": "{{check}} / {{table_name}} ({{severity}})",
           "refId": "A"
         }
@@ -285,7 +285,7 @@
       ],
       "targets": [
         {
-          "expr": "pawtograder_vacuum_alert{severity!=\"ok\"} == 1",
+          "expr": "pawtograder_vacuum_alert{namespace=\"$namespace\", severity!=\"ok\"} == 1",
           "legendFormat": "",
           "refId": "A",
           "instant": true,
@@ -329,7 +329,7 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_db_buffer_cache_total_used_bytes",
+          "expr": "pawtograder_db_buffer_cache_total_used_bytes{namespace=\"$namespace\"}",
           "legendFormat": "Buffer Cache Used",
           "refId": "A"
         }
@@ -362,12 +362,12 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_db_connections_used",
+          "expr": "pawtograder_db_connections_used{namespace=\"$namespace\"}",
           "legendFormat": "client backends",
           "refId": "A"
         },
         {
-          "expr": "pawtograder_db_connections_max",
+          "expr": "pawtograder_db_connections_max{namespace=\"$namespace\"}",
           "legendFormat": "max_connections",
           "refId": "B"
         }
@@ -399,7 +399,7 @@
       },
       "targets": [
         {
-          "expr": "topk(10, pawtograder_db_dead_tuples)",
+          "expr": "topk(10, pawtograder_db_dead_tuples{namespace=\"$namespace\"})",
           "legendFormat": "{{relname}}",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
       },
       "targets": [
         {
-          "expr": "topk(15, pawtograder_db_buffer_cache_bytes)",
+          "expr": "topk(15, pawtograder_db_buffer_cache_bytes{namespace=\"$namespace\"})",
           "legendFormat": "{{relname}}",
           "refId": "A"
         }
@@ -464,7 +464,7 @@
       },
       "targets": [
         {
-          "expr": "topk(30, pawtograder_table_sizes_total_bytes)",
+          "expr": "topk(30, pawtograder_table_sizes_total_bytes{namespace=\"$namespace\"})",
           "legendFormat": "{{relation}}",
           "refId": "A"
         }
@@ -505,27 +505,27 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_async_queue_size",
+          "expr": "pawtograder_async_queue_size{namespace=\"$namespace\"}",
           "legendFormat": "Async (GitHub)",
           "refId": "A"
         },
         {
-          "expr": "pawtograder_async_dlq_size",
+          "expr": "pawtograder_async_dlq_size{namespace=\"$namespace\"}",
           "legendFormat": "Async DLQ",
           "refId": "B"
         },
         {
-          "expr": "pawtograder_gradebook_row_recalculate_queue_size",
+          "expr": "pawtograder_gradebook_row_recalculate_queue_size{namespace=\"$namespace\"}",
           "legendFormat": "Gradebook Recalc",
           "refId": "C"
         },
         {
-          "expr": "pawtograder_discord_queue_size",
+          "expr": "pawtograder_discord_queue_size{namespace=\"$namespace\"}",
           "legendFormat": "Discord",
           "refId": "D"
         },
         {
-          "expr": "pawtograder_discord_dlq_size",
+          "expr": "pawtograder_discord_dlq_size{namespace=\"$namespace\"}",
           "legendFormat": "Discord DLQ",
           "refId": "E"
         }
@@ -552,6 +552,22 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "name": "namespace",
+        "label": "Namespace",
+        "description": "Single-select ON PURPOSE (includeAll false, multi false). The Vacuum Collector Health panel uses absent(), which returns empty if ANY matching series exists anywhere - so an All/regex selection would report a healthy neighbouring release or namespace as this deployment being fine, inverting exactly the signal that panel exists to give. Sourced from kube_pod_info rather than a pawtograder_* series so the variable stays populated when the exporter is the thing that is broken.",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(kube_pod_info, namespace)",
+        "regex": "pawtograder.*",
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "sort": 1,
+        "current": {},
+        "options": [],
+        "skipUrlSync": false
       }
     ]
   },

--- a/docs/grafana-dashboard-vacuum-health.json
+++ b/docs/grafana-dashboard-vacuum-health.json
@@ -293,8 +293,8 @@
       ]
     },
     {
-      "title": "Connections by State",
-      "description": "Database connections grouped by state (active, idle, idle in transaction)",
+      "title": "Connections vs Budget",
+      "description": "Client backends against max_connections. This was a per-state breakdown (pawtograder_db_connections{state}) from the metrics edge function; that series is gone, because it was queried once per functions pod (32x in prod). The postgres_exporter equivalent counts backend_type='client backend' and has no state breakdown - it is the connection count max_connections actually governs.",
       "type": "timeseries",
       "id": 22,
       "gridPos": { "h": 6, "w": 9, "x": 6, "y": 25 },
@@ -306,7 +306,7 @@
             "drawStyle": "line",
             "lineWidth": 2,
             "fillOpacity": 30,
-            "stacking": { "mode": "normal" },
+            "stacking": { "mode": "none" },
             "showPoints": "never"
           },
           "unit": "short"
@@ -319,9 +319,14 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_db_connections",
-          "legendFormat": "{{state}}",
+          "expr": "pawtograder_db_connections_used",
+          "legendFormat": "client backends",
           "refId": "A"
+        },
+        {
+          "expr": "pawtograder_db_connections_max",
+          "legendFormat": "max_connections",
+          "refId": "B"
         }
       ]
     },
@@ -391,8 +396,8 @@
       ]
     },
     {
-      "title": "Table Sizes (> 100 MB)",
-      "description": "Total table sizes including indexes and TOAST, tracking growth over time",
+      "title": "Table Sizes (> 10 MB, Top 30)",
+      "description": "Total table sizes including indexes and TOAST, tracking growth over time. Was pawtograder_db_table_total_bytes{relname} from the metrics edge function; now the postgres_exporter's pawtograder_table_sizes_total_bytes{relation}, which was already exporting the same data (schema-qualified relation label, >10 MiB, top 30) once instead of once per functions pod.",
       "type": "timeseries",
       "id": 25,
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 39 },
@@ -416,8 +421,8 @@
       },
       "targets": [
         {
-          "expr": "pawtograder_db_table_total_bytes",
-          "legendFormat": "{{relname}}",
+          "expr": "topk(30, pawtograder_table_sizes_total_bytes)",
+          "legendFormat": "{{relation}}",
           "refId": "A"
         }
       ]

--- a/docs/grafana-dashboard-vacuum-health.json
+++ b/docs/grafana-dashboard-vacuum-health.json
@@ -99,7 +99,7 @@
     },
     {
       "title": "Vacuum Collector Health",
-      "description": "1 = pawtograder_vacuum_alert is absent, i.e. the postgres_exporter's pawtograder_vacuum query is not reporting (function dropped or renamed, permission revoked, query error). Read this ALONGSIDE the two alert-count panels: those use `OR vector(0)`, so if the series vanishes entirely they render 0 and look green. Before this metric moved to the exporter, the metrics edge function emitted an explicit pawtograder_vacuum_alert{check=\"rpc_failed\",severity=\"error\"} 1 on RPC failure, which the count panels picked up. postgres_exporter has no equivalent: a failing custom query is dropped from the output and only sets pg_exporter_last_scrape_error, for which this chart defines no alert rule. This panel restores the fail-loud behaviour. The namespace matcher is REQUIRED, not cosmetic: absent() returns empty if ANY matching series exists, so unscoped (or with an All/regex $namespace) a healthy neighbouring release in the shared kube-prometheus-stack would render this deployment as Reporting while its own collector is dead - inverting the exact signal this panel exists to give. The $namespace variable is single-select for that reason.",
+      "description": "1 = NOT REPORTING: pawtograder_vacuum_alert is absent, i.e. the postgres_exporter's pawtograder_vacuum query is not reporting (function dropped or renamed, permission revoked, query error). This is the immediate DASHBOARD signal for that state; the alerting side is covered by PawtograderPostgresExporterQueryFailing (pg_exporter_last_scrape_error > 0, 15m) and PawtograderPostgresExporterDown (absent(pg_exporter_last_scrape_error), 30m) in templates/prometheus-rules.yaml. This panel is the at-a-glance version, not the only fail-loud mechanism. Why it is needed at all: the two alert-count panels use `OR vector(0)`, so if the series vanishes entirely they render 0 and look green. Before this metric moved to the exporter, the metrics edge function emitted an explicit pawtograder_vacuum_alert{check=\"rpc_failed\",severity=\"error\"} 1 on RPC failure, which the count panels picked up; postgres_exporter has no equivalent, because a failing custom query is dropped from the output rather than failing the scrape. Two things in this expression are load-bearing, both verified with promtool unit tests. (1) max() is NOT decorative. absent() preserves the equality matchers as output labels, so absent(...{namespace=\"X\"}) returns {namespace=\"X\"} 1 while vector(0) returns {} 0 - different label sets, so plain `or` returns BOTH and the stat panel has two series and no single collector state, during exactly the failure this panel reports. max() collapses them to one. (2) The namespace matcher is required: absent() returns empty if ANY matching series exists, so unscoped - or with an All/regex $namespace - a healthy neighbouring release in the shared kube-prometheus-stack would render this deployment as Reporting while its own collector is dead. The $namespace variable is single-select for that reason.",
       "type": "stat",
       "id": 26,
       "gridPos": { "h": 6, "w": 4, "x": 12, "y": 1 },
@@ -134,7 +134,7 @@
       },
       "targets": [
         {
-          "expr": "absent(pawtograder_vacuum_alert{namespace=\"$namespace\"}) OR vector(0)",
+          "expr": "max(absent(pawtograder_vacuum_alert{namespace=\"$namespace\"}) OR vector(0))",
           "legendFormat": "collector absent",
           "refId": "A"
         }

--- a/docs/grafana-dashboard-vacuum-health.json
+++ b/docs/grafana-dashboard-vacuum-health.json
@@ -98,11 +98,54 @@
       ]
     },
     {
+      "title": "Vacuum Collector Health",
+      "description": "1 = pawtograder_vacuum_alert is absent, i.e. the postgres_exporter's pawtograder_vacuum query is not reporting (function dropped or renamed, permission revoked, query error). Read this ALONGSIDE the two alert-count panels: those use `OR vector(0)`, so if the series vanishes entirely they render 0 and look green. Before this metric moved to the exporter, the metrics edge function emitted an explicit pawtograder_vacuum_alert{check=\"rpc_failed\",severity=\"error\"} 1 on RPC failure, which the count panels picked up. postgres_exporter has no equivalent: a failing custom query is dropped from the output and only sets pg_exporter_last_scrape_error, for which this chart defines no alert rule. This panel restores the fail-loud behaviour.",
+      "type": "stat",
+      "id": 26,
+      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 1 },
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "Reporting", "index": 0 },
+                "1": { "text": "NOT REPORTING", "index": 1 }
+              }
+            }
+          ],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "targets": [
+        {
+          "expr": "absent(pawtograder_vacuum_alert) OR vector(0)",
+          "legendFormat": "collector absent",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "title": "Gradebook Recalc Queue Depth",
       "description": "Messages pending in the gradebook row recalculation queue",
       "type": "timeseries",
       "id": 4,
-      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 1 },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 1 },
       "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -126,6 +126,20 @@ Each alert's expression depends on an exporter being present in the cluster:
 - replication alerts → the chart's own `postgres_exporter` custom query
   (`pawtograder_replication_*`, defined in `templates/monitoring.yaml`; read from
   the **primary's** `pg_stat_replication`, not `pg_replication_slots`).
+- vacuum health and RAM/buffer-cache dashboards
+  (`docs/grafana-dashboard-vacuum-health.json`) → the chart's own
+  `postgres_exporter` custom queries `pawtograder_vacuum_alert`,
+  `pawtograder_db_buffer_cache_bytes`,
+  `pawtograder_db_buffer_cache_total_used_bytes` and
+  `pawtograder_db_dead_tuples` (all in `templates/monitoring.yaml`). These used
+  to come from the `metrics` edge function, which meant Prometheus called
+  `database_ram_metrics()` and `vacuum_health_check()` once per functions pod —
+  32 replicas in prod, ~1.07 calls/sec, and **77.7% of all database execution
+  time**, almost all of it `pg_buffercache` scans (524,288 buffer descriptors
+  per call at `shared_buffers = 4GB`). They are global database state, so the
+  exporter — scraped once — is the right home. Metric and label names did not
+  change. The buffer-cache queries carry `cache_seconds: 300`, so the scan runs
+  at most once per 5 minutes even from that one target.
 - ESO alert → the External Secrets Operator's `/metrics`
   (`externalsecret_status_condition`).
 - cert alert → cert-manager's `/metrics`

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -183,6 +183,29 @@ query_preview)` label sets whenever a statement ran under more than one
 > read "down"). Summing per `queryid` keeps each series unique. If you add custom
 > queries, ensure their label sets are unique or you will re-break the endpoint.
 
+> **Externally managed database (`postgres.enabled=false`) has no DB metrics.**
+> Every DB-derived series this chart ships — `pawtograder_vacuum_alert`,
+> `pawtograder_db_buffer_cache*`, `pawtograder_db_dead_tuples`,
+> `pawtograder_db_connections_*`, `pawtograder_table_sizes_*`,
+> `pawtograder_replication_*`, `pawtograder_wal_archiving_*` and
+> `pg_stat_statements_top` — comes from the `postgres_exporter` **sidecar inside
+> the chart-managed Postgres StatefulSet**. With `postgres.enabled=false` that pod
+> does not exist, so there is no collector, and the `metrics` edge function no
+> longer gathers them either (it cost 77.7% of all database execution time when
+> Prometheus scraped it once per functions pod). The
+> `PawtograderPostgresExporter*` self-health rules are gated on the same
+> condition, so nothing would report the absence.
+>
+> `templates/validations.yaml` therefore **refuses** `monitoring.enabled=true`
+> together with `postgres.enabled=false` unless you set
+> `monitoring.externalPostgresExporter=true`, which asserts you run your own
+> exporter against the external database. In that mode the chart still renders the
+> `queries.yaml` ConfigMap (mount it into your exporter to keep the metric names
+> the dashboards and alert rules expect) but deliberately does **not** render its
+> own postgres-exporter Service or ServiceMonitor — they select the sidecar's pod,
+> which is absent, so they would sit permanently "down" and mask your real
+> exporter. Supply a ServiceMonitor for your own exporter instead.
+
 > **Every custom query sets `master: true`.** The exporter sidecar runs with
 > `PG_EXPORTER_AUTO_DISCOVER_DATABASES=true`, so without that flag a block runs
 > once per discovered database. Every query in `templates/monitoring.yaml` is

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -142,7 +142,7 @@ Each alert's expression depends on an exporter being present in the cluster:
   at most once per 5 minutes even from that one target.
 - exporter self-health alerts (`PawtograderPostgresExporterQueryFailing`,
   `PawtograderPostgresExporterDown`) → `pg_exporter_last_scrape_error`, which
-  postgres_exporter emits on every scrape. These exist because a failing custom
+  `postgres_exporter` emits on every scrape. These exist because a failing custom
   query is **silently dropped** from `/metrics` rather than failing the scrape,
   and the vacuum dashboard's `OR vector(0)` then renders the missing series as
   zero alerts — i.e. green. `absent()` is deliberately on this gauge and not on

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -140,6 +140,14 @@ Each alert's expression depends on an exporter being present in the cluster:
   exporter — scraped once — is the right home. Metric and label names did not
   change. The buffer-cache queries carry `cache_seconds: 300`, so the scan runs
   at most once per 5 minutes even from that one target.
+- exporter self-health alerts (`PawtograderPostgresExporterQueryFailing`,
+  `PawtograderPostgresExporterDown`) → `pg_exporter_last_scrape_error`, which
+  postgres_exporter emits on every scrape. These exist because a failing custom
+  query is **silently dropped** from `/metrics` rather than failing the scrape,
+  and the vacuum dashboard's `OR vector(0)` then renders the missing series as
+  zero alerts — i.e. green. `absent()` is deliberately on this gauge and not on
+  the `pawtograder_db_*` families, which are legitimately empty on a healthy
+  database (dead-tuple and buffer-cache queries have >100-tuple and >1 MiB floors).
 - ESO alert → the External Secrets Operator's `/metrics`
   (`externalsecret_status_condition`).
 - cert alert → cert-manager's `/metrics`

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -137,9 +137,15 @@ Each alert's expression depends on an exporter being present in the cluster:
   32 replicas in prod, ~1.07 calls/sec, and **77.7% of all database execution
   time**, almost all of it `pg_buffercache` scans (524,288 buffer descriptors
   per call at `shared_buffers = 4GB`). They are global database state, so the
-  exporter — scraped once — is the right home. Metric and label names did not
-  change. The buffer-cache queries carry `cache_seconds: 300`, so the scan runs
-  at most once per 5 minutes even from that one target.
+  exporter — scraped once — is the right home. These four kept their exact metric
+  and label names; **two other contracts did change** in the same move, and are
+  documented in `supabase/migrations/20260827120000_drop_database_ram_metrics.sql`
+  — the per-state `pawtograder_db_connections{state}` series is gone (use the
+  built-in `pg_stat_activity_count` if you need the breakdown), and table sizes
+  moved to `pawtograder_table_sizes_total_bytes{relation}` where the label is
+  `relation` rather than `relname` and its value is schema-qualified. The
+  buffer-cache queries carry `cache_seconds: 300`, so the scan runs at most once
+  per 5 minutes even from that one target.
 - exporter self-health alerts (`PawtograderPostgresExporterQueryFailing`,
   `PawtograderPostgresExporterDown`) → `pg_exporter_last_scrape_error`, which
   `postgres_exporter` emits on every scrape. These exist because a failing custom

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -176,24 +176,28 @@ query_preview)` label sets whenever a statement ran under more than one
 > `pg_stat_replication`) or specific to the application database
 > (`public.classes`, `public.submissions`, `public.help_requests`, the
 > `pawtograder_*` functions), so per-database execution is wrong in all of them.
-> Auto-discovery is **not** a no-op on this stack. Its query is
-> `SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND datname != current_database()`,
-> which on supabase/postgres returns `_supabase` and `storage_vectors` (verified
-> against 17.6). What kept it harmless so far is only that the queries fail or
-> return empty there — `pg_stat_statements`, `public.classes`,
-> `public.submissions` and `public.help_requests` all raise "relation does not
-> exist" (namespace skipped, nothing emitted), and `pawtograder_table_sizes`
-> matches no >10 MiB table in those schemas. Two consequences worth knowing:
-> the erroring blocks were setting `pg_exporter_last_scrape_error` on **every**
-> scrape, once per discovered database, which `master: true` clears; and the
-> `server` label is only `host:port` (`parseFingerprint(dsn)`, no database
-> name), so databases on one instance are indistinguishable by label — the first
-> time one of these queries does return a row from a second database, the result
-> is a genuinely **duplicate** label set and the same HTTP 500 failure mode as
-> the gotcha above, not merely a mis-ranked `topk`. A new block needs
-> `master: true` unless it truly means something different per database;
-> `charts/pawtograder/tests/render-guardrails.sh` asserts this and requires an
-> explicit `ALLOW_NO_MASTER` entry for any exception.
+> Whether auto-discovery bites depends on the Postgres image. Its query is
+> `SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND datname != current_database()`.
+> On the **currently deployed** supabase/postgres 17.4.x there is nothing to
+> find — the only databases are `postgres`, `template0` and `template1`, and
+> templates are excluded — so these blocks only ever run against the application
+> database and are **latent**. Confirmed on the live prod exporter:
+> `pg_exporter_last_scrape_error` is 0 and there is exactly one `server` label
+> value (`127.0.0.1:5432`) across the whole scrape. On **17.6.x and later**
+> Supabase adds `_supabase` and `storage_vectors` (verified against 17.6.1.132),
+> and then `pg_stat_statements`, `public.classes`, `public.submissions` and
+> `public.help_requests` would raise "relation does not exist" once per
+> discovered database on every scrape, while `pawtograder_table_sizes` would run
+> against the wrong databases. So `master: true` is a **prerequisite for the next
+> Postgres image bump**, not a fix for a present failure. It also guards
+> something worse than log noise: the `server` label is only `host:port`
+> (`parseFingerprint(dsn)`, no database name), so databases on one instance are
+> indistinguishable by label — the first time one of these queries returns a row
+> from a second database, the result is a genuinely **duplicate** label set and
+> the same HTTP 500 failure mode as the gotcha above, not merely a mis-ranked
+> `topk`. A new block needs `master: true` unless it truly means something
+> different per database; `charts/pawtograder/tests/render-guardrails.sh` asserts
+> this and requires an explicit `ALLOW_NO_MASTER` entry for any exception.
 
 ---
 

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -169,6 +169,32 @@ query_preview)` label sets whenever a statement ran under more than one
 > read "down"). Summing per `queryid` keeps each series unique. If you add custom
 > queries, ensure their label sets are unique or you will re-break the endpoint.
 
+> **Every custom query sets `master: true`.** The exporter sidecar runs with
+> `PG_EXPORTER_AUTO_DISCOVER_DATABASES=true`, so without that flag a block runs
+> once per discovered database. Every query in `templates/monitoring.yaml` is
+> either cluster-wide (`pg_stat_statements`, `pg_buffercache`, `pg_settings`,
+> `pg_stat_replication`) or specific to the application database
+> (`public.classes`, `public.submissions`, `public.help_requests`, the
+> `pawtograder_*` functions), so per-database execution is wrong in all of them.
+> Auto-discovery is **not** a no-op on this stack. Its query is
+> `SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate AND datname != current_database()`,
+> which on supabase/postgres returns `_supabase` and `storage_vectors` (verified
+> against 17.6). What kept it harmless so far is only that the queries fail or
+> return empty there — `pg_stat_statements`, `public.classes`,
+> `public.submissions` and `public.help_requests` all raise "relation does not
+> exist" (namespace skipped, nothing emitted), and `pawtograder_table_sizes`
+> matches no >10 MiB table in those schemas. Two consequences worth knowing:
+> the erroring blocks were setting `pg_exporter_last_scrape_error` on **every**
+> scrape, once per discovered database, which `master: true` clears; and the
+> `server` label is only `host:port` (`parseFingerprint(dsn)`, no database
+> name), so databases on one instance are indistinguishable by label — the first
+> time one of these queries does return a row from a second database, the result
+> is a genuinely **duplicate** label set and the same HTTP 500 failure mode as
+> the gotcha above, not merely a mis-ranked `topk`. A new block needs
+> `master: true` unless it truly means something different per database;
+> `charts/pawtograder/tests/render-guardrails.sh` asserts this and requires an
+> explicit `ALLOW_NO_MASTER` entry for any exception.
+
 ---
 
 ## Verifying alerts are live

--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -126,6 +126,12 @@ Each alert's expression depends on an exporter being present in the cluster:
 - replication alerts → the chart's own `postgres_exporter` custom query
   (`pawtograder_replication_*`, defined in `templates/monitoring.yaml`; read from
   the **primary's** `pg_stat_replication`, not `pg_replication_slots`).
+- **database availability** (`PawtograderPostgresUnavailable`, critical, `for`
+  `monitoring.prometheusRules.postgresUnavailableFor`, default 5m) →
+  **kube-state-metrics** (`kube_statefulset_status_replicas_ready`, labels
+  `statefulset` / `namespace`). Deliberately keyed OUTSIDE the postgres pod, and
+  the only rule in the chart that actually detects a dead or wedged primary — see
+  the fail-open note below.
 - vacuum health and RAM/buffer-cache dashboards
   (`docs/grafana-dashboard-vacuum-health.json`) → the chart's own
   `postgres_exporter` custom queries `pawtograder_vacuum_alert`,
@@ -182,6 +188,40 @@ query_preview)` label sets whenever a statement ran under more than one
 > entire `/metrics` endpoint**, taking down \_all* postgres metrics (the target
 > read "down"). Summing per `queryid` keeps each series unique. If you add custom
 > queries, ensure their label sets are unique or you will re-break the endpoint.
+
+> **Every other critical rule fails OPEN when the database is down.** This
+> predates the availability alert and is worth understanding before you trust any
+> of them as an outage signal. All of them are `metric > threshold` on series that
+> **disappear** in that scenario, and a threshold comparison against no data
+> returns no data — so they go silent rather than firing:
+>
+> | rule                                      | severity / `for` | series it reads                                    | why it vanishes                                                          |
+> | ----------------------------------------- | ---------------- | -------------------------------------------------- | ------------------------------------------------------------------------ |
+> | `PawtograderPostgresConnectionsSaturated` | critical / 5m    | `pawtograder_db_connections_*`                     | postgres_exporter is a **sidecar in the postgres pod**                   |
+> | `PawtograderRecalcStalled`                | critical / 3m    | `pawtograder_gradebook_row_recalculate_queue_size` | `metrics` edge function returns **HTTP 500** when its first DB RPC fails |
+> | `PawtograderAsyncDLQGrowing`              | critical / 1m    | `pawtograder_async_dlq_size`                       | same                                                                     |
+> | `PawtograderAsyncQueueBacklog`            | critical / 5m    | `pawtograder_async_queue_size`                     | same                                                                     |
+> | `PawtograderQueueOldestMessageAging`      | critical / 10m   | `pawtograder_queue_oldest_message_seconds`         | same                                                                     |
+>
+> Before `PawtograderPostgresUnavailable` existed, a wedged primary was therefore
+> **silent for 30 minutes** and then only warned
+> (`PawtograderPostgresExporterDown`). That became load-bearing when the Postgres
+> liveness probes were removed — nothing restarts a wedged postmaster
+> automatically now, so the condition has to page. `PawtograderPostgresUnavailable`
+> is keyed on kube-state-metrics precisely so it survives a dead database, a dead
+> exporter _and_ a dead edge function. **Do not remove it on the grounds that the
+> queue alerts appear to cover the same ground — they do not.**
+>
+> The two exporter self-health rules have a narrower job and keep their existing
+> shape: `PawtograderPostgresExporterQueryFailing` (warning, 15m) means a custom
+> query is broken while the DB is fine, and `PawtograderPostgresExporterDown`
+> (warning, 30m) means the exporter specifically is not being scraped. Neither is
+> an availability signal.
+>
+> Not fixed here: adding `absent()` companions to the queue alerts would close the
+> fail-open for those specific rules, but it changes the meaning of long-standing
+> critical alerts and risks paging on any edge-function scrape gap, so it belongs
+> in its own change.
 
 > **Externally managed database (`postgres.enabled=false`) has no DB metrics.**
 > Every DB-derived series this chart ships — `pawtograder_vacuum_alert`,

--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -32,6 +32,28 @@ The migrations changed in a release are the `supabase/migrations/*.sql` files
 added in that release's diff. Read them before deciding — an "additive" release
 is only additive if **every** new migration is.
 
+### Known accepted deviation: `database_ram_metrics()`
+
+`20260827120000_drop_database_ram_metrics.sql` drops
+`public.database_ram_metrics()` in the same release that stopped calling it,
+which is exactly what ["Preventing the §C case"](#preventing-the-c-case) says not
+to do. It was accepted deliberately, because the blast radius is observability
+only — the function is read by nothing but the metrics scrape path, writes
+nothing, and no user-facing data is lost or becomes unreadable.
+
+Rolling the app back **past** that release leaves the function dropped
+(migrations are forward-only, and the migration that created it is already
+recorded as applied, so a rollback does not recreate it). The older metrics edge
+function then calls it on every scrape, gets a PostgREST 404, and logs plus
+Sentry-reports it roughly once a second across the functions pods. The
+buffer-cache, dead-tuple, connection-state and table-size series are lost until
+it is fixed. Nothing else degrades.
+
+Remedy is a **forward-fix** (§C option 1), not a restore: ship a migration
+recreating the function — its body is in
+`20260325000000_autovacuum_tuning.sql`. Restoring from backup here would trade
+real data for metrics.
+
 ---
 
 ## A. Plain app rollback (no schema change)

--- a/supabase/functions/metrics/index.ts
+++ b/supabase/functions/metrics/index.ts
@@ -7,8 +7,34 @@ import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { serveWithSentryFlush } from "../_shared/SentryInit.ts";
 import * as Sentry from "npm:@sentry/deno@10.10.0";
 
-/** Best-effort cap for vacuum/RAM RPCs so a slow DB cannot stall the scrape. */
-const VACUUM_RAM_RPC_TIMEOUT_MS = 3000;
+/**
+ * SCOPE: this handler serves only metrics that are cheap AND either per-pod or
+ * freshness-sensitive. Global database state does NOT belong here.
+ *
+ * Prometheus scrapes every pod endpoint behind the functions Service, and prod pins the functions
+ * HPA at 32 replicas, so a 30s ServiceMonitor interval means ~1.07 scrapes/sec of this handler.
+ * Anything global gets queried 32× and emitted as 32 identical copies of the same series. Over a
+ * 42-day pg_stat_statements window that made this function 77.7% of ALL production database
+ * execution time:
+ *
+ *   database_ram_metrics()  3,036,749 calls  360.6 ms mean  77.7% of DB exec time
+ *   vacuum_health_check()   3,036,995 calls   32.8 ms mean   7.1%
+ *
+ * database_ram_metrics() was that expensive because it scans pg_buffercache — 524,288 buffer
+ * descriptors at shared_buffers = 4GB, per call, per pod.
+ *
+ * Both now live in the postgres_exporter's queries.yaml
+ * (charts/pawtograder/templates/monitoring.yaml), which is scraped once, from one pod. The metric
+ * and label names are unchanged, so dashboards and alerts kept working across the cutover.
+ *
+ * What stays here, and why: the queue sizes and circuit breaker states below are ~0.3% of DB exec
+ * time combined and drive paging alerts where scrape-interval freshness matters, and the
+ * Bottleneck/Upstash snapshots read Redis rather than Postgres. Moving them is a possible follow-up,
+ * not a cost problem.
+ */
+
+/** Best-effort cap for untyped RPCs so a slow DB cannot stall the scrape. */
+const RPC_TIMEOUT_MS = 3000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -26,9 +52,6 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
   });
 }
 
-/** Shape returned by `vacuum_health_check` (not yet on generated `Database` types). */
-type VacuumHealthRow = { check_name: string; severity: string; relname: string };
-
 /**
  * Shape returned by `get_discord_circuit_breaker_statuses` (not yet on generated `Database` types).
  *
@@ -37,13 +60,6 @@ type VacuumHealthRow = { check_name: string; severity: string; relname: string }
  * completely different remediations — a GitHub App installation versus a Discord server admin.
  */
 type DiscordCircuitRow = { scope: string; key: string; is_open: boolean; state: string; trip_count: number };
-
-/** Shape returned by `database_ram_metrics` rows. */
-type RamMetricRow = {
-  metric_name: string;
-  metric_value: number;
-  metric_labels?: Record<string, unknown> | null;
-};
 
 type RpcRowResult<T> = { data: T | null; error: { message: string } | null };
 
@@ -83,12 +99,12 @@ async function generatePrometheusMetrics(): Promise<Response> {
     // has not yet applied the Discord breaker migration.
     let discordCircuitBreakers: DiscordCircuitRow[] | null = null;
     try {
-      // Bounded like vacuum_health_check and database_ram_metrics below. This handler answers a
-      // Prometheus scrape, so an RPC that hangs does not just lose one gauge -- it stalls the whole
-      // response until the scrape times out and every metric in it is lost.
+      // Bounded: this handler answers a Prometheus scrape, so an RPC that hangs does not just lose
+      // one gauge -- it stalls the whole response until the scrape times out and every metric in it
+      // is lost.
       const d = await withTimeout(
         rpcUntyped<DiscordCircuitRow[]>(supabase, "get_discord_circuit_breaker_statuses"),
-        VACUUM_RAM_RPC_TIMEOUT_MS,
+        RPC_TIMEOUT_MS,
         "get_discord_circuit_breaker_statuses"
       );
       if (d.error) {
@@ -106,45 +122,6 @@ async function generatePrometheusMetrics(): Promise<Response> {
     } catch (redisMetricsError) {
       console.error("Error collecting Bottleneck/Upstash metrics:", redisMetricsError);
       Sentry.captureException(redisMetricsError);
-    }
-
-    let vacuumHealth: VacuumHealthRow[] | null = null;
-    let vacuumError: { message: string } | null = null;
-    try {
-      const v = await withTimeout(
-        rpcUntyped<VacuumHealthRow[]>(supabase, "vacuum_health_check"),
-        VACUUM_RAM_RPC_TIMEOUT_MS,
-        "vacuum_health_check"
-      );
-      vacuumHealth = v.data;
-      vacuumError = v.error;
-    } catch (e) {
-      vacuumError = e instanceof Error ? e : new Error(String(e));
-    }
-
-    let ramMetrics: RamMetricRow[] | null = null;
-    let ramError: { message: string } | null = null;
-    try {
-      const r = await withTimeout(
-        rpcUntyped<RamMetricRow[]>(supabase, "database_ram_metrics"),
-        VACUUM_RAM_RPC_TIMEOUT_MS,
-        "database_ram_metrics"
-      );
-      ramMetrics = r.data;
-      ramError = r.error;
-    } catch (e) {
-      ramError = e instanceof Error ? e : new Error(String(e));
-    }
-
-    if (vacuumError) {
-      const errMsg = vacuumError.message ?? String(vacuumError);
-      console.error("Error fetching vacuum health:", errMsg, vacuumError);
-      Sentry.captureException(vacuumError);
-    }
-
-    if (ramError) {
-      console.error("Error fetching RAM metrics:", ramError);
-      Sentry.captureException(ramError);
     }
 
     const asyncQueueCount = queueSizes?.[0]?.async_queue_size || 0;
@@ -277,55 +254,12 @@ ${queueOldestSeconds
       }
     }
 
-    // Vacuum health metrics
-    output += `
-# HELP pawtograder_vacuum_alert Vacuum health alert (1 = active alert). Labels: check, severity, table_name; on RPC failure also error_type (bounded code only, no raw message)
-# TYPE pawtograder_vacuum_alert gauge
-`;
-    if (vacuumError) {
-      const labels = `check="${escapeLabel("rpc_failed")}",severity="${escapeLabel("error")}",table_name="${escapeLabel("none")}",error_type="${escapeLabel("rpc_error")}"`;
-      output += `pawtograder_vacuum_alert{${labels}} 1 ${timestamp}\n`;
-    } else if (vacuumHealth && vacuumHealth.length > 0) {
-      for (const row of vacuumHealth) {
-        const labels = `check="${escapeLabel(row.check_name)}",severity="${escapeLabel(row.severity)}",table_name="${escapeLabel(row.relname)}"`;
-        output += `pawtograder_vacuum_alert{${labels}} 1 ${timestamp}\n`;
-      }
-    } else {
-      output += `pawtograder_vacuum_alert{check="none",severity="ok",table_name="none"} 0 ${timestamp}\n`;
-    }
-
-    // Database RAM metrics
-    if (ramMetrics && ramMetrics.length > 0) {
-      const metricDefs: Record<string, string> = {
-        buffer_cache_bytes: "Bytes of shared buffer cache used by a table/index",
-        buffer_cache_total_used_bytes: "Total bytes of shared buffer cache in use",
-        connections: "Number of database connections by state",
-        table_total_bytes: "Total size of a table including indexes and TOAST",
-        dead_tuples: "Number of dead tuples in a table"
-      };
-
-      // Group by metric name and emit HELP/TYPE once per metric
-      const grouped = new Map<string, typeof ramMetrics>();
-      for (const row of ramMetrics) {
-        const existing = grouped.get(row.metric_name) || [];
-        existing.push(row);
-        grouped.set(row.metric_name, existing);
-      }
-
-      for (const [metricName, rows] of grouped) {
-        const promName = `pawtograder_db_${metricName}`;
-        const help = metricDefs[metricName] || metricName;
-        output += `\n# HELP ${promName} ${help}\n# TYPE ${promName} gauge\n`;
-        for (const row of rows) {
-          const ml = row.metric_labels && typeof row.metric_labels === "object" ? row.metric_labels : {};
-          const labels = Object.entries(ml as Record<string, string>)
-            .map(([k, v]) => `${k}="${escapeLabel(String(v))}"`)
-            .join(",");
-          const labelStr = labels ? `{${labels}}` : "";
-          output += `${promName}${labelStr} ${row.metric_value} ${timestamp}\n`;
-        }
-      }
-    }
+    // Global database state (pawtograder_vacuum_alert, pawtograder_db_buffer_cache*,
+    // pawtograder_db_dead_tuples, pawtograder_db_connections, pawtograder_db_table_total_bytes) is
+    // deliberately NOT emitted here — see the scope note at the top of this file. It comes from the
+    // postgres_exporter's queries.yaml in charts/pawtograder/templates/monitoring.yaml, scraped once
+    // instead of once per functions pod. Connections and table sizes were already exported there as
+    // pawtograder_db_connections_{used,max,reserved} and pawtograder_table_sizes_{total,heap}_bytes.
 
     output += "\n";
 

--- a/supabase/functions/metrics/index.ts
+++ b/supabase/functions/metrics/index.ts
@@ -24,8 +24,11 @@ import * as Sentry from "npm:@sentry/deno@10.10.0";
  * descriptors at shared_buffers = 4GB, per call, per pod.
  *
  * Both now live in the postgres_exporter's queries.yaml
- * (charts/pawtograder/templates/monitoring.yaml), which is scraped once, from one pod. The metric
- * and label names are unchanged, so dashboards and alerts kept working across the cutover.
+ * (charts/pawtograder/templates/monitoring.yaml), which is scraped once, from one pod. The vacuum,
+ * buffer-cache and dead-tuple metrics kept their exact names and labels. Connections and table
+ * sizes did NOT: pawtograder_db_connections{state} is gone, and table sizes are now
+ * pawtograder_table_sizes_total_bytes{relation} with a schema-qualified value. See
+ * supabase/migrations/20260827120000_drop_database_ram_metrics.sql for the full mapping.
  *
  * What stays here, and why: the queue sizes and circuit breaker states below are ~0.3% of DB exec
  * time combined and drive paging alerts where scrape-interval freshness matters, and the

--- a/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
+++ b/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
@@ -1,0 +1,60 @@
+-- Drop public.database_ram_metrics(). It has no callers left.
+--
+-- WHY IT EXISTED: the `metrics` edge function (supabase/functions/metrics/index.ts)
+-- called it on every Prometheus scrape to publish buffer-cache usage, connection
+-- counts, table sizes and dead-tuple counts.
+--
+-- WHY IT IS GONE: Prometheus scrapes every pod endpoint behind the functions
+-- Service, and prod pins the functions HPA at 32 replicas, so a 30s interval
+-- meant ~1.07 calls/sec of a function whose mean execution time was 360.6 ms.
+-- Over a 42-day pg_stat_statements window that was 3,036,749 calls and 77.7% of
+-- ALL database execution time — for GLOBAL database state that is byte-identical
+-- from every pod, so 31 of every 32 calls were waste. The cost is the
+-- pg_buffercache scan: one row per buffer descriptor, and shared_buffers = 4GB
+-- means 524,288 descriptors per call.
+--
+-- Those metrics now come from the postgres-exporter's custom queries
+-- (charts/pawtograder/templates/monitoring.yaml, the queries.yaml ConfigMap),
+-- which is scraped ONCE — one postgres pod, one endpoint. Metric and label names
+-- were preserved exactly, so dashboards and alerts were unaffected.
+--
+-- =============================================================================
+-- DO NOT DROP THE pg_buffercache EXTENSION. IT IS STILL REQUIRED.
+-- =============================================================================
+-- Two earlier migrations justify pg_buffercache by naming this function:
+--
+--   20260722000000_enable_pg_buffercache.sql       ("Enable pg_buffercache so
+--     public.database_ram_metrics() can report buffer-cache metrics...")
+--   20260722120000_ensure_pg_buffercache_in_public.sql  (pins the extension to
+--     `public` because public.database_ram_metrics() runs with
+--     `SET search_path = pg_catalog, public` and referenced pg_buffercache
+--     unqualified)
+--
+-- Both of those comments are now STALE: the function they point at no longer
+-- exists. Do not read that as "pg_buffercache is unused" and drop it. The
+-- extension is still read on every postgres-exporter scrape by two blocks in
+-- queries.yaml:
+--
+--   pawtograder_db_buffer_cache        -> pawtograder_db_buffer_cache_bytes
+--   pawtograder_db_buffer_cache_total  -> pawtograder_db_buffer_cache_total_used_bytes
+--
+-- It must ALSO stay in the `public` schema, for the same reason as before,
+-- restated for the new caller: those queries reference `public.pg_buffercache`
+-- schema-qualified rather than trusting the exporter connection's search_path.
+-- Relocating the extension breaks them, and a broken custom query in
+-- postgres_exporter drops that namespace and sets
+-- pg_exporter_last_scrape_error — the buffer-cache panels go blank silently.
+--
+-- vacuum_health_check() is deliberately NOT dropped here: it is still run every
+-- 15 minutes by the `vacuum-health-monitor` pg_cron job (added alongside this
+-- function in 20260325000000_autovacuum_tuning.sql), and it is now also wrapped
+-- by the exporter's pawtograder_vacuum block.
+--
+-- NOTE ON GENERATED TYPES: database_ram_metrics IS present in the checked-in
+-- Supabase types (utils/supabase/SupabaseTypes.d.ts and the
+-- supabase/functions/_shared copy). Those are generated artifacts, refreshed
+-- wholesale by `npm run client`; this repo does not hand-prune them in the
+-- migration that drops a function. Nothing calls it, so nothing breaks — the
+-- stale entry just disappears at the next regeneration.
+
+DROP FUNCTION IF EXISTS public.database_ram_metrics();

--- a/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
+++ b/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
@@ -15,8 +15,42 @@
 --
 -- Those metrics now come from the postgres-exporter's custom queries
 -- (charts/pawtograder/templates/monitoring.yaml, the queries.yaml ConfigMap),
--- which is scraped ONCE — one postgres pod, one endpoint. Metric and label names
--- were preserved exactly, so dashboards and alerts were unaffected.
+-- which is scraped ONCE — one postgres pod, one endpoint.
+--
+-- METRIC COMPATIBILITY — four of six preserved exactly, two contracts CHANGED.
+-- (An earlier draft of this comment claimed all names and labels were preserved.
+-- That was wrong; corrected here, because an overstated compatibility claim in an
+-- ops log is worse than none.)
+--
+-- Preserved exactly, same metric name AND same label names:
+--   pawtograder_db_buffer_cache_bytes{relname}
+--   pawtograder_db_buffer_cache_total_used_bytes   (no labels)
+--   pawtograder_db_dead_tuples{relname}
+--   pawtograder_vacuum_alert{check,severity,table_name}
+--
+-- CHANGED — connections. This function emitted
+-- pawtograder_db_connections{state} (a per-state breakdown from
+-- pg_stat_activity). That series is GONE. The exporter's pre-existing
+-- pawtograder_db_connections block emits pawtograder_db_connections_used /
+-- _max / _reserved instead: a count of backend_type = 'client backend' against
+-- max_connections, with NO per-state dimension. It is the count max_connections
+-- actually governs and what the PawtograderPostgresConnections* alerts use, but
+-- it is not the same contract. If anything needs the state breakdown back, do
+-- NOT revive this function: postgres_exporter's built-in pg_stat_activity
+-- collector already publishes it as pg_stat_activity_count, labelled
+-- datname/state/usename/application_name/backend_type/wait_event_type/wait_event
+-- (verified in the pinned v0.18.0 metric map). It is on by default — the sidecar
+-- does not pass --disable-default-metrics — so the data is already being scraped.
+--
+-- CHANGED — table sizes. This function emitted
+-- pawtograder_db_table_total_bytes{relname} with a BARE table name. The
+-- exporter's pre-existing pawtograder_table_sizes block emits
+-- pawtograder_table_sizes_total_bytes / _heap_bytes, and BOTH the label name and
+-- its value format differ: the label is `relation`, not `relname`, and the value
+-- is schema-qualified (public.submissions, not submissions). Any query, panel or
+-- rule matching on relname= for table sizes must be rewritten to relation= with
+-- a schema prefix. The only consumer was
+-- docs/grafana-dashboard-vacuum-health.json, updated in the same PR.
 --
 -- =============================================================================
 -- DO NOT DROP THE pg_buffercache EXTENSION. IT IS STILL REQUIRED.

--- a/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
+++ b/supabase/migrations/20260827120000_drop_database_ram_metrics.sql
@@ -53,6 +53,37 @@
 -- docs/grafana-dashboard-vacuum-health.json, updated in the same PR.
 --
 -- =============================================================================
+-- ACCEPTED DEVIATION FROM THE EXPAND/CONTRACT RULE. READ BEFORE ROLLING BACK.
+-- =============================================================================
+-- docs/operations/rollback.md ("Preventing the §C case") says: never ship a
+-- destructive migration coupled to the same release that stops using the old
+-- shape — split it across two releases so a rollback target always exists.
+--
+-- This migration KNOWINGLY breaks that rule. It drops the function in the same
+-- release that stops calling it, so there is no rollback target: migrations are
+-- forward-only (charts/pawtograder/images/migrations/migrate.sh records each in
+-- supabase_migrations.schema_migrations and skips anything already applied), and
+-- the older migration that CREATES database_ram_metrics() is already recorded as
+-- applied, so a rollback does not recreate it.
+--
+-- Concretely, if the application image is rolled back past this release:
+--   the previous metrics edge function calls database_ram_metrics() on every
+--   scrape, gets a PostgREST 404, and logs + Sentry-reports it ~1.07 times a
+--   second (32 functions pods x 30s). The buffer-cache, dead-tuple,
+--   connection-state and table-size series are lost for the duration.
+--
+-- Judged acceptable because the blast radius is OBSERVABILITY ONLY. This
+-- function is read by nothing but the metrics scrape path — it writes nothing,
+-- no application query calls it, and no user-facing data is lost or becomes
+-- unreadable. That is a different class of risk from the schema drops the
+-- expand/contract rule exists to prevent.
+--
+-- REMEDY if a rollback happens: forward-fix, which is option 1 in
+-- rollback.md's own hierarchy — ship a migration recreating the function (its
+-- body is in 20260325000000_autovacuum_tuning.sql). Do NOT restore from backup
+-- for this; it would trade real data for metrics.
+--
+-- =============================================================================
 -- DO NOT DROP THE pg_buffercache EXTENSION. IT IS STILL REQUIRED.
 -- =============================================================================
 -- Two earlier migrations justify pg_buffercache by naming this function:


### PR DESCRIPTION
This PR grew past its original scope. It now carries four related changes to Postgres availability and monitoring, one per commit:

| commit | change |
|---|---|
| `98eab886` | **Perf** — move global DB metrics off the `metrics` edge function into the postgres-exporter (77.7% of all DB execution time) |
| `1649dafe` | **Cleanup** — drop the now-unreferenced `database_ram_metrics()`; `master: true` on every exporter query |
| `f0c39117` | **Monitoring** — alert when exporter custom queries fail or stop being scraped (closes a fail-open gap this PR created) |
| `6acd9990` | **Availability** — remove the Postgres liveness probes that killed prod twice on 2026-08-27 |

Chart `0.3.15` → `0.3.16`.

---

# 1. Availability: remove the Postgres liveness probes (`6acd9990`)

On **2026-08-27** the hardcoded liveness probes killed **both** the primary and the replica during a transient NetApp NFS stall, taking the platform down twice in one day:

```
14:02:19.677  all 7 pg_cron jobs log "job startup timeout"
              (the postmaster could not fork background workers)
14:02:44      kubelet: "Container postgres failed liveness probe, will be restarted"
14:02:45.452  shutdown checkpoint: 1397 buffers, write=0.122s, sync=0.002s   <- storage FINE
14:02:46.169  database system is shut down
14:02:51      all 3 realtime pods exit 1 (Postgrex admin_shutdown -> Erlang app exit + crash dump)
17:18:18      the same sequence again, on postgres-replica-0
```

**Before / after.** Both templates carried their own hardcoded block, and `failureThreshold` was unset in both, so both inherited the Kubernetes default of 3:

| | before | after |
|---|---|---|
| `postgres-statefulset.yaml` liveness | `initialDelay 30`, `period 10`, `timeout 5`, `failureThreshold` **unset → 3** ⇒ **~30s tolerance** | **removed** |
| `postgres-replica.yaml` liveness | `initialDelay 45`, `period 10`, `timeout 5`, `failureThreshold` **unset → 3** ⇒ **~30s tolerance** | **removed** |
| `postgres-statefulset.yaml` readiness | `initialDelay 10`, `period 5`, `timeout 3` | **unchanged** |
| `postgres-replica.yaml` readiness | `initialDelay 15`, `period 5`, `timeout 3` | **unchanged** |

**The probe was not wrong.** pg_cron's "job startup timeout" means the postmaster genuinely could not fork background workers, which is exactly what `pg_isready` needs — it really was unresponsive for 25s+. But the condition was **transient and self-resolving**: the shutdown checkpoint one second after the kill flushed 1397 buffers in 0.122s with a 2ms sync, so storage was healthy again by then. The probe's patience ran out roughly a second before the problem cleared itself. The cause was external network maintenance, and PGDATA is NetApp NFS where hard mounts *block* rather than error — so the fork path stalled while Postgres logged nothing (the log is empty for the 12 minutes before the kill).

## Why removed rather than loosened to ~90s

A ~90s window (`timeout 10` / `period 15` / `failureThreshold 6`) was the other candidate. Rejected, for two reasons:

**1. Restarting a single-writer Postgres cannot fix external storage, so waiting is strictly better.** Liveness only helps a *permanently wedged* postmaster: rare, warrants a human, and failover here is manual anyway. Against that, every misfire costs the 4 GB warm buffer pool, every connection, and a hard exit of all three realtime pods — disconnecting every WebSocket client at once. The expected value is negative.

**2. The crash-recovery risk defeats any sane window.** `pg_isready` also exits non-zero during recovery, printing `rejecting connections` (we observed exactly that on the replica at startup). This database is **~29 GB**, so WAL replay after an unclean stop can exceed 90s — and `initialDelaySeconds` does not help, because it delays the *first* probe rather than widening the window once probing begins. A 90s probe would kill the pod **mid-recovery**, and each kill is another unclean stop with *more* WAL to replay than the last: a self-worsening restart loop at exactly the moment the database can least afford one. The argument is stronger still on the replica, which is in continuous recovery by definition — a liveness probe there approximates a timer that kills it for falling behind.

## What this trades away

**A permanently wedged postmaster is no longer restarted automatically.** The pod stays `Running` and `NotReady` until a human intervenes. Accepted, because:

- **Readiness is kept**, and it is the useful, non-destructive half of the signal — an unready pod is removed from Service endpoints, so nothing is routed to a database that cannot serve.
- **The wedged case pages `critical` in 5m** via `PawtograderPostgresUnavailable`, added in `2ddbef14`. **An earlier revision of this PR claimed the `pawtograder.app` group already covered this within 1–5m. That was false**, and Codex was right to challenge it — it was the safety argument for removing the probe, so it mattered. Every critical rule that looked like coverage is `metric > threshold` on a series that *disappears* when the DB is gone: the queue gauges come from the metrics edge function, whose handler `throw`s on its first failed RPC and returns HTTP 500, and `PawtograderPostgresConnectionsSaturated` reads the exporter sidecar **in this same pod**. A threshold against no data returns no data, so they fail **open**. Before the fix a wedged primary was silent for 30 minutes and then only warned. See change 9 for the rule, its `for` reasoning, and the unit tests. Detection without amputation — but only because that rule now exists.

**No `values.yaml` knobs added.** The tight thresholds were not better for any deployment, so this is a chart-default fix rather than a per-install tuning question. If someone later wants them configurable, `postgres.livenessProbe` / `postgres.replica.livenessProbe` blocks would be the shape — noted as a follow-up, deliberately not done here. `prod-charts` overrides none of these, so it only picks up the new chart version.

**Untouched on purpose:** the seven liveness probes on stateless services (auth, functions, kong, rest, supavisor, web, realtime), where a restart genuinely does fix the problem.

---

# 2. Perf: move global DB metrics to the postgres-exporter (`98eab886`)
## The problem it fixes


`supabase/functions/metrics/index.ts` is **77.7% of all production database execution time.** From `pg_stat_statements` over a ~42-day window:

| RPC | calls | mean | share of DB exec time |
|---|---|---|---|
| `database_ram_metrics` | 3,036,749 | **360.6 ms** | **77.7%** |
| `vacuum_health_check` | 3,036,995 | 32.8 ms | 7.1% |
| `get_async_queue_sizes` | ~3.0M | ~1.9 ms | 0.2% |
| `get_circuit_breaker_statuses` | 3,037,064 | 0.29 ms | 0.1% |

**The root cause is scrape topology, not the SQL.** `charts/pawtograder/templates/monitoring.yaml` defines the `pawtograder-edge-functions` ServiceMonitor selecting the functions **Service** at `interval: 30s`. Prometheus scrapes *every pod endpoint* behind a Service, and prod pins the functions HPA at **32 replicas** — so that is ~1.07 scrapes/sec of the handler.

These are **global database state**: byte-identical from every pod. 31 of every 32 calls were pure waste, and they produced 32 duplicate copies of every series, which is why the dashboard panels all wrap in `max(...)`.

`database_ram_metrics()` costs 360 ms because it scans `pg_buffercache` — one row per buffer descriptor, and `shared_buffers = 4GB` means **524,288 descriptors per call**, 1.07 times a second. Confirmed by reading its body in `supabase/migrations/20260325000000_autovacuum_tuning.sql`.

## What moved

Into the postgres-exporter's `queries.yaml`, which is scraped **once** (one postgres pod, one endpoint):

| metric | before | after |
|---|---|---|
| `pawtograder_db_buffer_cache_bytes{relname}` | edge fn, 32× | **unchanged name/labels**, block `pawtograder_db_buffer_cache` + column `bytes` |
| `pawtograder_db_buffer_cache_total_used_bytes` | edge fn, 32× | **unchanged**, block `pawtograder_db_buffer_cache_total` + column `used_bytes` |
| `pawtograder_db_dead_tuples{relname}` | edge fn, 32× | **unchanged**, block `pawtograder_db_dead` + column `tuples` |
| `pawtograder_vacuum_alert{check,severity,table_name}` | edge fn, 32× | **unchanged name and all three labels**, block `pawtograder_vacuum` + column `alert` |

**Nothing was renamed.** postgres_exporter names each metric `<block>_<column>` (`fmt.Sprintf("%s_%s", namespace, columnName)`, verified in the v0.18.0 source), so the block/column splits above were chosen to land on the pre-existing names — including the ungainly block `pawtograder_db_dead` + column `tuples`, which is the only split that yields `pawtograder_db_dead_tuples`. There is a comment in the file saying so, and a new CI guardrail (below) that fails if anyone "tidies" it.

### Long → wide

`database_ram_metrics()` returns `(metric_name text, metric_labels jsonb, metric_value numeric)` — long format. postgres-exporter needs wide format (one row per label set, each numeric column becoming a metric), so `SELECT * FROM database_ram_metrics()` cannot work. The new blocks query `pg_buffercache` / `pg_stat_user_tables` directly, reproducing the RPC's filters exactly (>1 MiB buffer-cache floor, >100 dead tuples, top 20 each). This is also this file's house style — see the existing `pawtograder_db_connections` block.

`vacuum_health_check()` returns only text columns, so `alert` is a synthetic `1::float`; the label set is the payload, exactly as the edge function emitted it. The `NOT EXISTS` fallback row reproduces the old `{check="none",severity="ok",table_name="none"} 0` sentinel so the series stays continuously present when the database is healthy.

## What was dropped, not duplicated

The exporter already had these, so the edge function's versions were simply deleted:

- **connections** → `pawtograder_db_connections_{used,max,reserved}` (already `master: true`). Note this loses the old per-`state` breakdown (`pawtograder_db_connections{state}`); the exporter counts `backend_type = 'client backend'`, which is the count `max_connections` actually governs and what the `PawtograderPostgresConnections*` alerts use.
- **table sizes** → `pawtograder_table_sizes_{total,heap}_bytes{relation}` (schema-qualified label, >10 MiB, top 30) replaces `pawtograder_db_table_total_bytes{relname}`.

The only consumer of either dropped series was `docs/grafana-dashboard-vacuum-health.json` (a docs artifact, not a chart-deployed ConfigMap). Both panels were repointed at the exporter equivalents with the substitution explained in the panel description. **Nothing in `charts/` referenced either name** — grepped the whole tree.

## What stayed in the edge function, and why

`get_async_queue_sizes`, `get_circuit_breaker_statuses`, `get_discord_circuit_breaker_statuses`, and the Bottleneck/Upstash Redis snapshots. Combined they are ~0.3% of DB exec time, and they drive the `pawtograder.app` paging alerts where scrape-interval freshness matters (the Redis ones don't touch Postgres at all).

**Follow-up worth considering:** the queue-depth and circuit-breaker RPCs are still called 32× per interval. Even at 0.3% of DB time that is ~3M redundant calls per 42 days, and it is still the reason those series arrive 32-deep. Consolidating them into the exporter too would finish the job and let the dashboards drop their `max(...)` wrappers — but it is a behaviour change for alert freshness, so it belongs in its own PR.

## Details worth reviewing

- **`cache_seconds: 300` on both `pg_buffercache` blocks.** I verified the pinned exporter supports it rather than assuming: `values.yaml` pins `quay.io/prometheuscommunity/postgres-exporter:v0.18.0`, and in that tag `UserQuery` has `CacheSeconds uint64 \`yaml:"cache_seconds"\`` (`cmd/postgres_exporter/queries.go`), honoured per-namespace in `queryNamespaceMappings` (`cmd/postgres_exporter/namespace.go`) with no flag required. Cached metrics are re-emitted on every scrape, so Prometheus sees no staleness gap. Net effect on the buffer scan: from ~1.07/sec to ~2 per 300s.
- **`master: true` on all four blocks.** `pg_buffercache` is the cluster's shared buffer pool; `pg_stat_user_tables` is per-database; and `vacuum_health_check()` exists only in the application database. Without it, `PG_EXPORTER_AUTO_DISCOVER_DATABASES=true` would repeat the expensive scan once per discovered database and the vacuum block would raise "function does not exist" on every scrape, permanently lighting up `pg_exporter_last_scrape_error`.
- **No grant or migration needed.** The exporter connects as `supabase_admin` (`postgres-statefulset.yaml` `DATA_SOURCE_USER`), which `initdb` creates as the bootstrap **superuser** (`postgres-config.yaml`), so `pg_buffercache` — normally `pg_monitor`-gated — and the SECURITY DEFINER `vacuum_health_check()` are both already reachable. `pg_buffercache` is schema-qualified as `public.pg_buffercache` because migrations `20260722000000` / `20260722120000` pin the extension to `public` (relocating it if a base image put it in `extensions`); qualifying beats trusting the exporter connection's `search_path`.
- **Duplicate-series defence.** A duplicate label set makes the exporter's registry return **HTTP 500 for the entire `/metrics` endpoint**, taking down *all* postgres metrics — the failure mode already documented on `pg_stat_statements_top`. Moving these into the shared endpoint widens that blast radius, so: dead tuples uses `sum()/GROUP BY relname` and vacuum health uses `DISTINCT`, because both sources expose schema-*unqualified* names that repeat across `public`/`auth`/`storage`/`realtime`. (The old edge function had this latent bug; here it would be much worse.)
- **`public.vacuum_health_check()` and `database_ram_metrics()` are left in place.** The former is still used by the `vacuum-health-monitor` cron and now by the exporter. The latter is now unreferenced; dropping it is a separate, reversible cleanup.

## Verification

Every command below was run; output is real.

```
$ helm lint charts/pawtograder
==> Linting charts/pawtograder
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template test charts/pawtograder --set monitoring.enabled=true   # full chart
exit=0   (8116 lines)
```

`queries.yaml` is a YAML literal inside YAML, so I extracted and parsed the inner document and reconstructed the metric names the way the exporter does:

```
OK: outer YAML parsed 10 docs; inner queries.yaml parsed 13 query blocks

metric                                        usage    master  cache  labels
pawtograder_db_buffer_cache_bytes             GAUGE    True    300    relname
pawtograder_db_buffer_cache_total_used_bytes  GAUGE    True    300
pawtograder_db_dead_tuples                    GAUGE    True    0      relname
pawtograder_vacuum_alert                      GAUGE    True    0      check,severity,table_name
...
OK: no duplicate metric names across blocks
OK: all 4 migrated metrics present with the exact pre-existing names and labels
```

All four SQL blocks were executed against a real `supabase/postgres:17.6.1.132` (read-only), confirming they parse, run, and produce exactly the column names the exporter turns into metric and label names:

```
=== pg_buffercache extension location ===  pg_buffercache | public
=== vacuum_health_check exists? ===        vacuum_health_check() | secdef=t
=== BLOCK pawtograder_db_buffer_cache ===       9 rows  (job_run_details 39362560, ...)
=== BLOCK pawtograder_db_buffer_cache_total === used_bytes 107945984
=== BLOCK pawtograder_db_dead ===               2 rows
=== BLOCK pawtograder_vacuum ===                none | ok | none | 0     (healthy sentinel)
=== column names as the exporter sees them ===  check|text  severity|text  table_name|text  alert|double precision
```

The non-empty vacuum path was exercised separately with a duplicate label set injected (two same-named relations in different schemas, the real `xid_wraparound_risk` hazard) — `DISTINCT` collapsed it to one row and the sentinel was correctly suppressed.

```
$ charts/pawtograder/tests/render-guardrails.sh
...
== postgres_exporter metric names moved off the edge function are pinned ==
ok   [exporter metric pawtograder_db_buffer_cache_bytes]
ok   [exporter metric pawtograder_db_buffer_cache_total_used_bytes]
ok   [exporter metric pawtograder_db_dead_tuples]
ok   [exporter metric pawtograder_vacuum_alert]
...
All guard-rail render tests passed.
```

That guardrail is new. It is also negative-tested — renaming the `pawtograder_db_dead` block to `pawtograder_db_dead_tuples_oops` produces:

```
FAIL [exporter metric pawtograder_db_dead_tuples]: queries.yaml has no block named 'pawtograder_db_dead'
GUARD-RAIL TESTS FAILED
```

```
$ npm run test:functions          # CI's deno-unit-tests job
ok | 331 passed | 0 failed (2s)
ok | 19 passed | 0 failed (17ms)

$ npx prettier --check <all 6 touched files>
All matched files use Prettier code style!

$ npx next lint --file supabase/functions/metrics/index.ts
6 × Warning: Unexpected console statement. no-console      # all pre-existing
```

`deno check supabase/functions/metrics/index.ts` fails — but identically on unmodified `staging`, with the same single error, in the *generated* types file:

```
TS1254: A 'const' initializer in an ambient context must be a string or numeric literal...
  at supabase/functions/_shared/SupabaseTypes.d.ts:14326:26
```

This is pre-existing and repo-wide (it is why `npm run typecheck:functions` ends in `|| echo 'Type checking completed with errors'`). I confirmed it by stashing and re-running on the base commit: byte-identical output, so **this change introduces no new type error** — but I cannot claim a clean typecheck. `deno lint` on the file reports no unused symbols, which is the specific risk from deleting the RPC calls; its one finding (`no-inner-declarations` on `escapeLabel`) is also pre-existing.

**Not verified:** `promtool` is not available in this environment. `prometheus-rules.yaml` was **not modified** — grepping the whole `charts/` tree found no alert rule referencing any of the four moved metrics (only `pawtograder_db_connections_used`/`_max`, which are the exporter's own and untouched), so there was nothing to re-validate.

Chart version bumped 0.3.15 → 0.3.16, matching the in-PR convention in recent chart-touching commits.


---


---

# 3. Monitoring: alert when the exporter's custom queries fail (`f0c39117`)

Closes the fail-open gap **this PR created**, raised in review by `chatgpt-codex-connector`. The dashboard panel in `2250a188` was half the fix; this is the other half.

**The gap.** postgres_exporter does *not* fail a scrape when one custom query breaks — it drops that namespace from `/metrics` entirely and records the failure only in `pg_exporter_last_scrape_error`. I traced this through the pinned v0.18.0 rather than assuming it: a `db.Query` error becomes `queryNamespaceMapping`'s fatal (third) return (`namespace.go:51`), lands in `queryNamespaceMappings`' `errMap` (`namespace.go:234`), and `Server.Scrape` converts a non-empty `errMap` into the error (`server.go:126-135`) that `scrape()` turns into `e.error.Set(1)` (`postgres_exporter.go:700-704`).

That mattered because the vacuum dashboard reads `count(pawtograder_vacuum_alert{severity!="ok"} == 1) OR vector(0)`, so a dropped namespace renders as **0 active alerts — green**. The edge function used to emit an explicit `pawtograder_vacuum_alert{check="rpc_failed",severity="error"} 1` on RPC failure and the count picked it up; the exporter has no equivalent. A dropped function, a revoked grant, or a `pg_buffercache` relocated out of `public` would have looked exactly like a healthy database.

**Two rules**, in the existing `pawtograder.postgres` group (gated on `postgres.enabled`, same condition as the exporter sidecar):

| alert | expr | `for` | severity |
|---|---|---|---|
| `PawtograderPostgresExporterQueryFailing` | `max(pg_exporter_last_scrape_error{namespace="<ns>"}) > 0` | `15m` | `warning` |
| `PawtograderPostgresExporterDown` | `absent(pg_exporter_last_scrape_error{namespace="<ns>"})` | `30m` | `warning` |

**Severity justified by what it means:** monitoring has gone blind on vacuum/XID-wraparound and RAM telemetry. Nothing user-facing is broken, so this needs fixing in hours, not a 3am page — `warning`, consistent with how neighbouring rules describe themselves, and argued in the annotations.

**Two rules rather than one `or`**, because the `for` durations and the remediations genuinely differ: 15m / fix-the-query versus 30m / fix-the-scrape. `15m` matches `PawtograderPostgresConnectionsHigh` and `PawtograderWALArchiveFailing` so a single bad scrape cannot flap it; `30m` matches `PawtograderBackupMissing` so a StatefulSet roll or a Prometheus reload does not fire it.

**`absent()` is deliberately on this gauge and *not* on the `pawtograder_db_*` families.** Those are legitimately empty on a healthy database — `pawtograder_db_dead_tuples` only has series for tables over 100 dead tuples, and `pawtograder_db_buffer_cache_bytes` only for relations over 1 MiB — so `absent()` on them would page on an idle instance. This gauge is emitted on every scrape regardless of what the queries return, so its absence means exactly one thing.

`max()` follows the convention already stated in this group (*"max() not sum()"*): the ServiceMonitor attaches pod/instance/endpoint labels and this should be one alert, not one per label set. The group's existing note — *"No absent() arm — an exporter that is down must NOT page as connection saturation"* — is respected: the `absent()` check is its own alert with its own meaning, not an arm bolted onto a symptom rule.

**`promtool` — obtained this time.** I reported it unavailable earlier; I downloaded prometheus 2.53.3 for this change. Rendered the PrometheusRule, stripped the CRD wrapper to a bare `groups:` document, and validated: **23 rules SUCCESS before, 25 rules SUCCESS after.**

---

# 4. Ops-log correction

Fixed the pre-existing `pawtograder_db_connections` comment, which claimed auto-discovered per-database servers would "re-export the cluster-wide count under different `server` labels". They would not — `parseFingerprint(dsn)` is `host:port` with no database name, so the label sets **collide** and the exporter 500s the whole endpoint. I flagged this one myself as out-of-scope in an earlier round; now corrected.

# 5. Cleanup + master:true (commit `1649dafe`)

## 5a. Cleanup migration: drop `database_ram_metrics()`

`supabase/migrations/20260827120000_drop_database_ram_metrics.sql` — `DROP FUNCTION IF EXISTS public.database_ram_metrics();`

The function has no callers left. The migration exists mostly to carry a warning: **both** `20260722000000_enable_pg_buffercache.sql` and `20260722120000_ensure_pg_buffercache_in_public.sql` justify the `pg_buffercache` extension by naming this function, so those comments are now stale and the next reader could reasonably conclude the extension is unused and drop it. It isn't — it's read on every exporter scrape by the `pawtograder_db_buffer_cache` and `pawtograder_db_buffer_cache_total` blocks, and it must stay in `public` because those queries reference `public.pg_buffercache` schema-qualified. The migration states both facts explicitly.

`vacuum_health_check()` is deliberately **not** dropped: still used by the `vacuum-health-monitor` pg_cron job, and now also by the exporter's `pawtograder_vacuum` block.

Verified via `psql` against a real `supabase/postgres:17.6.1.132` inside `BEGIN … ROLLBACK` (DDL is transactional, so the local DB was left untouched): the statement parses, the zero-arg signature resolves, the function count goes 1 → 0 inside the transaction and back to 1 after rollback.

**Correction to note:** `database_ram_metrics` **is** present in the checked-in Supabase types (`utils/supabase/SupabaseTypes.d.ts:12673` and the `supabase/functions/_shared` copy) — it was not absent from them. It was called via `rpcUntyped` to unwrap the thenable builder for `withTimeout`, not because it was untyped. Those files are generated artifacts refreshed wholesale by `npm run client`; this repo does not hand-prune them in the migration that drops a function (checked the history of an earlier permanent drop), and nothing calls it, so the stale entry is harmless until the next regeneration. No type regeneration performed.

## 5b. `master: true` on every exporter query block (resolves the CodeRabbit finding)

Added to the five blocks that lacked it: `pg_stat_statements_top`, `pawtograder_classes`, `pawtograder_active_submissions`, `pawtograder_help_queue_depth`, `pawtograder_table_sizes`. **All 13 blocks now set it.** Fixed at the exporter rather than by filtering `server` in the dashboard expression, since the same problem applied to four other blocks and a `server` filter would need repeating in every panel and alert.

**Two corrections, both of which make this more than cosmetic:**

1. **The `server` label is not distinct per database.** It's `parseFingerprint(dsn)` (`cmd/postgres_exporter/util.go`, v0.18.0), which concatenates host and port and does **not** include the database name. So the consequence isn't a `topk` ranking across databases under separate labels — it's a genuinely **duplicate label set**, which returns **HTTP 500 for the entire `/metrics` endpoint**. Same failure mode already documented on `pg_stat_statements_top`.

2. **Whether auto-discovery bites is version-dependent** — and on the *currently deployed* image it does not. The discovery query (`cmd/postgres_exporter/queries.go:278`) is `SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false AND datname != current_database()`. Prod runs **`supabase/postgres:17.4.1.075`**, where the only databases are `postgres`, `template0` and `template1` — templates are excluded, so nothing is discovered. Confirmed on the live prod exporter: `pg_exporter_last_scrape_error` is **0** and there is exactly **one** `server` label value (`127.0.0.1:5432`) across the whole scrape. These five blocks are therefore **latent today**, not erroring.

   On **17.6.x and later** Supabase adds `_supabase` and `storage_vectors` (verified against `17.6.1.132`), and then:

   | block | on `_supabase` / `storage_vectors` |
   |---|---|
   | `pg_stat_statements_top` | ERROR — `relation "pg_stat_statements" does not exist` |
   | `pawtograder_classes` | ERROR — `relation "public.classes" does not exist` |
   | `pawtograder_active_submissions` | ERROR — `relation "public.submissions" does not exist` |
   | `pawtograder_help_queue_depth` | ERROR — `relation "public.help_requests" does not exist` |
   | `pawtograder_table_sizes` | runs, 0 rows (no >10 MiB table in public/auth/storage/realtime) |

   So `master: true` is a **prerequisite for the next Postgres image bump**, not a fix for a present failure — on 17.6.x the four erroring blocks would set `pg_exporter_last_scrape_error` on every scrape, once per discovered database, and `pawtograder_table_sizes` would run against the wrong databases. Combined with point 1, the `topk` panel is then also one colliding relation name away from a whole-endpoint 500.

   *(An earlier revision of this PR body and of the in-file comments asserted this consequence as present-day fact, based on my testing against 17.6.1.132 rather than the deployed 17.4.x. Corrected in `88f90f96`.)*

`render-guardrails.sh` now asserts that **every** block in the rendered `queries.yaml` sets `master: true`, with an explicit `ALLOW_NO_MASTER` opt-out list (empty today) so a genuinely per-database block has to be a deliberate, reviewable edit. Negative-tested.

### Re-verification after the follow-ups

```
$ helm lint charts/pawtograder                                    → 0 chart(s) failed
$ helm template test charts/pawtograder --set monitoring.enabled=true → exit 0 (8163 lines)
$ python3 check.py   # extract + parse inner queries.yaml, rebuild metric names
OK: no duplicate metric names across blocks
OK: all 4 migrated metrics present with the exact pre-existing names and labels
OK: all 13 query blocks set master: true
$ charts/pawtograder/tests/render-guardrails.sh
ok   [every exporter query block sets master: true] (13 blocks)
All guard-rail render tests passed.
$ npm run test:functions      → ok | 331 passed | 0 failed;  ok | 19 passed | 0 failed
$ npx prettier --check <6 touched non-SQL files> → All matched files use Prettier code style!
```

Negative test of the new assertion (one `master: true` removed):
```
FAIL [every exporter query block sets master: true]: block 'pawtograder_help_queue_depth' does not set master: true (and is not in ALLOW_NO_MASTER)
GUARD-RAIL TESTS FAILED
```

Prettier has no SQL parser, so the new `.sql` file is not prettier-checked — that applies identically to all 415 existing migrations, and CI's `prettier --check .` directory glob skips them.



---

# 6. Dashboard scoping — `absent()` cannot lie (`c57e3643`)

Second Codex finding, also valid: the collector-health panel added to close a fail-open bug **was itself fail-open**. `absent()` returns empty if *any* matching series exists, and this chart's `monitoring.yaml` notes the cluster's kube-prometheus-stack auto-discovers ServiceMonitors in **any** namespace — so staging, prod and every preview share one Prometheus. A healthy series from a neighbouring release made the panel render "Reporting" while the selected deployment's collector was dead.

Added a `namespace` template variable and scoped **all 17** expressions in the dashboard, not just `absent()` — a dashboard whose namespace selector silently applies to one panel and is ignored by fifteen others is its own trap. Two deliberate departures from the `postgres-deep-dive.json` house pattern, both forced by `absent()`:

- **`includeAll: false, multi: false`** — an `All`/regex selection would reintroduce the bug. Single-select makes `namespace="$namespace"` an exact match.
- **Sourced from `label_values(kube_pod_info, namespace)`**, not a `pawtograder_*` series, so the variable stays populated when the exporter is what's broken. Sourcing it from the metric whose absence we check would be circular.

The **alert rules did not have this bug** — both are scoped with `namespace="{{ $ns }}"`; verified in the render as `absent(pg_exporter_last_scrape_error{namespace="default"})`.

---


---

# 7. Review round 3 — `absent()` fallback, stale claim, false compatibility statement (`9bcea95e`)

Three findings; **two bots found the first one independently**.

## `absent(...) OR vector(0)` returned two series

The panel added to fix a fail-open bug was itself ambiguous *during the exact failure it reports*. `absent()` preserves its equality matchers as output labels, so with the metric absent the left arm is `{namespace="X"} 1` and `vector(0)` is `{} 0` — different label sets, so `or` returns **both** and the stat panel has no single collector state. With the metric present, `absent()` is empty and only `{} 0` remains, so the healthy path always worked. **That is why the earlier PromQL validation passed: syntactic validity was never the issue.**

Fixed by wrapping in `max(...)`, collapsing to one unlabelled series. I chose it over `or on() vector(0)` (which also works and keeps the namespace label) because a stat panel only needs the number, and `max()` is harder for a future reader to "simplify" back into the bug — this panel has now been broken twice by subtlety.

**Verified with `promtool` *unit tests*, not syntax checks.** Asserted the old shape really does return two series, that both candidate fixes return one, and that the shipped expression is single-series across four states:

| state | result |
|---|---|
| metric absent (collector dead) | `{} 1` |
| healthy sentinel row present | `{} 0` |
| real vacuum alerts firing | `{} 0` |
| neighbouring namespace healthy, **this** one dead | `{} 1` |

**Audit of the other 16 exprs: three use `OR vector(0)`, only one combined it with `absent()`.** The two `count(...) OR vector(0)` panels are provably safe — `count()` without `by` returns an unlabelled series, matching `vector(0)`'s label set, so `or` drops the right arm. Unit-tested across no-alerts (`{} 0`), two alerts (`{} 2`), and metric-absent (`{} 0`). **No other instance to fix.**

## Stale claim contradicted by this PR

The panel description still said the chart had no alert rule for exporter query failures — true when written, false two commits later. Reworded: the panel is the immediate **dashboard** signal, with `PawtograderPostgresExporterQueryFailing` and `PawtograderPostgresExporterDown` named as the alerting side, and no longer claims to be the only fail-loud mechanism.

## The migration's compatibility claim was false — corrected precisely

It said *"Metric and label names were preserved exactly."* Four of six were; **two contracts changed.** This one mattered most: it's an ops log, and the claim had already been relayed onward as "nothing was renamed."

**Preserved exactly (name *and* labels):** `pawtograder_db_buffer_cache_bytes{relname}`, `pawtograder_db_buffer_cache_total_used_bytes`, `pawtograder_db_dead_tuples{relname}`, `pawtograder_vacuum_alert{check,severity,table_name}`.

**CHANGED — connections.** `pawtograder_db_connections{state}` is **gone**; the exporter emits `_used`/`_max`/`_reserved`, a client-backend count with **no per-state dimension**. If the breakdown is needed, the built-in `pg_stat_activity` collector already publishes `pg_stat_activity_count{datname,state,usename,application_name,backend_type,wait_event_type,wait_event}` — verified in the pinned v0.18.0 metric map, and on by default (the sidecar has no `args` at all, confirmed in the rendered container spec). Nobody should revive the dropped function for this.

**CHANGED — table sizes.** `pawtograder_db_table_total_bytes{relname}` (bare name) → `pawtograder_table_sizes_total_bytes{relation}`, where **both the label name and its value format differ** (schema-qualified: `public.submissions`). Any query/panel/rule matching `relname=` for table sizes must become `relation=` with a schema prefix.

The same overstated sentence had propagated to two more places I wrote — `docs/operations/monitoring-alerting.md` and the scope note in `supabase/functions/metrics/index.ts`. Both corrected, pointing at the migration for the full mapping. The migration also records that an earlier draft overstated it, so the correction is visible rather than silently swapped.

## Re-verified

`helm lint` 0 failed · `helm template` exit 0 · `render-guardrails.sh` all pass · `promtool check rules` **25 rules SUCCESS** · all **17 dashboard exprs SUCCESS** · `promtool test rules` unit tests **SUCCESS** · `prettier --check .` clean with the **pinned 3.5.3 from `package-lock.json`**, not `npx` latest — the version trap that caused the one lint failure in this PR (`62d3757e`).

---


---

# 8. Guard the externally-managed-database mode (`e1474cbf`)

Codex P2, and correct. With `postgres.enabled=false` this PR made **every** DB-derived metric vanish silently: the exporter is a sidecar inside a StatefulSet that mode doesn't deploy, the migration drops `database_ram_metrics()` so the edge function can't fall back, and the two new `PawtograderPostgresExporter*` self-health rules are gated on the same condition — so nothing reported the absence either.

**Explicitly not fixed with a fallback collector in the edge function.** That reintroduces exactly what this PR removes: ~1.07 calls/sec of a 360 ms RPC across 32 functions replicas, measured at 77.7% of all database execution time. Re-adding a known-catastrophic cost to serve a configuration with no current deployment behind it (`postgres.enabled` defaults `true`, not overridden in the production values) is the wrong trade.

**Fixed by making the combination fail at install time instead of degrading silently.**

**Shape chosen: fail with an acknowledgement opt-out**, following `studio.allowUnauthenticatedIngress` rather than the unconditional fails in `validations.yaml`. Running your own exporter against the external DB is a legitimate setup the chart can't detect, so a hard fail would block real users while a silent degrade is worse than both. New key `monitoring.externalPostgresExporter` (default `false`).

**Guarded any-environment**, on the distinction the file already draws: environment-gated guards are about risk tolerance in durable tiers (`secrets.create`, `resetOnDrift`); any-environment guards cover configurations that simply *don't work* (`postgres.replica` without `walg`). This is the latter. It can't fire accidentally — it needs `monitoring.enabled=true` (default false) **and** `postgres.enabled=false` (default true).

**Also gated the exporter `Service` and `ServiceMonitor` on `postgres.enabled`** — beyond the literal finding, but they selected the absent sidecar's pod and rendered a permanently-"down" target that would *mask* the operator's real exporter in the one mode that survives the guard. The `queries.yaml` ConfigMap is deliberately **not** gated: it's worth mounting into an external exporter to keep the metric names the dashboards and rules expect.

| configuration | result |
|---|---|
| default (postgres on, monitoring off) | renders |
| monitoring on + postgres on (normal) | renders, Service + ServiceMonitor present |
| monitoring on + postgres off, **no ack** | **REFUSED** at `validations.yaml:54` |
| monitoring on + postgres off + ack | renders, no `:9187` target, ConfigMap kept |

Four new guardrail assertions (**49 total**) plus an `assert_rendered_lacks` helper. Negative-tested both ways — disarming the guard fails the suite; ungating the exporter Service fails the "no dangling target" assertion. Documented in `docs/operations/monitoring-alerting.md` so it's discoverable without hitting the guard.

---


---

# 9. Database availability alert — closing the gap the probe removal left (`2ddbef14`)

Codex P2, and the most consequential finding on this PR: it invalidated a claim **I** made, and that claim was the safety argument for change 1.

**The false claim.** Change 1's rationale said the wedged-primary case "surfaces as alerts — the `pawtograder.app` group pages critical within 1–5m". Verified false by reading every rendered expression:

| rule | severity / `for` | why it cannot fire |
|---|---|---|
| `PawtograderPostgresConnectionsSaturated` | critical / 5m | reads `pawtograder_db_connections_*`; postgres_exporter is a **sidecar in the postgres pod** |
| `PawtograderRecalcStalled` | critical / 3m | queue gauge from the metrics edge function |
| `PawtograderAsyncDLQGrowing` | critical / 1m | same |
| `PawtograderAsyncQueueBacklog` | critical / 5m | same |
| `PawtograderQueueOldestMessageAging` | critical / 10m | same |

They're all `metric > threshold` on series that **disappear** in that scenario — the edge-function handler does `if (queueError) throw queueError` and the outer catch returns **HTTP 500**, so the whole target goes away — and a threshold against no data returns no data. They fail **open**. Only `PawtograderPostgresExporterDown` noticed: warning, `for: 30m`. So removing liveness traded auto-restart for detection that didn't exist.

**The new rule:**

```
PawtograderPostgresUnavailable
  expr: max(kube_statefulset_status_replicas_ready{namespace="<ns>", statefulset="<pg-sts>"}) == 0
  for: 5m   (monitoring.prometheusRules.postgresUnavailableFor)
  severity: critical
```

Keyed on kube-state-metrics, deliberately **outside** the postgres pod, so it survives a dead database, a dead exporter *and* a dead edge function — and it is exactly the signal the retained `readinessProbe` produces. Metric name and labels (`statefulset`, `namespace`, STABLE) verified against the kube-state-metrics docs table rather than assumed; KSM is already a live dependency (`kube_job_status_*`, `kube_pod_status_phase`).

**`for: 5m`, reasoned not guessed.** It must outlast a normal rollout or it pages on every deploy — the StatefulSet legitimately goes not-ready on config changes. Budget: preStop fast shutdown (seconds) + possible cold pull of the supabase/postgres image (1–3 min) + start and readiness (`initialDelay` 10s + up to 3×5s) ≈ **3–4 min worst case** on a cold node. 5m clears that with margin, matches the existing 5m criticals, and is a **6× improvement** on the previous 30m warning. Configurable, following `discordCircuitOpenFor`.

**promtool unit tests, generated *from* the rendered rule** (expr, `for`, labels and annotations extracted, not hand-copied):

| scenario | result |
|---|---|
| healthy — 1 ready replica for 20m | never fires |
| 0 ready from t=0 | quiet at 4m (pending), **FIRING** at 6m and 20m |
| normal 3-minute rollout | never fires — the deploy-noise case |
| recovery (0 for 8m, then 1) | fires at 7m, clears at 14m |
| kube-state-metrics absent | silent |

Negative-tested: forcing `for: 15m` makes the 6m firing assertion fail (`got:[]`).

`PawtograderPostgresExporterDown` keeps warning/30m deliberately — with a real availability alert its job is the narrower "the exporter specifically is broken while the DB is fine". **Known limitation, deliberate:** no `absent()` arm, so an install without KSM gets silence rather than a false page, consistent with this file's stated philosophy. Asserted as a tested property.

The systemic fail-open is now recorded as a table in `docs/operations/monitoring-alerting.md` so nobody "simplifies" the availability alert away on the belief that the queue alerts cover it.

**Proposed follow-up, not implemented:** `absent()` companions on one or two of the most important queue alerts (`PawtograderRecalcStalled`, `PawtograderAsyncQueueBacklog`) would close the fail-open for those specific rules. Not bundled here because it changes the meaning of long-standing critical alerts and risks paging on any edge-function scrape gap — it wants its own change with its own thresholds.

---


---

# 10. Accepted deviation: expand/contract, for the RAM-metrics drop (`50787a0c`)

Codex raised this and **the finding is correct — it is not fixed. The drop stays.** Recorded here so the decision is visible rather than rediscovered during an incident.

**The rule this breaks.** `docs/operations/rollback.md` ("Preventing the §C case"): *"Never a destructive migration in the same release that stops reading the old column. That couples app and schema so tightly that no rollback target exists."* Migrations here are forward-only — `migrate.sh` records each in `supabase_migrations.schema_migrations` and skips anything applied — so the migration that *created* `database_ram_metrics()` is already recorded and a rollback does **not** recreate it. This PR ships the destructive migration in the same release that stops calling the function.

**Why accepted.** The blast radius is **observability only**. The function is read by nothing but the metrics scrape path: it writes nothing, no application query calls it, and no user-facing data is lost or becomes unreadable. That is a different class of risk from the column drops and type narrowings the rule exists to prevent, where a rolled-back app meets a schema it cannot read.

**The cost, stated plainly.** Rolling the app back past this release leaves the function dropped, so the previous metrics edge function calls it every scrape, gets a PostgREST 404, and logs plus Sentry-reports it ~1.07×/sec across 32 functions pods. Buffer-cache, dead-tuple, connection-state and table-size series are lost until fixed. Nothing else degrades.

**Remedy: forward-fix** — option 1 in `rollback.md`'s own hierarchy, not a fallback. Ship a migration recreating the function (body in `20260325000000_autovacuum_tuning.sql`). Explicitly **not** a restore from backup, which would trade real data for metrics.

**Recorded in two places:** an `ACCEPTED DEVIATION FROM THE EXPAND/CONTRACT RULE` section in the migration itself, and a *"Known accepted deviation: `database_ram_metrics()`"* subsection in `rollback.md` directly under its decision tree, where someone deciding a rollback actually looks.

No behaviour changed — the `DROP FUNCTION IF EXISTS` is untouched.

---

# Verification

| check | result |
|---|---|
| `helm lint charts/pawtograder` | 0 chart(s) failed |
| `helm template` (full chart, monitoring + replica + walg) | exit 0 |
| `promtool check rules` — rendered PrometheusRule, CRD wrapper stripped | **23 rules SUCCESS before → 25 SUCCESS after** |
| `promtool check rules` — all 17 dashboard exprs as PromQL | SUCCESS, 17 rules |
| `render-guardrails.sh` | all pass, incl. 4 metric-name pins, `master: true` on 13 blocks, and 2 new liveness assertions |
| rendered probe stanzas (parsed, not diffed) | both postgres containers: `livenessProbe` **ABSENT**, `readinessProbe` intact; 7 stateless-service liveness probes untouched |
| `npm run test:functions` | 331 passed + 19 passed, 0 failed |
| `prettier --check` (all touched non-SQL files) | clean |
| DROP migration | applied cleanly in CI (`Wait for Supabase + finalize schema` step succeeded) |

New guardrails are **negative-tested** — each fails when the property it pins is broken:

```
FAIL [exporter metric pawtograder_db_dead_tuples]: queries.yaml has no block named 'pawtograder_db_dead'
FAIL [every exporter query block sets master: true]: block 'pawtograder_help_queue_depth' does not set master: true
FAIL [postgres replica has no livenessProbe...]: templates/postgres-replica.yaml renders a livenessProbe
FAIL [postgres replica has no livenessProbe...]: templates/postgres-replica.yaml renders NO readinessProbe
```

## Known-failing, independent of this PR

- **`e2e-local`** fails identically on the merge base `d786f8d4` — which is the commit currently in production. Same test, file, line and browser: `[webkit] tests/e2e/grading.test.tsx:473:7 › Instructors can view the student's regrade request and resolve it`. Base: 1 failed / 2 flaky / 1151 passed. This branch: 1 failed / 3 flaky / 1150 passed.
- **`argos/platform`** is a human review gate (`"waiting for your decision"`); "removed" snapshots track which specs flaked or didn't run, which differs per run.

## Follow-ups deliberately not done here

- **Probe knobs in `values.yaml`** (`postgres.livenessProbe`, `postgres.replica.livenessProbe`). The tight thresholds weren't better for any deployment, so fixing the chart default is the right first move; making it configurable is a separate question.
- **Consolidating the remaining cheap RPCs** (`get_async_queue_sizes`, `get_circuit_breaker_statuses`, `get_discord_circuit_breaker_statuses`) into the exporter. ~0.3% of DB time but still 32× per interval, and still the reason those series arrive 32-deep. It changes alert freshness, so it wants its own PR.
- **Regenerating `SupabaseTypes.d.ts`.** `database_ram_metrics` remains in the generated types until the next `npm run client`. Harmless — nothing calls it — and this repo doesn't hand-prune generated files in the migration that drops a function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL monitoring for buffer cache usage, dead tuples, and vacuum health.
  * Updated Grafana dashboards with namespace filtering, connection capacity, and the top 30 largest tables.
  * Added alerts for exporter failures and downtime.
  * Added support for externally managed PostgreSQL exporters.

* **Bug Fixes**
  * Reduced redundant database metric collection and limited buffer-cache scans.
  * Prevented unnecessary PostgreSQL restarts during recovery.
  * Added safeguards against metric and label regressions.

* **Documentation**
  * Updated monitoring guidance and metric-source documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







