### PR TITLE
Edge autoscaling: unwedge the memory HPA (eszip cache 256Mi, target 80, chart 0.3.17) + stop the submission insert trigger rewriting inactive rows

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.16
+version: 0.3.17
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -188,6 +188,38 @@ assert_env_value() {
   fi
 }
 
+# assert_hpa_utilization "<label>" "<memory|cpu>" "<expected>" <extra --set args...>
+# Pins one HPA resource metric's averageUtilization, keyed on the RESOURCE NAME.
+#
+# The HPA renders `averageUtilization` once per metric, so the field name alone is
+# ambiguous — memory and cpu both produce a line spelled identically. Anchor on the
+# `name: <resource>` line and read the averageUtilization from the following lines
+# of that metric block, so a memory assertion cannot be satisfied by the cpu target.
+assert_hpa_utilization() {
+  local label="$1" resource="$2" want="$3"; shift 3
+  if ! helm template t "$CHART" "${BASE[@]}" \
+      --set edgeFunctions.autoscaling.enabled=true \
+      "$@" --show-only templates/edge-functions-hpa.yaml >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+    return
+  fi
+  local got
+  got="$(grep -A4 -E "^[[:space:]]*name: ${resource}\$" "$OUTFILE" \
+          | grep -E '^[[:space:]]*averageUtilization:' \
+          | head -1 | sed -E 's/^[[:space:]]*averageUtilization:[[:space:]]*//')"
+  if [ -z "$got" ]; then
+    echo "FAIL [$label]: no averageUtilization found for resource $resource"
+    FAILED=1
+  elif [ "$got" != "$want" ]; then
+    echo "FAIL [$label]: $resource averageUtilization rendered $got, expected $want"
+    FAILED=1
+  else
+    echo "ok   [$label]"
+  fi
+}
+
 echo "== baseline =="
 assert_renders "clean production baseline renders"
 
@@ -572,6 +604,16 @@ assert_renders "memory budget accepts a limit exactly equal to the computed sum"
 assert_refused "cold-load allowance below the largest bundle is refused" \
   "below the 64Mi needed to cover the largest bundle" \
   --set edgeFunctions.eszipColdLoadHeadroomMb=32
+
+# The HPA controller applies a default 10% tolerance, so a target of 100 is a dead
+# band of 90-110%. The edge tier's load-independent floor sat inside that band,
+# which wedged scaling in BOTH directions: it could not scale down (needs <90%) and
+# at 109% under load it could not scale up (needs >110%). 80 puts the band at
+# 72-88%, between the measured ~56% floor and ~146% loaded peak. Pin it so the
+# value cannot drift back to a number whose dead band swallows the floor.
+echo "== edge-function HPA targets are pinned (dead-band sizing, 2026-08-28) =="
+assert_hpa_utilization "memory target renders 80, not 100" memory 80
+assert_hpa_utilization "cpu target renders 200" cpu 200
 
 echo
 if [ "$FAILED" -ne 0 ]; then

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -156,6 +156,38 @@ assert_edge_envfrom_optional() {
   if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label]"; fi
 }
 
+# assert_env_value "<label>" "<template>" "<ENV_NAME>" "<expected value>" <extra --set args...>
+# Pins one container env var to an exact rendered value, matched by NAME then the
+# `value:` line immediately below it.
+#
+# Matching on the name is the whole point here rather than pedantry: the two eszip
+# budgets both render 268435456 at the current defaults (a 256Mi cache and a 256Mi
+# cold-load allowance are the same number of bytes), so a bare grep for the number
+# passes even if the two are swapped, or if one is left behind at 512Mi while the
+# other supplies the match. Anchor to the name and the adjacent line.
+assert_env_value() {
+  local label="$1" template="$2" envname="$3" want="$4"; shift 4
+  if ! helm template t "$CHART" "${BASE[@]}" "$@" --show-only "$template" >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    echo "       got: $(grep -oiE 'Error:.*' "$ERRFILE" | head -1)"
+    FAILED=1
+    return
+  fi
+  local got
+  got="$(grep -A1 -E "^[[:space:]]*- name: ${envname}\$" "$OUTFILE" \
+          | grep -E '^[[:space:]]*value:' \
+          | head -1 | sed -E 's/^[[:space:]]*value:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')"
+  if [ -z "$got" ]; then
+    echo "FAIL [$label]: $envname is not rendered in $template at all"
+    FAILED=1
+  elif [ "$got" != "$want" ]; then
+    echo "FAIL [$label]: $envname rendered $got, expected $want"
+    FAILED=1
+  else
+    echo "ok   [$label]"
+  fi
+}
+
 echo "== baseline =="
 assert_renders "clean production baseline renders"
 
@@ -511,6 +543,35 @@ assert_edge_envfrom_optional "edge-function channels envFrom is optional" \
   --set 'channels[0].web.hostname=canary.pawtograder.example.com' \
   --set 'channels[0].edgeFunctions.image.tag=v1.0.0' \
   --set channelWildcardTlsSecret=wildcard-tls
