### PR TITLE
Unbreak the edge metrics scrape on gzip; stop shipping a storage target that cannot work

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.18
+version: 0.3.19
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/images/edge-functions/main.ts
+++ b/charts/pawtograder/images/edge-functions/main.ts
@@ -933,10 +933,41 @@ Deno.serve(async (req: Request) => {
       }
       if (appended !== null) {
         try {
-          const body = await res.text();
+          // The worker's response may be COMPRESSED. Prometheus scrapes with
+          // `Accept-Encoding: gzip`, and worker.fetch(req) forwards the request
+          // verbatim (deliberately -- see the note above callWorker), so the
+          // runtime hands back a gzip-encoded body whenever the scraper asked
+          // for one. `res.text()` on that decodes raw DEFLATE bytes as UTF-8:
+          // every invalid byte becomes U+FFFD, and the result then shipped
+          // under the inherited `content-encoding: gzip` -- so Prometheus got
+          // `gzip: invalid header` and dropped the ENTIRE target, including the
+          // pawtograder_* queue series that predate this file.
+          //
+          // Plain `curl` sends no Accept-Encoding at all, which is why the
+          // uncompressed path tested clean and only Prometheus ever saw this.
+          //
+          // Decompress here rather than stripping Accept-Encoding from the
+          // forwarded request: the request object must stay untouched.
+          const encoding = (res.headers.get("content-encoding") ?? "").trim().toLowerCase();
+          let body: string;
+          if (encoding === "" || encoding === "identity") {
+            body = await res.text();
+          } else if (encoding === "gzip" && res.body) {
+            body = await new Response(res.body.pipeThrough(new DecompressionStream("gzip"))).text();
+          } else {
+            // Some other/unsupported encoding (or a declared encoding with no
+            // body). Appending would corrupt it exactly as above, so pass the
+            // worker response through untouched and lose only the edge series.
+            console.error(`[edge-metrics] unsupported content-encoding ${JSON.stringify(encoding)}, passing through`);
+            return res;
+          }
           const headers = new Headers(res.headers);
           // The body length changed; a stale content-length would truncate it.
           headers.delete("content-length");
+          // We are returning PLAINTEXT. Leaving a stale content-encoding here is
+          // the bug described above; the runtime re-applies compression per the
+          // caller's Accept-Encoding on the way out.
+          headers.delete("content-encoding");
           return new Response(body + appended, { status: res.status, statusText: res.statusText, headers });
         } catch (e) {
           console.error("[edge-metrics] could not read worker response body:", e);

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -726,11 +726,35 @@ spec:
 #
 # So single-tenant is the mode where the MAIN app serves it; multitenant is
 # where it moves to the admin app. The 404 was PROMETHEUS_METRICS_ENABLED being
-# unset, which storage.yaml now sets whenever monitoring.enabled=true.
+# unset.
 #
-# Still toggleable via monitoring.serviceMonitors.storage for a deploy that
-# genuinely cannot serve it (multitenant, or an image predating the flag).
-{{- if dig "serviceMonitors" "storage" true .Values.monitoring }}
+# But DO NOT set that flag on this image. It registers the route, and then the
+# first scrape kills the pod:
+#
+#   "Reply was already sent, did you forget to \"return reply\" in the
+#    \"/metrics\" (GET) route?"
+#   Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent
+#     -> uncaughtException -> PID 1 exits -> CrashLoopBackOff
+#
+# handleMetricsRequest writes the reply without returning it, so fastify's
+# onSend chain double-writes the head. Confirmed on staging 2026-09-04: setting
+# the flag crashlooped the storage tier on the ~30s scrape interval. The old
+# advice ("set the toggle false") was therefore right -- only its stated
+# mechanism was wrong, and a wrong mechanism is what made it look safe to
+# "correct".
+#
+# So monitoring.serviceMonitors.storage defaults to FALSE (values.yaml carries
+# the full note). Shipping the ServiceMonitor without the flag is not harmless
+# either: it is a permanently-DOWN target on a 404, which is what shipped
+# before, and a target that can never succeed trains everyone to ignore a DOWN
+# storage row.
+#
+# The route worth trying for real storage metrics is the ADMIN app on ADMIN_PORT
+# (5001), which registers the same handler behind a different hook chain. That
+# needs its own container port, Service port and ServiceMonitor, and the admin
+# app also exposes tenant/migration/s3-credential routes -- a deliberate
+# exposure decision, not a monitoring.enabled side effect.
+{{- if dig "serviceMonitors" "storage" false .Values.monitoring }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -711,11 +711,25 @@ spec:
       scrapeTimeout: {{ .Values.monitoring.scrapeTimeout }}
 {{- end }}
 ---
-# ServiceMonitor: storage-api. /metrics on the http port. Toggleable via
-# monitoring.serviceMonitors.storage: storage-api only exposes /metrics on its
-# admin app (ADMIN_PORT) or in multitenant mode — a single-tenant deploy serving
-# only :5000 returns 404, so Prometheus would flag it perpetually down. Set the
-# toggle false there.
+# ServiceMonitor: storage-api. /metrics on the http port.
+#
+# This comment used to say the opposite -- that /metrics lives only on the admin
+# app (ADMIN_PORT) or in multitenant mode, and that a single-tenant deploy on
+# :5000 necessarily 404s. That is backwards, and it cost this target 24h+ of
+# being DOWN in staging while the "expected" explanation sat right here. Read
+# off the dist bundle in supabase/storage-api:v1.48.26:
+#
+#   app.js         plugins.metrics({ enabledEndpoint: !isMultitenant, ... })
+#   plugins/metrics.js  if (prometheusMetricsEnabled) register(metricsEndpoint)
+#                       -> if (enabledEndpoint) fastify.get("/metrics", ...)
+#   config.js      prometheusMetricsEnabled = PROMETHEUS_METRICS_ENABLED === "true"
+#
+# So single-tenant is the mode where the MAIN app serves it; multitenant is
+# where it moves to the admin app. The 404 was PROMETHEUS_METRICS_ENABLED being
+# unset, which storage.yaml now sets whenever monitoring.enabled=true.
+#
+# Still toggleable via monitoring.serviceMonitors.storage for a deploy that
+# genuinely cannot serve it (multitenant, or an image predating the flag).
 {{- if dig "serviceMonitors" "storage" true .Values.monitoring }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/pawtograder/templates/monitoring.yaml
+++ b/charts/pawtograder/templates/monitoring.yaml
@@ -749,11 +749,18 @@ spec:
 # before, and a target that can never succeed trains everyone to ignore a DOWN
 # storage row.
 #
+# There is a second, independent reason never to enable it on the main app: that
+# port is PUBLICLY ROUTED. Kong's storage-v1 service maps /storage/v1/ to
+# storage:5000/ with strip_path: true and a cors plugin only, so /metrics would
+# answer at https://<api host>/storage/v1/metrics unauthenticated. Confirmed
+# against staging -- that URL reaches storage-api's own router.
+#
 # The route worth trying for real storage metrics is the ADMIN app on ADMIN_PORT
-# (5001), which registers the same handler behind a different hook chain. That
-# needs its own container port, Service port and ServiceMonitor, and the admin
-# app also exposes tenant/migration/s3-credential routes -- a deliberate
-# exposure decision, not a monitoring.enabled side effect.
+# (5001), which registers the same handler behind a different hook chain and is
+# NOT behind the Kong storage route. That needs its own container port, Service
+# port and ServiceMonitor, and the admin app also exposes
+# tenant/migration/s3-credential routes -- a deliberate exposure decision, not a
+# monitoring.enabled side effect.
 {{- if dig "serviceMonitors" "storage" false .Values.monitoring }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/pawtograder/templates/storage.yaml
+++ b/charts/pawtograder/templates/storage.yaml
@@ -99,6 +99,24 @@ spec:
               value: "true"
             - name: IMGPROXY_URL
               value: "http://{{ include "pawtograder.imgproxy.host" . }}:{{ .Values.imgproxy.service.port }}"
+            {{- if .Values.monitoring.enabled }}
+            # storage-api registers GET /metrics on the MAIN app (this container's
+            # http port) only when BOTH hold:
+            #   * PROMETHEUS_METRICS_ENABLED=true          -> config.js prometheusMetricsEnabled
+            #   * enabledEndpoint, which is `!isMultitenant` -> app.js
+            # We are single-tenant (MULTI_TENANT unset), so the second is already
+            # true and this flag is the only thing standing between the
+            # ServiceMonitor and a 200. Without it the route is simply not
+            # registered and the scrape 404s, which is a Prometheus target DOWN,
+            # not merely absent metrics.
+            #
+            # NB the mode logic runs the opposite way to intuition: multitenant is
+            # where the main app STOPS serving /metrics (it moves to the admin app
+            # on ADMIN_PORT). Verified against the dist bundle in
+            # supabase/storage-api:v1.48.26.
+            - name: PROMETHEUS_METRICS_ENABLED
+              value: "true"
+            {{- end }}
             {{- if eq .Values.storage.backend "s3" }}
             - name: STORAGE_BACKEND
               value: s3

--- a/charts/pawtograder/templates/storage.yaml
+++ b/charts/pawtograder/templates/storage.yaml
@@ -99,24 +99,6 @@ spec:
               value: "true"
             - name: IMGPROXY_URL
               value: "http://{{ include "pawtograder.imgproxy.host" . }}:{{ .Values.imgproxy.service.port }}"
-            {{- if .Values.monitoring.enabled }}
-            # storage-api registers GET /metrics on the MAIN app (this container's
-            # http port) only when BOTH hold:
-            #   * PROMETHEUS_METRICS_ENABLED=true          -> config.js prometheusMetricsEnabled
-            #   * enabledEndpoint, which is `!isMultitenant` -> app.js
-            # We are single-tenant (MULTI_TENANT unset), so the second is already
-            # true and this flag is the only thing standing between the
-            # ServiceMonitor and a 200. Without it the route is simply not
-            # registered and the scrape 404s, which is a Prometheus target DOWN,
-            # not merely absent metrics.
-            #
-            # NB the mode logic runs the opposite way to intuition: multitenant is
-            # where the main app STOPS serving /metrics (it moves to the admin app
-            # on ADMIN_PORT). Verified against the dist bundle in
-            # supabase/storage-api:v1.48.26.
-            - name: PROMETHEUS_METRICS_ENABLED
-              value: "true"
-            {{- end }}
             {{- if eq .Values.storage.backend "s3" }}
             - name: STORAGE_BACKEND
               value: s3

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -1104,29 +1104,26 @@ assert_grading_actions_source() {
 }
 assert_grading_actions_source
 
-echo "== storage-api /metrics is a two-condition endpoint =="
-# The storage ServiceMonitor scrapes /metrics on the MAIN app port. storage-api
-# registers that route only when PROMETHEUS_METRICS_ENABLED=true (and only in
-# single-tenant mode, which is the mode this chart deploys). Ship the
-# ServiceMonitor without the flag and the target is permanently DOWN on a 404 --
-# which is exactly how it shipped, for 24h+ in staging.
+echo "== storage-api /metrics must stay OFF on this image =="
+# PROMETHEUS_METRICS_ENABLED registers GET /metrics on storage-api's main app,
+# and handleMetricsRequest then writes the reply without returning it, so
+# fastify double-writes the head on the first scrape: ERR_HTTP_HEADERS_SENT ->
+# uncaughtException -> PID 1 exits. Setting the flag does not yield metrics, it
+# crashloops the storage tier on the scrape interval (staging, 2026-09-04).
 #
-# These two assertions keep the ServiceMonitor and the flag from drifting apart:
-# whatever turns one on must turn the other on.
-assert_env_value "storage sets PROMETHEUS_METRICS_ENABLED with monitoring on" \
-  templates/storage.yaml PROMETHEUS_METRICS_ENABLED true \
+# So the flag must never render, and the ServiceMonitor must not render by
+# default either -- without the flag it is a permanently-DOWN 404 target.
+assert_rendered_lacks "storage never sets PROMETHEUS_METRICS_ENABLED (crashloops the pod)" \
+  templates/storage.yaml "PROMETHEUS_METRICS_ENABLED" \
   --set monitoring.enabled=true --set web.metricsLeader.enabled=true \
   --set monitoring.prometheusRules.labels.release=kps
-assert_rendered_lacks "storage omits PROMETHEUS_METRICS_ENABLED with monitoring off" \
-  templates/storage.yaml "PROMETHEUS_METRICS_ENABLED" \
-  --set monitoring.enabled=false
 
-# assert_storage_scrape_paired
-# The ServiceMonitor and the env var must appear together. Renders the whole
-# chart once with monitoring on and asserts that if a storage ServiceMonitor
-# exists, the storage Deployment carries the flag.
-assert_storage_scrape_paired() {
-  local label="storage ServiceMonitor never ships without the flag"
+# assert_no_storage_servicemonitor
+# Whole-chart render: with monitoring fully on, there must be no storage
+# ServiceMonitor. Anchored on the ServiceMonitor kind so the storage Service and
+# Deployment (which legitimately render) cannot satisfy or defeat it.
+assert_no_storage_servicemonitor() {
+  local label="no storage ServiceMonitor by default"
   if ! helm template t "$CHART" "${BASE[@]}" \
       --set monitoring.enabled=true --set web.metricsLeader.enabled=true \
       --set monitoring.prometheusRules.labels.release=kps \
@@ -1135,19 +1132,46 @@ assert_storage_scrape_paired() {
     FAILED=1
     return
   fi
-  if ! grep -qE '^[[:space:]]*name: t-pawtograder-storage$' "$OUTFILE"; then
-    echo "FAIL [$label]: no storage ServiceMonitor rendered; assertion is not testing anything"
+  if awk '/^kind: ServiceMonitor$/{sm=1} /^  name: t-pawtograder-storage$/{if(sm)found=1} /^---$/{sm=0} END{exit !found}' "$OUTFILE"; then
+    echo "FAIL [$label]: a storage ServiceMonitor rendered; without the flag it is a permanent 404 target"
     FAILED=1
     return
   fi
-  if ! grep -qF "PROMETHEUS_METRICS_ENABLED" "$OUTFILE"; then
-    echo "FAIL [$label]: storage ServiceMonitor rendered but PROMETHEUS_METRICS_ENABLED did not"
+  # Sanity: the same render must still contain OTHER ServiceMonitors, or the
+  # assertion above would pass simply because monitoring did not render at all.
+  if ! grep -qE '^kind: ServiceMonitor$' "$OUTFILE"; then
+    echo "FAIL [$label]: no ServiceMonitors at all; assertion is not testing anything"
     FAILED=1
     return
   fi
   echo "ok   [$label]"
 }
-assert_storage_scrape_paired
+assert_no_storage_servicemonitor
+
+# Opt-in still works, for a deploy that scrapes the admin app or runs a fixed
+# image. The toggle is the documented escape hatch, so it must not rot.
+#
+# NOT assert_rendered_contains "kind: ServiceMonitor": monitoring.yaml renders
+# several of them, so that would pass whether or not the storage one appeared.
+assert_storage_servicemonitor_optin() {
+  local label="storage ServiceMonitor renderable on explicit opt-in"
+  if ! helm template t "$CHART" "${BASE[@]}" \
+      --set monitoring.enabled=true --set web.metricsLeader.enabled=true \
+      --set monitoring.prometheusRules.labels.release=kps \
+      --set monitoring.serviceMonitors.storage=true \
+      >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    FAILED=1
+    return
+  fi
+  if awk '/^kind: ServiceMonitor$/{sm=1} /^  name: t-pawtograder-storage$/{if(sm)found=1} /^---$/{sm=0} END{exit !found}' "$OUTFILE"; then
+    echo "ok   [$label]"
+  else
+    echo "FAIL [$label]: opt-in did not render a storage ServiceMonitor; the escape hatch is broken"
+    FAILED=1
+  fi
+}
+assert_storage_servicemonitor_optin
 
 echo "== edge /metrics demuxer must not re-emit a decoded body as encoded =="
 # assert_edge_metrics_encoding

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -1207,9 +1207,21 @@ assert_edge_metrics_encoding() {
     echo "FAIL [$label]: no gzip decode path; res.text() on an encoded body yields U+FFFD mojibake"
     bad=1
   fi
-  # An encoding it cannot decode must pass the response through untouched.
-  if ! grep -qE 'unsupported content-encoding' "$src"; then
-    echo "FAIL [$label]: no pass-through for an unsupported content-encoding"
+  # An encoding it cannot decode must pass the response through untouched. Match
+  # the CONTROL FLOW, not the log line: a branch that keeps the diagnostic but
+  # loses its `return res` would corrupt exactly the bodies this is protecting,
+  # and a message-only grep cannot tell the difference. Require `return res`
+  # within the few lines following the diagnostic, before the branch closes.
+  if ! awk '
+      /unsupported content-encoding/ { seen = 1; n = 0; next }
+      seen {
+        n++
+        if ($0 ~ /return res;/) { found = 1; exit }
+        if (n > 4 || $0 ~ /^[[:space:]]*}[[:space:]]*$/) { seen = 0 }
+      }
+      END { exit !found }
+    ' "$src"; then
+    echo "FAIL [$label]: unsupported-encoding branch does not return res; the response would be corrupted"
     bad=1
   fi
   if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label]"; fi

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -1104,6 +1104,94 @@ assert_grading_actions_source() {
 }
 assert_grading_actions_source
 
+echo "== storage-api /metrics is a two-condition endpoint =="
+# The storage ServiceMonitor scrapes /metrics on the MAIN app port. storage-api
+# registers that route only when PROMETHEUS_METRICS_ENABLED=true (and only in
+# single-tenant mode, which is the mode this chart deploys). Ship the
+# ServiceMonitor without the flag and the target is permanently DOWN on a 404 --
+# which is exactly how it shipped, for 24h+ in staging.
+#
+# These two assertions keep the ServiceMonitor and the flag from drifting apart:
+# whatever turns one on must turn the other on.
+assert_env_value "storage sets PROMETHEUS_METRICS_ENABLED with monitoring on" \
+  templates/storage.yaml PROMETHEUS_METRICS_ENABLED true \
+  --set monitoring.enabled=true --set web.metricsLeader.enabled=true \
+  --set monitoring.prometheusRules.labels.release=kps
+assert_rendered_lacks "storage omits PROMETHEUS_METRICS_ENABLED with monitoring off" \
+  templates/storage.yaml "PROMETHEUS_METRICS_ENABLED" \
+  --set monitoring.enabled=false
+
+# assert_storage_scrape_paired
+# The ServiceMonitor and the env var must appear together. Renders the whole
+# chart once with monitoring on and asserts that if a storage ServiceMonitor
+# exists, the storage Deployment carries the flag.
+assert_storage_scrape_paired() {
+  local label="storage ServiceMonitor never ships without the flag"
+  if ! helm template t "$CHART" "${BASE[@]}" \
+      --set monitoring.enabled=true --set web.metricsLeader.enabled=true \
+      --set monitoring.prometheusRules.labels.release=kps \
+      >"$OUTFILE" 2>"$ERRFILE"; then
+    echo "FAIL [$label]: render was REFUSED but should have succeeded"
+    FAILED=1
+    return
+  fi
+  if ! grep -qE '^[[:space:]]*name: t-pawtograder-storage$' "$OUTFILE"; then
+    echo "FAIL [$label]: no storage ServiceMonitor rendered; assertion is not testing anything"
+    FAILED=1
+    return
+  fi
+  if ! grep -qF "PROMETHEUS_METRICS_ENABLED" "$OUTFILE"; then
+    echo "FAIL [$label]: storage ServiceMonitor rendered but PROMETHEUS_METRICS_ENABLED did not"
+    FAILED=1
+    return
+  fi
+  echo "ok   [$label]"
+}
+assert_storage_scrape_paired
+
+echo "== edge /metrics demuxer must not re-emit a decoded body as encoded =="
+# assert_edge_metrics_encoding
+# Source-shape assertion (like assert_grading_actions_source above), on
+# images/edge-functions/main.ts rather than on a render. A functional test needs
+# the real runtime image AND a reachable Postgres for the metrics worker to
+# return 200, so it cannot run in chart CI, but the regression it guards took
+# down the whole edge target once already and would do so silently again.
+#
+# The bug: the append path did `await res.text()` and reused the worker's
+# headers. Prometheus scrapes with `Accept-Encoding: gzip` and the request is
+# forwarded verbatim, so the worker's body arrives gzip-encoded; .text() decoded
+# DEFLATE bytes as UTF-8 (every bad byte -> U+FFFD) and shipped the mojibake
+# under the inherited `content-encoding: gzip`. Prometheus: `gzip: invalid
+# header`, target DOWN, and every pawtograder_* queue series off that same
+# endpoint went with it. Plain curl sends no Accept-Encoding, so the manual test
+# passed.
+assert_edge_metrics_encoding() {
+  local label="append path handles content-encoding" bad=0
+  local src="$CHART/images/edge-functions/main.ts"
+  if [ ! -f "$src" ]; then
+    echo "FAIL [$label]: $src not found"
+    FAILED=1
+    return
+  fi
+  # The rewrite must drop content-encoding, since what it returns is plaintext.
+  if ! grep -qE 'headers\.delete\("content-encoding"\)' "$src"; then
+    echo "FAIL [$label]: rewrite does not delete content-encoding; a gzip scrape will be corrupted"
+    bad=1
+  fi
+  # ...and it must actually decode a gzip body rather than stringifying it.
+  if ! grep -qF 'DecompressionStream("gzip")' "$src"; then
+    echo "FAIL [$label]: no gzip decode path; res.text() on an encoded body yields U+FFFD mojibake"
+    bad=1
+  fi
+  # An encoding it cannot decode must pass the response through untouched.
+  if ! grep -qE 'unsupported content-encoding' "$src"; then
+    echo "FAIL [$label]: no pass-through for an unsupported content-encoding"
+    bad=1
+  fi
+  if [ "$bad" -ne 0 ]; then FAILED=1; else echo "ok   [$label]"; fi
+}
+assert_edge_metrics_encoding
+
 echo
 if [ "$FAILED" -ne 0 ]; then
   echo "GUARD-RAIL TESTS FAILED"

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1833,6 +1833,16 @@ monitoring:
     # Enabling the flag therefore does not produce metrics, it takes the storage
     # tier down on a ~30s scrape interval. Verified on staging 2026-09-04.
     #
+    # AND, independently: /metrics on the main app is PUBLICLY REACHABLE. Kong's
+    # storage-v1 service routes /storage/v1/ to storage:5000/ with
+    # strip_path: true and a cors plugin only -- no auth -- and the API-host
+    # ingress sends every path to Kong. So the endpoint would answer at
+    # https://<api host>/storage/v1/metrics from the internet, unauthenticated.
+    # Confirmed against staging: that URL reaches storage-api's own router (it
+    # returns storage-api's 404 JSON, not Kong's) while /storage/v1/status
+    # returns 200. Anyone "fixing" the crashloop by patching storage-api would
+    # still be publishing internal telemetry.
+    #
     # So we ship neither the flag nor the ServiceMonitor. Leaving the
     # ServiceMonitor on without the flag is merely a permanently-DOWN target (a
     # 404), which is what shipped before and what this default fixes: a target

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1815,11 +1815,37 @@ monitoring:
 
   # Per-component ServiceMonitor toggles (all default on). Set one false when a
   # component doesn't expose a scrapeable /metrics endpoint in your topology, so
-  # Prometheus doesn't flag it perpetually "down". e.g. storage-api serves
-  # /metrics only on its admin app / in multitenant mode; disable it on a
-  # single-tenant deploy.
+  # Prometheus doesn't flag it perpetually "down".
   serviceMonitors:
-    storage: true
+    # OFF by default, and this is not a cardinality or noise decision -- it is
+    # the only safe setting on supabase/storage-api v1.48.26.
+    #
+    # /metrics on the main app is registered when PROMETHEUS_METRICS_ENABLED is
+    # set (single-tenant registers it on the main app; multitenant moves it to
+    # ADMIN_PORT). But the handler does not `return reply`, so fastify's onSend
+    # chain double-writes the response head on the first scrape:
+    #
+    #   "Reply was already sent, did you forget to \"return reply\" in the
+    #    \"/metrics\" (GET) route?"
+    #   Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent
+    #     -> uncaughtException -> PID 1 exits -> CrashLoopBackOff
+    #
+    # Enabling the flag therefore does not produce metrics, it takes the storage
+    # tier down on a ~30s scrape interval. Verified on staging 2026-09-04.
+    #
+    # So we ship neither the flag nor the ServiceMonitor. Leaving the
+    # ServiceMonitor on without the flag is merely a permanently-DOWN target (a
+    # 404), which is what shipped before and what this default fixes: a target
+    # that cannot succeed is worse than no target, because it trains everyone to
+    # ignore a DOWN storage row.
+    #
+    # To actually collect these, the route to try is the ADMIN app on ADMIN_PORT
+    # (default 5001), which registers the same handler but a different hook
+    # chain. That needs its own container port, Service port and ServiceMonitor,
+    # and the admin app also exposes tenant/migration/s3-credential routes, so
+    # exposing it even cluster-internally is a deliberate tradeoff -- not
+    # something to switch on as a side effect of monitoring.enabled.
+    storage: false
     # ServiceMonitor for the dedicated metrics-leader Deployment. Only rendered
     # when web.metricsLeader.enabled is also true, so leaving this on costs
     # nothing on installs that do not run a leader.

--- a/docs/operations/metrics-gap-remediation.md
+++ b/docs/operations/metrics-gap-remediation.md
@@ -1393,6 +1393,19 @@ on both edge channels, and all eight dashboard ConfigMaps updated in place.
 
 ### 12.1 What passed
 
+Revisions 89 and 90 (chart 0.3.19, tag
+`fix-metrics-scrape-gzip-and-storage-84a5b11`) then deployed the fixes; the edge
+result below is measured against revision 90.
+
+**Edge scrape, after the fix.** Every `pawtograder-staging` target reads `up`,
+including all edge pods, and the endpoint behaves correctly on the Prometheus
+path (bearer token + `Accept-Encoding: gzip`): 200, body begins `1f 8b 08 00`,
+gunzips cleanly, 36 `pawtograder_edge_*` samples plus 19 pre-existing
+queue/bottleneck/breaker samples, zero U+FFFD bytes, and the same metric-family
+set as the uncompressed response. 5 distinct `function` label values (invoked
+functions, not the ~55 known ones), 496 edge series total against the ~8.6k
+budget, zero restarts and zero `OOMKilled`, 412 MiB peak working set.
+
 - **Leader.** Exactly one pod exports the workflow family
   (`count(count by (pod)(web_workflow_runs_recent)) == 1`). The sentinel
   `web_workflow_metrics_last_success_timestamp_seconds` is present with
@@ -1447,23 +1460,50 @@ queue-depth alerts went blind. The values still rendering in Grafana came from
 the `pawtograder-preview-pr-*` namespaces, which run older images. That is an
 easy thing to mistake for a healthy staging.
 
-**(b) `storage` had been DOWN for 24h+ on a 404, for a reason this repo
-documented backwards.** The ServiceMonitor's own comment asserted that
+**(b) `storage` had been DOWN for 24h+ on a 404, and the fix that looked
+obvious takes the tier down.** The ServiceMonitor's comment asserted that
 storage-api serves `/metrics` only on the admin app or in multitenant mode, and
 that a single-tenant deploy necessarily 404s. Read off the dist bundle in
-`supabase/storage-api:v1.48.26`, the opposite holds:
+`supabase/storage-api:v1.48.26`, that is backwards:
 
 ```
 app.js              plugins.metrics({ enabledEndpoint: !isMultitenant, ... })
 plugins/metrics.js  if (prometheusMetricsEnabled) register(metricsEndpoint)
                       -> if (enabledEndpoint) fastify.get("/metrics", ...)
-config.js           prometheusMetricsEnabled = PROMETHEUS_METRICS_ENABLED === "true"
+config.js:252       prometheusMetricsEnabled = PROMETHEUS_METRICS_ENABLED === "true"
 ```
 
-Single-tenant is the mode where the **main** app serves it. The 404 was
-`PROMETHEUS_METRICS_ENABLED` never being set. A wrong comment is worse than no
-comment here: it supplied a ready explanation for a real outage and kept anyone
-from looking further.
+Single-tenant is the mode where the **main** app serves it, gated only on
+`PROMETHEUS_METRICS_ENABLED`. So the flag was set, deployed to staging as
+revision 89, and the storage tier went into CrashLoopBackOff:
+
+```
+"Reply was already sent, did you forget to \"return reply\" in the \"/metrics\" (GET) route?"
+Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
+  -> uncaughtException -> PID 1 exits
+```
+
+`handleMetricsRequest` writes the reply without returning it, so fastify's
+`onSend` chain double-writes the response head. The route exists and the
+handler is fatally broken, on a ~30s scrape interval. Reverted in revision 90;
+storage recovered with no further restarts.
+
+The uncomfortable part is that the original advice ("set the toggle false") was
+correct, and its stated mechanism was wrong. A wrong mechanism attached to a
+right conclusion is worse than no comment at all: it presents as an error to
+correct, and correcting it broke production behaviour that the wrong reasoning
+had been protecting. Verifying the mechanism against the bundle was necessary
+but not sufficient -- the missing step was checking what the endpoint does when
+called, not just whether it is registered.
+
+Resolution: ship neither the flag nor the ServiceMonitor.
+`monitoring.serviceMonitors.storage` now defaults to **false**, because a
+permanently-DOWN 404 target is itself a defect -- it trains everyone to ignore a
+DOWN storage row. Storage metrics remain uncollected. The route worth trying is
+the admin app on `ADMIN_PORT` (5001), which registers the same handler behind a
+different hook chain, but that needs its own container port, Service port and
+ServiceMonitor, and the admin app also exposes tenant/migration/s3-credential
+routes -- an exposure decision, not a `monitoring.enabled` side effect.
 
 ### 12.4 Standing checks to add to §8.0
 

--- a/docs/operations/metrics-gap-remediation.md
+++ b/docs/operations/metrics-gap-remediation.md
@@ -1420,7 +1420,7 @@ budget, zero restarts and zero `OOMKilled`, 412 MiB peak working set.
   produced the expected shape, with the route label as the parameterized pattern
   and the status bucketed:
 
-  ```
+  ```text
   web_http_request_duration_seconds_bucket{le="0.5",route="/api/lti/jwks",method="GET",status="5xx"} 4
   ```
 
@@ -1466,7 +1466,7 @@ storage-api serves `/metrics` only on the admin app or in multitenant mode, and
 that a single-tenant deploy necessarily 404s. Read off the dist bundle in
 `supabase/storage-api:v1.48.26`, that is backwards:
 
-```
+```text
 app.js              plugins.metrics({ enabledEndpoint: !isMultitenant, ... })
 plugins/metrics.js  if (prometheusMetricsEnabled) register(metricsEndpoint)
                       -> if (enabledEndpoint) fastify.get("/metrics", ...)
@@ -1477,7 +1477,7 @@ Single-tenant is the mode where the **main** app serves it, gated only on
 `PROMETHEUS_METRICS_ENABLED`. So the flag was set, deployed to staging as
 revision 89, and the storage tier went into CrashLoopBackOff:
 
-```
+```text
 "Reply was already sent, did you forget to \"return reply\" in the \"/metrics\" (GET) route?"
 Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
   -> uncaughtException -> PID 1 exits
@@ -1496,6 +1496,20 @@ had been protecting. Verifying the mechanism against the bundle was necessary
 but not sufficient -- the missing step was checking what the endpoint does when
 called, not just whether it is registered.
 
+And there is a second, independent reason, which the crashloop masked: **that
+port is publicly routed.** Kong's `storage-v1` service maps `/storage/v1/` to
+`storage:5000/` with `strip_path: true` and a `cors` plugin only -- no auth --
+and the API-host ingress sends every path to Kong. Confirmed from outside the
+cluster: `https://api.staging.pawtograder.net/storage/v1/metrics` reaches
+storage-api's own router (it returns storage-api's 404 JSON, not Kong's) while
+`/storage/v1/status` returns 200. Had the handler worked, the flag would have
+published internal telemetry to the internet unauthenticated. Anyone who
+"fixes" the crashloop by patching storage-api still has this problem.
+
+Credit where due: the crashloop was found by deploying it, but the public-route
+exposure was caught in review, not by testing. Two independent fatal flaws in a
+three-line change whose mechanism had been verified against the shipped bundle.
+
 Resolution: ship neither the flag nor the ServiceMonitor.
 `monitoring.serviceMonitors.storage` now defaults to **false**, because a
 permanently-DOWN 404 target is itself a defect -- it trains everyone to ignore a
@@ -1503,7 +1517,8 @@ DOWN storage row. Storage metrics remain uncollected. The route worth trying is
 the admin app on `ADMIN_PORT` (5001), which registers the same handler behind a
 different hook chain, but that needs its own container port, Service port and
 ServiceMonitor, and the admin app also exposes tenant/migration/s3-credential
-routes -- an exposure decision, not a `monitoring.enabled` side effect.
+routes -- an exposure decision, not a `monitoring.enabled` side effect. It is at
+least not behind the Kong storage route.
 
 ### 12.4 Standing checks to add to §8.0
 

--- a/docs/operations/metrics-gap-remediation.md
+++ b/docs/operations/metrics-gap-remediation.md
@@ -1,7 +1,9 @@
 # Metrics gap remediation — tracking doc
 
-**Status:** WS-LEADER, WS-EDGE and WS-APP (with the WS-DASH dashboards) all
-implemented on `metrics-pr0-cleanup` (chart 0.3.18, gates off). Nothing deployed.
+**Status:** all four workstreams merged as #952 (chart 0.3.18) and deployed to
+`pawtograder-staging` on 2026-09-04. Staging validation found two scrape
+regressions, fixed on `fix/metrics-scrape-gzip-and-storage` (chart 0.3.19); see
+§12. Prod gates still unflipped.
 **Opened:** 2026-09-03
 **Scope:** platform (chart, app, edge image, migrations) + prod-charts (values, deploy)
 **Target:** Khoury production, namespace `pawtograder-prod`
@@ -1379,3 +1381,97 @@ object state, and Jon for anything needing psql or port-forward.
    it runs without cluster access. If the plugin turns out to be present, use it
    at Gate 5 as a bonus; if not, nothing in the plan changes. Cheapest way to
    find out is a `helm plugin list` line in the next workflow run.
+
+---
+
+## 12. Staging validation, 2026-09-04 (helm revision 88, chart 0.3.18)
+
+Deployed to `pawtograder-staging` on ripley at 16:43 UTC, image tag
+`staging-1a6f224`. The rollout itself was clean: chart 0.3.18 on every pod, the
+`metrics-leader` Deployment + Service + ServiceMonitor present, `EDGE_METRICS=1`
+on both edge channels, and all eight dashboard ConfigMaps updated in place.
+
+### 12.1 What passed
+
+- **Leader.** Exactly one pod exports the workflow family
+  (`count(count by (pod)(web_workflow_runs_recent)) == 1`). The sentinel
+  `web_workflow_metrics_last_success_timestamp_seconds` is present with
+  `count == 1` and an age of 150s, inside one refresh plus one scrape. 16
+  refreshes, **zero** `web_workflow_metrics_refresh_errors_total` series,
+  refresh p95 0.94s against a 10s scrape timeout.
+- **WS-APP.** `pawtograder_submissions_created_total` (148 series) and
+  `pawtograder_grading_actions_total` (444 series) both live, from exactly one
+  exporter instance, with the `pawtograder_*` family count intact at 21.
+- **`web_http_*`.** Verified by request rather than by inspection, because on an
+  idle staging the family is legitimately absent: hitting `/api/lti/jwks`
+  produced `web_http_request_duration_seconds_bucket{route="/api/lti/jwks",
+  method="GET",status="5xx"}`. The route label is the parameterized pattern and
+  the status is bucketed, as designed.
+
+### 12.2 Four §8.1 sub-checks read empty, and that is correct
+
+`web_workflow_queue_seconds`, `web_workflow_run_seconds`,
+`web_workflow_errors_recent`, and the `window="1h"` half of
+`web_workflow_runs_recent` were all empty. All four are 1h-window aggregates
+(`lib/metrics.ts`), and staging had no workflow runs inside that hour: the 24h
+window read 501 success + 2 failure for `class_id=1`. A gauge that is never
+`.set()` emits no sample, so an idle hour is indistinguishable from a broken
+RPC by inspection alone.
+
+**Do not sign off on these four from a point read.** Seed or trigger workflow
+runs and re-check inside the same hour, or the check is vacuous.
+
+### 12.3 Two regressions found, fixed separately
+
+**(a) The edge target went DOWN, taking the pre-existing series with it.**
+`up{job="pawtograder-functions"}` flipped 1 to 0 across all 16 pods three
+minutes after the rollout, with `lastError: gzip: invalid header`.
+
+Prometheus scrapes with `Accept-Encoding: gzip`; the demuxer forwards the
+request verbatim, so the worker's body arrives gzip-encoded, and the append
+path's `res.text()` decoded DEFLATE bytes as UTF-8 and re-emitted the result
+under the inherited `content-encoding: gzip`. Recognizable from the body's
+first bytes: `1f ef bf bd 08 00`, the gzip magic with `8b` replaced by U+FFFD.
+
+Two things about this are worth carrying forward. First, plain `curl` sends no
+`Accept-Encoding` at all, so the functional test in §8.3 passed against a code
+path Prometheus never takes: **testing an exposition endpoint with bare `curl`
+proves nothing.** Second, the blast radius was the whole target, not just the
+new series. The `pawtograder_async_*`, `pawtograder_bottleneck_*` and
+`pawtograder_circuit_breaker_*` families come off that same endpoint, so
+`queues-and-workers` and `rate-limiting` went dark for staging too and the
+queue-depth alerts went blind. The values still rendering in Grafana came from
+the `pawtograder-preview-pr-*` namespaces, which run older images. That is an
+easy thing to mistake for a healthy staging.
+
+**(b) `storage` had been DOWN for 24h+ on a 404, for a reason this repo
+documented backwards.** The ServiceMonitor's own comment asserted that
+storage-api serves `/metrics` only on the admin app or in multitenant mode, and
+that a single-tenant deploy necessarily 404s. Read off the dist bundle in
+`supabase/storage-api:v1.48.26`, the opposite holds:
+
+```
+app.js              plugins.metrics({ enabledEndpoint: !isMultitenant, ... })
+plugins/metrics.js  if (prometheusMetricsEnabled) register(metricsEndpoint)
+                      -> if (enabledEndpoint) fastify.get("/metrics", ...)
+config.js           prometheusMetricsEnabled = PROMETHEUS_METRICS_ENABLED === "true"
+```
+
+Single-tenant is the mode where the **main** app serves it. The 404 was
+`PROMETHEUS_METRICS_ENABLED` never being set. A wrong comment is worse than no
+comment here: it supplied a ready explanation for a real outage and kept anyone
+from looking further.
+
+### 12.4 Standing checks to add to §8.0
+
+Baseline capture missed both regressions because it counted series rather than
+checking targets. Add:
+
+- `up{namespace="<ns>"} == 0`: enumerate every DOWN target by job **before**
+  reading any panel, and treat a target that was already down as in scope, not
+  as background.
+- For each target's `lastError` in the Prometheus targets API, not just `up`.
+  `gzip: invalid header` and `404 Not Found` are both invisible in `up` alone.
+- `curl -H 'Accept-Encoding: gzip' <pod>:<port>/metrics | gunzip`: must
+  actually decompress. Run this against any endpoint with a proxy, demuxer, or
+  rewrite in front of it.

--- a/docs/operations/metrics-gap-remediation.md
+++ b/docs/operations/metrics-gap-remediation.md
@@ -1403,10 +1403,13 @@ on both edge channels, and all eight dashboard ConfigMaps updated in place.
   `pawtograder_grading_actions_total` (444 series) both live, from exactly one
   exporter instance, with the `pawtograder_*` family count intact at 21.
 - **`web_http_*`.** Verified by request rather than by inspection, because on an
-  idle staging the family is legitimately absent: hitting `/api/lti/jwks`
-  produced `web_http_request_duration_seconds_bucket{route="/api/lti/jwks",
-  method="GET",status="5xx"}`. The route label is the parameterized pattern and
-  the status is bucketed, as designed.
+  idle staging the family is legitimately absent. Hitting `/api/lti/jwks`
+  produced the expected shape, with the route label as the parameterized pattern
+  and the status bucketed:
+
+  ```
+  web_http_request_duration_seconds_bucket{le="0.5",route="/api/lti/jwks",method="GET",status="5xx"} 4
+  ```
 
 ### 12.2 Four §8.1 sub-checks read empty, and that is correct
 


### PR DESCRIPTION
Follow-up to #952. Two Prometheus targets were down on staging. **Deployed and validated on staging** (revision 90, chart 0.3.19, image tag `fix-metrics-scrape-gzip-and-storage-84a5b11`) — see "Validation" below.

## 1. Edge: `gzip: invalid header` (regression from #952) — fixed

All edge pods went `up=1 -> 0` three minutes after #952's rollout.

Prometheus scrapes with `Accept-Encoding: gzip`. `worker.fetch(req)` forwards the request verbatim (deliberately, per the note above `callWorker`), so the metrics worker's response arrives **gzip-encoded**. The append path then did:

```ts
const body = await res.text();          // decodes DEFLATE bytes as UTF-8
const headers = new Headers(res.headers);
headers.delete("content-length");        // but NOT content-encoding
return new Response(body + appended, { ..., headers });
```

Every invalid byte became U+FFFD and the result shipped under the inherited `content-encoding: gzip`. Body's first bytes were `1f ef bf bd 08 00` — the gzip magic with `8b` replaced by U+FFFD. **Plain `curl` sends no `Accept-Encoding`**, which is why #952's functional test passed against a path Prometheus never takes.

Blast radius was the whole target: `pawtograder_async_*`, `pawtograder_bottleneck_*`, `pawtograder_circuit_breaker_*` and `pawtograder_queue_oldest_message_seconds` come off that same endpoint, so `queues-and-workers` and `rate-limiting` went dark and the queue-depth alerts went blind. What kept rendering in Grafana came from `pawtograder-preview-pr-*` namespaces on older images.

Fix: decompress with `DecompressionStream("gzip")` when the response is encoded, delete `content-encoding` (what we return is plaintext; the runtime re-applies compression per the caller's `Accept-Encoding`), and pass an undecodable encoding through untouched. The request object is still never rewritten.

## 2. Storage: 404 — **not** fixed, and deliberately so

`job="pawtograder-storage"` had been down for 24h+ on a 404 (pre-existing, not from #952). The ServiceMonitor's comment said storage-api serves `/metrics` only on the admin app or in multitenant mode. Read off the dist bundle in `supabase/storage-api:v1.48.26`, that is backwards:

```
app.js              plugins.metrics({ enabledEndpoint: !isMultitenant, ... })
plugins/metrics.js  if (prometheusMetricsEnabled) register(metricsEndpoint)
                      -> if (enabledEndpoint) fastify.get("/metrics", ...)
config.js:252       prometheusMetricsEnabled = PROMETHEUS_METRICS_ENABLED === "true"
```

Single-tenant is where the **main** app serves it, gated only on `PROMETHEUS_METRICS_ENABLED`. So I set the flag, deployed it as staging revision 89, **and it crashlooped the storage tier**:

```
"Reply was already sent, did you forget to "return reply" in the "/metrics" (GET) route?"
Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
  -> uncaughtException -> PID 1 exits -> CrashLoopBackOff
```

`handleMetricsRequest` writes the reply without returning it, so fastify's `onSend` chain double-writes the head. The route exists and the handler is fatally broken, on a ~30s scrape interval. Reverted in revision 90; storage recovered with zero further restarts.

The original advice ("set the toggle false") was correct and only its stated *mechanism* was wrong — which is worse than no comment, because it presents as an error to correct, and correcting it broke behaviour the wrong reasoning had been protecting. Verifying the mechanism against the bundle was necessary but not sufficient; the missing step was calling the endpoint, not just confirming it was registered.

**Resolution: ship neither the flag nor the ServiceMonitor.** `monitoring.serviceMonitors.storage` now defaults to `false`, because a permanently-DOWN 404 target is itself a defect — it trains everyone to ignore a DOWN storage row. Explicit opt-in still renders.

**Storage metrics remain uncollected.** The route worth trying is the admin app on `ADMIN_PORT` (5001), same handler behind a different hook chain. That needs its own container port, Service port and ServiceMonitor, and the admin app also exposes tenant/migration/s3-credential routes — an exposure decision for you, not a `monitoring.enabled` side effect. Happy to do it as a separate PR if you want storage metrics.

## Validation on staging (revision 90)

Every target in `pawtograder-staging` now reads `up`:

```
BEFORE (rev 88)                          AFTER (rev 90)
 20 pawtograder-functions   down  <--     14 pawtograder-functions        up
  2 pawtograder-storage     down  <--        (ServiceMonitor removed)
  2 pawtograder-auth        up             2 pawtograder-auth            up
  2 pawtograder-kong        up             2 pawtograder-kong            up
  1 pawtograder-metrics-leader up          1 pawtograder-metrics-leader  up
  1 pawtograder-postgres-exporter up       1 pawtograder-postgres-exporter up
  3 pawtograder-realtime    up             3 pawtograder-realtime        up
  2 pawtograder-web         up             2 pawtograder-web             up
```

The endpoint on the real Prometheus path (bearer token + `Accept-Encoding: gzip`):

- 200, `content-encoding: gzip`, body begins `1f 8b 08 00`, **gunzips cleanly** (134 lines)
- 36 `pawtograder_edge_*` samples **plus** 19 pre-existing queue/bottleneck/breaker samples — the collateral is back
- **zero** U+FFFD bytes; identical metric-family set to the uncompressed response

§8.3 criteria: 5 distinct `function` label values (invoked functions, not the ~55 known ones — the 32x multiplier the doc warned about is absent), all real function names with no `_unknown`, 496 edge series against the ~8.6k budget, zero restarts, zero `OOMKilled`, 412 MiB peak working set. The 60-minute leak check (`count by (function, instance)` not growing monotonically) still needs a full hour.

## Guard-rails

- `storage never sets PROMETHEUS_METRICS_ENABLED (crashloops the pod)`, `no storage ServiceMonitor by default`, `storage ServiceMonitor renderable on explicit opt-in`. **Both negative controls verified to fail** when the guarded condition is reintroduced.
- The first commit's `assert_storage_scrape_paired` is **deleted — it was passing for the wrong reason**, matching the storage *Service* by name and `PROMETHEUS_METRICS_ENABLED` as a rendered YAML *comment* rather than an env var. The replacements anchor on `kind: ServiceMonitor`. Worth knowing when reviewing the rest of this script.
- Source-shape assertion on the demuxer's encoding handling (a functional test needs the runtime image *and* a reachable Postgres, so it cannot run in chart CI). Verified to fail when the fix is reverted.
- `render-guardrails.sh` all pass incl. `assert_web_render_unchanged` (18 renders, zero differences); `helm lint` clean; `deno check` on `main.ts` 24 errors before and after, unchanged.

## Merge notes

- Staging currently runs this branch's chart. Merging redeploys it from `staging`; reverting is a redeploy from `staging` at the previous commit.
- Chart 0.3.19 already rolled every Deployment in revision 89/90. Merging will additionally restart **`studio`** — its `checksum/config` covers `monitoring.yaml`, and the comment rewrite changed that checksum. Verified by render-diff: that annotation is the *only* difference between what staging runs and this branch's HEAD.

## Also from validation (no code change)

Four §8.1 sub-checks read empty and are **correct**: `web_workflow_queue_seconds`, `web_workflow_run_seconds`, `web_workflow_errors_recent` and the `window="1h"` half of `web_workflow_runs_recent` are 1h-window aggregates, and staging had no workflow runs in that hour (24h window: 501 success + 2 failure). A gauge never `.set()` emits nothing, so an idle hour is indistinguishable from a broken RPC — those four can't be signed off from a point read. Recorded in the tracking doc §12, along with the standing `up{}` / `lastError` / gzip checks §8.0 was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