+
+# The eszip cache is a load-INDEPENDENT term in per-pod RSS, so it sets the FLOOR
+# the memory-target HPA measures against the request. At 512Mi that floor sat at
+# ~992Mi against prod's 1Gi request, i.e. ~100% before any load, and the HPA
+# pinned at maxReplicas 32 with CPU at 5% — see the note on eszipCacheMaxMb in
+# values.yaml. 2026-08-28 halved it to 256Mi. Pin the rendered BYTES so a future
+# edit cannot quietly restore 512 and re-pin the autoscaler: this is a number
+# whose regression is invisible in behaviour for hours (the floor climbs with
+# cache warmth after each deploy) and then permanent.
+echo "== edge-function eszip byte budgets are pinned (HPA floor, 2026-08-28) =="
+assert_env_value "eszip cache renders 256Mi in bytes" \
+  templates/edge-functions.yaml EDGE_ESZIP_CACHE_MAX_BYTES 268435456
+assert_env_value "eszip cold-load allowance renders 256Mi in bytes" \
+  templates/edge-functions.yaml EDGE_ESZIP_COLD_LOAD_MAX_BYTES 268435456
+
+# The budget assertion is the thing that makes the four terms safe to tune at all,
+# so prove it still REFUSES rather than trusting that it would. 2650Mi is the exact
+# sum at the current defaults (256 + 256 + 8 x 256 + 90), so one MiB below it is
+# the tightest possible negative case and it also pins the arithmetic itself.
+assert_refused "memory budget refuses a limit one MiB below the computed sum" \
+  "+ ~90Mi Deno host = 2650Mi" \
+  --set edgeFunctions.resources.limits.memory=2649Mi
+assert_renders "memory budget accepts a limit exactly equal to the computed sum" \
+  --set edgeFunctions.resources.limits.memory=2650Mi
+# eszipColdLoadHeadroomMb must still cover the largest bundle in the image. It is
+# NOT reduced alongside the cache: halving the cache makes cold reads MORE frequent.
+assert_refused "cold-load allowance below the largest bundle is refused" \
+  "below the 64Mi needed to cover the largest bundle" \
+  --set edgeFunctions.eszipColdLoadHeadroomMb=32
 
 echo
 if [ "$FAILED" -ne 0 ]; then

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1147,22 +1147,65 @@ edgeFunctions:
   # Byte budget for the eszip cache the main.ts demuxer keeps of the bundles it
   # has served. This is a real term in the container memory budget and it is the
   # one that is easy to forget: a pod holds one bundle per DISTINCT FUNCTION it
-  # has ever been asked for, bundles run 19-59MB, and the image ships 55 of them
-  # (~2.2GB total). Unbounded, that alone exceeded the container limit and
-  # OOM-killed pods after a few days' uptime (2026-08-19).
+  # has ever been asked for. Unbounded, that alone exceeded the container limit
+  # and OOM-killed pods after a few days' uptime (2026-08-19).
+  #
+  # Bundle inventory, measured 2026-08-28 from /home/deno/eszips in a running
+  # pod (the earlier "55 bundles, ~2.2GB, 19-59MB" here was stale — it came from
+  # the Dockerfile bundler's own log line, which main.ts still quotes):
+  #   58 bundles, 1390MiB total; min 5.5MiB / median 30.7MiB / max 43.2MiB.
+  # Averaging these is how you get surprised, so size the cache off the MEDIAN:
+  # 512Mi holds ~16 of 58, 256Mi holds ~8.
   #
   # The container budget is four terms that must be reconciled together:
   #   eszipCacheMaxMb + eszipColdLoadHeadroomMb
   #     + (maxParallelism x worker.memoryLimitMb) + ~90Mi host
-  # At the defaults: 512Mi + 256Mi + (8 x 256Mi) + 90Mi = 2906Mi (~2.8Gi), which
-  # is why the edge tier wants a limit at or above 4Gi. Raise this only alongside
-  # that sum.
+  # At these defaults: 256Mi + 256Mi + (8 x 256Mi) + 90Mi = 2650Mi (~2.6Gi),
+  # which is why the edge tier wants a limit at or above 4Gi. Raise this only
+  # alongside that sum.
   #
-  # 512Mi holds ~13 average bundles — comfortably more than the handful of
-  # functions a pod serves repeatedly — so the LRU only churns on rare ones.
+  # 2026-08-28: 512 -> 256, to make the memory metric mean something again.
+  #
+  # The edge HPA had been pinned at maxReplicas 32 with memory 106% against a
+  # 100% target while CPU sat at 5% of a 200% target — an autoscaler that can
+  # only ever say "already at max" is not autoscaling, and it left no burst
+  # headroom ahead of a ~2k WAU ramp. The cause is a per-pod memory FLOOR that
+  # is load-INDEPENDENT and dominated by this cache:
+  #   ~320Mi Deno host baseline (measured, see resources notes)
+  #    512Mi eszip cache at its cap
+  #   ~160Mi isolates (8 x ~20Mi marginal under eszip, per main.ts)
+  #   -------
+  #   ~992Mi against prod's 1Gi request  => ~100% before any load at all.
+  #
+  # Confirmed by a natural experiment during the 2026-08-28 deploy: the pods
+  # were recreated, and the SAME fleet under the SAME load went from mean
+  # 1094Mi / 32 replicas pinned (pods aged 8h-2d5h) to mean 504Mi / 12 replicas
+  # (pods <1h). Nothing about traffic changed — only cache warmth. The floor
+  # climbs after every deploy until it crosses the target, then sticks there.
+  #
+  # Halving the cache takes ~256Mi off that floor, so utilization tracks isolate
+  # load rather than cache occupancy. The trade is explicit and cheap: a pod
+  # caches ~8 distinct functions instead of ~16, out of 58. A miss is a LOCAL
+  # read from the image layer at /home/deno/eszips plus an eszip parse — not a
+  # network fetch and not a transpile. main.ts falls back to raw servicePath
+  # (the slow, memory-heavy path) only when a bundle is MISSING from the image,
+  # which is not what eviction causes.
+  #
+  # NOT done here, deliberately: resources.requests.memory stays as it is. With
+  # the cache at 256 the floor drops to ~576Mi idle / ~736Mi loaded, so raising
+  # the request to 1.5Gi would put a FULLY LOADED pod near 48% and the memory
+  # target could never be reached — flipping the failure from pinned-at-max to
+  # pinned-at-min, with CPU at 5% unable to trigger either way. Re-set the
+  # request and targetMemoryUtilizationPercentage from measured idle-vs-loaded
+  # numbers taken from pods that have been up ~24h on this setting, not from
+  # this arithmetic. Deeper caveat: the load-DEPENDENT component is only ~160Mi
+  # against a 576-832Mi floor, so memory is a structurally weak scaling signal
+  # here at ANY request value. The real fix is scaling on a load signal —
+  # pgmq queue depth (pawtograder_async_queue_size and friends already exist).
+  #
   # In MiB, matching worker.memoryLimitMb below. (Kept in MiB rather than bytes
   # because YAML renders a bare 536870912 as 5.36870912e+08 through Helm.)
-  eszipCacheMaxMb: 512
+  eszipCacheMaxMb: 256
   # Headroom for bundle bytes the cache accounting does NOT see: a bundle being
   # read on a cache miss, and one the LRU evicted (or refused as oversized) while
   # a worker creation still holds a reference to it. Those buffers are real and
@@ -1172,8 +1215,12 @@ edgeFunctions:
   # EdgeRuntime.userWorkers.create() rather than for the whole request, which is
   # what keeps this term small — but it is not zero, and a burst of cold requests
   # for DISTINCT functions right after a pod starts is when it peaks. 256Mi is
-  # roughly four of the largest bundle in the image (58.4MiB measured); after
-  # warmup the working set is resident and this is not touched at all.
+  # roughly four of the largest bundle in the image (58.4MiB when this was
+  # written; re-measured 43.2MiB on 2026-08-28, so the render-time floor of
+  # 64Mi is now conservative — left alone deliberately, it costs nothing).
+  # After warmup the working set is resident and this is not touched at all.
+  # Deliberately NOT reduced alongside eszipCacheMaxMb above: this term covers
+  # COLD reads, and halving the cache makes cold reads more frequent, not less.
   eszipColdLoadHeadroomMb: 256
   worker:
     memoryLimitMb: 256
@@ -1189,10 +1236,12 @@ edgeFunctions:
   # (eszipCacheMaxMb + eszipColdLoadHeadroomMb
   #   + maxParallelism x worker.memoryLimitMb + ~90Mi host), which is asserted at
   # render time by pawtograder.edgeFunctions.assertMemoryBudget.
-  # 4Gi rather than 2Gi because the documented working configuration -- the 512Mi
-  # cache and 256Mi cold-load defaults with maxParallelism 8 -- comes to 2906Mi
-  # (~2.8Gi) and did not fit 2Gi, so the old default was a combination the
-  # guardrail now rejects outright.
+  # 4Gi rather than 2Gi because the documented working configuration does not fit
+  # 2Gi, so the old default was a combination the guardrail now rejects outright.
+  # That was 2906Mi (~2.8Gi) when the cache was 512Mi; at the current 256Mi cache
+  # it is 2650Mi (~2.6Gi), still well past 2Gi. The limit is deliberately NOT
+  # lowered to track the cache: it is the backstop described below, and the slack
+  # is the point.
   #
   # This is a backstop, not a target: with the cache bounded, a pod's steady state
   # is the cache plus admitted isolates, and the headroom exists so the runtime

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1173,9 +1173,10 @@ edgeFunctions:
   # is load-INDEPENDENT and dominated by this cache:
   #   ~320Mi Deno host baseline (measured, see resources notes)
   #    512Mi eszip cache at its cap
-  #   ~160Mi isolates (8 x ~20Mi marginal under eszip, per main.ts)
   #   -------
-  #   ~992Mi against prod's 1Gi request  => ~100% before any load at all.
+  #   ~832Mi against prod's 1Gi request  => ~81% before a request is served,
+  #          and measured idle sat higher still (~98%) because a pod keeps
+  #          some isolates resident between requests.
   #
   # Confirmed by a natural experiment during the 2026-08-28 deploy: the pods
   # were recreated, and the SAME fleet under the SAME load went from mean
@@ -1191,17 +1192,31 @@ edgeFunctions:
   # (the slow, memory-heavy path) only when a bundle is MISSING from the image,
   # which is not what eviction causes.
   #
-  # NOT done here, deliberately: resources.requests.memory stays as it is. With
-  # the cache at 256 the floor drops to ~576Mi idle / ~736Mi loaded, so raising
-  # the request to 1.5Gi would put a FULLY LOADED pod near 48% and the memory
-  # target could never be reached — flipping the failure from pinned-at-max to
-  # pinned-at-min, with CPU at 5% unable to trigger either way. Re-set the
-  # request and targetMemoryUtilizationPercentage from measured idle-vs-loaded
-  # numbers taken from pods that have been up ~24h on this setting, not from
-  # this arithmetic. Deeper caveat: the load-DEPENDENT component is only ~160Mi
-  # against a 576-832Mi floor, so memory is a structurally weak scaling signal
-  # here at ANY request value. The real fix is scaling on a load signal —
-  # pgmq queue depth (pawtograder_async_queue_size and friends already exist).
+  # Isolate sizing, corrected 2026-08-28: an earlier version of this note put the
+  # load-dependent term at 8 x ~20Mi = ~160Mi, reading the "~16-20MB marginal"
+  # figure out of main.ts. That figure describes the marginal cost of an ADDITIONAL
+  # isolate for the SAME function once its module graph is loaded; a real isolate
+  # under production load measures ~116Mi. So the load-dependent band is
+  # 8 x ~116Mi = ~900Mi, and with the cache at 256 a pod runs a ~576Mi floor
+  # (56% of prod's 1Gi request) up to a ~1500Mi loaded peak (146%).
+  #
+  # That makes memory a STRONG scaling signal here — ~900Mi of swing on a ~576Mi
+  # floor. An earlier version of this note concluded the opposite ("structurally
+  # weak signal at any request value") and pointed at pgmq queue depth as the real
+  # fix; that conclusion rested on the ~160Mi figure and is retracted. The problem
+  # was never signal strength. It was that the floor sat inside the HPA's default
+  # 90-110% dead band, which is what autoscaling.targetMemoryUtilizationPercentage
+  # below now addresses.
+  #
+  # NOT changed here: resources.requests.memory. Note the corrected numbers also
+  # retire the argument the earlier note gave for leaving it alone (that a 1.5Gi
+  # request would strand a loaded pod near 48%) — at a ~1500Mi loaded peak, 1.5Gi
+  # would read ~98%, not 48%. The request is simply out of scope for this change:
+  # the target bump below is what was measured and confirmed live, and the request
+  # should be re-set from the idle-vs-loaded band observed on pods that have been
+  # up ~24h on these settings rather than from either version of this arithmetic.
+  # The two are coupled — the target is a percentage OF the request, so moving one
+  # without redoing the band calculation re-wedges the dead band.
   #
   # In MiB, matching worker.memoryLimitMb below. (Kept in MiB rather than bytes
   # because YAML renders a bare 536870912 as 5.36870912e+08 through Helm.)
@@ -1259,7 +1274,33 @@ edgeFunctions:
     enabled: false
     minReplicas: 2
     maxReplicas: 10
-    targetMemoryUtilizationPercentage: 100
+    # 2026-08-28: 100 -> 80. This is the number that actually explains the
+    # pinning, and it is not "the target was too low".
+    #
+    # The HPA controller applies a default 10% TOLERANCE before acting, so a
+    # target of 100 is really a DEAD BAND of 90-110%, not "above 100 scales up".
+    # Anything landing inside that band moves nothing in either direction. With
+    # the per-pod floor at ~98% of the request, the fleet could never scale DOWN
+    # (that needs <90%), so once an earlier spike had driven it to maxReplicas it
+    # stayed there permanently; and at 109% under load it still would not scale
+    # UP (that needs >110%). Both directions were wedged by the same band.
+    #
+    # Measured band with eszipCacheMaxMb at 256 (see the note on that value):
+    # floor ~576Mi = 56% of prod's 1Gi request, loaded peak ~1500Mi = 146%.
+    # A target of 80 puts the dead band at 72-88%, which sits cleanly BETWEEN
+    # those two -- the floor is below it, so a quiet fleet can scale down; a
+    # loaded pod is above it, so a busy fleet can scale up.
+    #
+    # Confirmed live on the prod fleet, cache already at 256Mi:
+    #   18:46   109%/100%   12 replicas   pinned
+    #   18:48   109%/80%    12 replicas   target changed
+    #   18:49    78%/80%    20 replicas   scaled, then settled at equilibrium
+    #
+    # Changing the target is not a substitute for sizing the request from
+    # measured data -- see the resources note above. The two interact: this
+    # target is expressed as a percentage OF the request, so re-setting the
+    # request without redoing this arithmetic re-wedges the band.
+    targetMemoryUtilizationPercentage: 80
     targetCPUUtilizationPercentage: 200
   service:
     port: 9000

--- a/supabase/migrations/20260828120000_submissions_insert_hook_skip_already_inactive.sql
+++ b/supabase/migrations/20260828120000_submissions_insert_hook_skip_already_inactive.sql
@@ -1,0 +1,174 @@
+-- submissions_insert_hook_optimized: stop rewriting rows that are already inactive.
+--
+-- The BEFORE INSERT hook on public.submissions deactivates the prior active
+-- submission for the student (or group) before making the new row active. Two of
+-- its three UPDATE statements had no predicate on is_active:
+--
+--   UPDATE public.submissions SET is_active = false
+--   WHERE assignment_id = NEW.assignment_id AND profile_id = NEW.profile_id;
+--
+-- so every insert rewrote EVERY prior row for that (assignment, profile) -- or
+-- (assignment, group) -- including the rows already sitting at is_active = false.
+-- The work is therefore O(submissions that student has ever made) per insert,
+-- when the actual job is O(1): there is at most one active row to demote, which
+-- the partial unique indexes from 20260424200000 already guarantee
+-- (submissions_one_active_individual_per_student, submissions_one_active_group_per_group).
+--
+-- Measured in production before this change:
+--   * 1,798 inserts produced 1,110,155 row UPDATEs on public.submissions.
+--   * 288,483 of 362,964 rows (79%) were already is_active = false, i.e. rewritten
+--     for no reason.
+--   * The top-level `INSERT INTO public.submissions` through PostgREST ran
+--     826 calls, mean 1320ms, max 7687ms, against the `authenticated` role's 8s
+--     statement_timeout -- and 54 statement timeouts were logged during a
+--     330-submission test wave, clustered toward the end of the wave as
+--     per-student row counts grew.
+--
+-- Scale note, so nobody reads this as a production fire: in prod the fan-out is
+-- still small -- mean 4.5 rows per (assignment, profile), p95 16, and only 39
+-- groups above 100. The 1,483-rows-for-one-insert worst case is from a LOAD TEST
+-- dataset with a few thousand submissions per student. This is a correctness and
+-- efficiency fix whose value is in load testing and in the long tail, not an
+-- outage being stopped.
+--
+-- Why this preserves behaviour: each statement's job is "deactivate everything
+-- currently active in this scope". `AND is_active` skips only rows that are
+-- ALREADY false, so the post-statement state is identical. That holds even if the
+-- data has drifted to several active rows in one scope, because the predicate
+-- still matches every active one. Setting is_active = false on a row where it is
+-- already false is a no-op on the row itself.
+--
+-- BEHAVIOUR CHANGE, stated plainly rather than buried: fewer rows updated means
+-- fewer rows written to public.audit. audit_submissions_update is an AFTER UPDATE
+-- ... FOR EACH STATEMENT trigger with transition tables, and
+-- audit_statement_trigger() inserts one audit row per row in NEW_TABLE, so the
+-- audit volume tracks rows affected. The entries this removes recorded
+-- is_active false -> false with nothing else changed: no-op updates. Removing
+-- them removes audit NOISE, not audit history of real changes. Audit data is
+-- compliance-adjacent, so this is called out here (and in the PR) for a reviewer
+-- to accept knowingly. The same applies to broadcast_submission_change_trigger
+-- (AFTER INSERT OR UPDATE OR DELETE ... FOR EACH ROW), which no longer emits a
+-- realtime broadcast for a row whose state did not change.
+--
+-- The third UPDATE in this function -- the one that demotes straggler individual
+-- submissions via a FROM public.assignment_groups_members join -- ALREADY had
+-- `AND s.is_active = true` and is unchanged here. It is reproduced verbatim
+-- because CREATE OR REPLACE FUNCTION must restate the whole body.
+--
+-- Signature is unchanged (submissions_insert_hook_optimized() RETURNS trigger),
+-- so submissions_insert_hook_trigger is deliberately NOT dropped and recreated;
+-- CREATE OR REPLACE rebinds the existing trigger to the new body.
+
+CREATE OR REPLACE FUNCTION public.submissions_insert_hook_optimized()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  assigned_ordinal integer;
+  v_in_group boolean;
+  r RECORD;
+BEGIN
+  CASE TG_OP
+  WHEN 'INSERT' THEN
+    IF NEW.assignment_group_id IS NOT NULL THEN
+      INSERT INTO public.submission_ordinal_counters
+        (assignment_id, assignment_group_id, profile_id, next_ordinal, updated_at)
+      VALUES
+        (NEW.assignment_id::bigint,
+         NEW.assignment_group_id::bigint,
+         '00000000-0000-0000-0000-000000000000'::uuid,
+         2,
+         now())
+      ON CONFLICT (assignment_id, assignment_group_id, profile_id) DO UPDATE SET
+        next_ordinal = public.submission_ordinal_counters.next_ordinal + 1,
+        updated_at = now()
+      RETURNING (public.submission_ordinal_counters.next_ordinal - 1) INTO assigned_ordinal;
+
+      NEW.ordinal = assigned_ordinal;
+
+      IF NOT NEW.is_not_graded THEN
+        NEW.is_active = true;
+        -- `AND is_active` added 20260828: without it this rewrote every prior
+        -- submission for the group, already-inactive ones included.
+        UPDATE public.submissions
+        SET is_active = false
+        WHERE assignment_id = NEW.assignment_id
+          AND assignment_group_id = NEW.assignment_group_id
+          AND is_active;
+
+        FOR r IN (
+          WITH demoted AS (
+            UPDATE public.submissions s
+            SET is_active = false
+            FROM public.assignment_groups_members agm
+            WHERE agm.assignment_id = NEW.assignment_id
+              AND agm.assignment_group_id = NEW.assignment_group_id
+              AND s.assignment_id = NEW.assignment_id
+              AND s.profile_id = agm.profile_id
+              AND s.assignment_group_id IS NULL
+              AND s.is_active = true
+            RETURNING s.profile_id
+          )
+          SELECT DISTINCT gcs.class_id, gcs.gradebook_id, gcs.student_id, gcs.is_private
+          FROM demoted d
+          JOIN public.gradebook_column_students gcs ON gcs.student_id = d.profile_id
+          JOIN public.gradebook_columns gc
+            ON gc.id = gcs.gradebook_column_id
+           AND gc.dependencies->'assignments' @> to_jsonb(ARRAY[NEW.assignment_id]::bigint[])
+        ) LOOP
+          PERFORM public.enqueue_gradebook_row_recalculation(
+            r.class_id, r.gradebook_id, r.student_id, r.is_private, 'group_submission_demote_individual', NULL
+          );
+        END LOOP;
+      END IF;
+    ELSE
+      IF NEW.profile_id IS NOT NULL THEN
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.assignment_groups_members
+          WHERE assignment_id = NEW.assignment_id
+            AND profile_id = NEW.profile_id
+        ) INTO v_in_group;
+        IF v_in_group THEN
+          RAISE EXCEPTION
+            'Cannot create individual submission for profile % on assignment %: student is in an assignment group; submissions must go through the group repository.',
+            NEW.profile_id, NEW.assignment_id
+            USING ERRCODE = 'check_violation';
+        END IF;
+      END IF;
+
+      INSERT INTO public.submission_ordinal_counters
+        (assignment_id, assignment_group_id, profile_id, next_ordinal, updated_at)
+      VALUES
+        (NEW.assignment_id::bigint, 0::bigint, NEW.profile_id::uuid, 2, now())
+      ON CONFLICT (assignment_id, assignment_group_id, profile_id) DO UPDATE SET
+        next_ordinal = public.submission_ordinal_counters.next_ordinal + 1,
+        updated_at = now()
+      RETURNING (public.submission_ordinal_counters.next_ordinal - 1) INTO assigned_ordinal;
+
+      NEW.ordinal = assigned_ordinal;
+
+      IF NOT NEW.is_not_graded THEN
+        NEW.is_active = true;
+        -- `AND is_active` added 20260828: this is the hot one. Without it every
+        -- insert rewrote the student's entire submission history for the
+        -- assignment (1,483 rows for a single insert at the worst measured).
+        UPDATE public.submissions
+        SET is_active = false
+        WHERE assignment_id = NEW.assignment_id
+          AND profile_id = NEW.profile_id
+          AND is_active;
+      END IF;
+    END IF;
+
+    RETURN NEW;
+  ELSE
+    RAISE EXCEPTION 'Unexpected TG_OP: "%". Should not occur!', TG_OP;
+  END CASE;
+END;
+$$;
+
+COMMENT ON FUNCTION public.submissions_insert_hook_optimized() IS
+  'Assigns ordinals, manages is_active, rejects individual INSERT when the student is in a group, demotes straggler individual rows on new group submission and enqueues gradebook row recalc for demoted students. Deactivation UPDATEs are predicated on is_active so an insert does not rewrite already-inactive history (20260828).';


### PR DESCRIPTION
Four changes, one commit each. Three are edge-tier autoscaling; one is an unrelated database fix that rides along.

| # | Change | File |
|---|---|---|
| 1 | Submission insert trigger stops rewriting already-inactive rows | `supabase/migrations/20260828120000_…sql` |
| 2 | `edgeFunctions.eszipCacheMaxMb` 512 → 256 | `charts/pawtograder/values.yaml` |
| 3 | `edgeFunctions.autoscaling.targetMemoryUtilizationPercentage` 100 → 80 | `charts/pawtograder/values.yaml` |
| 4 | Chart version 0.3.16 → 0.3.17 | `charts/pawtograder/Chart.yaml` |

---

## 1. `submissions_insert_hook_optimized`: skip already-inactive rows

`public.submissions_insert_hook_optimized` is a `BEFORE INSERT` trigger that deactivates the prior active submission before making the new row active. Its deactivation `UPDATE`s had no predicate on `is_active`, so **every insert rewrote every prior row** for that `(assignment_id, profile_id)` — or `(assignment_id, assignment_group_id)` — including rows already at `is_active = false`.

The work was O(submissions the student has ever made) per insert, when the job is O(1): the partial unique indexes from `20260424200000` already guarantee at most one active row to demote.

New migration: **`supabase/migrations/20260828120000_submissions_insert_hook_skip_already_inactive.sql`**

### Correction to the brief: two of three, not three of three

The function contains exactly three `UPDATE public.submissions` statements, but **only two lacked the predicate**. The third — the one that demotes straggler individual submissions through a `FROM public.assignment_groups_members` join — already had `AND s.is_active = true` and is **unchanged**. It appears in the migration only because `CREATE OR REPLACE FUNCTION` must restate the whole body.

The two actual changes, both adding one line:

```sql
-- group-scoped (NEW.assignment_group_id IS NOT NULL branch)
 WHERE assignment_id = NEW.assignment_id
   AND assignment_group_id = NEW.assignment_group_id
+  AND is_active;

-- profile-scoped (individual branch) — the hot one
 WHERE assignment_id = NEW.assignment_id
   AND profile_id = NEW.profile_id
+  AND is_active;
```

`is_active` is `NOT NULL DEFAULT false`, so the bare `AND is_active` has no three-valued-logic hazard.

I verified `20260424200000` is genuinely the latest definition (the only other is `20250815120816`, earlier), and that the **live** function body matches it — `pg_get_functiondef` from a running Postgres, not just the migration text.

### Behaviour preservation — verified, not assumed

The reasoning: each statement's job is "deactivate everything currently active in this scope". `AND is_active` skips only rows already `false`, so the post-statement state is identical — including under drift to several active rows, since the predicate still matches every active one.

Checked against the function body rather than taken on faith, then tested. Same insert, old function vs new, on a real Postgres inside `BEGIN … ROLLBACK`:

```
--- post-insert state (id, is_active) ---   OLD            NEW
  116 | f                                    116 | f        116 | f
  117 | f                                    117 | f        117 | f
  118 | f                                    118 | f        118 | f
  119 | f                                    119 | f        119 | f
 4862 | t   (new row)                       4862 | t       4863 | t
--- invariant: exactly one active ---
 total 5 | active 1                          5 | 1          5 | 1
```

`diff` of the two post-states is a single line: the new row's `id` (4862 vs 4863), because the identity sequence is non-transactional and advanced between the two runs. The `is_active` distribution and the one-active-row invariant are identical.

### Audit implication — stated plainly, not buried

**Fewer rows updated means fewer rows written to `public.audit`.** `audit_submissions_update` is `AFTER UPDATE … FOR EACH STATEMENT` with transition tables, and `audit_statement_trigger()` does one `INSERT … SELECT … FROM NEW_TABLE JOIN OLD_TABLE`, i.e. **one audit row per row affected**. So audit volume tracks rows updated, and this reduces it.

Measured on the equivalence test above: **exactly 3 fewer audit rows** (1051 → 1048). The scope had 4 prior rows, 1 active. Old rewrote all 4 (1 real demotion + 3 no-ops); new rewrote 1. The delta is precisely the 3 already-inactive rows.

Every entry removed recorded `is_active` **false → false** with nothing else changed — a no-op update. This removes audit *noise*, not audit history of real changes. Audit data is compliance-adjacent, so it is documented in the migration header and here for a reviewer to accept knowingly rather than discover later.

`broadcast_submission_change_trigger` (`FOR EACH ROW`) is affected the same way: it no longer emits a realtime broadcast for a row whose state did not change.

### Severity — not a production fire

In production the fan-out is **small**: mean 4.5 rows per `(assignment, profile)`, p95 16, only 39 groups above 100. The 1,483-rows-for-one-insert worst case is from **load-test** data with a few thousand submissions per student. This is a correctness and efficiency fix whose value is in load testing and the long tail.

Supporting production measurements: 1,798 inserts produced 1,110,155 row `UPDATE`s; 288,483 of 362,964 rows (79%) were already inactive. The top-level `INSERT INTO public.submissions` via PostgREST ran **826 calls, mean 1320ms, max 7687ms** against the `authenticated` role's 8s `statement_timeout`, with 54 statement timeouts logged during a 330-submission test wave, clustering as per-student row counts grew.

### `EXPLAIN (ANALYZE, BUFFERS)`, real table and triggers, 1504-row scope

Seeded to the measured worst case inside `BEGIN … ROLLBACK`:

| | before | after |
|---|---|---|
| plan | **Seq Scan** | **Bitmap Index Scan** on `idx_submissions_assignment_profile_group_active` |
| rows updated | 1504 | **1** |
| buffers | 27620 hit, 66 dirtied, 63 written | **105 hit** |
| `broadcast_submission_change_trigger` | 1504 calls, 105.0ms | **1 call, 1.3ms** |
| `trigger_update_leaderboard_on_submission_active` | 1504 calls, 6.0ms | **1 call, 0.2ms** |
| `audit_submissions_update` | 1 call, 66.6ms | 1 call, **1.6ms** |
| FK re-check triggers | 4 × 1504 calls, ~67ms | **none** |
| **execution time** | **284.5 ms** | **10.7 ms** |

~27× faster, 263× fewer buffer hits. It also lets the planner use a partial index that **already existed** — no new index needed.

On the FK re-check lines: I re-ran the identical `UPDATE` a second time within the same transaction to check they weren't an artifact of my seeding. They fired 1504 times (tracking rows updated, not the 1500 seeded), so they are genuinely part of the fan-out cost.

Signature is unchanged (`submissions_insert_hook_optimized() RETURNS trigger`), so `submissions_insert_hook_trigger` is deliberately **not** dropped and recreated — `CREATE OR REPLACE` rebinds the existing trigger. Confirmed the live trigger definition to be sure.

---

## 2. `eszipCacheMaxMb` 512 → 256

The edge HPA had been pinned at `maxReplicas` 32 with `memory: 106%/100%` while CPU sat at 5% of a 200% target, leaving no burst headroom ahead of a ~2k WAU ramp. The eszip cache is a **load-independent** term in per-pod RSS, so it sets the floor the memory-target HPA measures against the request:

```
~320 Mi  Deno host baseline (prior measurement, recorded in values.yaml)
 512 Mi  eszip cache at its cap
────────
~832 Mi  = ~81% of prod's 1Gi request before a request is served
```

Confirmed by a natural experiment during the 2026-08-28 deploy: pods were recreated, and the same fleet under the same load went from **mean 1094 Mi / 32 replicas pinned** (pods 8h–2d5h old) to **mean 504 Mi / 12 replicas** (pods <1h). Only cache warmth changed.

### Stale bundle measurements, corrected

The old comment's figures came from the Dockerfile bundler's log line and had drifted. Re-measured from `/home/deno/eszips` in a running pod:

| | comment said | measured 2026-08-28 |
|---|---|---|
| bundles in image | 55 | **58** |
| total size | ~2.2 GB | **1390 MiB** (1458119028 B) |
| size range | 19–59 MB | **min 5.5 / median 30.7 / max 43.2 MiB** |
| held by a 512Mi cache | "~13 average" | **~16 at median** (16.7) |
| held by a 256Mi cache | — | **~8** (8.3) |

58 is independently corroborated: `supabase/functions/` has exactly 58 function directories. Sized off the **median**, not the mean (24.0 MiB) — the old "~13 average" is how you get surprised.

The trade is explicit and cheap: a pod caches ~8 distinct functions instead of ~16, out of 58. A miss is a **local read from the image layer plus an eszip parse** — not a network fetch, not a transpile. `main.ts` falls back to raw `servicePath` only when a bundle is **missing from the image**, which eviction does not cause.

`eszipColdLoadHeadroomMb` stays 256 — it covers **cold** reads, and halving the cache makes those *more* frequent, not less. Its comment's "58.4MiB largest bundle" is annotated with the re-measured 43.2 MiB, noting the 64Mi render-time floor is now conservative and deliberately left alone.

### Budget assertion, as the template computes it

`_edge-functions-workload.tpl` asserts `eszipCacheMaxMb + eszipColdLoadHeadroomMb + (maxParallelism × worker.memoryLimitMb) + 90Mi host ≤ limits.memory`. The host constant is a literal `$hostMi := 90`, and `maxParallelism` is **required** — it `fail`s when unset or non-positive, so the isolate term is never inferred.

Rather than assert the arithmetic, I made the template print it by rendering one MiB under the sum:

```
before (cache 512, limit 2905Mi):
  512Mi + 256Mi + isolates 2048Mi (8 x 256Mi) + ~90Mi Deno host = 2906Mi
after  (cache 256, limit 2649Mi):
  256Mi + 256Mi + isolates 2048Mi (8 x 256Mi) + ~90Mi Deno host = 2650Mi
```

2650Mi ≤ 4Gi, so **the limit needs no change**. Exactly `2650Mi` passes; `2649Mi` fails. The limit stays 4Gi rather than tracking the cache down — it is a backstop and the slack is the point.

---

## 3. `targetMemoryUtilizationPercentage` 100 → 80

**This is the finding that actually explains the pinning**, and it is not "the target was too low".

The HPA controller applies a default **10% tolerance** before acting, so a target of 100 is really a **dead band of 90–110%**, not "above 100 scales up". With the floor at ~98% of the request the fleet could never scale **down** (needs <90%), so once an earlier spike drove it to 32 it stayed there permanently; and at 109% under load it still would not scale **up** (needs >110%). Both directions wedged by the same band.

Measured band with the cache at 256Mi: floor **~576 Mi (56%** of prod's 1Gi request), loaded peak **~1500 Mi (146%)**. A target of 80 puts the dead band at **72–88%** — cleanly between the two.

Confirmed live on the prod fleet, cache already at 256Mi:

```
18:46   109%/100%   12 replicas   pinned
18:48   109%/80%    12 replicas   target changed
18:49    78%/80%    20 replicas   scaled, then settled at equilibrium
```

### Two figures from commit 1 of this PR, retracted

Rather than leave them in the repo record:

- The load-dependent term was given as 8 × ~20Mi = **~160Mi**, taken from `main.ts`'s "~16–20MB marginal" figure. That figure is the marginal cost of an *additional* isolate for the *same* function; a real isolate under production load measures **~116Mi**, so the band is 8 × ~116Mi = **~900Mi**.
- The conclusion drawn from it — *"memory is a structurally weak scaling signal here at any request value"*, with pgmq queue depth as the real fix — **is retracted**. ~900Mi of swing on a ~576Mi floor is a *strong* signal. The problem was never signal strength; it was the floor sitting inside the dead band.

The floor decomposition is corrected the same way: ~320Mi host + cache is the load-independent part, with measured idle higher (~98% at a 512Mi cache) because a pod keeps some isolates resident between requests.

### `resources.requests.memory` still not changed — with the reason updated

It stays as it is, but honesty requires flagging that **the corrected numbers retire the argument commit 1 gave for leaving it alone.** That argument said a 1.5Gi request would strand a fully loaded pod near 48%; at a ~1500Mi loaded peak, 1.5Gi reads **~98%**, not 48%. So "1.5Gi is a trap" no longer holds and should not be relied on.

The request is simply **out of scope** here: the target bump is what was measured and confirmed live, and the request should be re-set from the idle-vs-loaded band observed on pods up **~24h** on these settings — not from either version of the arithmetic. The two are coupled, since the target is a percentage *of* the request, so moving one without redoing the band calculation re-wedges the dead band.

---

## 4. Chart version 0.3.16 → 0.3.17

Changes 2 and 3 are chart **defaults**, so they only reach a deployment through a new chart version. Production already runs `pawtograder-0.3.16` — deploying "0.3.16" again would pull the previously published chart and silently ship none of this.

## Production overrides: this PR alone does not move prod

Both edge values are overridden in the prod-charts repo, so **the chart defaults here do not change production by themselves**:

- `targetMemoryUtilizationPercentage` at `values-prod.yaml:492` (still 100)
- `eszipCacheMaxMb` at `values-prod.yaml:471` (already overridden to 256 out-of-band)

Verified by rendering this chart against the live prod values file: the HPA still comes out at `averageUtilization: 100`. Prod needs a separate ops commit in prod-charts, which is being handled outside this PR. prod-charts was read-only here and is not modified.

## Verification

Everything below was run against this branch. helm `v3.20.2`, matching the `azure/setup-helm@v4` pin in `.github/workflows/lint.yml`.

**`helm lint`** — `1 chart(s) linted, 0 chart(s) failed` (only the pre-existing `icon is recommended` INFO).

**Full-chart `helm template`** — exit 0, 3137 lines, and `helm.sh/chart: pawtograder-0.3.17` in the rendered labels (confirms change 4 took).

**Rendered eszip env vars**, matched by *name* — both budgets are `268435456` at these settings, so a bare value grep proves nothing:

```
$ helm template t charts/pawtograder --show-only templates/edge-functions.yaml | grep -A1 EDGE_ESZIP
            - name: EDGE_ESZIP_CACHE_MAX_BYTES
              value: "268435456"
--
            - name: EDGE_ESZIP_COLD_LOAD_MAX_BYTES
              value: "268435456"
```

**Rendered HPA**, matched by resource name — `averageUtilization` is spelled identically for both metrics, so the field name alone is ambiguous:

```
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 200
```

**`charts/pawtograder/tests/render-guardrails.sh`** (the script CI runs) — all pre-existing cases pass, plus seven new:

```
== edge-function eszip byte budgets are pinned (HPA floor, 2026-08-28) ==
ok   [eszip cache renders 256Mi in bytes]
ok   [eszip cold-load allowance renders 256Mi in bytes]
ok   [memory budget refuses a limit one MiB below the computed sum]
ok   [memory budget accepts a limit exactly equal to the computed sum]
ok   [cold-load allowance below the largest bundle is refused]
== edge-function HPA targets are pinned (dead-band sizing, 2026-08-28) ==
ok   [memory target renders 80, not 100]
ok   [cpu target renders 200]

All guard-rail render tests passed.
```

**Both new pins proven non-vacuous.** Temporarily restoring `eszipCacheMaxMb: 512`:

```
FAIL [eszip cache renders 256Mi in bytes]: EDGE_ESZIP_CACHE_MAX_BYTES rendered 536870912, expected 268435456
ok   [eszip cold-load allowance renders 256Mi in bytes]
FAIL [memory budget refuses a limit one MiB below the computed sum]: refused, but message missing expected text: + ~90Mi Deno host = 2650Mi
FAIL [memory budget accepts a limit exactly equal to the computed sum]: render was REFUSED but should have succeeded
GUARD-RAIL TESTS FAILED
```

The cold-load assertion stayed **green** — which is the point of anchoring to the name; a bare `268435456` grep would have been satisfied by the other env var. Temporarily restoring `targetMemoryUtilizationPercentage: 100`:

```
FAIL [memory target renders 80, not 100]: memory averageUtilization rendered 100, expected 80
ok   [cpu target renders 200]
GUARD-RAIL TESTS FAILED
```

It read 100 rather than cpu's 200, confirming the resource-name keying works.

**`npm run test:functions`** — both halves, `331 passed | 0 failed` and `19 passed | 0 failed`. (Run as the two underlying `deno test` invocations from a non-`/tmp`, non-dot-directory path: the local `deno` is snap-confined and cannot read either, which is an environment artifact and not a repo issue.)

**Database verification** — against a real Postgres 17.6 (`supabase/postgres` container), everything inside `BEGIN … ROLLBACK`:
- migration applies with `ON_ERROR_STOP=1`, zero errors
- `diff` of `pg_get_functiondef` before/after shows **only** the two added predicates plus their explanatory comments — nothing else in the body drifted
- behaviour-equivalence and `EXPLAIN (ANALYZE, BUFFERS)` results as tabled above

**Prettier** at the version pinned in `package-lock.json` (**3.5.3** — the working checkout's `node_modules` has 3.9.6, and a prior PR was broken by exactly that 3.9-vs-3.5.3 markdown difference):

```
$ prettier --version
3.5.3
$ prettier --check .
Checking formatting...
All matched files use Prettier code style!   (exit 0)
```

`charts/` is in `.prettierignore` (Helm Go-templates break its YAML parser) and Prettier has no SQL parser, so this diff is a formatting no-op either way; the repo-wide check is included to show nothing else regressed. `bash -n` on the modified test script passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
