### PR TITLE
feat(async-worker): make drain concurrency and visibility timeout tunable, and instrument createRepo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,65 @@ jobs:
       - name: Run linting check
         run: npm run lint
 
+  # Jest unit tests (tests/unit).
+  #
+  # These were previously UNGATED. CI's only Jest invocation was in deploy.yml:
+  #   npx jest --runInBand --testPathPatterns "tests/unit/issue"
+  # which matches `tests/unit/issue*` only — so every other file under tests/unit
+  # ran nowhere. That was discovered on PR #956 when a stale expectation
+  # (`Expected: 8, Received: 3`, after the isolate-lifetime fallback landed) sat
+  # failing while CI stayed green, and ~117 tests across two PRs turned out to be
+  # green-by-omission. Widening the deploy.yml pattern was the other option, but
+  # that job needs a live Supabase and takes ~30 min; these are pure-logic tests
+  # that want fast feedback, so they get their own lane next to deno-unit-tests.
+  #
+  # No RUN_SUPABASE_INTEGRATION_TESTS here on purpose: the Supabase-backed files
+  # under tests/unit gate themselves on that flag and self-skip without it, so
+  # they stay in deploy.yml where a database actually exists.
+  jest-unit-tests:
+    runs-on: pawtograder-ci
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-node-22-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-node-22-
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      # `npm ci`, NOT `npm install`, and this is load-bearing. package.json has
+      # `jest: ^30.1.2`, so `npm install` drifts to 30.4.x while package-lock.json
+      # still pins a single hoisted `jest-mock@30.0.5`. jest-runtime@30.4.2 calls
+      # `moduleMocker.clearMocksOnScope()`, which 30.0.5 does not have, so every
+      # suite carrying `@jest-environment node` dies with
+      # "TypeError: this._moduleMocker.clearMocksOnScope is not a function"
+      # before running a single test — 43 suites locally. jest-runtime@30.1.2, the
+      # locked version, never calls it, so the locked pair is self-consistent.
+      # Verified by unpacking both versions. Refreshing the lockfile's jest deps
+      # would fix it at the source and is worth doing separately.
+      - name: Install dependencies
+        run: npm ci
+      # SCOPED to the suites this PR added, deliberately, rather than all of
+      # tests/unit. A repo-wide gate is the right end state but I could not
+      # verify it would be green: under the locked jest pair 11 of 101 suites
+      # still fail locally, and I could not attribute those without the repo's
+      # own jest.config.js dependencies, so turning it on repo-wide risks
+      # blocking unrelated PRs on pre-existing red. Widening it, and refreshing
+      # the lockfile's jest deps so `npm install` stops drifting, is the
+      # follow-up. Adding a file here is one line; that is the point.
+      - name: Run Jest unit tests
+        run: |
+          npx jest --runInBand \
+            tests/unit/async-worker-tuning.test.ts \
+            tests/unit/create-repo-step-timings.test.ts
+
   # Guard-rail render tests: assert templates/validations.yaml still REFUSES a
   # dangerous production values combination (e2e bypasses, plaintext/
   # non-recoverable secrets, seeding, resetOnDrift, floating image tags,

--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.20
+version: 0.3.21
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/examples/values-prod.yaml
+++ b/charts/pawtograder/examples/values-prod.yaml
@@ -210,13 +210,47 @@ edgeFunctions:
   # visibility timeout. Correct outcome, terrible latency. At ~0.6 msg/min a 585-student
   # enrollment burst is ~15 hours.
   #
-  # To double throughput and stop the mid-flight redeliveries, raise BOTH — the timeout has to
-  # cover a whole batch of drainConcurrency (x120s/message), and the render is refused if it does
-  # not:
+  # There are TWO ceilings over the batch, and the render is refused if either is broken:
+  # visibilityTimeoutSeconds >= drainConcurrency x 120 AND worker.timeoutMs/1000 >= the same.
+  # worker.timeoutMs is the ISOLATE LIFETIME, and the whole batch runs in one isolate: a
+  # configuration whose modelled batch outlives it is incoherent, because if it ever did overrun
+  # the archive calls would not run and successful work would redeliver. Under n x 120 against the
+  # 400s default the largest coherent concurrency is THREE, so a raised visibility timeout ALWAYS
+  # has to bring worker.timeoutMs with it. This is a coherence rule only: the claim that isolates
+  # are currently being truncated mid-batch was measured and retracted (the runtime's wall-clock
+  # recycle log is flat at ~200/hour whether or not a burst is running, which is baseline churn
+  # from leased mode's resident isolate). The 300s visibility timeout remains the established
+  # cause of the re-reads.
+  #
+  # So the cheapest correct first move here is NOT to raise concurrency. It is to leave
+  # drainConcurrency at 4 and lift both timeouts to cover the modelled batch:
+  #
+  #   githubAsyncWorker:
+  #     drainConcurrency: 4
+  #     visibilityTimeoutSeconds: 480   # 4 x 120
+  #   worker:
+  #     timeoutMs: 480000               # the isolate must outlive the batch
+  #   gracefulExitTimeoutSeconds: 490   # >= worker.timeoutMs
+  #   terminationGracePeriodSeconds: 510 # >= preStopSleepSeconds + gracefulExitTimeout
+  #
+  # Doubling throughput on top of that means moving all of it again, together — 8 x 120 = 960:
   #
   #   githubAsyncWorker:
   #     drainConcurrency: 8
-  #     visibilityTimeoutSeconds: 960   # 8 x 120
+  #     visibilityTimeoutSeconds: 960
+  #   worker:
+  #     timeoutMs: 960000
+  #   gracefulExitTimeoutSeconds: 970
+  #   terminationGracePeriodSeconds: 990
+  #
+  # Do NOT set drainConcurrency: 8 with worker.timeoutMs left at 400000. That combination is
+  # incoherent — a batch modelled at 960s inside a 400s isolate — and the chart refuses it. Stated
+  # the other way round: if worker.timeoutMs stays at the 400000 default, the largest coherent
+  # drainConcurrency is 3, so under the current isolate lifetime there is NO throughput increase
+  # available from this knob alone. Raising the lifetime is the price of raising concurrency.
+  # Be deliberate about the blast radius before choosing it: worker.timeoutMs is per-isolate for
+  # EVERY function in this pod, and a 960s lifetime means isolates live 2.4x longer and accumulate
+  # correspondingly more heap on a tier that has OOM-killed PID 1 twice.
   #
   # Do it as its own deploy, ahead of a known release burst rather than during one, and watch
   # pgmq queue depth, the edge pods' memory (all 8 handlers share ONE 256MiB leaseholder isolate),

--- a/charts/pawtograder/examples/values-prod.yaml
+++ b/charts/pawtograder/examples/values-prod.yaml
@@ -199,6 +199,36 @@ edgeFunctions:
   resources:
     requests: { cpu: "200m", memory: "512Mi" }
     limits:   { cpu: "2",    memory: "4Gi"   }
+  # github-async-worker pgmq drain tuning. LEFT AT THE CHART DEFAULTS (4 / 300) on purpose: those
+  # are the values that were hardcoded in the worker before they became tunable, so this example
+  # deploys today's behaviour and the throughput decision stays an explicit operator action.
+  #
+  # It IS a decision this tier has to make. Measured here on 2026-09-07: CS 4530 enqueued 58
+  # create_repo messages at once and they took 88 MINUTES to drain (2-4 completing every ~7 min,
+  # mean time-in-queue 3,230s), tripping PawtograderQueueOldestMessageAging for over an hour, and
+  # 20 of the 58 were re-read (read_ct > 1, max 3) because a ~420s batch outlives a 300s
+  # visibility timeout. Correct outcome, terrible latency. At ~0.6 msg/min a 585-student
+  # enrollment burst is ~15 hours.
+  #
+  # To double throughput and stop the mid-flight redeliveries, raise BOTH — the timeout has to
+  # cover a whole batch of drainConcurrency (x120s/message), and the render is refused if it does
+  # not:
+  #
+  #   githubAsyncWorker:
+  #     drainConcurrency: 8
+  #     visibilityTimeoutSeconds: 960   # 8 x 120
+  #
+  # Do it as its own deploy, ahead of a known release burst rather than during one, and watch
+  # pgmq queue depth, the edge pods' memory (all 8 handlers share ONE 256MiB leaseholder isolate),
+  # the GitHub secondary-rate-limit / circuit-breaker signals, and — the one that bites first —
+  # whether org INVITATIONS start lagging: a create_repo holds one of the 40 slots in the
+  # fleet-wide per-org content limiter for ~280s (measured p50 279.5s here on 2026-09-07), and
+  # invitations draw from that same pool. 8 is the chart's ceiling and it
+  # is still only ~1.2 msg/min; anything beyond that needs more than one concurrent leaseholder,
+  # which is a code change, not a values change. See values.yaml for the full reasoning.
+  githubAsyncWorker:
+    drainConcurrency: 4
+    visibilityTimeoutSeconds: 300
   # Mount the same SMTP Secret GoTrue uses, rather than populating a second OpenBao `smtp` bundle.
   # Without it SMTP_HOST is unset in the functions environment, and the notification processor read
   # that as "no work found" -- deferring the email queue indefinitely with no error anywhere, which

--- a/charts/pawtograder/examples/values-prod.yaml
+++ b/charts/pawtograder/examples/values-prod.yaml
@@ -230,10 +230,13 @@ edgeFunctions:
   #     visibilityTimeoutSeconds: 480   # 4 x 120
   #   worker:
   #     timeoutMs: 480000               # the isolate must outlive the batch
-  #   gracefulExitTimeoutSeconds: 490   # >= worker.timeoutMs
+  #   gracefulExitTimeoutSeconds: 490   # >= worker.timeoutMs, or a rollout kills the batch
   #   terminationGracePeriodSeconds: 510 # >= preStopSleepSeconds + gracefulExitTimeout
+  #   metrics:
+  #     # Top finite bucket must reach the new lifetime or the 400-480s range all lands in +Inf.
+  #     buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 400, 480]
   #
-  # Doubling throughput on top of that means moving all of it again, together — 8 x 120 = 960:
+  # Doubling throughput on top of that means moving all FIVE again, together — 8 x 120 = 960:
   #
   #   githubAsyncWorker:
   #     drainConcurrency: 8
@@ -242,6 +245,14 @@ edgeFunctions:
   #     timeoutMs: 960000
   #   gracefulExitTimeoutSeconds: 970
   #   terminationGracePeriodSeconds: 990
+  #   metrics:
+  #     buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 400, 960]
+  #
+  # Every one of those five is enforced at render time (templates/validations.yaml), so an
+  # incomplete bundle is refused rather than deployed: the visibility timeout and the isolate
+  # lifetime must cover the modelled batch, the graceful exit must cover the isolate lifetime, the
+  # SIGKILL backstop must cover preStop + graceful exit, and the top metrics bucket must reach the
+  # lifetime whenever metrics are enabled.
   #
   # Do NOT set drainConcurrency: 8 with worker.timeoutMs left at 400000. That combination is
   # incoherent — a batch modelled at 960s inside a 400s isolate — and the chart refuses it. Stated

--- a/charts/pawtograder/templates/_edge-functions-workload.tpl
+++ b/charts/pawtograder/templates/_edge-functions-workload.tpl
@@ -278,6 +278,18 @@ spec:
             # so the cardinality delta has a single attributable cause.
             - name: EDGE_METRICS
               value: {{ ternary "1" "0" $ctx.Values.edgeFunctions.metrics.enabled | quote }}
+            # github-async-worker pgmq drain tuning, read by
+            # supabase/functions/_shared/asyncWorkerTuning.ts. Defaults (4 / 300)
+            # are the values that were hardcoded in the worker until 2026-09-07,
+            # when a 58-message create_repo burst took 88 minutes to drain and
+            # re-read 20 of those 58 against the 300s timeout. The two are
+            # COUPLED — visibilityTimeoutSeconds must cover a whole batch of
+            # drainConcurrency (x120s/message) — and validations.yaml enforces
+            # that whenever concurrency is raised. See values.yaml.
+            - name: GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY
+              value: {{ $ctx.Values.edgeFunctions.githubAsyncWorker.drainConcurrency | quote }}
+            - name: GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS
+              value: {{ $ctx.Values.edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds | quote }}
             # Latency histogram bounds in seconds. The top finite bucket must be
             # >= worker.timeoutMs/1000 or every request that hits the worker
             # timeout lands in +Inf and the upper quantiles become an

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -229,8 +229,12 @@ through: a 60s timeout re-serves a create_repo (~280s, measured) four times over
 while it is still in flight, which is strictly worse than the status quo.
 
 Bounds are refused rather than clamped here so a typo is visible at deploy time.
-asyncWorkerTuning.ts clamps the same bounds at runtime, because these can also
-reach the pod through edgeFunctions.envFromSecrets, which the chart never sees.
+These chart values are the ONLY supported way to set the two variables:
+_edge-functions-workload.tpl renders them as explicit `env` entries, and an `env`
+entry beats anything from `envFrom`, so edgeFunctions.envFromSecrets cannot
+override them. asyncWorkerTuning.ts clamps the same bounds at runtime anyway, as
+defence in depth against the chart being bypassed (a hand-edited Deployment,
+`kubectl set env`, a local `supabase functions serve`).
 */ -}}
 {{- if .Values.edgeFunctions.enabled -}}
 {{- $gaw := .Values.edgeFunctions.githubAsyncWorker -}}
@@ -259,6 +263,60 @@ reach the pod through edgeFunctions.envFromSecrets, which the chart never sees.
 {{- $lifetimeMs := .Values.edgeFunctions.worker.timeoutMs | int -}}
 {{- if lt (div $lifetimeMs 1000) $need -}}
 {{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d requires edgeFunctions.worker.timeoutMs >= %d (%ds = %d x 120s/message), but it is %d (%ds). worker.timeoutMs is the ISOLATE LIFETIME (main.ts passes it to EdgeRuntime as workerTimeoutMs), and the whole batch runs inside ONE leaseholder isolate: if the batch outlives it the isolate is killed before Promise.allSettled reaches the archive calls, so every message in flight is re-provisioned from scratch on redelivery. Note beforeUnload.wallClockRatio=%v asks the isolate to retire at half the lifetime, so treat the lifetime as the hard cap and not the budget. Raising it lengthens EVERY function's isolate lifetime in this pod, and gracefulExitTimeoutSeconds (%v) / terminationGracePeriodSeconds (%v) must stay above it or a rollout cuts the drain off anyway — so the concurrency bump is a coupled change, not a one-line one." $n (mul $need 1000) $need $n $lifetimeMs (div $lifetimeMs 1000) .Values.edgeFunctions.beforeUnload.wallClockRatio .Values.edgeFunctions.gracefulExitTimeoutSeconds .Values.edgeFunctions.terminationGracePeriodSeconds) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+The drain-coherence rules above are useless on their own if a ROLLOUT can cut
+the batch shorter than the isolate lifetime does, so the same arithmetic has to
+hold across the shutdown path. Two rules, both unconditional because they are
+properties of the edge tier and not of this worker:
+
+  gracefulExitTimeoutSeconds        >= worker.timeoutMs / 1000
+  terminationGracePeriodSeconds     >= preStopSleepSeconds + gracefulExitTimeoutSeconds
+
+edge-runtime intercepts SIGTERM and lets in-flight handlers finish for up to
+--graceful-exit-timeout; past that they are cut off. So a graceful-exit shorter
+than the isolate lifetime means a rollout terminates a batch that the isolate
+itself would have allowed to finish — the archive calls never run, and work
+GitHub has already done is redelivered. terminationGracePeriodSeconds is the
+kubelet's SIGKILL backstop and has to sit above preStop + graceful exit or the
+kubelet kills the pod mid-drain regardless of what the runtime intended.
+
+These were previously documented in values.yaml ("Sizing:
+gracefulExitTimeoutSeconds >= worker.timeoutMs") and asserted nowhere, which is
+why 8 / 960 / 960000 with the default 410s graceful exit rendered clean and the
+guard-rail suite blessed it. The chart defaults satisfy both (410 >= 400;
+430 >= 10 + 410), so this refuses nothing that exists today — it only refuses
+raising worker.timeoutMs without carrying the drain settings with it.
+*/ -}}
+{{- if .Values.edgeFunctions.enabled -}}
+{{- $lifeSec := div (.Values.edgeFunctions.worker.timeoutMs | int) 1000 -}}
+{{- $graceful := .Values.edgeFunctions.gracefulExitTimeoutSeconds | int -}}
+{{- $preStop := .Values.edgeFunctions.preStopSleepSeconds | int -}}
+{{- $termGrace := .Values.edgeFunctions.terminationGracePeriodSeconds | int -}}
+{{- if lt $graceful $lifeSec -}}
+{{- fail (printf "edgeFunctions.gracefulExitTimeoutSeconds=%d is below edgeFunctions.worker.timeoutMs (%dms = %ds). edge-runtime's --graceful-exit-timeout is how long in-flight handlers get to finish after SIGTERM, so a value below the isolate lifetime means a ROLLOUT cuts off work the isolate itself would have let finish. For the github-async-worker that means a batch killed before its pgmq archive calls, so repos that were created successfully are provisioned again on redelivery. Set gracefulExitTimeoutSeconds >= %d (the chart default leaves 10s of headroom: 410 for a 400s lifetime), and keep terminationGracePeriodSeconds above preStopSleepSeconds + this value." $graceful (.Values.edgeFunctions.worker.timeoutMs | int) $lifeSec $lifeSec) -}}
+{{- end -}}
+{{- if lt $termGrace (add $preStop $graceful) -}}
+{{- fail (printf "edgeFunctions.terminationGracePeriodSeconds=%d is below preStopSleepSeconds (%d) + gracefulExitTimeoutSeconds (%d) = %d. terminationGracePeriodSeconds is the kubelet's SIGKILL backstop: below that sum the pod is killed mid-drain no matter what --graceful-exit-timeout was set to, so the graceful exit is decorative and in-flight batches die without archiving. Set terminationGracePeriodSeconds >= %d." $termGrace $preStop $graceful (add $preStop $graceful) (add $preStop $graceful)) -}}
+{{- end -}}
+{{- /*
+And the metrics coupling, which is the other thing a raised worker.timeoutMs
+silently breaks: the top FINITE latency bucket must still reach the worker
+lifetime, or everything between the old bucket and the new lifetime lands in
++Inf and the upper quantiles become an extrapolation off the last finite bound
+-- precisely for the long batches the timeout was raised to accommodate.
+values.yaml says "raise it alongside any timeout increase"; render-guardrails.sh
+asserts it for the renders it happens to exercise. Neither can catch an
+operator's own values file, which is what this rule is for. Only checked when
+metrics are on, because the buckets are inert otherwise.
+*/ -}}
+{{- if .Values.edgeFunctions.metrics.enabled -}}
+{{- $top := last .Values.edgeFunctions.metrics.buckets | float64 -}}
+{{- if lt $top (float64 $lifeSec) -}}
+{{- fail (printf "edgeFunctions.metrics.buckets ends at %v seconds, below edgeFunctions.worker.timeoutMs (%ds). Every request that runs to the worker lifetime would land in +Inf, so p95/p99 stop meaning anything at exactly the moment this tier is in trouble. Extend the list so its last element is >= %d (keep it ascending; the default list ends ON the default 400s lifetime)." $top $lifeSec $lifeSec) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -312,11 +312,36 @@ values.yaml says "raise it alongside any timeout increase"; render-guardrails.sh
 asserts it for the renders it happens to exercise. Neither can catch an
 operator's own values file, which is what this rule is for. Only checked when
 metrics are on, because the buckets are inert otherwise.
+
+CHECKING ONLY THE LAST ELEMENT WAS NOT ENOUGH, and the gap re-opened the exact
+hole this rule was added to close. The runtime does not merely read the last
+bound: histogramBuckets (images/edge-functions/main.ts) REJECTS a list with a
+non-finite or non-positive element, or one that is not strictly increasing, and
+SILENTLY falls back to DEFAULT_EDGE_BUCKETS -- which ends at 400. So
+[0.05, 1, 0.5, 960] satisfied "last >= lifetime" here, was thrown away at boot,
+and left a 960s lifetime being measured with 400s buckets. Validate the same
+three properties main.ts does, in the same order, before trusting the last
+element to mean anything.
 */ -}}
 {{- if .Values.edgeFunctions.metrics.enabled -}}
-{{- $top := last .Values.edgeFunctions.metrics.buckets | float64 -}}
+{{- $buckets := .Values.edgeFunctions.metrics.buckets -}}
+{{- if not $buckets -}}
+{{- fail "edgeFunctions.metrics.buckets is empty while edgeFunctions.metrics.enabled=true. main.ts would fall back to its own default list (ending at 400s), so the rendered configuration would not be the one in force. Set an explicit ascending list whose last element reaches worker.timeoutMs/1000." -}}
+{{- end -}}
+{{- $prev := 0.0 -}}
+{{- range $i, $b := $buckets -}}
+{{- $cur := $b | float64 -}}
+{{- if le $cur 0.0 -}}
+{{- fail (printf "edgeFunctions.metrics.buckets[%d]=%v is not positive. main.ts's histogramBuckets rejects a non-positive or non-finite bound and silently falls back to its default list (ending at 400s), so this list would never reach the runtime and the top-bucket check below would be meaningless." $i $b) -}}
+{{- end -}}
+{{- if and (gt $i 0) (le $cur $prev) -}}
+{{- fail (printf "edgeFunctions.metrics.buckets is not strictly increasing: element %d (%v) is not greater than the previous (%v). main.ts's histogramBuckets rejects that and silently falls back to its default list (ending at 400s) -- so a list that merely ENDS high, e.g. [0.05, 1, 0.5, 960], would be discarded at boot and every request past 400s would land in +Inf anyway." $i $b $prev) -}}
+{{- end -}}
+{{- $prev = $cur -}}
+{{- end -}}
+{{- $top := last $buckets | float64 -}}
 {{- if lt $top (float64 $lifeSec) -}}
-{{- fail (printf "edgeFunctions.metrics.buckets ends at %v seconds, below edgeFunctions.worker.timeoutMs (%ds). Every request that runs to the worker lifetime would land in +Inf, so p95/p99 stop meaning anything at exactly the moment this tier is in trouble. Extend the list so its last element is >= %d (keep it ascending; the default list ends ON the default 400s lifetime)." $top $lifeSec $lifeSec) -}}
+{{- fail (printf "edgeFunctions.metrics.buckets ends at %v seconds, below edgeFunctions.worker.timeoutMs (%ds). Every request that runs to the worker lifetime would land in +Inf, so p95/p99 stop meaning anything at exactly the moment this tier is in trouble. Extend the list so its last element is >= %d (keep it strictly increasing; the default list ends ON the default 400s lifetime)." $top $lifeSec $lifeSec) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -185,3 +185,50 @@ cannot detect.
 {{- fail "postgres.persistence.storageClass is empty — it would bind the database PVC to the cluster's DEFAULT StorageClass, which may be node-local (local-path): node loss = data loss. Production must name a replicated storage class explicitly (Ceph RBD, EBS, ...)." -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+github-async-worker drain tuning. Any environment.
+
+These two values are COUPLED, and the coupling is the whole reason there is a
+render-time rule: edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds is
+the pgmq visibility timeout, and it has to cover the worst case for a WHOLE
+BATCH of drainConcurrency messages, not for one message. On 2026-09-07 a
+58-message create_repo burst drained in 88 minutes at 2-4 messages per ~7 min
+iteration, and 20 of the 58 came back with read_ct > 1 because a ~420s batch
+outlived the hardcoded 300s timeout — pgmq re-served messages that were still
+in flight. Raising concurrency lengthens the batch (the handlers' GitHub calls
+serialize through the shared Bottleneck limiters), so raising it against an
+unraised timeout makes that worse, not better, and would push read_ct toward
+the worker's poison-pill threshold with LEGITIMATE provisioning work.
+
+The rule deliberately only bites when drainConcurrency is raised ABOVE the
+default: the default pair (4, 300) violates the invariant and is the measured
+status quo, preserved so a chart upgrade changes nothing on its own. Refusing
+it would refuse every existing install.
+
+Bounds are refused rather than clamped here so a typo is visible at deploy time.
+asyncWorkerTuning.ts clamps the same bounds at runtime, because these can also
+reach the pod through edgeFunctions.envFromSecrets, which the chart never sees.
+*/ -}}
+{{- if .Values.edgeFunctions.enabled -}}
+{{- $gaw := .Values.edgeFunctions.githubAsyncWorker -}}
+{{- $nRaw := $gaw.drainConcurrency | toString -}}
+{{- $vtRaw := $gaw.visibilityTimeoutSeconds | toString -}}
+{{- if not (regexMatch "^[0-9]+$" $nRaw) -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency must be an integer 1-8 (got %q). This is the pgmq read fan-out AND the worker's concurrency ceiling; a non-numeric value would be clamped back to the default 4 at runtime, so the deploy would not do what it says." $nRaw) -}}
+{{- end -}}
+{{- if not (regexMatch "^[0-9]+$" $vtRaw) -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds must be an integer 60-1800 (got %q). This is the pgmq visibility timeout; a non-numeric value would be clamped back to the default 300s at runtime." $vtRaw) -}}
+{{- end -}}
+{{- $n := int $nRaw -}}
+{{- $vt := int $vtRaw -}}
+{{- if or (lt $n 1) (gt $n 8) -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d is outside 1-8. 0 would drain NOTHING while every liveness signal stayed green (indistinguishable from a hung queue). Above 8: every in-flight create_repo holds one of the 40 slots in the FLEET-WIDE per-org Bottleneck content limiter for ~280s (measured p50 279.5s, 2026-09-07), and that same pool serves org invitations and handout syncs — so a high concurrency starves students' org invitations behind a convoy of repo creations. All those handlers also share ONE 256MiB leaseholder isolate (worker.memoryLimitMb) on a tier that OOM-killed PID 1 twice in 2026-08. Past 8 needs more than one concurrent leaseholder, not a bigger number." $n) -}}
+{{- end -}}
+{{- if or (lt $vt 60) (gt $vt 1800) -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=%d is outside 60-1800. Below 60s a single create_repo (~105s of serialized GitHub work, measured 2026-09-07) is guaranteed to be re-served while still in flight; above 1800s the timeout becomes the RECOVERY LATENCY for a message whose isolate really died, and 1800s is already 1.5x the PawtograderQueueOldestMessageAging window so a genuinely stuck message still pages someone." $vt) -}}
+{{- end -}}
+{{- if and (gt $n 4) (lt $vt (mul $n 120)) -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d requires visibilityTimeoutSeconds >= %d (%d x 120s/message), but it is %d. The visibility timeout must cover a whole batch of %d, not one message: the batch runs concurrently but its GitHub calls serialize through the shared Bottleneck limiters, so batch wall clock grows with concurrency (measured 2026-09-07: ~420s for a batch of 4, which already re-read 20 of 58 messages against a 300s timeout). Raising concurrency against a short timeout multiplies mid-flight redeliveries and walks read_ct toward the poison-pill DLQ with legitimate provisioning work. Set visibilityTimeoutSeconds: %d." $n (mul $n 120) $n $vt $n (mul $n 120)) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -201,10 +201,32 @@ serialize through the shared Bottleneck limiters), so raising it against an
 unraised timeout makes that worse, not better, and would push read_ct toward
 the worker's poison-pill threshold with LEGITIMATE provisioning work.
 
-The rule deliberately only bites when drainConcurrency is raised ABOVE the
-default: the default pair (4, 300) violates the invariant and is the measured
-status quo, preserved so a chart upgrade changes nothing on its own. Refusing
-it would refuse every existing install.
+THERE ARE TWO CEILINGS, not one, and both have to cover the batch:
+
+  visibilityTimeoutSeconds  >= drainConcurrency x 120
+  worker.timeoutMs / 1000   >= drainConcurrency x 120
+
+The second one is the isolate lifetime handed to EdgeRuntime as workerTimeoutMs
+(charts/pawtograder/images/edge-functions/main.ts). It is a CONFIG-COHERENCE
+rule: budgeting a batch longer than the isolate that runs it is incoherent
+advice, because if the batch ever did overrun, Promise.allSettled would not
+reach the archive calls and successful work would redeliver. Under n x 120
+against the 400s default the largest coherent concurrency is THREE, which is
+why the exact legacy pair below is exempt and everything else is checked.
+(beforeUnload.wallClockRatio=50 also asks the isolate to retire at HALF the
+lifetime, ~200s at 400s; workerRun.ts's bounded-mode budget comment cites that
+number.) This rule asserts nothing about live behaviour — the claim that
+isolates are currently truncated mid-batch was measured and retracted; the
+runtime's wall-clock recycle count is flat at ~200/hour regardless of burst.
+
+GRANDFATHERING IS NARROW ON PURPOSE: only the EXACT legacy pair (4, 300) is
+exempt, because that is the configuration that was hardcoded in the worker and
+is therefore already running everywhere — refusing it would refuse every
+existing install and break the "a chart upgrade changes nothing" contract. Any
+other combination is a deliberate act and gets both invariants enforced. An
+earlier version of this rule was gated on `n > 4`, which let 4/60 and 1/60
+through: a 60s timeout re-serves a create_repo (~280s, measured) four times over
+while it is still in flight, which is strictly worse than the status quo.
 
 Bounds are refused rather than clamped here so a typo is visible at deploy time.
 asyncWorkerTuning.ts clamps the same bounds at runtime, because these can also
@@ -228,7 +250,15 @@ reach the pod through edgeFunctions.envFromSecrets, which the chart never sees.
 {{- if or (lt $vt 60) (gt $vt 1800) -}}
 {{- fail (printf "edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=%d is outside 60-1800. Below 60s a single create_repo (~105s of serialized GitHub work, measured 2026-09-07) is guaranteed to be re-served while still in flight; above 1800s the timeout becomes the RECOVERY LATENCY for a message whose isolate really died, and 1800s is already 1.5x the PawtograderQueueOldestMessageAging window so a genuinely stuck message still pages someone." $vt) -}}
 {{- end -}}
-{{- if and (gt $n 4) (lt $vt (mul $n 120)) -}}
-{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d requires visibilityTimeoutSeconds >= %d (%d x 120s/message), but it is %d. The visibility timeout must cover a whole batch of %d, not one message: the batch runs concurrently but its GitHub calls serialize through the shared Bottleneck limiters, so batch wall clock grows with concurrency (measured 2026-09-07: ~420s for a batch of 4, which already re-read 20 of 58 messages against a 300s timeout). Raising concurrency against a short timeout multiplies mid-flight redeliveries and walks read_ct toward the poison-pill DLQ with legitimate provisioning work. Set visibilityTimeoutSeconds: %d." $n (mul $n 120) $n $vt $n (mul $n 120)) -}}
+{{- $need := mul $n 120 -}}
+{{- $isLegacyPair := and (eq $n 4) (eq $vt 300) -}}
+{{- if not $isLegacyPair -}}
+{{- if lt $vt $need -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d requires visibilityTimeoutSeconds >= %d (%d x 120s/message), but it is %d. The visibility timeout must cover the whole batch (%d concurrent messages), not a single message: the batch runs concurrently but its GitHub calls serialize through the fleet-wide per-org Bottleneck content limiter, so batch wall clock grows with concurrency (measured 2026-09-07: ~420s for a batch of 4, create_repo p50 279.5s, which already re-read 20 of 58 messages against a 300s timeout). A timeout below the batch re-serves messages that are still in flight, multiplying duplicate GitHub work and walking read_ct toward the poison-pill DLQ with legitimate provisioning work. Set visibilityTimeoutSeconds: %d. (Only the exact legacy pair 4/300 is exempt from this rule, because that is what every install is already running.)" $n $need $n $vt $n $need) -}}
+{{- end -}}
+{{- $lifetimeMs := .Values.edgeFunctions.worker.timeoutMs | int -}}
+{{- if lt (div $lifetimeMs 1000) $need -}}
+{{- fail (printf "edgeFunctions.githubAsyncWorker.drainConcurrency=%d requires edgeFunctions.worker.timeoutMs >= %d (%ds = %d x 120s/message), but it is %d (%ds). worker.timeoutMs is the ISOLATE LIFETIME (main.ts passes it to EdgeRuntime as workerTimeoutMs), and the whole batch runs inside ONE leaseholder isolate: if the batch outlives it the isolate is killed before Promise.allSettled reaches the archive calls, so every message in flight is re-provisioned from scratch on redelivery. Note beforeUnload.wallClockRatio=%v asks the isolate to retire at half the lifetime, so treat the lifetime as the hard cap and not the budget. Raising it lengthens EVERY function's isolate lifetime in this pod, and gracefulExitTimeoutSeconds (%v) / terminationGracePeriodSeconds (%v) must stay above it or a rollout cuts the drain off anyway — so the concurrency bump is a coupled change, not a one-line one." $n (mul $need 1000) $need $n $lifetimeMs (div $lifetimeMs 1000) .Values.edgeFunctions.beforeUnload.wallClockRatio .Values.edgeFunctions.gracefulExitTimeoutSeconds .Values.edgeFunctions.terminationGracePeriodSeconds) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -856,10 +856,35 @@ assert_refused "raising the worker lifetime with default buckets is refused when
   --set edgeFunctions.worker.timeoutMs=960000 \
   --set edgeFunctions.gracefulExitTimeoutSeconds=970 \
   --set edgeFunctions.terminationGracePeriodSeconds=990
-assert_renders "the same render is accepted with the buckets extended to 960" \
+assert_renders "the same render is accepted with a strictly-increasing list reaching 960" \
   --set edgeFunctions.metrics.enabled=true \
   "${TUNE8[@]}" \
   --set 'edgeFunctions.metrics.buckets={0.05,0.1,0.25,0.5,1,2,5,10,30,60,120,300,400,960}'
+# Checking only the LAST element was not enough: main.ts's histogramBuckets
+# rejects a non-positive or non-strictly-increasing list and silently falls back
+# to its own default (ending at 400s), so a list that merely ENDS at 960 would be
+# discarded at boot and the 400-960s range would land in +Inf regardless. The
+# rule now validates the same three properties, in the same order, as main.ts.
+assert_refused "a list that ends high but is not strictly increasing is refused" \
+  "is not strictly increasing" \
+  --set edgeFunctions.metrics.enabled=true \
+  "${TUNE8[@]}" \
+  --set 'edgeFunctions.metrics.buckets={0.05,1,0.5,960}'
+assert_refused "a repeated bucket bound is refused (strictly, not merely non-decreasing)" \
+  "is not greater than the previous" \
+  --set edgeFunctions.metrics.enabled=true \
+  "${TUNE8[@]}" \
+  --set 'edgeFunctions.metrics.buckets={0.05,1,1,960}'
+assert_refused "a zero bucket bound is refused" \
+  "is not positive" \
+  --set edgeFunctions.metrics.enabled=true \
+  "${TUNE8[@]}" \
+  --set 'edgeFunctions.metrics.buckets={0,1,2,960}'
+assert_refused "a negative bucket bound is refused" \
+  "is not positive" \
+  --set edgeFunctions.metrics.enabled=true \
+  "${TUNE8[@]}" \
+  --set 'edgeFunctions.metrics.buckets={-1,1,2,960}'
 # ...and the buckets are inert with metrics off, so the rule must not fire there.
 assert_renders "buckets shorter than the lifetime are tolerated with metrics off" \
   "${TUNE8[@]}"

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -747,6 +747,71 @@ assert_refused "cold-load allowance below the largest bundle is refused" \
   "below the 64Mi needed to cover the largest bundle" \
   --set edgeFunctions.eszipColdLoadHeadroomMb=32
 
+# github-async-worker drain tuning. The DEFAULTS are the assertion that matters
+# most: 4 / 300 are the values that were hardcoded in processBatch() before they
+# became tunable, so a chart upgrade must change nothing on its own. If either
+# default drifts, an install silently gets a different pgmq fan-out or visibility
+# timeout than the one that was measured on 2026-09-07 (58 create_repo messages,
+# 88 minutes to drain, 20 of 58 re-read against the 300s timeout).
+echo "== github-async-worker drain tuning: defaults, overrides, and the VT invariant =="
+assert_env_value "drain concurrency defaults to today's hardcoded 4" \
+  templates/edge-functions.yaml GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY 4
+assert_env_value "visibility timeout defaults to today's hardcoded 300s" \
+  templates/edge-functions.yaml GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS 300
+# An explicit override has to actually reach the pod, and both have to move
+# together: 8 x 120 = 960 is the smallest timeout the invariant allows at 8.
+assert_env_value "drain concurrency is settable" \
+  templates/edge-functions.yaml GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY 8 \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
+assert_env_value "visibility timeout is settable" \
+  templates/edge-functions.yaml GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS 960 \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
+# The invariant: the visibility timeout must cover a whole batch of `n`, not one
+# message. Raising concurrency alone is the change that LOOKS like a throughput
+# fix and actually multiplies mid-flight redeliveries, so it is refused outright.
+assert_refused "raising concurrency without raising the visibility timeout is refused" \
+  "requires visibilityTimeoutSeconds >= 960" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8
+assert_refused "a partially-raised visibility timeout is still refused" \
+  "requires visibilityTimeoutSeconds >= 720" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=6 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=719
+assert_renders "concurrency 6 renders at exactly 6 x 120s" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=6 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=720
+# ...but the default pair (4, 300) also violates it and must keep rendering: it is
+# the measured status quo, deliberately grandfathered, or every existing install
+# would be refused. The rule only bites above the default concurrency.
+assert_renders "the default pair renders even though 300 < 4 x 120" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=4 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=300
+# Bounds. 0 is the dangerous one: it drains NOTHING while the lease is held and
+# every heartbeat stays green, which reads as a hung queue rather than as a
+# misconfiguration.
+assert_refused "drain concurrency 0 is refused" \
+  "would drain NOTHING" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=0
+assert_refused "drain concurrency above the 8 ceiling is refused" \
+  "is outside 1-8" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=16 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=1800
+assert_refused "a visibility timeout below the 60s floor is refused" \
+  "is outside 60-1800" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=30
+assert_refused "a visibility timeout above the 1800s ceiling is refused" \
+  "is outside 60-1800" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=3600
+# A non-numeric value must be refused here rather than left to the runtime clamp:
+# the pod would come up on the default and the deploy would not do what it says.
+assert_refused "a non-numeric drain concurrency is refused" \
+  "must be an integer 1-8" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=four
+assert_refused "a non-numeric visibility timeout is refused" \
+  "must be an integer 60-1800" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=5m
+
 # The HPA controller applies a default 10% tolerance, so a target of 100 is a dead
 # band of 90-110%. The edge tier's load-independent floor sat inside that band,
 # which wedged scaling in BOTH directions: it could not scale down (needs <90%) and

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -753,22 +753,26 @@ assert_refused "cold-load allowance below the largest bundle is refused" \
 # default drifts, an install silently gets a different pgmq fan-out or visibility
 # timeout than the one that was measured on 2026-09-07 (58 create_repo messages,
 # 88 minutes to drain, 20 of 58 re-read against the 300s timeout).
-echo "== github-async-worker drain tuning: defaults, overrides, and the VT invariant =="
+echo "== github-async-worker drain tuning: defaults, overrides, and BOTH batch ceilings =="
 assert_env_value "drain concurrency defaults to today's hardcoded 4" \
   templates/edge-functions.yaml GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY 4
 assert_env_value "visibility timeout defaults to today's hardcoded 300s" \
   templates/edge-functions.yaml GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS 300
-# An explicit override has to actually reach the pod, and both have to move
-# together: 8 x 120 = 960 is the smallest timeout the invariant allows at 8.
+# An explicit override has to actually reach the pod, and ALL THREE numbers have
+# to move together: 8 x 120 = 960 is the smallest visibility timeout AND the
+# smallest isolate lifetime the invariants allow at 8.
+TUNE8=(
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
+  --set edgeFunctions.worker.timeoutMs=960000
+)
 assert_env_value "drain concurrency is settable" \
   templates/edge-functions.yaml GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY 8 \
-  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
-  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
+  "${TUNE8[@]}"
 assert_env_value "visibility timeout is settable" \
   templates/edge-functions.yaml GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS 960 \
-  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
-  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
-# The invariant: the visibility timeout must cover a whole batch of `n`, not one
+  "${TUNE8[@]}"
+# Ceiling 1: the visibility timeout must cover a whole batch of `n`, not one
 # message. Raising concurrency alone is the change that LOOKS like a throughput
 # fix and actually multiplies mid-flight redeliveries, so it is refused outright.
 assert_refused "raising concurrency without raising the visibility timeout is refused" \
@@ -778,15 +782,50 @@ assert_refused "a partially-raised visibility timeout is still refused" \
   "requires visibilityTimeoutSeconds >= 720" \
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=6 \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=719
-assert_renders "concurrency 6 renders at exactly 6 x 120s" \
+# Ceiling 2: the ISOLATE LIFETIME (worker.timeoutMs, 400s by default) must also
+# cover the modelled batch. This is a config-coherence rule — budgeting a batch
+# longer than the isolate that runs it cannot hold as advice, because an overrun
+# would skip the archive calls — and it is NOT a claim that isolates are being
+# truncated today (that was measured and retracted). A raised concurrency plus a
+# raised visibility timeout with the lifetime left at 400s is the incoherent
+# combination this chart's example used to recommend.
+assert_refused "8/960 with the default 400s isolate lifetime is refused" \
+  "requires edgeFunctions.worker.timeoutMs >= 960000" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
+assert_renders "8/960 renders once the isolate lifetime covers the batch" \
+  "${TUNE8[@]}"
+# The same trap one step down, and the fix that does not touch concurrency at
+# all: 4 x 120 = 480 needs BOTH timeouts, because the model's 480s budget for a
+# batch of 4 does not fit the 400s lifetime. (Only the exact 4/300 pair below is
+# exempt from that arithmetic.)
+assert_refused "raising only the visibility timeout at n=4 still leaves the isolate too short" \
+  "requires edgeFunctions.worker.timeoutMs >= 480000" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=480
+assert_renders "4/480 renders with a 480s isolate lifetime" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=480 \
+  --set edgeFunctions.worker.timeoutMs=480000
+assert_renders "concurrency 6 renders at exactly 6 x 120s on both ceilings" \
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=6 \
-  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=720
-# ...but the default pair (4, 300) also violates it and must keep rendering: it is
-# the measured status quo, deliberately grandfathered, or every existing install
-# would be refused. The rule only bites above the default concurrency.
-assert_renders "the default pair renders even though 300 < 4 x 120" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=720 \
+  --set edgeFunctions.worker.timeoutMs=720000
+# ...but the EXACT legacy pair (4, 300) violates both ceilings and must keep
+# rendering: it is what was hardcoded in the worker, so every install is already
+# running it and refusing it would refuse every upgrade. The exemption is that
+# pair ONLY. It used to be gated on `n > 4`, which let 4/60 and 1/60 through — a
+# 60s timeout re-serves a ~280s create_repo four times over while it is still in
+# flight, which is strictly worse than the status quo it was grandfathering.
+assert_renders "the exact legacy pair 4/300 still renders" \
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=4 \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=300
+assert_refused "4/60 is refused (not covered by the legacy exemption)" \
+  "requires visibilityTimeoutSeconds >= 480" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=4 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=60
+assert_refused "1/60 is refused (not covered by the legacy exemption)" \
+  "requires visibilityTimeoutSeconds >= 120" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=1 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=60
 # Bounds. 0 is the dangerous one: it drains NOTHING while the lease is held and
 # every heartbeat stays green, which reads as a hung queue rather than as a
 # misconfiguration.

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -761,10 +761,17 @@ assert_env_value "visibility timeout defaults to today's hardcoded 300s" \
 # An explicit override has to actually reach the pod, and ALL THREE numbers have
 # to move together: 8 x 120 = 960 is the smallest visibility timeout AND the
 # smallest isolate lifetime the invariants allow at 8.
+# NOTE the graceful-drain trio. An earlier version of this array stopped at
+# worker.timeoutMs, and this suite then asserted that 8/960/960000 RENDERS —
+# blessing a configuration that a rollout kills at the 410s default
+# --graceful-exit-timeout, i.e. 550s short of the modelled batch, which is the
+# same lost-archive redelivery from the shutdown path instead of the runtime.
 TUNE8=(
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=8
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
   --set edgeFunctions.worker.timeoutMs=960000
+  --set edgeFunctions.gracefulExitTimeoutSeconds=970
+  --set edgeFunctions.terminationGracePeriodSeconds=990
 )
 assert_env_value "drain concurrency is settable" \
   templates/edge-functions.yaml GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY 8 \
@@ -793,7 +800,12 @@ assert_refused "8/960 with the default 400s isolate lifetime is refused" \
   "requires edgeFunctions.worker.timeoutMs >= 960000" \
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960
-assert_renders "8/960 renders once the isolate lifetime covers the batch" \
+assert_refused "8/960/960000 with the default 410s graceful exit is refused" \
+  "gracefulExitTimeoutSeconds=410 is below edgeFunctions.worker.timeoutMs" \
+  --set edgeFunctions.githubAsyncWorker.drainConcurrency=8 \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=960 \
+  --set edgeFunctions.worker.timeoutMs=960000
+assert_renders "8/960 renders once the isolate lifetime AND the drain cover the batch" \
   "${TUNE8[@]}"
 # The same trap one step down, and the fix that does not touch concurrency at
 # all: 4 x 120 = 480 needs BOTH timeouts, because the model's 480s budget for a
@@ -802,13 +814,55 @@ assert_renders "8/960 renders once the isolate lifetime covers the batch" \
 assert_refused "raising only the visibility timeout at n=4 still leaves the isolate too short" \
   "requires edgeFunctions.worker.timeoutMs >= 480000" \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=480
-assert_renders "4/480 renders with a 480s isolate lifetime" \
+assert_refused "4/480/480000 without the matching graceful exit is refused" \
+  "gracefulExitTimeoutSeconds=410 is below edgeFunctions.worker.timeoutMs" \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=480 \
   --set edgeFunctions.worker.timeoutMs=480000
+assert_renders "4/480 renders with a 480s isolate lifetime and a 490/510 drain" \
+  --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=480 \
+  --set edgeFunctions.worker.timeoutMs=480000 \
+  --set edgeFunctions.gracefulExitTimeoutSeconds=490 \
+  --set edgeFunctions.terminationGracePeriodSeconds=510
 assert_renders "concurrency 6 renders at exactly 6 x 120s on both ceilings" \
   --set edgeFunctions.githubAsyncWorker.drainConcurrency=6 \
   --set edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds=720 \
-  --set edgeFunctions.worker.timeoutMs=720000
+  --set edgeFunctions.worker.timeoutMs=720000 \
+  --set edgeFunctions.gracefulExitTimeoutSeconds=730 \
+  --set edgeFunctions.terminationGracePeriodSeconds=750
+
+# The shutdown-path rules on their own, independent of this worker: they are
+# properties of the edge tier, and the defaults (410 >= 400, 430 >= 10 + 410)
+# satisfy both, so these refuse nothing that exists today.
+echo "== edge-function shutdown path must outlive the isolate =="
+assert_renders "the default graceful-drain trio renders" \
+  --set edgeFunctions.enabled=true
+assert_refused "a graceful exit below the isolate lifetime is refused" \
+  "gracefulExitTimeoutSeconds=300 is below edgeFunctions.worker.timeoutMs (400000ms = 400s)" \
+  --set edgeFunctions.gracefulExitTimeoutSeconds=300
+assert_refused "a SIGKILL backstop below preStop + graceful exit is refused" \
+  "the graceful exit is decorative" \
+  --set edgeFunctions.terminationGracePeriodSeconds=419
+assert_refused "a raised isolate lifetime with the default graceful exit is refused" \
+  "gracefulExitTimeoutSeconds=410 is below edgeFunctions.worker.timeoutMs (900000ms = 900s)" \
+  --set edgeFunctions.worker.timeoutMs=900000
+
+# The metrics coupling, now enforced at render time rather than only asserted for
+# the renders this suite happens to exercise: a raised worker lifetime with the
+# default 400s top bucket puts everything in the newly-permitted range into +Inf.
+echo "== edge metrics buckets must reach the worker lifetime (render-time) =="
+assert_refused "raising the worker lifetime with default buckets is refused when metrics are on" \
+  "below edgeFunctions.worker.timeoutMs (960s)" \
+  --set edgeFunctions.metrics.enabled=true \
+  --set edgeFunctions.worker.timeoutMs=960000 \
+  --set edgeFunctions.gracefulExitTimeoutSeconds=970 \
+  --set edgeFunctions.terminationGracePeriodSeconds=990
+assert_renders "the same render is accepted with the buckets extended to 960" \
+  --set edgeFunctions.metrics.enabled=true \
+  "${TUNE8[@]}" \
+  --set 'edgeFunctions.metrics.buckets={0.05,0.1,0.25,0.5,1,2,5,10,30,60,120,300,400,960}'
+# ...and the buckets are inert with metrics off, so the rule must not fire there.
+assert_renders "buckets shorter than the lifetime are tolerated with metrics off" \
+  "${TUNE8[@]}"
 # ...but the EXACT legacy pair (4, 300) violates both ceilings and must keep
 # rendering: it is what was hardcoded in the worker, so every install is already
 # running it and refusing it would refuse every upgrade. The exemption is that

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1426,9 +1426,13 @@ edgeFunctions:
   # 1800s is 1.5x the queue-aging alert window, so a genuinely stuck message
   # still pages a human instead of sitting invisible for hours. Out-of-range
   # values are refused at render time and, if they reach the pod some other way
-  # (a hand-edited Deployment, `kubectl set env`), clamped at runtime rather than
-  # taking the worker down — a `0` would drain nothing while every liveness
-  # signal stayed green. Note these are rendered as explicit `env` entries, and
+  # (a hand-edited Deployment, `kubectl set env`), fixed up at runtime rather
+  # than taking the worker down — a `0` would drain nothing while every liveness
+  # signal stayed green. The runtime fix-up ENFORCES the two ceilings by
+  # degrading concurrency, so on a bypass path a lone drainConcurrency=8 with the
+  # timeouts left alone actually runs at 2 (floor(300/120)) and says so in the
+  # log and in Sentry. Set them here and the render-time rules make that
+  # impossible in the first place. Note these are rendered as explicit `env` entries, and
   # an `env` entry beats `envFrom`, so edgeFunctions.envFromSecrets CANNOT be
   # used to override them: set them here.
   githubAsyncWorker:

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1363,12 +1363,21 @@ edgeFunctions:
   #     visibilityTimeoutSeconds: 960   # 8 x 120
   #   worker:
   #     timeoutMs: 960000               # 8 x 120s: the isolate must outlive the batch
-  #   gracefulExitTimeoutSeconds: 970   # >= worker.timeoutMs
+  #   gracefulExitTimeoutSeconds: 970   # >= worker.timeoutMs, or a ROLLOUT truncates the batch
   #   terminationGracePeriodSeconds: 990 # >= preStop + gracefulExitTimeout
+  #   metrics:
+  #     buckets: [..., 300, 400, 960]   # top finite bucket >= the new lifetime
+  #
+  # All five are enforced by templates/validations.yaml, so a partial bundle is
+  # refused at render time rather than deployed: a graceful exit shorter than the
+  # isolate lifetime lets a rollout kill a batch before its archive calls, and a
+  # bucket list that stops at 400 puts everything in the newly-permitted range
+  # into +Inf.
   #
   # If that blast radius is unacceptable, the cheaper and better-scoped first
-  # move is to leave drainConcurrency at 4 and lift only the two timeouts to
-  # cover the batch that is ALREADY running (480s / 480000ms). That fixes the
+  # move is to leave drainConcurrency at 4 and lift the timeouts to cover the
+  # batch that is ALREADY running (480s VT / 480000ms lifetime / 490 graceful /
+  # 510 termination grace / buckets ending at 480). That fixes the
   # redeliveries without changing GitHub concurrency at all, and it is the
   # change with the shortest argument behind it.
   #
@@ -1417,8 +1426,11 @@ edgeFunctions:
   # 1800s is 1.5x the queue-aging alert window, so a genuinely stuck message
   # still pages a human instead of sitting invisible for hours. Out-of-range
   # values are refused at render time and, if they reach the pod some other way
-  # (envFromSecrets), clamped at runtime rather than taking the worker down —
-  # a `0` would drain nothing while every liveness signal stayed green.
+  # (a hand-edited Deployment, `kubectl set env`), clamped at runtime rather than
+  # taking the worker down — a `0` would drain nothing while every liveness
+  # signal stayed green. Note these are rendered as explicit `env` entries, and
+  # an `env` entry beats `envFrom`, so edgeFunctions.envFromSecrets CANNOT be
+  # used to override them: set them here.
   githubAsyncWorker:
     drainConcurrency: 4
     visibilityTimeoutSeconds: 300

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1431,8 +1431,15 @@ edgeFunctions:
   # signal stayed green. The runtime fix-up ENFORCES the two ceilings by
   # degrading concurrency, so on a bypass path a lone drainConcurrency=8 with the
   # timeouts left alone actually runs at 2 (floor(300/120)) and says so in the
-  # log and in Sentry. Set them here and the render-time rules make that
-  # impossible in the first place. Note these are rendered as explicit `env` entries, and
+  # log and in Sentry. Two details of that fix-up worth knowing: an absent or
+  # malformed EDGE_WORKER_TIMEOUT_MS is treated as 400s rather than "unknown",
+  # because that is what main.ts falls back to for the same input, so the
+  # lifetime ceiling caps concurrency at 3 unless worker.timeoutMs is really
+  # raised; and if the timeout cannot cover even ONE message the worker floors
+  # concurrency at 1 AND raises its own sleep_seconds to the 120s one-message
+  # budget, since it passes that value on every pgmq read and a floored-but-
+  # incoherent pair would just re-read a multi-minute create_repo. Set them here
+  # and the render-time rules make all of that impossible in the first place. Note these are rendered as explicit `env` entries, and
   # an `env` entry beats `envFrom`, so edgeFunctions.envFromSecrets CANNOT be
   # used to override them: set them here.
   githubAsyncWorker:

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1302,24 +1302,75 @@ edgeFunctions:
   # Everything still ended up correct (58/58 repos, no duplicates, empty DLQ) —
   # this is a throughput and redelivery problem, not a correctness one.
   #
-  # HOW THE TWO KNOBS RELATE (the invariant — do not break it):
+  # HOW THE KNOBS RELATE — TWO CEILINGS, not one, and a batch must fit under
+  # BOTH (do not break either):
   #
   #   visibilityTimeoutSeconds >= drainConcurrency x 120
+  #   worker.timeoutMs / 1000  >= drainConcurrency x 120
   #
-  # The visibility timeout must cover the worst case for a WHOLE BATCH of
-  # `drainConcurrency`, not for one message: all of them run concurrently in one
-  # isolate, but their GitHub calls serialize through the shared Bottleneck
-  # limiters, so batch wall clock grows with concurrency. 120s/message is
-  # calibrated from the incident (420s for a batch of 4 ≈ 105s/message, rounded
-  # up). validations.yaml REFUSES a render that raises drainConcurrency above
-  # the default without satisfying this, because raising concurrency against a
-  # too-short timeout makes the re-read storm worse rather than better; the
-  # default pair (4, 300) violates it and is grandfathered as the measured
-  # status quo.
+  # Both are about a WHOLE BATCH of `drainConcurrency`, never about one message:
+  # all of them run concurrently in ONE isolate, but their GitHub calls
+  # serialize through the fleet-wide content limiter (below), so batch wall
+  # clock grows with concurrency. 120s/message is calibrated from the incident
+  # (420s for a batch of 4 ≈ 105s/message, rounded up; create_repo p50 279.5s).
   #
-  # A worked example, for the CS 2000-shaped burst this exists for:
-  #   drainConcurrency: 8
-  #   visibilityTimeoutSeconds: 960   # 8 x 120
+  # The second ceiling is the ISOLATE LIFETIME. worker.timeoutMs is handed to
+  # EdgeRuntime as workerTimeoutMs, and a batch that outlives it is killed
+  # BEFORE its archive calls run — so the repos exist, the messages were never
+  # archived, and pgmq redelivers work that already succeeded. That is strictly
+  # worse than a duplicate read. beforeUnload.wallClockRatio (50) asks the
+  # isolate to retire at HALF the lifetime, so treat worker.timeoutMs as the
+  # hard cap rather than the budget.
+  #
+  # The second ceiling is a CONFIG-COHERENCE rule, not a claim about what the
+  # runtime is doing right now. Under n x 120 against the 400s default lifetime
+  # the largest coherent concurrency is THREE (3 x 120 = 360; 4 x 120 = 480 >
+  # 400), so even the shipped default of 4 sits just outside the conservative
+  # model — which is why only the EXACT legacy pair (4, 300) is grandfathered.
+  # The practical consequence: you cannot raise the visibility timeout without
+  # raising worker.timeoutMs, and the worked example below therefore moves THREE
+  # values, not two.
+  #
+  # DO NOT read this as "isolates are being killed mid-batch". That was asserted
+  # here in an earlier draft and then MEASURED AND RETRACTED (2026-09-07): the
+  # runtime's `wall clock duraiton reached` log (its typo) was FLAT at ~200/hour
+  # across the functions pods before, during and after the 58-repo burst (197 at
+  # 03:00, 242 at 04:00, 225 at 05:00, 192 idle at 12:00). That is baseline
+  # churn — leased mode keeps a resident isolate polling, so it reaches the 400s
+  # wall clock and recycles about every 3.5 min per pod — and nothing in it ties
+  # a termination to an unarchived message. The 300s visibility timeout remains
+  # the established cause of the 20-of-58 re-reads. Note too that n x 120 is a
+  # conservative upper bound: the ~420s figure is a completion cadence including
+  # poll and re-poke latency, and a fully parallel batch of 4 at p50 279.5s
+  # would be ~280-300s.
+  #
+  # validations.yaml refuses any combination that breaks either ceiling. Only
+  # the EXACT legacy pair (4, 300) is exempt, because that is what was hardcoded
+  # in the worker and is therefore already running everywhere; anything else is
+  # a deliberate act and is checked. (4/60 and 1/60 are refused for the same
+  # reason 8/300 is — a 60s timeout re-serves a ~280s create_repo four times
+  # over while it is still in flight.)
+  #
+  # A worked example, for the CS 2000-shaped burst this exists for. Note it is a
+  # COUPLED change and its blast radius is wider than this worker: raising
+  # worker.timeoutMs lengthens EVERY function's isolate lifetime in the pod
+  # (longer-lived isolates accumulate more heap, which is what cpuSoftMs and
+  # beforeUnload exist to bound), and the graceful-drain trio has to move with
+  # it or a rollout truncates the batch anyway.
+  #
+  #   githubAsyncWorker:
+  #     drainConcurrency: 8
+  #     visibilityTimeoutSeconds: 960   # 8 x 120
+  #   worker:
+  #     timeoutMs: 960000               # 8 x 120s: the isolate must outlive the batch
+  #   gracefulExitTimeoutSeconds: 970   # >= worker.timeoutMs
+  #   terminationGracePeriodSeconds: 990 # >= preStop + gracefulExitTimeout
+  #
+  # If that blast radius is unacceptable, the cheaper and better-scoped first
+  # move is to leave drainConcurrency at 4 and lift only the two timeouts to
+  # cover the batch that is ALREADY running (480s / 480000ms). That fixes the
+  # redeliveries without changing GitHub concurrency at all, and it is the
+  # change with the shortest argument behind it.
   #
   # Why the range is 1..8 rather than "as high as you like":
   #   * THE BINDING CONSTRAINT IS A SHARED GITHUB LIMITER, not this pod.

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1281,6 +1281,96 @@ edgeFunctions:
     # render-guardrails.sh asserts monotonicity and that the top bucket is
     # >= worker.timeoutMs/1000; raise it alongside any timeout increase.
     buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 400]
+  # ---------------------------------------------------------------------------
+  # github-async-worker drain tuning (pgmq `async_calls` / `..._low_priority`)
+  # ---------------------------------------------------------------------------
+  # Rendered as GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY and
+  # GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS and consumed by
+  # supabase/functions/_shared/asyncWorkerTuning.ts, which holds the bounds and
+  # the full narrative. Both were HARDCODED (4 / 300) in the worker until
+  # 2026-09-07; the defaults here reproduce that exactly, so upgrading this
+  # chart changes nothing until you set a value.
+  #
+  # WHAT WAS MEASURED (Khoury prod, 2026-09-07). CS 4530 released an assignment
+  # and enqueued 58 `create_repo` messages at once at 04:01:00 UTC. The last one
+  # drained at 05:37:28 UTC — 88 MINUTES for 58 messages, mean time-in-queue
+  # 3,230s, worst 5,788s, with 2-4 messages completing every ~7 minutes.
+  # PawtograderQueueOldestMessageAging (1200s for 10m, critical) fired for over
+  # an hour and was a TRUE POSITIVE. 20 of the 58 messages came back with
+  # read_ct > 1 (max 3) because a ~420s batch outlives a 300s visibility
+  # timeout, so pgmq re-served messages that were still being processed.
+  # Everything still ended up correct (58/58 repos, no duplicates, empty DLQ) —
+  # this is a throughput and redelivery problem, not a correctness one.
+  #
+  # HOW THE TWO KNOBS RELATE (the invariant — do not break it):
+  #
+  #   visibilityTimeoutSeconds >= drainConcurrency x 120
+  #
+  # The visibility timeout must cover the worst case for a WHOLE BATCH of
+  # `drainConcurrency`, not for one message: all of them run concurrently in one
+  # isolate, but their GitHub calls serialize through the shared Bottleneck
+  # limiters, so batch wall clock grows with concurrency. 120s/message is
+  # calibrated from the incident (420s for a batch of 4 ≈ 105s/message, rounded
+  # up). validations.yaml REFUSES a render that raises drainConcurrency above
+  # the default without satisfying this, because raising concurrency against a
+  # too-short timeout makes the re-read storm worse rather than better; the
+  # default pair (4, 300) violates it and is grandfathered as the measured
+  # status quo.
+  #
+  # A worked example, for the CS 2000-shaped burst this exists for:
+  #   drainConcurrency: 8
+  #   visibilityTimeoutSeconds: 960   # 8 x 120
+  #
+  # Why the range is 1..8 rather than "as high as you like":
+  #   * THE BINDING CONSTRAINT IS A SHARED GITHUB LIMITER, not this pod.
+  #     `create_repo` wraps the whole github.createRepo() call in the
+  #     Redis-backed (therefore FLEET-WIDE, per-org) content limiter
+  #     `create_content:<org>:<GITHUB_APP_ID>`, which is
+  #     { reservoir: 40, maxConcurrent: 40, refresh 40/60s }. A create_repo
+  #     measured p50 279.5s on 2026-09-07, so every in-flight repo creation
+  #     holds one of those 40 slots and one reservoir token for ~4.7 MINUTES.
+  #     The same pool serves org INVITATIONS (POST /orgs/{org}/invitations) and
+  #     sync_repo_to_handout, so as concurrency rises toward 40 the minutes-long
+  #     repo creations form a convoy and invitations queue behind them —
+  #     students unable to join the org, which is a worse symptom than a slow
+  #     queue. Concurrency is per leaseholder while the limiter is per org and
+  #     fleet-wide, so several classes releasing into the same org compound it,
+  #     and the reservoir caps starts at 40/min per org regardless. 8 is 20% of
+  #     the pool: even with all 8 held for the full ~280s, 32 slots remain for
+  #     invitations and syncs.
+  #   * every message in a batch is processed inside the SINGLE leaseholder
+  #     isolate, which is capped at worker.memoryLimitMb (256MiB) and
+  #     early-drops at half that. Concurrency multiplies envelopes, Octokit
+  #     responses and file contents inside that one box, and an isolate killed
+  #     at the cap mid-handler is exactly the read_ct-climbing failure the
+  #     worker's poison-pill guard exists for. This tier OOM-killed PID 1 twice
+  #     in 2026-08 (see the eszipCacheMaxMb note above and the maxParallelism
+  #     note in examples/values-prod.yaml) and its container budget already sits
+  #     at ~2650Mi against a 4Gi limit, so there is no room to grow the isolate.
+  #   * concurrency multiplies concurrent GitHub API calls against ONE shared
+  #     App installation quota per org. The Bottleneck limiters in
+  #     supabase/functions/_shared/ and the github_circuit_breakers table are
+  #     the only backstops, so past the limiters' own concurrency the extra
+  #     parallelism becomes queueing inside Bottleneck, not throughput.
+  # 8 (a doubling of the measured configuration, and the same number as
+  # maxParallelism) is the largest step worth taking without re-measuring
+  # isolate memory, content-limiter occupancy and secondary-rate-limit
+  # behaviour under a real burst. Note
+  # that 8 is ~1.2 msg/min, i.e. ~8h for a 585-message burst: going materially
+  # faster needs MORE THAN ONE concurrent leaseholder (see workerRun.ts), which
+  # is a separate design change, not a bigger number here.
+  #
+  # visibilityTimeoutSeconds is bounded 60..1800. The timeout is also the
+  # RECOVERY LATENCY for a message whose isolate really died (memory cap,
+  # worker.timeoutMs, eviction): nothing retries it until the timeout expires.
+  # 1800s is 1.5x the queue-aging alert window, so a genuinely stuck message
+  # still pages a human instead of sitting invisible for hours. Out-of-range
+  # values are refused at render time and, if they reach the pod some other way
+  # (envFromSecrets), clamped at runtime rather than taking the worker down —
+  # a `0` would drain nothing while every liveness signal stayed green.
+  githubAsyncWorker:
+    drainConcurrency: 4
+    visibilityTimeoutSeconds: 300
   worker:
     memoryLimitMb: 256
     timeoutMs: 400000 # 400s worker lifetime (hosted paid-plan default)

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1497,7 +1497,8 @@ function attachStepTimingsToScope(snapshot: StepTimingsSnapshot, scope?: Sentry.
 function attachHandledFailureTimings(
   timings: StepTimings | undefined,
   scope: Sentry.Scope | undefined,
-  handledStep: string
+  handledStep: string,
+  error?: unknown
 ): void {
   if (!timings || !scope) return;
   try {
@@ -1505,7 +1506,13 @@ function attachHandledFailureTimings(
     // The step whose failure was handled here. NOT `failed_step`, which is reserved for an error
     // that escaped the whole operation. Op-namespaced for the same reason as every other timing tag
     // (see attachSnapshotToScope): two instrumented operations share one envelope scope.
-    scope.setTag(`step_timings_${timings.op}_handled_failure_step`, handledStep);
+    //
+    // Prefer the step that actually raised THIS error over the caller's label. One catch can cover
+    // several timed steps — the rulesets try/catch below spans both the LIST and the DETAIL request
+    // — and a hardcoded label there tagged a failed DETAIL request as `ruleset_list`, contradicting
+    // the context blob beside it and sending endpoint-level filtering to the wrong place.
+    const step = timings.stepForError(error) ?? handledStep;
+    scope.setTag(`step_timings_${timings.op}_handled_failure_step`, step);
   } catch {
     /* diagnostics must never break the operation they describe */
   }
@@ -1548,7 +1555,7 @@ async function finalizeRepo(
   } catch (patchErr) {
     console.error("Error patching repo settings (squash merge / template flag)", patchErr);
     scope?.setTag("patch_repo_settings_failed", "true");
-    attachHandledFailureTimings(timings, scope, "patch_repo_settings");
+    attachHandledFailureTimings(timings, scope, "patch_repo_settings", patchErr);
     Sentry.captureException(patchErr, scope);
   }
   // Enable GitHub Actions (workaround for GitHub bug where Actions isn't always enabled on template-generated repos)
@@ -1571,7 +1578,7 @@ async function finalizeRepo(
   } catch (actionsErr) {
     console.error("Error enabling GitHub Actions", actionsErr);
     scope?.setTag("enable_actions_failed", "true");
-    attachHandledFailureTimings(timings, scope, "enable_actions");
+    attachHandledFailureTimings(timings, scope, "enable_actions", actionsErr);
     Sentry.captureException(actionsErr, scope);
   }
   // Resolve the repo's actual default branch rather than assuming `main`: a FORK inherits the
@@ -1621,7 +1628,10 @@ async function finalizeRepo(
     // Log but don't fail repo creation if ruleset creation fails
     console.error("Error applying branch protection ruleset", rulesetError);
     scope?.setTag("ruleset_creation_failed", "true");
-    attachHandledFailureTimings(timings, scope, "branch_protection_ruleset");
+    // Coarse fallback only: this catch sits OUTSIDE applyBranchProtectionRuleset, so the throw may
+    // have come from any of its timed sub-steps (ruleset_get_octokit / _list / _detail / _write) or
+    // from untimed code between them. stepForError picks the exact one when it can.
+    attachHandledFailureTimings(timings, scope, "branch_protection_ruleset", rulesetError);
     Sentry.captureException(rulesetError, scope);
   }
 
@@ -1975,7 +1985,9 @@ export async function applyBranchProtectionRuleset(
     } else {
       // List failures shouldn't kill repo creation. Fall through assuming none.
       console.warn(`Could not list rulesets for ${org}/${repoName}:`, e);
-      attachHandledFailureTimings(timings, scope, "ruleset_list");
+      // `ruleset_list` is the fallback, not the assumption: this catch also covers the ruleset
+      // DETAIL request a few lines up, and that is exactly the misattribution stepForError fixes.
+      attachHandledFailureTimings(timings, scope, "ruleset_list", e);
       Sentry.captureException(e, scope);
       existingRulesetId = null;
       existingRules = null;
@@ -3198,7 +3210,7 @@ async function syncRepoPermissionsInstrumented(
     Sentry.withScope((s) => {
       s.setFingerprint(["staff-team-roster-unavailable"]);
       // Attach to the FORKED scope this capture actually uses, not to `scope`.
-      attachHandledFailureTimings(timings, s, "staff_team_members");
+      attachHandledFailureTimings(timings, s, "staff_team_members", err);
       Sentry.captureException(err, s);
     });
     console.error(`Could not read staff team for ${org}/${courseSlug}; not removing any collaborators`, err);

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -82,7 +82,7 @@ import {
 import { createHash } from "node:crypto";
 import { FileListing } from "./FunctionTypes.d.ts";
 import { UserVisibleError } from "./HandlerUtils.ts";
-import { bucketDurationMs, countStep, StepTimings, type StepTimingsSnapshot, timeStep } from "./stepTimings.ts";
+import { attachSnapshotToScope, countStep, StepTimings, type StepTimingsSnapshot, timeStep } from "./stepTimings.ts";
 
 const adminsThatShouldNotBeListedAsAdmins = ["smaran-teja", "jonathantarun", "ricksva", "jondenman", "tsrats"];
 /**
@@ -1462,45 +1462,23 @@ export function isTeamAlreadyExistsError(e: unknown): boolean {
 }
 
 /**
- * Attach a finished step-timings snapshot to the Sentry scope, so the breakdown lands in Bugsink
- * next to whatever exception was reported for the same job — the failure case is exactly when the
- * per-step numbers are most useful.
+ * Attach a finished step-timings snapshot to the Sentry scope for the operation being measured.
  *
- * Tags vs context is deliberate. Sentry tags are INDEXED and want low cardinality, so only the
- * operation name, the slowest step's name, a coarse duration BUCKET, the failing step, and the
- * small integer counters go in tags (all of them searchable/groupable: "show me every create_repo
- * whose slowest step was get_head_sha"). The full millisecond breakdown is a JSON blob and belongs
- * in `setContext`, where it is displayed but not indexed.
+ * The writing itself lives in `attachSnapshotToScope` (_shared/stepTimings.ts), which documents why
+ * every write goes through this scope object and never through `Sentry.addBreadcrumb`, and why the
+ * tag keys are namespaced per operation.
  *
- * Passed to `StepTimings.finish()` as the sink, which already swallows sink failures — Sentry
- * bookkeeping must never turn a successful repo creation into a failed one.
+ * The scope handed to us is ALREADY per-message: `processBatch` shares one scope across the
+ * `drainConcurrency` envelopes it runs concurrently, but `processEnvelope` clones it per envelope
+ * (github-async-worker/index.ts:613) before any handler sees it, and `Sentry.Scope.clone()` copies
+ * tags and contexts by value. Attaching here — rather than to a scope this function clones for
+ * itself — is deliberate and is what makes an ESCAPING error carry its own breakdown: the worker
+ * captures that error with this same envelope scope, so the event arrives in Bugsink with this
+ * operation's steps on it. A private clone would isolate nothing extra and would drop the snapshot
+ * from precisely the event we most want it on.
  */
 function attachStepTimingsToScope(snapshot: StepTimingsSnapshot, scope?: Sentry.Scope): void {
-  if (!scope) return;
-  scope.setContext(`step_timings_${snapshot.op}`, snapshot as unknown as Record<string, unknown>);
-  scope.setTag("step_timings_op", snapshot.op);
-  scope.setTag("step_timings_slowest_step", snapshot.slowest_step ?? "none");
-  scope.setTag("step_timings_total_bucket", bucketDurationMs(snapshot.total_ms));
-  // A partial snapshot is a mid-operation view (see attachHandledFailureTimings), so its total and
-  // its step list are both incomplete by construction. Tag it, or the two kinds of event are
-  // indistinguishable in Bugsink and someone will read a partial total as an operation duration.
-  scope.setTag("step_timings_partial", String(snapshot.partial));
-  scope.setTag("step_timings_error_escaped", String(snapshot.error_escaped));
-  if (snapshot.failed_step) {
-    scope.setTag("step_timings_failed_step", snapshot.failed_step);
-  }
-  // Counters are small integers (poll attempts, retried sub-calls), so they are tag-safe and are
-  // the fields we most want to filter on: `wait_for_repo_ready_attempts` alone distinguishes
-  // "returned immediately" from "burned the full 30 x 2000ms = 60s poll budget".
-  for (const [name, value] of Object.entries(snapshot.counts)) {
-    scope.setTag(`step_timings_${name}`, String(value));
-  }
-  Sentry.addBreadcrumb({
-    message: `step timings ${snapshot.op}`,
-    category: "timing",
-    level: "info",
-    data: snapshot as unknown as Record<string, unknown>
-  });
+  attachSnapshotToScope(snapshot, scope);
 }
 
 /**
@@ -1525,8 +1503,9 @@ function attachHandledFailureTimings(
   try {
     attachStepTimingsToScope(timings.snapshot(), scope);
     // The step whose failure was handled here. NOT `failed_step`, which is reserved for an error
-    // that escaped the whole operation.
-    scope.setTag("step_timings_handled_failure_step", handledStep);
+    // that escaped the whole operation. Op-namespaced for the same reason as every other timing tag
+    // (see attachSnapshotToScope): two instrumented operations share one envelope scope.
+    scope.setTag(`step_timings_${timings.op}_handled_failure_step`, handledStep);
   } catch {
     /* diagnostics must never break the operation they describe */
   }

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -82,6 +82,7 @@ import {
 import { createHash } from "node:crypto";
 import { FileListing } from "./FunctionTypes.d.ts";
 import { UserVisibleError } from "./HandlerUtils.ts";
+import { bucketDurationMs, countStep, StepTimings, type StepTimingsSnapshot, timeStep } from "./stepTimings.ts";
 
 const adminsThatShouldNotBeListedAsAdmins = ["smaran-teja", "jonathantarun", "ricksva", "jondenman", "tsrats"];
 /**
@@ -1461,6 +1462,43 @@ export function isTeamAlreadyExistsError(e: unknown): boolean {
 }
 
 /**
+ * Attach a finished step-timings snapshot to the Sentry scope, so the breakdown lands in Bugsink
+ * next to whatever exception was reported for the same job — the failure case is exactly when the
+ * per-step numbers are most useful.
+ *
+ * Tags vs context is deliberate. Sentry tags are INDEXED and want low cardinality, so only the
+ * operation name, the slowest step's name, a coarse duration BUCKET, the failing step, and the
+ * small integer counters go in tags (all of them searchable/groupable: "show me every create_repo
+ * whose slowest step was get_head_sha"). The full millisecond breakdown is a JSON blob and belongs
+ * in `setContext`, where it is displayed but not indexed.
+ *
+ * Passed to `StepTimings.finish()` as the sink, which already swallows sink failures — Sentry
+ * bookkeeping must never turn a successful repo creation into a failed one.
+ */
+function attachStepTimingsToScope(snapshot: StepTimingsSnapshot, scope?: Sentry.Scope): void {
+  if (!scope) return;
+  scope.setContext(`step_timings_${snapshot.op}`, snapshot as unknown as Record<string, unknown>);
+  scope.setTag("step_timings_op", snapshot.op);
+  scope.setTag("step_timings_slowest_step", snapshot.slowest_step ?? "none");
+  scope.setTag("step_timings_total_bucket", bucketDurationMs(snapshot.total_ms));
+  if (snapshot.failed_step) {
+    scope.setTag("step_timings_failed_step", snapshot.failed_step);
+  }
+  // Counters are small integers (poll attempts, retried sub-calls), so they are tag-safe and are
+  // the fields we most want to filter on: `wait_for_repo_ready_attempts` alone distinguishes
+  // "returned immediately" from "burned the full 30 x 2000ms = 60s poll budget".
+  for (const [name, value] of Object.entries(snapshot.counts)) {
+    scope.setTag(`step_timings_${name}`, String(value));
+  }
+  Sentry.addBreadcrumb({
+    message: `step timings ${snapshot.op}`,
+    category: "timing",
+    level: "info",
+    data: snapshot as unknown as Record<string, unknown>
+  });
+}
+
+/**
  * Shared post-create finalization: enable squash merge + template flag, enable Actions, resolve the
  * default branch's head SHA, and apply the branch-protection ruleset. Run identically for freshly
  * created, repaired, and adopted pre-existing repos so the paths never drift. Returns the head SHA.
@@ -1470,7 +1508,8 @@ async function finalizeRepo(
   org: string,
   repoName: string,
   opts: { is_template_repo?: boolean; branch_protection?: BranchProtectionConfig },
-  scope?: Sentry.Scope
+  scope?: Sentry.Scope,
+  timings?: StepTimings
 ): Promise<string> {
   const { is_template_repo, branch_protection = DEFAULT_BRANCH_PROTECTION } = opts;
   // Enable squash merging; set template flag when applicable. These are non-essential settings on an
@@ -1479,17 +1518,19 @@ async function finalizeRepo(
   // matching the enable-Actions and ruleset steps below.
   scope?.setTag("github_operation", "patch_repo_settings");
   try {
-    await retryWithBackoff(
-      () =>
-        octokit.request("PATCH /repos/{owner}/{repo}", {
-          owner: org,
-          repo: repoName,
-          allow_squash_merge: true,
-          is_template: is_template_repo ? true : false
-        }),
-      3, // maxRetries
-      1000, // baseDelayMs
-      scope
+    await timeStep(timings, "patch_repo_settings", () =>
+      retryWithBackoff(
+        () =>
+          octokit.request("PATCH /repos/{owner}/{repo}", {
+            owner: org,
+            repo: repoName,
+            allow_squash_merge: true,
+            is_template: is_template_repo ? true : false
+          }),
+        3, // maxRetries
+        1000, // baseDelayMs
+        scope
+      )
     );
   } catch (patchErr) {
     console.error("Error patching repo settings (squash merge / template flag)", patchErr);
@@ -1499,17 +1540,19 @@ async function finalizeRepo(
   // Enable GitHub Actions (workaround for GitHub bug where Actions isn't always enabled on template-generated repos)
   scope?.setTag("github_operation", "enable_actions");
   try {
-    await retryWithBackoff(
-      () =>
-        octokit.request("PUT /repos/{owner}/{repo}/actions/permissions", {
-          owner: org,
-          repo: repoName,
-          enabled: true,
-          allowed_actions: "all"
-        }),
-      3,
-      1000,
-      scope
+    await timeStep(timings, "enable_actions", () =>
+      retryWithBackoff(
+        () =>
+          octokit.request("PUT /repos/{owner}/{repo}/actions/permissions", {
+            owner: org,
+            repo: repoName,
+            enabled: true,
+            allowed_actions: "all"
+          }),
+        3,
+        1000,
+        scope
+      )
     );
   } catch (actionsErr) {
     console.error("Error enabling GitHub Actions", actionsErr);
@@ -1520,37 +1563,45 @@ async function finalizeRepo(
   // UPSTREAM's default branch (which may be `master`), and a template-generated repo inherits the
   // template's. Hardcoding `heads/main` would 404 the ref lookup for any such repo.
   scope?.setTag("github_operation", "get_default_branch");
-  const repoMeta = await retryWithBackoff(
-    () =>
-      octokit.request("GET /repos/{owner}/{repo}", {
-        owner: org,
-        repo: repoName
-      }),
-    3, // maxRetries
-    1000, // baseDelayMs
-    scope
+  const repoMeta = await timeStep(timings, "get_default_branch", () =>
+    retryWithBackoff(
+      () =>
+        octokit.request("GET /repos/{owner}/{repo}", {
+          owner: org,
+          repo: repoName
+        }),
+      3, // maxRetries
+      1000, // baseDelayMs
+      scope
+    )
   );
   const defaultBranch = repoMeta.data.default_branch || "main";
   scope?.setTag("default_branch", defaultBranch);
   scope?.setTag("github_operation", "get_head_sha");
   scope?.setTag("ref", `heads/${defaultBranch}`);
-  const heads = await retryWithBackoff(
-    () =>
-      octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
-        owner: org,
-        repo: repoName,
-        ref: `heads/${defaultBranch}`
-      }),
-    5, // maxRetries
-    3000, // baseDelayMs
-    scope
+  // NOTE (2026-09-07 latency hunt): this is the call with the deepest retry ladder in the path —
+  // maxRetries 5 / baseDelayMs 3000 = 3+6+12+24+48 = 93s of sleep if it 404s all the way. The
+  // incident logs contain no retry lines at all, so the ladder did NOT fire; this timing exists to
+  // keep proving that from the data rather than from absence-of-logs.
+  const heads = await timeStep(timings, "get_head_sha", () =>
+    retryWithBackoff(
+      () =>
+        octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
+          owner: org,
+          repo: repoName,
+          ref: `heads/${defaultBranch}`
+        }),
+      5, // maxRetries
+      3000, // baseDelayMs
+      scope
+    )
   );
   scope?.setTag("head_sha", heads.data.object.sha);
 
   // Apply branch protection ruleset per the assignment's configuration.
   scope?.setTag("github_operation", "create_branch_protection_ruleset");
   try {
-    await applyBranchProtectionRuleset(org, repoName, branch_protection, scope);
+    await applyBranchProtectionRuleset(org, repoName, branch_protection, scope, timings);
   } catch (rulesetError) {
     // Log but don't fail repo creation if ruleset creation fails
     console.error("Error applying branch protection ruleset", rulesetError);
@@ -1561,12 +1612,47 @@ async function finalizeRepo(
   return heads.data.object.sha as string;
 }
 
+/**
+ * Step-level timing wrapper around repo creation. See _shared/stepTimings.ts for the measurement
+ * that motivated it: 58 prod `create_repo` messages on 2026-09-07 took p50 279.5s each (vs
+ * sync_student_team p50 1.0s on the same pods), with only ~5s of that explained (the template
+ * generate call, timestamped in the logs) and ~275s spent inside code that logged nothing.
+ *
+ * The body is untouched and lives in `createRepoInstrumented`; this wrapper only creates the
+ * collector and reports it from a `finally`, so the breakdown is emitted on the throw path too.
+ * Note that `total_ms` here is createRepo's OWN wall time: the async worker wraps this whole call
+ * in `getCreateContentLimiter(org).schedule(...)`, so any wait for a limiter slot happens before we
+ * are entered and is deliberately not part of this number.
+ */
 export async function createRepo(
   org: string,
   repoName: string,
   template_repo: string,
   options: CreateRepoOptions = {},
   scope?: Sentry.Scope
+): Promise<string> {
+  const timings = new StepTimings("create_repo", {
+    meta: {
+      org,
+      repo_name: repoName,
+      template_repo,
+      creation_method: options.creation_method ?? "template"
+    }
+  });
+  try {
+    return await createRepoInstrumented(org, repoName, template_repo, options, scope, timings);
+  } finally {
+    timings.finish((snapshot) => attachStepTimingsToScope(snapshot, scope));
+  }
+}
+
+async function createRepoInstrumented(
+  org: string,
+  repoName: string,
+  template_repo: string,
+  options: CreateRepoOptions,
+  scope: Sentry.Scope | undefined,
+  timings: StepTimings
 ): Promise<string> {
   const { is_template_repo, creation_method = "template", branch_protection = DEFAULT_BRANCH_PROTECTION } = options;
   scope?.setTag("github_operation", "create_repo");
@@ -1596,7 +1682,10 @@ export async function createRepo(
     return stubFakeSha("e2e-stub-", repoName);
   }
 
-  const octokit = await getOctoKit(org, scope);
+  // Timed because it is not free on a cold isolate: the FIRST getOctoKit in a process does
+  // `GET /app/installations` and constructs one throttled Octokit per installation. On a warm
+  // isolate this is a map lookup and should read as ~0ms — which is itself the useful signal.
+  const octokit = await timeStep(timings, "get_octokit", () => getOctoKit(org, scope));
   if (!octokit) {
     throw new UserVisibleError("No GitHub installation found for organization " + org);
   }
@@ -1612,36 +1701,46 @@ export async function createRepo(
     if (creation_method === "fork") {
       // Fork the upstream into our org with the chosen name. Forks are
       // asynchronous on GitHub's side, so we poll for size > 0 below.
-      await retryWithBackoff(
-        () =>
-          octokit.request("POST /repos/{owner}/{repo}/forks", {
-            owner,
-            repo,
-            organization: org,
-            name: repoName,
-            default_branch_only: true
-          }),
-        2, // maxRetries
-        5000, // baseDelayMs
-        scope
+      await timeStep(timings, "create_fork", () =>
+        retryWithBackoff(
+          () =>
+            octokit.request("POST /repos/{owner}/{repo}/forks", {
+              owner,
+              repo,
+              organization: org,
+              name: repoName,
+              default_branch_only: true
+            }),
+          2, // maxRetries
+          5000, // baseDelayMs
+          scope
+        )
       );
     } else {
-      const resp = await retryWithBackoff(
-        () =>
-          octokit.request("POST /repos/{template_owner}/{template_repo}/generate", {
-            template_repo: repo,
-            template_owner: owner,
-            owner: org,
-            name: repoName,
-            private: true
-          }),
-        2, // maxRetries
-        5000, // baseDelayMs
-        scope
+      // The one step whose cost we already know from the incident logs: "Creating repo ... via
+      // template" at 04:01:00.673 and its response at 04:01:05.569, i.e. ~4.9s. Timed anyway so the
+      // single summary line is self-contained and we do not have to correlate two log lines again.
+      const resp = await timeStep(timings, "template_generate", () =>
+        retryWithBackoff(
+          () =>
+            octokit.request("POST /repos/{template_owner}/{template_repo}/generate", {
+              template_repo: repo,
+              template_owner: owner,
+              owner: org,
+              name: repoName,
+              private: true
+            }),
+          2, // maxRetries
+          5000, // baseDelayMs
+          scope
+        )
       );
       console.log(JSON.stringify(resp.headers, null, 2));
     }
-    await waitForRepoReady(octokit, org, repoName, scope);
+    // On the delete+regenerate repair path this whole closure runs TWICE; StepTimings accumulates
+    // per step and reports the call count in `repeated`, so a second pass is visible rather than
+    // silently doubling a step's number.
+    await waitForRepoReady(octokit, org, repoName, scope, timings);
   };
 
   scope?.setTag("github_operation", "create_repo_request");
@@ -1659,24 +1758,32 @@ export async function createRepo(
       // it is EMPTY, a previous attempt left it half-created — REPAIR it by deleting and
       // regenerating rather than adopting a blank repo forever (the old, broken behavior).
       scope?.setTag("repo_already_exists", "true");
-      const empty = await isRepoEmpty(octokit, org, repoName);
+      timings.setMeta("repo_already_exists", true);
+      const empty = await timeStep(timings, "is_repo_empty", () => isRepoEmpty(octokit, org, repoName));
       scope?.setTag("existing_repo_empty", empty.toString());
+      timings.setMeta("existing_repo_empty", empty);
       if (empty) {
         // Diagnose the source first: a genuinely-broken template must yield a precise,
         // non-retryable error instead of an endless delete/regenerate loop.
-        await assertSourceNotEmpty(octokit, owner, repo, template_repo);
+        await timeStep(timings, "assert_source_not_empty", () =>
+          assertSourceNotEmpty(octokit, owner, repo, template_repo)
+        );
         // Safety invariant: only ever delete a VERIFIED-EMPTY repo, and never the template/source.
         if (org === owner && repoName === repo) {
           throw new NonRetryableRepoError(`Refusing to delete ${org}/${repoName}: it is the template/source repo`);
         }
         scope?.setTag("github_operation", "delete_empty_repo_for_repair");
         try {
-          await octokit.request("DELETE /repos/{owner}/{repo}", { owner: org, repo: repoName });
+          await timeStep(timings, "delete_empty_repo_for_repair", () =>
+            octokit.request("DELETE /repos/{owner}/{repo}", { owner: org, repo: repoName })
+          );
         } catch (delErr) {
           if (!(delErr instanceof RequestError) || delErr.status !== 404) throw delErr;
         }
         // GitHub frees the name shortly after deletion; give it a moment before regenerating.
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        // Timed (not changed) so this fixed 2s is attributed rather than showing up as
+        // unaccounted_ms — the whole point of the instrumentation is that nothing is unexplained.
+        await timeStep(timings, "post_delete_sleep", () => new Promise((resolve) => setTimeout(resolve, 2000)));
         try {
           await createAndWaitReady();
         } catch (repairErr) {
@@ -1687,7 +1794,9 @@ export async function createRepo(
           // dead-lettering a slow-but-fine repo on the first attempt.
           if (repairErr instanceof UserVisibleError && repairErr.message.includes("did not become ready")) {
             console.error("Repaired repo did not become ready after delete+regenerate", repairErr);
-            await assertSourceNotEmpty(octokit, owner, repo, template_repo);
+            await timeStep(timings, "assert_source_not_empty", () =>
+              assertSourceNotEmpty(octokit, owner, repo, template_repo)
+            );
           }
           throw repairErr;
         }
@@ -1700,7 +1809,9 @@ export async function createRepo(
       // transient condition, so re-throw the original readiness error as retryable rather than
       // dead-lettering a slow-but-fine repo on the first attempt.
       console.error("Repo did not become ready after create", createErr);
-      await assertSourceNotEmpty(octokit, owner, repo, template_repo);
+      await timeStep(timings, "assert_source_not_empty", () =>
+        assertSourceNotEmpty(octokit, owner, repo, template_repo)
+      );
       throw createErr;
     } else {
       console.error("Error creating repo", createErr);
@@ -1711,7 +1822,7 @@ export async function createRepo(
   scope?.setTag("github_operation", "create_repo_request_done");
   // Shared finalize (settings, Actions, head SHA, branch protection) for fresh, repaired, and
   // adopted-pre-existing repos alike.
-  return await finalizeRepo(octokit, org, repoName, { is_template_repo, branch_protection }, scope);
+  return await finalizeRepo(octokit, org, repoName, { is_template_repo, branch_protection }, scope, timings);
 }
 
 /**
@@ -1764,7 +1875,8 @@ export async function applyBranchProtectionRuleset(
   org: string,
   repoName: string,
   cfg: BranchProtectionConfig,
-  scope?: Sentry.Scope
+  scope?: Sentry.Scope,
+  timings?: StepTimings
 ): Promise<void> {
   scope?.setTag("github_operation", "apply_branch_protection_ruleset");
   scope?.setTag("org", org);
@@ -1792,7 +1904,7 @@ export async function applyBranchProtectionRuleset(
     return;
   }
 
-  const octokit = await getOctoKit(org, scope);
+  const octokit = await timeStep(timings, "ruleset_get_octokit", () => getOctoKit(org, scope));
   if (!octokit) {
     throw new UserVisibleError("No GitHub installation found for organization " + org);
   }
@@ -1802,19 +1914,25 @@ export async function applyBranchProtectionRuleset(
   let existingRulesetId: number | null = null;
   let existingRules: Parameters<typeof planBranchProtectionAction>[1] = null;
   try {
-    const existing = await octokit.paginate("GET /repos/{owner}/{repo}/rulesets", {
-      owner: org,
-      repo: repoName,
-      per_page: 100
-    });
+    // Broken out as its own step: this is a PAGINATED list, so it is one request per page and the
+    // count is not bounded by anything in our code.
+    const existing = await timeStep(timings, "ruleset_list", () =>
+      octokit.paginate("GET /repos/{owner}/{repo}/rulesets", {
+        owner: org,
+        repo: repoName,
+        per_page: 100
+      })
+    );
     const ours = existing.find((r) => r.name === BRANCH_PROTECTION_RULESET_NAME);
     if (ours) {
       existingRulesetId = ours.id;
-      const detail = await octokit.request("GET /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
-        owner: org,
-        repo: repoName,
-        ruleset_id: ours.id
-      });
+      const detail = await timeStep(timings, "ruleset_detail", () =>
+        octokit.request("GET /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
+          owner: org,
+          repo: repoName,
+          ruleset_id: ours.id
+        })
+      );
       // detail.data.rules has the same shape we build. Cast to the helper type.
       existingRules = (detail.data.rules ?? []) as NonNullable<typeof existingRules>;
     }
@@ -1864,40 +1982,46 @@ export async function applyBranchProtectionRuleset(
 
   try {
     if (action.kind === "create") {
-      await retryWithBackoff(
-        () => octokit.request("POST /repos/{owner}/{repo}/rulesets", body(action.rules)),
-        3,
-        1000,
-        scope
+      await timeStep(timings, "ruleset_write", () =>
+        retryWithBackoff(
+          () => octokit.request("POST /repos/{owner}/{repo}/rulesets", body(action.rules)),
+          3,
+          1000,
+          scope
+        )
       );
       scope?.setTag("ruleset_created", "true");
       return;
     }
     if (action.kind === "update" && existingRulesetId != null) {
-      await retryWithBackoff(
-        () =>
-          octokit.request("PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
-            ...body(action.rules),
-            ruleset_id: existingRulesetId
-          }),
-        3,
-        1000,
-        scope
+      await timeStep(timings, "ruleset_write", () =>
+        retryWithBackoff(
+          () =>
+            octokit.request("PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
+              ...body(action.rules),
+              ruleset_id: existingRulesetId
+            }),
+          3,
+          1000,
+          scope
+        )
       );
       scope?.setTag("ruleset_updated", "true");
       return;
     }
     if (action.kind === "delete" && existingRulesetId != null) {
-      await retryWithBackoff(
-        () =>
-          octokit.request("DELETE /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
-            owner: org,
-            repo: repoName,
-            ruleset_id: existingRulesetId
-          }),
-        3,
-        1000,
-        scope
+      await timeStep(timings, "ruleset_write", () =>
+        retryWithBackoff(
+          () =>
+            octokit.request("DELETE /repos/{owner}/{repo}/rulesets/{ruleset_id}", {
+              owner: org,
+              repo: repoName,
+              ruleset_id: existingRulesetId
+            }),
+          3,
+          1000,
+          scope
+        )
       );
       scope?.setTag("ruleset_deleted", "true");
       return;
@@ -1941,15 +2065,30 @@ export async function createBranchProtectionRuleset(
  * background mirroring completes; the same pattern is already used for
  * template-generated repos in `assignment-create-all-repos`.
  */
-async function waitForRepoReady(octokit: Octokit, org: string, repoName: string, scope?: Sentry.Scope): Promise<void> {
+async function waitForRepoReady(
+  octokit: Octokit,
+  org: string,
+  repoName: string,
+  scope?: Sentry.Scope,
+  timings?: StepTimings
+): Promise<void> {
   scope?.setTag("github_operation", "wait_for_repo_ready");
   const maxAttempts = 30;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Attempt COUNT is instrumented separately from elapsed time on purpose. The loop is capped at
+    // 30 attempts x 2000ms = 60s, so the count is what says whether this loop contributed ~0s or
+    // essentially its entire budget — elapsed time alone cannot tell "returned on attempt 1 after a
+    // slow GET" apart from "polled 29 times". Against the 2026-09-07 p50 of 279.5s, even the full
+    // 60s only covers about a fifth of the gap, so this number bounds how much of the 4.7 minutes
+    // this loop can possibly own.
+    countStep(timings, "wait_for_repo_ready_attempts");
     try {
-      const { data } = await octokit.request("GET /repos/{owner}/{repo}", {
-        owner: org,
-        repo: repoName
-      });
+      const { data } = await timeStep(timings, "wait_for_repo_ready_requests", () =>
+        octokit.request("GET /repos/{owner}/{repo}", {
+          owner: org,
+          repo: repoName
+        })
+      );
       // `size` is only refreshed by a lagging GitHub background job — on a freshly generated/forked
       // repo it can stay 0 for minutes even after the content has landed, so it is NOT a reliable
       // readiness signal on its own (a fully-populated repo would time out here). Keep it as a fast
@@ -1960,11 +2099,13 @@ async function waitForRepoReady(octokit: Octokit, org: string, repoName: string,
       }
       const defaultBranch = (data as { default_branch?: string }).default_branch || "main";
       try {
-        await octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
-          owner: org,
-          repo: repoName,
-          ref: `heads/${defaultBranch}`
-        });
+        await timeStep(timings, "wait_for_repo_ready_requests", () =>
+          octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
+            owner: org,
+            repo: repoName,
+            ref: `heads/${defaultBranch}`
+          })
+        );
         return; // default branch ref exists → the initial commit has landed
       } catch (refErr) {
         // 404/409 → branch not created yet; anything else is a real error.
@@ -1977,7 +2118,11 @@ async function waitForRepoReady(octokit: Octokit, org: string, repoName: string,
         throw e;
       }
     }
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    // The 2000ms sleep is timed but NOT changed: separating sleep from request time is what
+    // distinguishes "we deliberately waited" from "GitHub (or a limiter in front of it) made us
+    // wait". Together, wait_for_repo_ready_sleep + wait_for_repo_ready_requests is the full cost of
+    // this loop.
+    await timeStep(timings, "wait_for_repo_ready_sleep", () => new Promise((resolve) => setTimeout(resolve, 2000)));
   }
   throw new UserVisibleError(`Repo ${org}/${repoName} did not become ready in time`);
 }
@@ -2900,6 +3045,22 @@ export type SyncRepoPermissionsOptions = {
   studentTeamPermission?: "pull" | null;
 };
 
+/**
+ * Step-timing wrapper, same shape and same motivation as the one on `createRepo`.
+ *
+ * This function is instrumented because of what the 2026-09-07 numbers actually measure. The
+ * ~279.5s p50 was derived from pgmq (`archived_at - (vt - 300s)`), i.e. it is the duration of the
+ * whole `create_repo` MESSAGE — and the worker's create_repo case calls
+ * `github.syncRepoPermissions(...)` immediately after `createRepo` returns, inside the same
+ * message. So the unexplained ~275s is not necessarily inside repo creation at all: it can be here.
+ * This path makes far more GitHub calls than createRepo does (two team-slug resolutions, the staff
+ * roster, the full org member list, a paginated collaborator list, a paginated repo-teams list, a
+ * fresh membership check per not-yet-cached user, then one write per collaborator added or removed),
+ * and several of them are paginated, so their cost is bounded by org size rather than by anything
+ * in our code. Timing them is the only way to tell which half of the message owns the 4.7 minutes.
+ *
+ * The body is unchanged in `syncRepoPermissionsInstrumented`; this wrapper only reports.
+ */
 export async function syncRepoPermissions(
   org: string,
   repo: string,
@@ -2907,6 +3068,33 @@ export async function syncRepoPermissions(
   githubUsernamesMixedCase: string[],
   _scope?: Sentry.Scope,
   options: SyncRepoPermissionsOptions = {}
+): Promise<{ madeChanges: boolean; removalsSkipped: boolean }> {
+  const timings = new StepTimings("sync_repo_permissions", {
+    meta: { org, repo, course_slug: courseSlug, user_count: githubUsernamesMixedCase.length }
+  });
+  try {
+    return await syncRepoPermissionsInstrumented(
+      org,
+      repo,
+      courseSlug,
+      githubUsernamesMixedCase,
+      _scope,
+      options,
+      timings
+    );
+  } finally {
+    timings.finish((snapshot) => attachStepTimingsToScope(snapshot, _scope));
+  }
+}
+
+async function syncRepoPermissionsInstrumented(
+  org: string,
+  repo: string,
+  courseSlug: string,
+  githubUsernamesMixedCase: string[],
+  _scope: Sentry.Scope | undefined,
+  options: SyncRepoPermissionsOptions,
+  timings: StepTimings
 ): Promise<{ madeChanges: boolean; removalsSkipped: boolean }> {
   if (isGithubStubEnabled()) {
     await recordE2eGithubCall(
@@ -2930,14 +3118,16 @@ export async function syncRepoPermissions(
     org = owner;
     repo = repoName;
   }
-  const octokit = await getOctoKit(org, scope);
+  const octokit = await timeStep(timings, "get_octokit", () => getOctoKit(org, scope));
   if (!octokit) {
     throw new Error("No octokit found for organization " + org);
   }
   // Resolve to the team's real GitHub slug: if the team was created out-of-band and GitHub
   // normalized its slug differently from `${courseSlug}-staff`, the literal would 404 on the
   // members/repo-access endpoints below, silently leaving repos without staff access.
-  const team_slug = await resolveExistingTeamSlug(org, `${courseSlug}-staff`, octokit);
+  const team_slug = await timeStep(timings, "resolve_staff_team_slug", () =>
+    resolveExistingTeamSlug(org, `${courseSlug}-staff`, octokit)
+  );
   // JSON tuple, not `org + "-" + courseSlug`, for the same reason as teamSlugCache above: string
   // concat is ambiguous and could serve one course's staff roster to another.
   const staffCacheKey = JSON.stringify([org, courseSlug]);
@@ -2954,7 +3144,11 @@ export async function syncRepoPermissions(
   // a legitimate reason to remove collaborators.
   let staffTeamUsernames: string[] | null = null;
   try {
-    staffTeamUsernames = (await staffTeamCache.get(staffCacheKey)) ?? null;
+    // Timed at the AWAIT, not at the request: this is a promise cache, so a second concurrent job
+    // for the same course blocks here on the first job's in-flight roster read. That wait is real
+    // latency for this message and would otherwise be invisible.
+    staffTeamUsernames =
+      (await timeStep(timings, "staff_team_members", () => staffTeamCache.get(staffCacheKey))) ?? null;
   } catch (err) {
     // ONLY the "team does not exist at all" case degrades to an unknown roster and carries on.
     // A 403 (secondary rate limit), 502, network error, or a members read that failed while the
@@ -2987,18 +3181,24 @@ export async function syncRepoPermissions(
       })
     );
   }
-  const orgMembers = await orgMembershipCache.get(org);
+  // Same promise-cache note as the staff roster above. On a cold isolate this is a PAGINATED list
+  // of every member of the org, which for a large course org is many sequential requests.
+  const orgMembers = await timeStep(timings, "org_members", () => orgMembershipCache.get(org));
   const allOrgMembers = orgMembers?.map((u) => u.login.toLowerCase());
-  const existingAccess = await retryWithBackoff(
-    () =>
-      octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
-        owner: org,
-        repo,
-        per_page: 100
-      }),
-    5,
-    3000,
-    scope
+  // maxRetries 5 / baseDelayMs 3000 — the same 93s worst-case ladder as get_head_sha. No retry
+  // lines appear in the 2026-09-07 logs, so it did not fire; timed so we can say that from data.
+  const existingAccess = await timeStep(timings, "list_collaborators", () =>
+    retryWithBackoff(
+      () =>
+        octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
+          owner: org,
+          repo,
+          per_page: 100
+        }),
+      5,
+      3000,
+      scope
+    )
   );
   const existingUsernames = existingAccess
     .filter((c) => c.role_name === "admin" || c.role_name === "write" || c.role_name === "maintain")
@@ -3010,36 +3210,50 @@ export async function syncRepoPermissions(
   });
   // console.log(`${org}/${repo} existing collaborators: ${existingUsernames.join(", ")}`);
   //Check if staff team has access to the repo, if not, add it
-  const teamsWithAccess = await octokit.paginate("GET /repos/{owner}/{repo}/teams", {
-    owner: org,
-    repo
-  });
+  const teamsWithAccess = await timeStep(timings, "list_repo_teams", () =>
+    octokit.paginate("GET /repos/{owner}/{repo}/teams", {
+      owner: org,
+      repo
+    })
+  );
   if (!teamsWithAccess.length || !teamsWithAccess.some((t) => t.slug === team_slug)) {
     madeChanges = true;
-    await octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
-      org,
-      team_slug,
-      owner: org,
-      repo,
-      permission: "maintain"
-    });
+    await timeStep(timings, "grant_staff_team", () =>
+      octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
+        org,
+        team_slug,
+        owner: org,
+        repo,
+        permission: "maintain"
+      })
+    );
   }
   // Optionally grant the students team read access (mode 2 handout repos). Resolve the real slug for
   // the same reason as the staff team above, so grant/revoke hit the correct team endpoint.
-  const studentsTeamSlug = await resolveExistingTeamSlug(org, `${courseSlug}-students`, octokit);
+  const studentsTeamSlug = await timeStep(timings, "resolve_students_team_slug", () =>
+    resolveExistingTeamSlug(org, `${courseSlug}-students`, octokit)
+  );
   if (options.studentTeamPermission) {
+    // Bound to a local so the narrowing survives into the closure below: TypeScript discards the
+    // `if (options.studentTeamPermission)` narrowing inside a callback (options is a mutable
+    // parameter), so passing `options.studentTeamPermission` there would widen back to
+    // `"pull" | null | undefined`. Same value, same request — this is a typing artifact of wrapping
+    // the call in a timing closure, not a behavior change.
+    const studentTeamPermission = options.studentTeamPermission;
     const hasStudentsTeam = teamsWithAccess.some(
-      (t) => t.slug === studentsTeamSlug && t.permission === options.studentTeamPermission
+      (t) => t.slug === studentsTeamSlug && t.permission === studentTeamPermission
     );
     if (!hasStudentsTeam) {
       madeChanges = true;
-      await octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
-        org,
-        team_slug: studentsTeamSlug,
-        owner: org,
-        repo,
-        permission: options.studentTeamPermission
-      });
+      await timeStep(timings, "grant_students_team", () =>
+        octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
+          org,
+          team_slug: studentsTeamSlug,
+          owner: org,
+          repo,
+          permission: studentTeamPermission
+        })
+      );
       scope?.addBreadcrumb({
         category: "github",
         message: `${org}/${repo} granted ${studentsTeamSlug} team ${options.studentTeamPermission}`,
@@ -3051,12 +3265,14 @@ export async function syncRepoPermissions(
     const hasStudentsTeamAccess = teamsWithAccess.some((t) => t.slug === studentsTeamSlug);
     if (hasStudentsTeamAccess) {
       madeChanges = true;
-      await octokit.request("DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
-        org,
-        team_slug: studentsTeamSlug,
-        owner: org,
-        repo
-      });
+      await timeStep(timings, "revoke_students_team", () =>
+        octokit.request("DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
+          org,
+          team_slug: studentsTeamSlug,
+          owner: org,
+          repo
+        })
+      );
       scope?.addBreadcrumb({
         category: "github",
         message: `${org}/${repo} removed ${studentsTeamSlug} team access`,
@@ -3087,44 +3303,51 @@ export async function syncRepoPermissions(
 
     // For each user not in cached org, check if they're actually in the org now (fresh API call)
     // and also handle potential username changes
-    const verificationResults = await Promise.all(
-      desiredUsersNotInCachedOrg.map((username) =>
-        limiter.schedule(async () => {
-          // First, try to verify current membership with fresh API call
-          try {
-            await octokit.request("GET /orgs/{org}/members/{username}", {
-              org,
-              username
-            });
-            // User IS in org - they were just not in the stale cache
-            scope?.addBreadcrumb({
-              category: "github",
-              message: `${username} verified as org member (was not in cache)`,
-              level: "info"
-            });
-            return { username, isInOrg: true, newUsername: null };
-          } catch (membershipError: unknown) {
-            const err = membershipError as { status?: number };
-            if (err.status === 404 || err.status === 302) {
-              // User is NOT in org - might be a username change
-              const result = await updateGitHubUsernameForUser(username, octokit, adminSupabase, scope);
-              if (result.newUsername) {
-                // Username changed - verify new username is in org
-                try {
-                  await octokit.request("GET /orgs/{org}/members/{username}", {
-                    org,
-                    username: result.newUsername
-                  });
-                  return { username, isInOrg: true, newUsername: result.newUsername };
-                } catch {
-                  return { username, isInOrg: false, newUsername: result.newUsername };
+    // One fresh `GET /orgs/{org}/members/{username}` per user missing from the cached member list,
+    // fanned out 20 at a time, and each 404 additionally triggers a username re-resolution that
+    // reads Supabase and calls GitHub again. Timed as one step, with a counter for the fan-out
+    // size, because the cost here scales with the roster rather than with the repo.
+    countStep(timings, "org_membership_checks", desiredUsersNotInCachedOrg.length);
+    const verificationResults = await timeStep(timings, "verify_org_membership", () =>
+      Promise.all(
+        desiredUsersNotInCachedOrg.map((username) =>
+          limiter.schedule(async () => {
+            // First, try to verify current membership with fresh API call
+            try {
+              await octokit.request("GET /orgs/{org}/members/{username}", {
+                org,
+                username
+              });
+              // User IS in org - they were just not in the stale cache
+              scope?.addBreadcrumb({
+                category: "github",
+                message: `${username} verified as org member (was not in cache)`,
+                level: "info"
+              });
+              return { username, isInOrg: true, newUsername: null };
+            } catch (membershipError: unknown) {
+              const err = membershipError as { status?: number };
+              if (err.status === 404 || err.status === 302) {
+                // User is NOT in org - might be a username change
+                const result = await updateGitHubUsernameForUser(username, octokit, adminSupabase, scope);
+                if (result.newUsername) {
+                  // Username changed - verify new username is in org
+                  try {
+                    await octokit.request("GET /orgs/{org}/members/{username}", {
+                      org,
+                      username: result.newUsername
+                    });
+                    return { username, isInOrg: true, newUsername: result.newUsername };
+                  } catch {
+                    return { username, isInOrg: false, newUsername: result.newUsername };
+                  }
                 }
+                return { username, isInOrg: false, newUsername: null };
               }
-              return { username, isInOrg: false, newUsername: null };
+              throw membershipError;
             }
-            throw membershipError;
-          }
-        })
+          })
+        )
       )
     );
 
@@ -3155,12 +3378,18 @@ export async function syncRepoPermissions(
   });
   for (const username of newAccess) {
     madeChanges = true;
-    const resp = await octokit.request("PUT /repos/{owner}/{repo}/collaborators/{username}", {
-      owner: org,
-      repo,
-      username,
-      permission: "write"
-    });
+    // Accumulated across the loop, with a counter for how many writes were actually issued. One
+    // request per collaborator, issued SEQUENTIALLY — so this step is (users to add) x (per-write
+    // latency), and the counter is what lets us divide those two apart after the fact.
+    countStep(timings, "collaborators_added");
+    const resp = await timeStep(timings, "add_collaborator", () =>
+      octokit.request("PUT /repos/{owner}/{repo}/collaborators/{username}", {
+        owner: org,
+        repo,
+        username,
+        permission: "write"
+      })
+    );
     scope?.addBreadcrumb({
       category: "github",
       message: `${org}/${repo} adding collaborator ${username}`,
@@ -3184,11 +3413,14 @@ export async function syncRepoPermissions(
     });
 
     console.log(`removing collaborator ${username} from ${org}/${repo}`);
-    await octokit.request("DELETE /repos/{owner}/{repo}/collaborators/{username}", {
-      owner: org,
-      repo,
-      username
-    });
+    countStep(timings, "collaborators_removed");
+    await timeStep(timings, "remove_collaborator", () =>
+      octokit.request("DELETE /repos/{owner}/{repo}/collaborators/{username}", {
+        owner: org,
+        repo,
+        username
+      })
+    );
   }
   // `removalsSkipped` is REPORTED, not just logged. A run that could not read the staff roster
   // performed only the additive half of the sync, and a caller that then writes

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1481,6 +1481,11 @@ function attachStepTimingsToScope(snapshot: StepTimingsSnapshot, scope?: Sentry.
   scope.setTag("step_timings_op", snapshot.op);
   scope.setTag("step_timings_slowest_step", snapshot.slowest_step ?? "none");
   scope.setTag("step_timings_total_bucket", bucketDurationMs(snapshot.total_ms));
+  // A partial snapshot is a mid-operation view (see attachHandledFailureTimings), so its total and
+  // its step list are both incomplete by construction. Tag it, or the two kinds of event are
+  // indistinguishable in Bugsink and someone will read a partial total as an operation duration.
+  scope.setTag("step_timings_partial", String(snapshot.partial));
+  scope.setTag("step_timings_error_escaped", String(snapshot.error_escaped));
   if (snapshot.failed_step) {
     scope.setTag("step_timings_failed_step", snapshot.failed_step);
   }
@@ -1496,6 +1501,35 @@ function attachStepTimingsToScope(snapshot: StepTimingsSnapshot, scope?: Sentry.
     level: "info",
     data: snapshot as unknown as Record<string, unknown>
   });
+}
+
+/**
+ * Attach the timings so far to the scope for a HANDLED failure that is about to be reported and
+ * then recovered from.
+ *
+ * Sentry applies scope data at CAPTURE time. `createRepo` attaches its finished snapshot in a
+ * `finally` at the very end, so every `Sentry.captureException` that happens mid-operation — and in
+ * this file those are exactly the interesting ones: patch_repo_settings, enable_actions, the
+ * ruleset, the rulesets-list read, the staff-roster read, each of which is deliberately
+ * log-and-continue — would otherwise arrive in Bugsink with no timing context at all. Attaching a
+ * partial snapshot first is cheap (a read of the accumulators) and cannot affect the final one:
+ * `snapshot()` does not mutate, and `finish()` remains single-shot, so the summary log line is
+ * still emitted exactly once with the complete numbers.
+ */
+function attachHandledFailureTimings(
+  timings: StepTimings | undefined,
+  scope: Sentry.Scope | undefined,
+  handledStep: string
+): void {
+  if (!timings || !scope) return;
+  try {
+    attachStepTimingsToScope(timings.snapshot(), scope);
+    // The step whose failure was handled here. NOT `failed_step`, which is reserved for an error
+    // that escaped the whole operation.
+    scope.setTag("step_timings_handled_failure_step", handledStep);
+  } catch {
+    /* diagnostics must never break the operation they describe */
+  }
 }
 
 /**
@@ -1535,6 +1569,7 @@ async function finalizeRepo(
   } catch (patchErr) {
     console.error("Error patching repo settings (squash merge / template flag)", patchErr);
     scope?.setTag("patch_repo_settings_failed", "true");
+    attachHandledFailureTimings(timings, scope, "patch_repo_settings");
     Sentry.captureException(patchErr, scope);
   }
   // Enable GitHub Actions (workaround for GitHub bug where Actions isn't always enabled on template-generated repos)
@@ -1557,6 +1592,7 @@ async function finalizeRepo(
   } catch (actionsErr) {
     console.error("Error enabling GitHub Actions", actionsErr);
     scope?.setTag("enable_actions_failed", "true");
+    attachHandledFailureTimings(timings, scope, "enable_actions");
     Sentry.captureException(actionsErr, scope);
   }
   // Resolve the repo's actual default branch rather than assuming `main`: a FORK inherits the
@@ -1606,6 +1642,7 @@ async function finalizeRepo(
     // Log but don't fail repo creation if ruleset creation fails
     console.error("Error applying branch protection ruleset", rulesetError);
     scope?.setTag("ruleset_creation_failed", "true");
+    attachHandledFailureTimings(timings, scope, "branch_protection_ruleset");
     Sentry.captureException(rulesetError, scope);
   }
 
@@ -1641,6 +1678,13 @@ export async function createRepo(
   });
   try {
     return await createRepoInstrumented(org, repoName, template_repo, options, scope, timings);
+  } catch (error) {
+    // The ONLY place that knows an error was not recovered from. Individual steps throw routinely
+    // (poll misses on a freshly generated repo, the 422 that opens the duplicate-repo path, the
+    // non-essential finalize settings), and every one of those is caught downstream — so `time()`
+    // deliberately does not flag them and this catch promotes the one that actually escaped.
+    timings.noteEscapingError(error);
+    throw error;
   } finally {
     timings.finish((snapshot) => attachStepTimingsToScope(snapshot, scope));
   }
@@ -1952,6 +1996,7 @@ export async function applyBranchProtectionRuleset(
     } else {
       // List failures shouldn't kill repo creation. Fall through assuming none.
       console.warn(`Could not list rulesets for ${org}/${repoName}:`, e);
+      attachHandledFailureTimings(timings, scope, "ruleset_list");
       Sentry.captureException(e, scope);
       existingRulesetId = null;
       existingRules = null;
@@ -3082,6 +3127,11 @@ export async function syncRepoPermissions(
       options,
       timings
     );
+  } catch (error) {
+    // Same reasoning as createRepo: flag only what escapes. This path recovers from a missing staff
+    // team on purpose (TeamNotFoundError degrades to "do not remove anyone" and carries on).
+    timings.noteEscapingError(error);
+    throw error;
   } finally {
     timings.finish((snapshot) => attachStepTimingsToScope(snapshot, _scope));
   }
@@ -3168,6 +3218,8 @@ async function syncRepoPermissionsInstrumented(
     scope?.setTag("staff_team_roster", "unavailable");
     Sentry.withScope((s) => {
       s.setFingerprint(["staff-team-roster-unavailable"]);
+      // Attach to the FORKED scope this capture actually uses, not to `scope`.
+      attachHandledFailureTimings(timings, s, "staff_team_members");
       Sentry.captureException(err, s);
     });
     console.error(`Could not read staff team for ${org}/${courseSlug}; not removing any collaborators`, err);

--- a/supabase/functions/_shared/asyncWorkerTuning.ts
+++ b/supabase/functions/_shared/asyncWorkerTuning.ts
@@ -132,11 +132,21 @@ export const VISIBILITY_TIMEOUT_ENV = "GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SE
 /**
  * The isolate lifetime, read only to CHECK the second ceiling — this module
  * never sets it. Rendered by the same chart template that renders the two knobs
- * above (chart: edgeFunctions.worker.timeoutMs), so it is present in the same
- * container env; when it is absent (local `supabase functions serve`, tests) the
- * check is skipped rather than guessed at.
+ * above (chart: edgeFunctions.worker.timeoutMs), so it is normally present in
+ * the same container env; when it is absent or malformed the ceiling falls back
+ * to DEFAULT_ISOLATE_LIFETIME_SECONDS, matching the demuxer, rather than being
+ * skipped.
  */
 export const ISOLATE_LIFETIME_ENV = "EDGE_WORKER_TIMEOUT_MS";
+/**
+ * What to assume when `EDGE_WORKER_TIMEOUT_MS` is absent or malformed: 400s,
+ * because that is what the demuxer that creates the isolate assumes for exactly
+ * the same input — `charts/pawtograder/images/edge-functions/main.ts:61`,
+ * `Number(Deno.env.get("EDGE_WORKER_TIMEOUT_MS")) || 400 * 1000`. Treating it as
+ * "unknown" and skipping the ceiling would let this module bless a batch longer
+ * than the isolate it will actually run in. Keep this in step with main.ts.
+ */
+export const DEFAULT_ISOLATE_LIFETIME_SECONDS = 400;
 
 /** Today's hardcoded `n`. Keeping this as the default is what makes the change inert until configured. */
 export const DEFAULT_DRAIN_CONCURRENCY = 4;
@@ -371,14 +381,43 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
   if (vt.issue) issues.push(vt.issue);
 
   // Read the isolate lifetime (the second ceiling). Never written, only read:
-  // this module cannot change how long EdgeRuntime keeps the isolate. Absent or
-  // unparseable means "unknown", and an unknown ceiling is skipped rather than
-  // guessed at — see ISOLATE_LIFETIME_ENV.
+  // this module cannot change how long EdgeRuntime keeps the isolate.
+  //
+  // AN ABSENT OR MALFORMED VALUE IS NOT "UNKNOWN", IT IS 400s. The demuxer that
+  // actually creates the isolate is not undecided about it:
+  //
+  //   charts/pawtograder/images/edge-functions/main.ts:61
+  //   const WORKER_TIMEOUT_MS = Number(Deno.env.get("EDGE_WORKER_TIMEOUT_MS")) || 400 * 1000;
+  //
+  // An earlier version of this function treated absent/garbage as "ceiling
+  // unknown, skip the check", which green-lit a 960s batch inside an isolate
+  // that really lives 400s — the resolver declining to decide something the
+  // runtime had already decided. Mirroring the fallback keeps the two tied; if
+  // main.ts's default ever moves, DEFAULT_ISOLATE_LIFETIME_SECONDS moves with it.
   const lifetimeRaw = env.get(ISOLATE_LIFETIME_ENV);
-  const lifetimeSeconds =
-    lifetimeRaw !== undefined && /^\d+$/.test(lifetimeRaw.trim())
-      ? Math.floor(Number(lifetimeRaw.trim()) / 1000)
-      : undefined;
+  const lifetimeTrimmed = lifetimeRaw?.trim() ?? "";
+  let lifetimeSeconds = DEFAULT_ISOLATE_LIFETIME_SECONDS;
+  if (lifetimeTrimmed !== "") {
+    // `Number(...) || default` is what main.ts does, so 0, a negative and any
+    // non-numeric string all land on the same 400s there. Reported separately
+    // from the clamp so an operator can tell "you typed garbage" from "your
+    // pair was reduced".
+    const parsedMs = Number(lifetimeTrimmed);
+    if (!Number.isFinite(parsedMs) || parsedMs <= 0) {
+      issues.push({
+        env: ISOLATE_LIFETIME_ENV,
+        raw: lifetimeRaw,
+        effective: DEFAULT_ISOLATE_LIFETIME_SECONDS,
+        kind: "rejected",
+        message:
+          `${ISOLATE_LIFETIME_ENV}=${JSON.stringify(lifetimeRaw)} is not a positive number of ` +
+          `milliseconds; assuming ${DEFAULT_ISOLATE_LIFETIME_SECONDS}s, which is what main.ts falls ` +
+          `back to for the same input, so the ceiling used here matches the isolate you actually get.`
+      });
+    } else {
+      lifetimeSeconds = Math.floor(parsedMs / 1000);
+    }
+  }
 
   // THE EXACT LEGACY PAIR IS REPORTED, NOT ENFORCED. (4, 300) is what was
   // hardcoded in processBatch() before any of this was configurable, so it is
@@ -403,7 +442,7 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
           `on purpose; raise ${VISIBILITY_TIMEOUT_ENV} to >= ${requiredForConfigured} to fix it.`
       });
     }
-    if (lifetimeSeconds !== undefined && lifetimeSeconds < requiredForConfigured) {
+    if (lifetimeSeconds < requiredForConfigured) {
       issues.push({
         env: ISOLATE_LIFETIME_ENV,
         raw: lifetimeRaw,
@@ -455,14 +494,12 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
   // worse than draining slowly on this path specifically: there is no render
   // error for anyone to read, so a refusal would be a silent stop.
   const caps: { limit: number; because: string }[] = [
-    { limit: Math.floor(vt.value / PER_MESSAGE_VT_BUDGET_SECONDS), because: `${VISIBILITY_TIMEOUT_ENV}=${vt.value}s` }
-  ];
-  if (lifetimeSeconds !== undefined) {
-    caps.push({
+    { limit: Math.floor(vt.value / PER_MESSAGE_VT_BUDGET_SECONDS), because: `${VISIBILITY_TIMEOUT_ENV}=${vt.value}s` },
+    {
       limit: Math.floor(lifetimeSeconds / PER_MESSAGE_VT_BUDGET_SECONDS),
       because: `${ISOLATE_LIFETIME_ENV}=${lifetimeSeconds}s`
-    });
-  }
+    }
+  ];
   const binding = caps.reduce((lowest, c) => (c.limit < lowest.limit ? c : lowest));
   const coherentN = Math.max(MIN_DRAIN_CONCURRENCY, Math.min(n.value, binding.limit));
 
@@ -482,19 +519,52 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
     });
   }
 
-  // Only reachable when the VT itself is below one message's budget, so no
-  // positive `n` is coherent. Floored at 1 deliberately — see above.
-  if (binding.limit < MIN_DRAIN_CONCURRENCY) {
+  // THE FLOOR MUST STILL BE COHERENT. Flooring `n` at 1 is right — n=0 drains
+  // nothing while every liveness signal stays green — but on its own it left the
+  // other half of the pair broken: with VT=60 the floor returned n=1 against a
+  // 60s timeout while ONE message is budgeted at 120s, so processBatch ran a
+  // knowingly incoherent pair and a multi-minute create_repo was re-read
+  // repeatedly. The floor has to bring the timeout up with it.
+  //
+  // Raising the VT here is legitimate in a way that raising it to chase `n`
+  // never was: the worker passes `sleep_seconds` on every pgmq_public.read, so
+  // it OWNS that value and needs no chart change to honour it, and this is the
+  // one case where there is no concurrency left to give up. It is only reachable
+  // when the configured VT cannot cover a single message.
+  let effectiveVt = vt.value;
+  const requiredForEffective = requiredVisibilityTimeoutSeconds(coherentN);
+  if (effectiveVt < requiredForEffective) {
+    effectiveVt = requiredForEffective;
     issues.push({
       env: VISIBILITY_TIMEOUT_ENV,
-      effective: vt.value,
-      kind: "invariant",
+      raw: String(vt.value),
+      effective: effectiveVt,
+      kind: "clamped",
       message:
-        `no coherent concurrency exists at ${binding.because}: even one message is budgeted at ` +
-        `${PER_MESSAGE_VT_BUDGET_SECONDS}s. Draining at n=1 anyway, because n=0 would drain nothing ` +
-        `while every liveness signal stayed green. Raise it to >= ${PER_MESSAGE_VT_BUDGET_SECONDS}.`
+        `visibility timeout raised from ${vt.value}s to ${effectiveVt}s: ${binding.because} cannot cover ` +
+        `even one message (${PER_MESSAGE_VT_BUDGET_SECONDS}s), so concurrency was already floored at ` +
+        `${coherentN} (never 0 — that drains nothing while every liveness signal stays green) and the ` +
+        `timeout had to come up with it. The worker sets sleep_seconds on every pgmq read, so this needs ` +
+        `no chart change; set ${VISIBILITY_TIMEOUT_ENV} >= ${PER_MESSAGE_VT_BUDGET_SECONDS} to make it ` +
+        `explicit.`
     });
   }
 
-  return { drainConcurrency: coherentN, visibilityTimeoutSeconds: vt.value, issues };
+  // The one ceiling this function cannot fix by itself. `sleep_seconds` is ours;
+  // the isolate lifetime belongs to the demuxer, so if it is below even one
+  // message's budget all we can do is drain at n=1 and say so.
+  if (lifetimeSeconds < requiredForEffective) {
+    issues.push({
+      env: ISOLATE_LIFETIME_ENV,
+      effective: lifetimeSeconds,
+      kind: "invariant",
+      message:
+        `isolate lifetime ${lifetimeSeconds}s is below the ${requiredForEffective}s a batch of ` +
+        `${coherentN} needs, and this module cannot raise it — it belongs to the demuxer. Draining at ` +
+        `n=${coherentN} anyway. Raise edgeFunctions.worker.timeoutMs to >= ${requiredForEffective * 1000} ` +
+        `(keeping gracefulExitTimeoutSeconds / terminationGracePeriodSeconds above it).`
+    });
+  }
+
+  return { drainConcurrency: coherentN, visibilityTimeoutSeconds: effectiveVt, issues };
 }

--- a/supabase/functions/_shared/asyncWorkerTuning.ts
+++ b/supabase/functions/_shared/asyncWorkerTuning.ts
@@ -93,17 +93,23 @@
  *
  * Raising `n` without raising the VT therefore RE-CREATES the incident, worse:
  * a longer batch against the same 300s VT means more messages redelivered
- * mid-flight, not fewer. That is why this module reports the violation instead
- * of leaving the two values as unrelated constants, and why the chart REFUSES
- * to render a raised concurrency with an unraised timeout
- * (templates/validations.yaml).
+ * mid-flight, not fewer. Two mechanisms stop that, at different layers:
+ * templates/validations.yaml REFUSES to render an incoherent combination, and
+ * `resolveAsyncWorkerTuning` ENFORCES coherence at runtime by degrading `n`
+ * until it fits under both ceilings (never by inflating a timeout, and never to
+ * 0). The runtime half exists because the chart cannot see the Helm-bypass
+ * paths — a hand-edited Deployment, `kubectl set env`, a local `supabase
+ * functions serve` — and an earlier version of this module only LOGGED the
+ * violation there before handing the broken numbers to processBatch anyway,
+ * which defended nothing.
  *
  * DEFAULTS ARE TODAY'S HARDCODED VALUES ON PURPOSE (n=4, VT=300). Deploying
  * this change alters nothing until someone sets the env vars, so the throughput
  * decision stays an explicit, reviewable operator action rather than a side
- * effect of a chart upgrade. The default pair (4, 300) DOES violate the
- * invariant above — that is the measured status quo, deliberately preserved,
- * and it is reported as a warning rather than clamped.
+ * effect of a chart upgrade. That exact pair DOES violate both ceilings under
+ * the model, and it is the ONE combination that is reported without being
+ * enforced — re-coherencing the status quo would change production behaviour on
+ * deploy, which is precisely what this change promises not to do.
  */
 
 /**
@@ -364,57 +370,131 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
   });
   if (vt.issue) issues.push(vt.issue);
 
-  // The invariant check. Reported, never enforced by mutating the values: the
-  // default pair (4, 300) violates it, and silently raising the VT on a
-  // default deploy would break the "defaults reproduce today's behaviour
-  // exactly" contract that makes this change safe to ship. The chart refuses
-  // the combination at render time for any RAISED concurrency, which is where
-  // a hard failure belongs.
-  const required = requiredVisibilityTimeoutSeconds(n.value);
-  if (vt.value < required) {
-    issues.push({
-      env: VISIBILITY_TIMEOUT_ENV,
-      effective: vt.value,
-      kind: "invariant",
-      message:
-        `visibility timeout ${vt.value}s is below the ${required}s a batch of ${n.value} can take ` +
-        `(${n.value} x ${PER_MESSAGE_VT_BUDGET_SECONDS}s/message, calibrated from the 2026-09-07 burst: ` +
-        `~7min for a batch of 4). Messages will be re-read while still in flight — that is the ` +
-        `read_ct>1 on 20 of 58 messages from that incident. Raise ${VISIBILITY_TIMEOUT_ENV} to >= ${required}.`
-    });
-  }
-
-  // Second ceiling: the isolate lifetime. A configuration whose modelled batch
-  // outlives the isolate is incoherent — if it ever did overrun, the archive
-  // calls would not run and successful work would redeliver — so it is reported
-  // on the same footing as the visibility timeout. This is a coherence check,
-  // NOT evidence that isolates are being truncated: see the header for the
-  // measurement that retracted that claim.
-  //
-  // Checked here as well as in the chart as DEFENCE IN DEPTH against the chart
-  // being bypassed: a hand-edited Deployment, `kubectl set env`, a local
-  // `supabase functions serve`, or any future non-Helm deploy path. It is NOT
-  // justified by edgeFunctions.envFromSecrets — see the note on the env vars
-  // above; that path cannot reach these variables at all.
+  // Read the isolate lifetime (the second ceiling). Never written, only read:
+  // this module cannot change how long EdgeRuntime keeps the isolate. Absent or
+  // unparseable means "unknown", and an unknown ceiling is skipped rather than
+  // guessed at — see ISOLATE_LIFETIME_ENV.
   const lifetimeRaw = env.get(ISOLATE_LIFETIME_ENV);
-  if (lifetimeRaw !== undefined && /^\d+$/.test(lifetimeRaw.trim())) {
-    const lifetimeSeconds = Math.floor(Number(lifetimeRaw.trim()) / 1000);
-    if (lifetimeSeconds < required) {
+  const lifetimeSeconds =
+    lifetimeRaw !== undefined && /^\d+$/.test(lifetimeRaw.trim())
+      ? Math.floor(Number(lifetimeRaw.trim()) / 1000)
+      : undefined;
+
+  // THE EXACT LEGACY PAIR IS REPORTED, NOT ENFORCED. (4, 300) is what was
+  // hardcoded in processBatch() before any of this was configurable, so it is
+  // what every deployment is already running; "re-coherencing" it here would
+  // change production behaviour on deploy, which is the one thing this change
+  // promises not to do. It genuinely violates both ceilings under the n x 120
+  // model, so it is reported loudly and left alone. Everything else is a
+  // deliberate act by whoever set the env var, and gets ENFORCED below.
+  const requiredForConfigured = requiredVisibilityTimeoutSeconds(n.value);
+  const isLegacyPair = n.value === DEFAULT_DRAIN_CONCURRENCY && vt.value === DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+  if (isLegacyPair) {
+    if (vt.value < requiredForConfigured) {
+      issues.push({
+        env: VISIBILITY_TIMEOUT_ENV,
+        effective: vt.value,
+        kind: "invariant",
+        message:
+          `visibility timeout ${vt.value}s is below the ${requiredForConfigured}s a batch of ${n.value} can ` +
+          `take (${n.value} x ${PER_MESSAGE_VT_BUDGET_SECONDS}s/message, calibrated from the 2026-09-07 ` +
+          `burst: ~7min for a batch of 4). Messages can be re-read while still in flight — that is the ` +
+          `read_ct>1 on 20 of 58 messages from that incident. This is the LEGACY PAIR (4/300), left as-is ` +
+          `on purpose; raise ${VISIBILITY_TIMEOUT_ENV} to >= ${requiredForConfigured} to fix it.`
+      });
+    }
+    if (lifetimeSeconds !== undefined && lifetimeSeconds < requiredForConfigured) {
       issues.push({
         env: ISOLATE_LIFETIME_ENV,
         raw: lifetimeRaw,
         effective: lifetimeSeconds,
         kind: "invariant",
         message:
-          `isolate lifetime ${lifetimeSeconds}s (${ISOLATE_LIFETIME_ENV}) is below the ${required}s a ` +
-          `batch of ${n.value} can take. The whole batch runs in ONE isolate, so it will be killed ` +
-          `before the archive calls run and every in-flight message will be re-provisioned on ` +
-          `redelivery. Raise edgeFunctions.worker.timeoutMs to >= ${required * 1000} (and keep ` +
-          `gracefulExitTimeoutSeconds / terminationGracePeriodSeconds above it). Note ` +
-          `beforeUnload.wallClockRatio asks the isolate to retire at half this.`
+          `isolate lifetime ${lifetimeSeconds}s (${ISOLATE_LIFETIME_ENV}) is below the ` +
+          `${requiredForConfigured}s a batch of ${n.value} can take. The whole batch runs in ONE isolate, ` +
+          `so an overrun would be killed before the archive calls and every in-flight message would be ` +
+          `re-provisioned on redelivery. Legacy pair (4/300), left as-is; raise ` +
+          `edgeFunctions.worker.timeoutMs to >= ${requiredForConfigured * 1000} (keeping ` +
+          `gracefulExitTimeoutSeconds / terminationGracePeriodSeconds above it) to fix it.`
       });
     }
+    return { drainConcurrency: n.value, visibilityTimeoutSeconds: vt.value, issues };
   }
 
-  return { drainConcurrency: n.value, visibilityTimeoutSeconds: vt.value, issues };
+  // ENFORCEMENT, and the direction of it is the whole point.
+  //
+  // This function used to only REPORT a broken pair and then hand the broken
+  // numbers to processBatch anyway, which made it useless exactly where it was
+  // the only check standing: on the Helm-bypass paths (hand-edited Deployment,
+  // `kubectl set env`) that the chart's render-time refusals cannot see. Setting
+  // GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY=8 and nothing else produced 8/300 — a
+  // batch modelled at 960s going visible at 300s, i.e. duplicated in-flight
+  // GitHub work and legitimate provisioning messages walking toward the
+  // poison-pill DLQ. A check that observes a fault it could have prevented is
+  // not defence in depth.
+  //
+  // We DEGRADE CONCURRENCY rather than inflate the timeout:
+  //
+  //   n = max(1, min(n_configured, floor(VT / 120), floor(lifetime / 120)))
+  //
+  //  * it satisfies BOTH ceilings simultaneously, by construction. Raising the
+  //    VT to fit `n` instead would satisfy the batch invariant while possibly
+  //    breaking the isolate-lifetime ceiling — trading one incoherence for
+  //    another, and the isolate ceiling is the one that loses the archive calls.
+  //  * it fails toward LESS THROUGHPUT, which is a slower queue. The other
+  //    direction fails toward duplicated GitHub work and re-provisioned repos.
+  //    A slow queue is visible and recoverable; re-provisioning is neither.
+  //  * it never returns 0. `n: 0` would drain nothing while the lease is held
+  //    and every heartbeat stays green — indistinguishable from a hung queue,
+  //    and the worst outcome available here. When the ceilings cannot be
+  //    satisfied at all (a VT below one message's 120s budget) we land on 1 and
+  //    say so, because draining slowly and incoherently still beats not
+  //    draining.
+  //
+  // We do NOT refuse to process the batch. Halting on a misconfiguration is
+  // worse than draining slowly on this path specifically: there is no render
+  // error for anyone to read, so a refusal would be a silent stop.
+  const caps: { limit: number; because: string }[] = [
+    { limit: Math.floor(vt.value / PER_MESSAGE_VT_BUDGET_SECONDS), because: `${VISIBILITY_TIMEOUT_ENV}=${vt.value}s` }
+  ];
+  if (lifetimeSeconds !== undefined) {
+    caps.push({
+      limit: Math.floor(lifetimeSeconds / PER_MESSAGE_VT_BUDGET_SECONDS),
+      because: `${ISOLATE_LIFETIME_ENV}=${lifetimeSeconds}s`
+    });
+  }
+  const binding = caps.reduce((lowest, c) => (c.limit < lowest.limit ? c : lowest));
+  const coherentN = Math.max(MIN_DRAIN_CONCURRENCY, Math.min(n.value, binding.limit));
+
+  if (coherentN !== n.value) {
+    issues.push({
+      env: DRAIN_CONCURRENCY_ENV,
+      effective: coherentN,
+      kind: "clamped",
+      message:
+        `drain concurrency reduced from ${n.value} to ${coherentN}: ${binding.because} only covers ` +
+        `${binding.limit} concurrent message(s) at ${PER_MESSAGE_VT_BUDGET_SECONDS}s each. Concurrency is ` +
+        `degraded rather than the timeout inflated, so both the visibility timeout and the isolate ` +
+        `lifetime stay above the modelled batch — the queue drains slower instead of re-serving work ` +
+        `that is still in flight. To actually get ${n.value}-way concurrency, raise ` +
+        `${VISIBILITY_TIMEOUT_ENV} and edgeFunctions.worker.timeoutMs to >= ${requiredForConfigured}s ` +
+        `(and the graceful-exit / termination-grace values with them).`
+    });
+  }
+
+  // Only reachable when the VT itself is below one message's budget, so no
+  // positive `n` is coherent. Floored at 1 deliberately — see above.
+  if (binding.limit < MIN_DRAIN_CONCURRENCY) {
+    issues.push({
+      env: VISIBILITY_TIMEOUT_ENV,
+      effective: vt.value,
+      kind: "invariant",
+      message:
+        `no coherent concurrency exists at ${binding.because}: even one message is budgeted at ` +
+        `${PER_MESSAGE_VT_BUDGET_SECONDS}s. Draining at n=1 anyway, because n=0 would drain nothing ` +
+        `while every liveness signal stayed green. Raise it to >= ${PER_MESSAGE_VT_BUDGET_SECONDS}.`
+    });
+  }
+
+  return { drainConcurrency: coherentN, visibilityTimeoutSeconds: vt.value, issues };
 }

--- a/supabase/functions/_shared/asyncWorkerTuning.ts
+++ b/supabase/functions/_shared/asyncWorkerTuning.ts
@@ -34,10 +34,53 @@
  *     was margin, but a burst several times longer would not have any, and the
  *     work that would get dead-lettered is LEGITIMATE provisioning.
  *
- * THE INVARIANT, which is the part that must survive future edits:
+ * THE INVARIANT, which is the part that must survive future edits. There are
+ * TWO ceilings over the same quantity, and a batch has to fit under BOTH:
  *
- *   The visibility timeout must exceed the worst-case time to process a WHOLE
- *   BATCH OF `n`, not the worst case for a single message.
+ *   visibility timeout    >= worst-case time to process a whole batch of `n`
+ *   isolate lifetime      >= worst-case time to process a whole batch of `n`
+ *
+ * i.e. neither is about a single message. The second ceiling is
+ * `EDGE_WORKER_TIMEOUT_MS` (chart: `edgeFunctions.worker.timeoutMs`, 400s),
+ * which the demuxer hands to EdgeRuntime as `workerTimeoutMs`. The whole batch
+ * runs inside ONE leaseholder isolate, so if the batch outlives that lifetime
+ * the isolate dies before `Promise.allSettled` reaches the archive calls: the
+ * repos got created and the messages never got archived, so pgmq redelivers and
+ * the work is redone. Note also that `beforeUnload.wallClockRatio: 50` asks the
+ * isolate to retire at HALF the lifetime (~200s at 400s) — workerRun.ts's
+ * bounded-mode budget comment cites that same ~200s — so 400s is the hard cap,
+ * not the budget.
+ *
+ * WHAT THE SECOND CEILING IS AND IS NOT. It is a CONFIG-COHERENCE rule: a
+ * visibility timeout the isolate cannot outlive is incoherent advice, whatever
+ * the runtime happens to be doing. `n * 120` and a 400s lifetime give an honest
+ * maximum coherent `n` of THREE (3 x 120 = 360 <= 400; 4 x 120 = 480 > 400), so
+ * even the shipped default of 4 sits just outside the conservative model — which
+ * is exactly why the chart grandfathers the EXACT legacy pair (4, 300) and
+ * checks everything else. Raising the visibility timeout without raising
+ * `edgeFunctions.worker.timeoutMs` produces a combination that cannot hold, and
+ * the chart refuses it.
+ *
+ * IT IS NOT A CLAIM THAT ISOLATES ARE BEING KILLED MID-BATCH TODAY. An earlier
+ * version of this comment said that, and it was MEASURED AND RETRACTED
+ * (2026-09-07). The runtime logs `wall clock duraiton reached: isolate: <id>`
+ * (the typo is the runtime's), and hourly counts across the functions pods were
+ * FLAT at ~200/hour before, during and after the 58-repo burst (197 at 03:00,
+ * 242 at 04:00, 225 at 05:00, 192 idle at 12:00). That is baseline churn:
+ * leased mode deliberately keeps a resident isolate polling, so it reaches the
+ * 400s wall clock and recycles roughly every 3.5 minutes per pod. Nothing in
+ * that signal ties a termination to an unarchived message, so mid-batch
+ * truncation is UNPROVEN and the ~20% bump during the burst is not its
+ * signature. The 300s visibility timeout remains the established cause of the
+ * 20-of-58 re-reads.
+ *
+ * Note also that the linear `n * 120` model is a deliberately CONSERVATIVE
+ * upper bound. The measured ~420s cadence is a completion cadence, not a proven
+ * handler duration — it includes idle-poll and re-poke latency — and a
+ * perfectly parallel batch of 4 create_repos at p50 279.5s would be ~280-300s,
+ * which fits inside 400s. The conservative model is kept because the fleet-wide
+ * content limiter makes the batch partially serial (below) and because erring
+ * toward a longer timeout costs nothing but recovery latency.
  *
  * A batch is not "n independent messages in parallel" in wall-clock terms. The
  * GitHub calls inside the handlers funnel through the shared `Bottleneck`
@@ -67,6 +110,14 @@
 export const DRAIN_CONCURRENCY_ENV = "GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY";
 /** Env var read for the pgmq visibility timeout (chart: edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds). */
 export const VISIBILITY_TIMEOUT_ENV = "GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS";
+/**
+ * The isolate lifetime, read only to CHECK the second ceiling — this module
+ * never sets it. Rendered by the same chart template that renders the two knobs
+ * above (chart: edgeFunctions.worker.timeoutMs), so it is present in the same
+ * container env; when it is absent (local `supabase functions serve`, tests) the
+ * check is skipped rather than guessed at.
+ */
+export const ISOLATE_LIFETIME_ENV = "EDGE_WORKER_TIMEOUT_MS";
 
 /** Today's hardcoded `n`. Keeping this as the default is what makes the change inert until configured. */
 export const DEFAULT_DRAIN_CONCURRENCY = 4;
@@ -318,6 +369,33 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
         `~7min for a batch of 4). Messages will be re-read while still in flight — that is the ` +
         `read_ct>1 on 20 of 58 messages from that incident. Raise ${VISIBILITY_TIMEOUT_ENV} to >= ${required}.`
     });
+  }
+
+  // Second ceiling: the isolate lifetime. A configuration whose modelled batch
+  // outlives the isolate is incoherent — if it ever did overrun, the archive
+  // calls would not run and successful work would redeliver — so it is reported
+  // on the same footing as the visibility timeout. This is a coherence check,
+  // NOT evidence that isolates are being truncated: see the header for the
+  // measurement that retracted that claim. Checked here as well as in the chart
+  // because the chart cannot see values that arrive via envFromSecrets.
+  const lifetimeRaw = env.get(ISOLATE_LIFETIME_ENV);
+  if (lifetimeRaw !== undefined && /^\d+$/.test(lifetimeRaw.trim())) {
+    const lifetimeSeconds = Math.floor(Number(lifetimeRaw.trim()) / 1000);
+    if (lifetimeSeconds < required) {
+      issues.push({
+        env: ISOLATE_LIFETIME_ENV,
+        raw: lifetimeRaw,
+        effective: lifetimeSeconds,
+        kind: "invariant",
+        message:
+          `isolate lifetime ${lifetimeSeconds}s (${ISOLATE_LIFETIME_ENV}) is below the ${required}s a ` +
+          `batch of ${n.value} can take. The whole batch runs in ONE isolate, so it will be killed ` +
+          `before the archive calls run and every in-flight message will be re-provisioned on ` +
+          `redelivery. Raise edgeFunctions.worker.timeoutMs to >= ${required * 1000} (and keep ` +
+          `gracefulExitTimeoutSeconds / terminationGracePeriodSeconds above it). Note ` +
+          `beforeUnload.wallClockRatio asks the isolate to retire at half this.`
+      });
+    }
   }
 
   return { drainConcurrency: n.value, visibilityTimeoutSeconds: vt.value, issues };

--- a/supabase/functions/_shared/asyncWorkerTuning.ts
+++ b/supabase/functions/_shared/asyncWorkerTuning.ts
@@ -1,0 +1,324 @@
+/**
+ * Drain tuning for the pgmq-backed async workers (github-async-worker today).
+ *
+ * WHY THIS FILE EXISTS — the 2026-09-07 CS 4530 provisioning incident.
+ *
+ * CS 4530 released an assignment and enqueued 58 `create_repo` messages onto
+ * `async_calls` in one shot at 04:01:00 UTC. The last one drained at 05:37:28
+ * UTC: 88 MINUTES for 58 messages. Average time-in-queue was 3,230s (54 min),
+ * worst 5,788s (96 min). The observed pattern was 2-4 messages completing
+ * roughly every 7 minutes, which tripped `PawtograderQueueOldestMessageAging`
+ * (1200s for 10m, critical) for over an hour. That alert was a TRUE POSITIVE.
+ * The end state was correct — 58/58 repos provisioned, no duplicates, empty
+ * DLQ — so this was purely a throughput and redelivery problem.
+ *
+ * Two numbers in processBatch() were hardcoded and are the whole story:
+ *
+ *  1. `n: 4` on the pgmq `read` call is the CONCURRENCY CEILING, not a batch
+ *     size hint. `beginWorkerRun` (see workerRun.ts) grants ONE leaseholder per
+ *     deployment, and that leaseholder processes the batch with
+ *     `Promise.allSettled`, i.e. n messages at a time. 4 in parallel per ~7 min
+ *     iteration is ~0.6 msg/min, which is exactly what was measured. Nothing
+ *     about the lease, the number of pokes per minute, or the pod count changes
+ *     that: `n` is the knob.
+ *
+ *  2. `sleep_seconds: 300` is the pgmq VISIBILITY TIMEOUT, and at a ~7 min
+ *     (420s) iteration it is SHORTER THAN THE WORK. Messages became visible
+ *     again while still being actively processed: 20 of the 58 messages had
+ *     `read_ct` > 1 (max 3). The comment that used to sit above that call
+ *     asserted 300s was "well above observed p99 handler durations" — that
+ *     assertion is falsified for `create_repo` under burst, and re-reading a
+ *     message that is still in flight is wasted GitHub quota at exactly the
+ *     moment the queue is deepest. It also walks `read_ct` toward
+ *     PGMQ_MAX_READ_CT (10), which DLQs a message as poison — at 3 reads there
+ *     was margin, but a burst several times longer would not have any, and the
+ *     work that would get dead-lettered is LEGITIMATE provisioning.
+ *
+ * THE INVARIANT, which is the part that must survive future edits:
+ *
+ *   The visibility timeout must exceed the worst-case time to process a WHOLE
+ *   BATCH OF `n`, not the worst case for a single message.
+ *
+ * A batch is not "n independent messages in parallel" in wall-clock terms. The
+ * GitHub calls inside the handlers funnel through the shared `Bottleneck`
+ * limiters in _shared/ (one App installation quota per org), so raising `n`
+ * lengthens the batch roughly linearly rather than leaving it flat. The
+ * measurement is the calibration: 420s of wall clock for a batch of 4 is
+ * ~105s of serialized work per message, and PER_MESSAGE_VT_BUDGET_SECONDS
+ * rounds that to 120s for headroom. Hence
+ * `requiredVisibilityTimeoutSeconds(n) = n * 120`.
+ *
+ * Raising `n` without raising the VT therefore RE-CREATES the incident, worse:
+ * a longer batch against the same 300s VT means more messages redelivered
+ * mid-flight, not fewer. That is why this module reports the violation instead
+ * of leaving the two values as unrelated constants, and why the chart REFUSES
+ * to render a raised concurrency with an unraised timeout
+ * (templates/validations.yaml).
+ *
+ * DEFAULTS ARE TODAY'S HARDCODED VALUES ON PURPOSE (n=4, VT=300). Deploying
+ * this change alters nothing until someone sets the env vars, so the throughput
+ * decision stays an explicit, reviewable operator action rather than a side
+ * effect of a chart upgrade. The default pair (4, 300) DOES violate the
+ * invariant above — that is the measured status quo, deliberately preserved,
+ * and it is reported as a warning rather than clamped.
+ */
+
+/** Env var read for the pgmq `read` fan-out (chart: edgeFunctions.githubAsyncWorker.drainConcurrency). */
+export const DRAIN_CONCURRENCY_ENV = "GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY";
+/** Env var read for the pgmq visibility timeout (chart: edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds). */
+export const VISIBILITY_TIMEOUT_ENV = "GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS";
+
+/** Today's hardcoded `n`. Keeping this as the default is what makes the change inert until configured. */
+export const DEFAULT_DRAIN_CONCURRENCY = 4;
+/**
+ * 1, not 0. `n: 0` reads nothing at all, so the queue drains at zero messages
+ * per minute while every liveness signal (lease held, heartbeats, no errors)
+ * stays green — indistinguishable from a hung queue, and the deepest failure
+ * mode this whole file exists to avoid.
+ */
+export const MIN_DRAIN_CONCURRENCY = 1;
+/**
+ * 8, matching `edgeFunctions.maxParallelism`. The ceiling is not an arbitrary
+ * round number; three constraints bound it, and the FIRST one is the binding
+ * one:
+ *
+ *  * THE SHARED CONTENT LIMITER, which is the real ceiling. `create_repo`
+ *    wraps the ENTIRE `github.createRepo(...)` call in a single
+ *    `getCreateContentLimiter(org).schedule(...)` (github-async-worker/index.ts
+ *    ~line 992), and that limiter is REDIS-BACKED, i.e. FLEET-WIDE per org, keyed
+ *    `create_content:<org>:<GITHUB_APP_ID>` with
+ *    `{ reservoir: 40, maxConcurrent: 40, refresh 40/60s }`
+ *    (_shared/GitHubWrapper.ts ~line 254). A `create_repo` measured p50 279.5s
+ *    on prod 2026-09-07 across all 58 messages, so EACH IN-FLIGHT REPO CREATION
+ *    HOLDS ONE OF THE 40 CONCURRENCY SLOTS AND ONE RESERVOIR TOKEN FOR ~4.7
+ *    MINUTES.
+ *
+ *    That pool is shared, not dedicated: `reinviteToOrgTeam`'s
+ *    `POST /orgs/{org}/invitations` draws from it (GitHubWrapper.ts ~line 2508),
+ *    and `sync_repo_to_handout` holds a slot for the whole sync
+ *    (GitHubSyncHelpers.ts ~line 1550). So as `n` rises toward 40, minutes-long
+ *    repo creations occupy the pool and ORG INVITATIONS QUEUE BEHIND THEM — a
+ *    convoy that shows up as students unable to join the org, i.e. a different
+ *    and worse symptom than a slow queue. `n` is per leaseholder but the limiter
+ *    is per org and fleet-wide, so several classes releasing into the SAME org
+ *    at once compound it. And the reservoir means only 40 creations can START
+ *    per minute per org no matter what `n` is, so a large `n` buys nothing.
+ *
+ *    8 is 20% of the pool: even with every slot held for the full ~280s there
+ *    are 32 left for invitations and syncs, and it stays far from the regime
+ *    where outer jobs can monopolise the pool.
+ *
+ *    WARNING FOR FUTURE EDITORS — a latent deadlock, not a live one. Nothing
+ *    inside `createRepo` re-enters this limiter today (verified:
+ *    GitHubWrapper.ts ~1564-1720 schedules nothing), so there is no nesting on
+ *    the SAME limiter and no deadlock. But "wrap a long multi-step operation in
+ *    the content limiter" is one refactor away from the classic Bottleneck
+ *    deadlock: move any permission/invitation call INSIDE that wrapper while
+ *    >= maxConcurrent outer jobs are running, and every slot is held by an outer
+ *    job waiting on an inner job that can never start. Do not move
+ *    limiter-scheduled calls inside the `createRepo` wrapper. If you ever do,
+ *    this ceiling has to come DOWN, not up.
+ *
+ *    Note also what the limiter does NOT explain: at n=4 there are only 4
+ *    concurrent jobs against 40 slots and 40 tokens/minute, so nothing queued
+ *    during the incident. The ~280s per repo is real work in an uninstrumented
+ *    stretch of `createRepo`, and it is not this file's problem.
+ *
+ *  * MEMORY. All `n` handlers run inside ONE isolate — the leaseholder's — and
+ *    that isolate is capped at `edgeFunctions.worker.memoryLimitMb` (256MiB)
+ *    with graceful early-drop at half that (`lowMemoryMultiplier: 2`, ~128MiB).
+ *    So `n` multiplies concurrent envelopes, Octokit responses and file
+ *    contents inside a 256MiB box, and an isolate killed at the memory cap
+ *    mid-handler is precisely the "read_ct climbs without bound" failure
+ *    PGMQ_MAX_READ_CT was added for. This tier has a real OOM history
+ *    (2026-08-11 and 2026-08-19 both OOM-killed PID 1; see the eszip-cache and
+ *    maxParallelism notes in values.yaml and examples/values-prod.yaml) and
+ *    its container budget is already ~2650Mi against a 4Gi limit, so there is
+ *    no slack to grow the isolate to compensate.
+ *
+ *  * GITHUB QUOTA. Raising `n` multiplies concurrent GitHub API calls against
+ *    ONE shared App installation quota per org. Beyond the content limiter
+ *    above, the only backstops are the other `Bottleneck` limiters in _shared/
+ *    and the `github_circuit_breakers` table, so past their concurrency the
+ *    extra parallelism converts into queueing (or secondary-rate-limit errors),
+ *    not throughput. 8 is a doubling of the measured configuration, which is the
+ *    largest step worth taking without re-measuring isolate memory,
+ *    content-pool occupancy and secondary-limit behaviour under a real burst.
+ *
+ * Note what 8 does NOT do: at ~1.2 msg/min it is ~8 hours for a 585-message
+ * burst. Getting materially past that needs more than one concurrent
+ * leaseholder, which is a separate design change and deliberately out of scope
+ * here.
+ */
+export const MAX_DRAIN_CONCURRENCY = 8;
+
+/** Today's hardcoded `sleep_seconds`. Preserved as the default; see the header. */
+export const DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 300;
+/**
+ * 60s floor. Anything shorter guarantees the incident's redelivery storm even
+ * for a single fast message — `create_repo` alone measured ~105s of serialized
+ * GitHub work — and a VT below the work is strictly worse than no change at
+ * all, because every redelivery spends quota re-doing work in flight.
+ */
+export const MIN_VISIBILITY_TIMEOUT_SECONDS = 60;
+/**
+ * 1800s (30 min) ceiling. The VT is also the RECOVERY LATENCY for a message
+ * whose isolate really did die (memory cap, `worker.timeoutMs` 400s wall clock,
+ * pod eviction): nothing can retry it until the VT expires. 1800s is 1.5x the
+ * `PawtograderQueueOldestMessageAging` window (1200s), so a genuinely stuck
+ * message is guaranteed to page a human rather than sit invisible for hours,
+ * and it still leaves room for the whole legal `n` range
+ * (8 x 120s = 960s < 1800s).
+ */
+export const MAX_VISIBILITY_TIMEOUT_SECONDS = 1800;
+
+/**
+ * Per-message share of a batch's wall clock, used to express the VT-vs-n
+ * invariant. Calibrated from the incident: 420s for a batch of 4 is ~105s per
+ * message, rounded up to 120s for headroom. It is per-message and not "the
+ * duration of one handler" because the batch runs concurrently but its GitHub
+ * calls serialize through the shared Bottleneck limiters, so batch wall clock
+ * scales with `n`.
+ */
+export const PER_MESSAGE_VT_BUDGET_SECONDS = 120;
+
+/** The invariant, as a function: VT must exceed the worst case for a whole batch of `n`. */
+export function requiredVisibilityTimeoutSeconds(drainConcurrency: number): number {
+  return drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS;
+}
+
+/** Minimal shape of `Deno.env` this module needs, so it is testable off-Deno. */
+export type EnvReader = { get(name: string): string | undefined };
+
+export type TuningIssue = {
+  /** Env var the issue is about. */
+  env: string;
+  /** Raw configured value, as read (undefined when the issue is not about a rejected value). */
+  raw?: string;
+  /** Value actually in force after clamping / falling back. */
+  effective: number;
+  /** Human-readable explanation, safe to log and to attach to a Sentry tag. */
+  message: string;
+  kind: "rejected" | "clamped" | "invariant";
+};
+
+export type AsyncWorkerTuning = {
+  /** pgmq `read` fan-out; also the worker's concurrency ceiling. */
+  drainConcurrency: number;
+  /** pgmq `read` `sleep_seconds` (visibility timeout). */
+  visibilityTimeoutSeconds: number;
+  /** Non-fatal problems worth surfacing exactly once per isolate. */
+  issues: TuningIssue[];
+};
+
+type Bounds = { env: string; min: number; max: number; fallback: number };
+
+/**
+ * Parse one bounded integer knob.
+ *
+ * Three separate behaviours, each chosen because the alternative is an outage:
+ *  * unset / empty  -> default, silently. This is the normal case.
+ *  * unparseable    -> default, REPORTED. A typo (`"four"`, `"4 "`, `"1e3"`,
+ *                      `""` after a bad chart render) must not become 0 or NaN;
+ *                      `n: 0` drains nothing and `sleep_seconds: NaN` is
+ *                      rejected by pgmq, taking the worker down for a
+ *                      misconfiguration it could have ridden out.
+ *  * out of range   -> CLAMPED to the bound, REPORTED. Clamping rather than
+ *                      falling back keeps the operator's INTENT (they asked for
+ *                      "more"), while the bound keeps the pod alive.
+ */
+function readBounded(env: EnvReader, b: Bounds): { value: number; issue?: TuningIssue } {
+  const raw = env.get(b.env);
+  if (raw === undefined || raw.trim() === "") return { value: b.fallback };
+
+  // Number.parseInt would happily accept "4kB" and "1.9"; require a clean
+  // non-negative integer so a unit suffix or a float is reported, not truncated.
+  const trimmed = raw.trim();
+  const parsed = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return {
+      value: b.fallback,
+      issue: {
+        env: b.env,
+        raw,
+        effective: b.fallback,
+        kind: "rejected",
+        message: `${b.env}=${JSON.stringify(raw)} is not a non-negative integer; falling back to ${b.fallback}`
+      }
+    };
+  }
+  if (parsed < b.min) {
+    return {
+      value: b.min,
+      issue: {
+        env: b.env,
+        raw,
+        effective: b.min,
+        kind: "clamped",
+        message: `${b.env}=${trimmed} is below the minimum ${b.min}; clamped to ${b.min}`
+      }
+    };
+  }
+  if (parsed > b.max) {
+    return {
+      value: b.max,
+      issue: {
+        env: b.env,
+        raw,
+        effective: b.max,
+        kind: "clamped",
+        message: `${b.env}=${trimmed} is above the maximum ${b.max}; clamped to ${b.max}`
+      }
+    };
+  }
+  return { value: parsed };
+}
+
+/**
+ * Resolve both knobs from the environment, clamped, plus any issues to report.
+ *
+ * Pure and env-injected so the clamping rules are unit-testable under Jest
+ * (tests/unit/async-worker-tuning.test.ts) — this module deliberately does not
+ * touch the `Deno` global.
+ */
+export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
+  const issues: TuningIssue[] = [];
+
+  const n = readBounded(env, {
+    env: DRAIN_CONCURRENCY_ENV,
+    min: MIN_DRAIN_CONCURRENCY,
+    max: MAX_DRAIN_CONCURRENCY,
+    fallback: DEFAULT_DRAIN_CONCURRENCY
+  });
+  if (n.issue) issues.push(n.issue);
+
+  const vt = readBounded(env, {
+    env: VISIBILITY_TIMEOUT_ENV,
+    min: MIN_VISIBILITY_TIMEOUT_SECONDS,
+    max: MAX_VISIBILITY_TIMEOUT_SECONDS,
+    fallback: DEFAULT_VISIBILITY_TIMEOUT_SECONDS
+  });
+  if (vt.issue) issues.push(vt.issue);
+
+  // The invariant check. Reported, never enforced by mutating the values: the
+  // default pair (4, 300) violates it, and silently raising the VT on a
+  // default deploy would break the "defaults reproduce today's behaviour
+  // exactly" contract that makes this change safe to ship. The chart refuses
+  // the combination at render time for any RAISED concurrency, which is where
+  // a hard failure belongs.
+  const required = requiredVisibilityTimeoutSeconds(n.value);
+  if (vt.value < required) {
+    issues.push({
+      env: VISIBILITY_TIMEOUT_ENV,
+      effective: vt.value,
+      kind: "invariant",
+      message:
+        `visibility timeout ${vt.value}s is below the ${required}s a batch of ${n.value} can take ` +
+        `(${n.value} x ${PER_MESSAGE_VT_BUDGET_SECONDS}s/message, calibrated from the 2026-09-07 burst: ` +
+        `~7min for a batch of 4). Messages will be re-read while still in flight — that is the ` +
+        `read_ct>1 on 20 of 58 messages from that incident. Raise ${VISIBILITY_TIMEOUT_ENV} to >= ${required}.`
+    });
+  }
+
+  return { drainConcurrency: n.value, visibilityTimeoutSeconds: vt.value, issues };
+}

--- a/supabase/functions/_shared/asyncWorkerTuning.ts
+++ b/supabase/functions/_shared/asyncWorkerTuning.ts
@@ -106,6 +106,19 @@
  * and it is reported as a warning rather than clamped.
  */
 
+/**
+ * THE CHART VALUES ARE THE ONLY SUPPORTED INPUT for both knobs below.
+ * `_edge-functions-workload.tpl` renders them as explicit `env` entries with a
+ * literal `value:`, and in Kubernetes an `env` entry WINS over anything supplied
+ * by `envFrom` — so setting them through `edgeFunctions.envFromSecrets` is
+ * silently ignored and the pod keeps the chart-rendered numbers. An earlier
+ * version of this file claimed that secret path worked and used it to justify
+ * the runtime validation; the claim was wrong and is withdrawn. The validation
+ * stands on its own merits (defence in depth against a hand-edited Deployment,
+ * `kubectl set env`, or a local `supabase functions serve`), and it is also the
+ * only thing standing between a malformed value and pgmq.
+ */
+
 /** Env var read for the pgmq `read` fan-out (chart: edgeFunctions.githubAsyncWorker.drainConcurrency). */
 export const DRAIN_CONCURRENCY_ENV = "GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY";
 /** Env var read for the pgmq visibility timeout (chart: edgeFunctions.githubAsyncWorker.visibilityTimeoutSeconds). */
@@ -376,8 +389,13 @@ export function resolveAsyncWorkerTuning(env: EnvReader): AsyncWorkerTuning {
   // calls would not run and successful work would redeliver — so it is reported
   // on the same footing as the visibility timeout. This is a coherence check,
   // NOT evidence that isolates are being truncated: see the header for the
-  // measurement that retracted that claim. Checked here as well as in the chart
-  // because the chart cannot see values that arrive via envFromSecrets.
+  // measurement that retracted that claim.
+  //
+  // Checked here as well as in the chart as DEFENCE IN DEPTH against the chart
+  // being bypassed: a hand-edited Deployment, `kubectl set env`, a local
+  // `supabase functions serve`, or any future non-Helm deploy path. It is NOT
+  // justified by edgeFunctions.envFromSecrets — see the note on the env vars
+  // above; that path cannot reach these variables at all.
   const lifetimeRaw = env.get(ISOLATE_LIFETIME_ENV);
   if (lifetimeRaw !== undefined && /^\d+$/.test(lifetimeRaw.trim())) {
     const lifetimeSeconds = Math.floor(Number(lifetimeRaw.trim()) / 1000);

--- a/supabase/functions/_shared/stepTimings.ts
+++ b/supabase/functions/_shared/stepTimings.ts
@@ -279,6 +279,27 @@ export class StepTimings {
     }
   }
 
+  /**
+   * The step that threw `error`, if `error` is the most recent throw a timed step produced.
+   *
+   * Same identity match as `noteEscapingError`, exposed for HANDLED failures. A single `catch` in
+   * this codebase can cover more than one timed step — `applyBranchProtectionRuleset` wraps the
+   * rulesets LIST and the ruleset DETAIL request in one try/catch — so a hardcoded step label on
+   * the resulting Sentry tag can contradict the context blob sitting next to it and point
+   * operational filtering at the wrong GitHub endpoint. Asking which step actually raised THIS
+   * error object removes the guess.
+   *
+   * Returns null when the error did not come from a timed step, so callers can fall back to a
+   * coarser label of their own rather than get a wrong one.
+   */
+  stepForError(error: unknown): string | null {
+    try {
+      return this.lastThrow && this.lastThrow.error === error ? this.lastThrow.step : null;
+    } catch {
+      return null;
+    }
+  }
+
   /** Attach low-cardinality context (org, creation_method, whether the repair path ran, ...). */
   setMeta(key: string, value: string | number | boolean): void {
     try {

--- a/supabase/functions/_shared/stepTimings.ts
+++ b/supabase/functions/_shared/stepTimings.ts
@@ -1,0 +1,342 @@
+/**
+ * Per-step wall-clock instrumentation for a multi-step GitHub operation, emitted as ONE structured
+ * log line per operation.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Khoury production, 2026-09-07: 58 `create_repo` messages were processed by github-async-worker.
+ * Per-message duration derived from pgmq (`archived_at - (vt - 300s)`, since `pgmq.read` stamps
+ * `vt = read_time + sleep_seconds` and `archive` preserves it):
+ *
+ *     min 235.0s   p50 279.5s   p90 294.7s   max 304.0s   avg 277.6s
+ *     86% of all 58 landed in a 40-second band between 260s and 300s
+ *
+ * In the SAME batches on the SAME pods, `sync_student_team` had p50 1.0s and `sync_staff_team`
+ * p50 0.5s. So repo creation took ~4.7 minutes each and nothing in the code said where it went.
+ *
+ * What had already been ruled out before this module was written (do not re-litigate these from the
+ * timings alone — they were checked against the incident logs directly):
+ *
+ *   1. Retry backoff. `retryWithBackoff` logs "...retrying in Nms (attempt X/Y)" on every retry.
+ *      There are ZERO such lines in the incident window, so no ladder fired — including the worst
+ *      one (get_head_sha at maxRetries 5 / baseDelayMs 3000 = 93s of sleep).
+ *   2. The create-content rate limiter. Redis-backed, {reservoir 40, maxConcurrent 40, refresh
+ *      40/60_000}; only 4 messages ran concurrently, so nothing queued on it. Its `schedule()` wait
+ *      also happens OUTSIDE createRepo, so it is not visible here by construction.
+ *   3. `waitForRepoReady` timing out: it is hard-capped at 30 attempts x 2000ms = 60s and throws a
+ *      distinct UserVisibleError on timeout, which does not appear in the logs.
+ *   4. The template generate call: logged at 04:01:00.673, response at 04:01:05.569 — ~5 SECONDS.
+ *
+ * That left ~275s per message inside a stretch of code with no instrumentation at all. This module
+ * is that instrumentation. It is DIAGNOSTIC ONLY: it must not change any behavior, control flow,
+ * retry parameter, or timeout.
+ *
+ * DESIGN CONSTRAINTS
+ * ------------------
+ * - ONE log line per operation, not one per step. 58 repos x ~10 steps of individual lines is
+ *   unreadable and expensive to ship. Per-step lines exist but are off unless
+ *   PAWTOGRADER_STEP_TIMINGS_DEBUG=1.
+ * - The instrumentation can never throw and can never change what the instrumented code returns or
+ *   throws. Every public method swallows its own internal failures, and `time()` re-throws the
+ *   ORIGINAL error untouched after recording the elapsed time of the step that failed. A failure is
+ *   exactly when the breakdown is most valuable, so partial timings must still be reported.
+ * - No npm:/https: imports. This module is unit-tested from Jest (tests/unit) as well as running
+ *   under Deno in the edge functions, so it stays dependency-free and takes its clock, logger, and
+ *   env reader by injection (same pattern as _shared/SentryContext.ts and emailTransportConfig.ts).
+ *   Sentry wiring lives in the caller, which already imports Sentry, and is passed in as a sink.
+ */
+
+/** Reads one environment variable. Injectable for tests. */
+export type StepTimingsEnvReader = (key: string) => string | undefined;
+
+const denoEnv: StepTimingsEnvReader = (key) => {
+  try {
+    // `Deno` is absent under Jest and `Deno.env.get` throws without --allow-env. Either way the
+    // debug toggle is a nice-to-have; never let reading it break the operation being measured.
+    return Deno.env.get(key);
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Grep for this to pull every timing line out of the pod logs, e.g.
+ *   kubectl logs ... | grep -F '[step-timings]' | sed 's/^.*\[step-timings\] //' | jq -s '...'
+ * The prefix is deliberately stable and machine-parseable: the rest of the line is exactly one JSON
+ * object, so the whole incident can be aggregated with jq without a log-parsing rule.
+ */
+export const STEP_TIMINGS_LOG_PREFIX = "[step-timings]";
+
+/** Per-step lines. Off by default — see the "ONE log line per operation" constraint above. */
+export const STEP_TIMINGS_DEBUG_LOG_PREFIX = "[step-timings-debug]";
+export const STEP_TIMINGS_DEBUG_ENV_VAR = "PAWTOGRADER_STEP_TIMINGS_DEBUG";
+
+export type StepTimingsMeta = Record<string, string | number | boolean>;
+
+export type StepTimingsSnapshot = {
+  /** Operation name, e.g. "create_repo". Low cardinality — safe as a Sentry tag. */
+  op: string;
+  /** Wall-clock ms from construction to `finish()`. */
+  total_ms: number;
+  /** Step name -> total ms spent in that step (summed if the step ran more than once). */
+  steps: Record<string, number>;
+  /** Step name -> call count, but ONLY for steps that ran more than once (e.g. the repair path). */
+  repeated: Record<string, number>;
+  /** Named counters, e.g. wait_for_repo_ready poll attempts. */
+  counts: Record<string, number>;
+  /** Sum of `steps`. */
+  accounted_ms: number;
+  /**
+   * total_ms - accounted_ms. THE most important field for the 2026-09-07 investigation: if the
+   * unexplained ~275s shows up here rather than in a named step, the time is being spent between
+   * the instrumented calls (or inside a limiter/queue wrapper we have not named yet), not in any
+   * single GitHub request.
+   */
+  unaccounted_ms: number;
+  /** Name of the step with the largest total, or null if no step was recorded. */
+  slowest_step: string | null;
+  slowest_ms: number;
+  /** Name of the step that threw, if any. */
+  failed_step: string | null;
+  /** Caller-supplied low-cardinality context (org, creation_method, ...). */
+  meta: StepTimingsMeta;
+};
+
+/** Receives the finished snapshot. Used by the caller to push timings into Sentry. */
+export type StepTimingsSink = (snapshot: StepTimingsSnapshot) => void;
+
+export type StepTimingsOptions = {
+  /** Clock. Injectable so tests are deterministic. Defaults to Date.now. */
+  now?: () => number;
+  /** Where the single summary line goes. Defaults to console.log. */
+  log?: (line: string) => void;
+  /** Env reader for the debug toggle. */
+  readEnv?: StepTimingsEnvReader;
+  /** Force per-step debug lines on/off, bypassing the env var. Tests use this. */
+  debug?: boolean;
+  /** Initial low-cardinality context. */
+  meta?: StepTimingsMeta;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Coarse duration bucket, for use as a Sentry TAG. Tags are indexed and want low cardinality, so
+ * the raw millisecond total belongs in a context (see StepTimingsSnapshot) and only the bucket
+ * belongs in a tag. Boundaries are chosen around the measured incident: the 240-300s bucket is the
+ * one 86% of the 2026-09-07 create_repo messages fell into.
+ */
+export function bucketDurationMs(ms: number): string {
+  if (!isFiniteNumber(ms) || ms < 0) return "unknown";
+  if (ms < 1_000) return "0-1s";
+  if (ms < 5_000) return "1-5s";
+  if (ms < 15_000) return "5-15s";
+  if (ms < 60_000) return "15-60s";
+  if (ms < 120_000) return "60-120s";
+  if (ms < 240_000) return "120-240s";
+  if (ms < 300_000) return "240-300s";
+  return "300s+";
+}
+
+/**
+ * Accumulates per-step elapsed times for one operation and emits a single structured line.
+ *
+ * Every method is failure-proof: internal bookkeeping runs inside try/catch, so a bug in this class
+ * cannot take down repo creation. `time()` is the one method that touches caller control flow, and
+ * it does so only by re-throwing the caller's own error.
+ */
+export class StepTimings {
+  readonly op: string;
+  private readonly now: () => number;
+  private readonly log: (line: string) => void;
+  private readonly debugEnabled: boolean;
+  private readonly startedAt: number;
+  private readonly stepOrder: string[] = [];
+  private readonly stepMs = new Map<string, number>();
+  private readonly stepCalls = new Map<string, number>();
+  private readonly counters = new Map<string, number>();
+  private readonly meta: StepTimingsMeta;
+  private failedStep: string | null = null;
+  private finished = false;
+
+  constructor(op: string, options: StepTimingsOptions = {}) {
+    this.op = op;
+    this.now = options.now ?? (() => Date.now());
+    this.log = options.log ?? ((line: string) => console.log(line));
+    this.meta = { ...(options.meta ?? {}) };
+    let debug = options.debug;
+    if (debug === undefined) {
+      const raw = (options.readEnv ?? denoEnv)(STEP_TIMINGS_DEBUG_ENV_VAR);
+      debug = raw?.trim() === "1" || raw?.trim().toLowerCase() === "true";
+    }
+    this.debugEnabled = debug === true;
+    this.startedAt = this.readClock();
+  }
+
+  /**
+   * Run `fn`, record how long it took under `step`, and return/throw EXACTLY what `fn` did.
+   *
+   * On throw the elapsed time is still recorded and the step is marked as the failing one, then the
+   * original error is re-thrown unmodified — the instrumentation must never mask, wrap, or delay an
+   * error, and a failed run is precisely when the breakdown of the steps that DID complete matters.
+   */
+  async time<T>(step: string, fn: () => Promise<T> | T): Promise<T> {
+    const started = this.readClock();
+    let result: T;
+    try {
+      result = await fn();
+    } catch (error) {
+      this.add(step, this.readClock() - started);
+      this.markFailed(step);
+      throw error;
+    }
+    this.add(step, this.readClock() - started);
+    return result;
+  }
+
+  /** Manually add elapsed ms to a step. Same accumulation semantics as `time()`. */
+  add(step: string, elapsedMs: number): void {
+    try {
+      const ms = isFiniteNumber(elapsedMs) && elapsedMs > 0 ? Math.round(elapsedMs) : 0;
+      if (!this.stepMs.has(step)) {
+        this.stepOrder.push(step);
+        this.stepMs.set(step, 0);
+        this.stepCalls.set(step, 0);
+      }
+      this.stepMs.set(step, (this.stepMs.get(step) ?? 0) + ms);
+      this.stepCalls.set(step, (this.stepCalls.get(step) ?? 0) + 1);
+      if (this.debugEnabled) {
+        this.log(`${STEP_TIMINGS_DEBUG_LOG_PREFIX} op=${this.op} step=${step} ms=${ms}`);
+      }
+    } catch {
+      /* instrumentation must never throw */
+    }
+  }
+
+  /**
+   * Bump a named counter. Used for `wait_for_repo_ready_attempts`: the poll loop is capped at 30
+   * attempts x 2000ms, so the attempt COUNT alone decides whether that loop contributed ~0s or the
+   * full ~60s, and the elapsed time for the step cannot distinguish "returned on attempt 1 after a
+   * slow request" from "polled 29 times".
+   */
+  count(name: string, delta = 1): void {
+    try {
+      if (!isFiniteNumber(delta)) return;
+      this.counters.set(name, (this.counters.get(name) ?? 0) + delta);
+    } catch {
+      /* instrumentation must never throw */
+    }
+  }
+
+  /** Attach low-cardinality context (org, creation_method, whether the repair path ran, ...). */
+  setMeta(key: string, value: string | number | boolean): void {
+    try {
+      this.meta[key] = value;
+    } catch {
+      /* instrumentation must never throw */
+    }
+  }
+
+  /** Mark `step` as the one that failed. Idempotent: the FIRST failure wins. */
+  markFailed(step: string): void {
+    try {
+      if (this.failedStep === null) this.failedStep = step;
+    } catch {
+      /* instrumentation must never throw */
+    }
+  }
+
+  /** Current view of the timings. Safe to call at any point, including mid-operation. */
+  snapshot(): StepTimingsSnapshot {
+    const steps: Record<string, number> = {};
+    const repeated: Record<string, number> = {};
+    let accounted = 0;
+    let slowestStep: string | null = null;
+    let slowestMs = 0;
+    for (const name of this.stepOrder) {
+      const ms = this.stepMs.get(name) ?? 0;
+      steps[name] = ms;
+      accounted += ms;
+      const calls = this.stepCalls.get(name) ?? 0;
+      if (calls > 1) repeated[name] = calls;
+      if (slowestStep === null || ms > slowestMs) {
+        slowestStep = name;
+        slowestMs = ms;
+      }
+    }
+    const counts: Record<string, number> = {};
+    for (const [name, value] of this.counters) counts[name] = value;
+    const total = Math.max(0, Math.round(this.readClock() - this.startedAt));
+    return {
+      op: this.op,
+      total_ms: total,
+      steps,
+      repeated,
+      counts,
+      accounted_ms: accounted,
+      unaccounted_ms: total - accounted,
+      slowest_step: slowestStep,
+      slowest_ms: slowestMs,
+      failed_step: this.failedStep,
+      meta: { ...this.meta }
+    };
+  }
+
+  /**
+   * Emit the single summary line and hand the snapshot to `sink` (used to attach it to the Sentry
+   * scope). Call from a `finally` so it runs on both the success and the throw path.
+   *
+   * Idempotent: a second call is a no-op, so a nested `finally` cannot double-log. A throwing sink
+   * is swallowed — pushing timings into Sentry is strictly best-effort and must not convert a
+   * successful repo creation into a failure, nor replace a real error with a reporting error.
+   */
+  finish(sink?: StepTimingsSink): StepTimingsSnapshot | undefined {
+    try {
+      if (this.finished) return undefined;
+      this.finished = true;
+      const snapshot = this.snapshot();
+      try {
+        this.log(`${STEP_TIMINGS_LOG_PREFIX} ${JSON.stringify(snapshot)}`);
+      } catch {
+        /* a logger or serializer failure must not break the operation */
+      }
+      if (sink) {
+        try {
+          sink(snapshot);
+        } catch {
+          /* best-effort Sentry attachment */
+        }
+      }
+      return snapshot;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private readClock(): number {
+    try {
+      const value = this.now();
+      return isFiniteNumber(value) ? value : 0;
+    } catch {
+      return 0;
+    }
+  }
+}
+
+/**
+ * Time `fn` under `step` when `timings` is present, otherwise just run it.
+ *
+ * Lets the instrumented helpers take `timings` as an OPTIONAL trailing parameter, so exported
+ * functions (applyBranchProtectionRuleset, called from several other edge functions) keep their
+ * existing signatures and callers that do not care pay nothing.
+ */
+export function timeStep<T>(timings: StepTimings | undefined, step: string, fn: () => Promise<T> | T): Promise<T> | T {
+  return timings ? timings.time(step, fn) : fn();
+}
+
+/** Bump a counter when timings are present. Mirrors `timeStep` for the optional-param pattern. */
+export function countStep(timings: StepTimings | undefined, name: string, delta = 1): void {
+  timings?.count(name, delta);
+}

--- a/supabase/functions/_shared/stepTimings.ts
+++ b/supabase/functions/_shared/stepTimings.ts
@@ -417,3 +417,85 @@ export function timeStep<T>(timings: StepTimings | undefined, step: string, fn: 
 export function countStep(timings: StepTimings | undefined, name: string, delta = 1): void {
   timings?.count(name, delta);
 }
+
+/**
+ * The bits of `Sentry.Scope` this module writes to, described structurally so the module stays free
+ * of `npm:` imports (see the header: that is what keeps it Jest-testable, and also what puts it in
+ * the Next program, so it must type-check under BOTH toolchains). A real `Sentry.Scope` satisfies
+ * this; so does a plain object in a test, which is how the isolation tests below can prove that
+ * nothing leaks between two concurrently-running operations.
+ */
+export interface StepTimingsScope {
+  setTag?: (key: string, value: string | number | boolean) => unknown;
+  setContext?: (key: string, context: Record<string, unknown>) => unknown;
+  // `level` is the literal "info", not `string`: Sentry.Scope#addBreadcrumb takes a `Breadcrumb`
+  // whose level is a `SeverityLevel` union, and a widened `string` here makes Sentry.Scope fail to
+  // satisfy this interface (parameters are checked contravariantly), which `deno check` catches as
+  // TS2345 at the call site.
+  addBreadcrumb?: (breadcrumb: {
+    message: string;
+    category: string;
+    level: "info";
+    data: Record<string, unknown>;
+  }) => unknown;
+}
+
+/**
+ * Attach a snapshot to ONE scope: full breakdown as context, a few indexed tags, and a breadcrumb.
+ *
+ * SCOPE ISOLATION — why everything here goes through the passed-in `scope` and nothing through the
+ * module-level `Sentry.*` helpers. `processBatch` runs `drainConcurrency` (default 4) envelopes
+ * concurrently under `Promise.allSettled` and hands the SAME Sentry.Scope to every
+ * `processEnvelope`. `processEnvelope` then does `_scope.clone()` per envelope
+ * (github-async-worker/index.ts:613, and Scope.clone() copies _tags/_contexts/_breadcrumbs by
+ * value), so the scope OBJECT that reaches createRepo is already per-message and writing to it is
+ * safe. `Sentry.addBreadcrumb()` is NOT: it writes to the ISOLATION scope
+ * (@sentry/core breadcrumbs.js -> getIsolationScope().addBreadcrumb), which all four concurrent
+ * messages share, so an earlier version of this code interleaved four repos' timing breadcrumbs
+ * onto every event in the isolate. Hence `scope.addBreadcrumb(...)`, never `Sentry.addBreadcrumb`.
+ *
+ * TAG NAMESPACING — tag keys are prefixed with the operation name because a single create_repo
+ * message runs TWO instrumented operations against the same envelope scope (createRepo, then
+ * syncRepoPermissions). Unprefixed keys meant the second one silently overwrote the first one's
+ * slowest step, bucket and counters, so an event could report `wait_for_repo_ready_attempts` from
+ * createRepo next to sync_repo_permissions' totals. Two operations x a handful of keys keeps
+ * cardinality trivial, and each operation's tags can now be filtered on independently.
+ *
+ * Tags vs context is deliberate: tags are indexed and want low cardinality, so only the slowest
+ * step's NAME, a coarse duration BUCKET, the escaped/partial booleans, the failing step, and the
+ * small integer counters go in tags. The full millisecond breakdown is a JSON blob and belongs in
+ * `setContext`, where it is displayed but not indexed.
+ *
+ * Never throws: this is diagnostics attached to an operation that is often already failing.
+ */
+export function attachSnapshotToScope(snapshot: StepTimingsSnapshot, scope?: StepTimingsScope): void {
+  if (!scope) return;
+  try {
+    const prefix = `step_timings_${snapshot.op}`;
+    scope.setContext?.(prefix, snapshot as unknown as Record<string, unknown>);
+    scope.setTag?.(`${prefix}_slowest_step`, snapshot.slowest_step ?? "none");
+    scope.setTag?.(`${prefix}_total_bucket`, bucketDurationMs(snapshot.total_ms));
+    // A partial snapshot is a mid-operation view, so its total and step list are incomplete by
+    // construction. Tag it, or the two kinds of event are indistinguishable in Bugsink and someone
+    // will read a partial total as an operation duration.
+    scope.setTag?.(`${prefix}_partial`, String(snapshot.partial));
+    scope.setTag?.(`${prefix}_error_escaped`, String(snapshot.error_escaped));
+    if (snapshot.failed_step) {
+      scope.setTag?.(`${prefix}_failed_step`, snapshot.failed_step);
+    }
+    // Counters are small integers (poll attempts, collaborator writes), so they are tag-safe and
+    // are the fields we most want to filter on: `wait_for_repo_ready_attempts` alone distinguishes
+    // "returned immediately" from "burned the full 30 x 2000ms = 60s poll budget".
+    for (const [name, value] of Object.entries(snapshot.counts)) {
+      scope.setTag?.(`${prefix}_${name}`, String(value));
+    }
+    scope.addBreadcrumb?.({
+      message: `step timings ${snapshot.op}`,
+      category: "timing",
+      level: "info",
+      data: snapshot as unknown as Record<string, unknown>
+    });
+  } catch {
+    /* diagnostics must never break the operation they describe */
+  }
+}

--- a/supabase/functions/_shared/stepTimings.ts
+++ b/supabase/functions/_shared/stepTimings.ts
@@ -49,11 +49,21 @@
 /** Reads one environment variable. Injectable for tests. */
 export type StepTimingsEnvReader = (key: string) => string | undefined;
 
+// Reached through `globalThis` rather than naming `Deno` directly, and that is load-bearing for the
+// WEB build, not a style choice. tsconfig.json excludes `supabase/`, but a file it excludes is still
+// pulled into the program when an INCLUDED file imports it — and `tests/unit/*.test.ts` sits under
+// the root `**/*.ts` include and imports this module. So a bare `Deno.env.get` here fails
+// `next build` with "Cannot find name 'Deno'" even though `deno check` is perfectly happy, which is
+// exactly how it reached CI unnoticed. Note the irony: keeping this module dependency-free (so Jest
+// can exercise it) is what puts it in the Next program at all; the sibling modules that reference
+// `Deno` freely all carry `npm:`/`jsr:` specifiers that make TypeScript skip them.
+type DenoEnvGlobal = { Deno?: { env?: { get?: (key: string) => string | undefined } } };
+
 const denoEnv: StepTimingsEnvReader = (key) => {
   try {
-    // `Deno` is absent under Jest and `Deno.env.get` throws without --allow-env. Either way the
-    // debug toggle is a nice-to-have; never let reading it break the operation being measured.
-    return Deno.env.get(key);
+    // Absent under Jest, and `Deno.env.get` throws without --allow-env. Either way the debug toggle
+    // is a nice-to-have; never let reading it break the operation being measured.
+    return (globalThis as DenoEnvGlobal).Deno?.env?.get?.(key);
   } catch {
     return undefined;
   }
@@ -96,8 +106,33 @@ export type StepTimingsSnapshot = {
   /** Name of the step with the largest total, or null if no step was recorded. */
   slowest_step: string | null;
   slowest_ms: number;
-  /** Name of the step that threw, if any. */
+  /**
+   * True when an error escaped the whole operation (see `noteEscapingError`).
+   *
+   * NOT "some step threw". Most steps in this path throw as a matter of routine: `waitForRepoReady`
+   * polls a freshly generated repo and normally collects several 404/409s before the ref appears,
+   * the duplicate-repository path is entered BY catching a 422, and `finalizeRepo` treats
+   * patch_repo_settings / enable_actions / the ruleset as non-essential and logs-and-continues. An
+   * earlier version flagged all of those, so a completely healthy create_repo emitted a snapshot
+   * labelled as failed — which is worse than no signal when the whole point is to read 58 of these
+   * lines looking for a latency outlier.
+   */
+  error_escaped: boolean;
+  /**
+   * The timed step the escaping error came from, when it is attributable — i.e. the error object
+   * that escaped is the SAME object a timed step threw. Null when nothing escaped, and also null
+   * when the escaping error was raised outside any timed step (e.g. `waitForRepoReady`'s
+   * "did not become ready" UserVisibleError, which is thrown after its loop rather than by one of
+   * the timed requests inside it; `error_escaped` is still true, and the
+   * `wait_for_repo_ready_attempts` counter tells that story instead).
+   */
   failed_step: string | null;
+  /**
+   * True when this snapshot was taken mid-operation rather than at `finish()`. Handled-failure
+   * Sentry captures attach one of these, since Sentry applies scope data at CAPTURE time and those
+   * captures happen long before the operation ends.
+   */
+  partial: boolean;
   /** Caller-supplied low-cardinality context (org, creation_method, ...). */
   meta: StepTimingsMeta;
 };
@@ -159,6 +194,14 @@ export class StepTimings {
   private readonly counters = new Map<string, number>();
   private readonly meta: StepTimingsMeta;
   private failedStep: string | null = null;
+  private errorEscaped = false;
+  /**
+   * The most recent throw seen by `time()`, kept ONLY so an escaping error can be attributed back
+   * to the step that raised it, by object identity. Holding the error itself is deliberate: matching
+   * on identity is what distinguishes "this 404 was caught and retried" from "this 404 is the error
+   * that killed the job".
+   */
+  private lastThrow: { step: string; error: unknown } | null = null;
   private finished = false;
 
   constructor(op: string, options: StepTimingsOptions = {}) {
@@ -178,9 +221,15 @@ export class StepTimings {
   /**
    * Run `fn`, record how long it took under `step`, and return/throw EXACTLY what `fn` did.
    *
-   * On throw the elapsed time is still recorded and the step is marked as the failing one, then the
-   * original error is re-thrown unmodified — the instrumentation must never mask, wrap, or delay an
-   * error, and a failed run is precisely when the breakdown of the steps that DID complete matters.
+   * On throw the elapsed time is still recorded and the original error is re-thrown unmodified —
+   * the instrumentation must never mask, wrap, or delay an error, and a failed run is precisely
+   * when the breakdown of the steps that DID complete matters.
+   *
+   * A throw here does NOT mark the operation as failed. It only remembers the error so that, IF the
+   * same error later escapes the whole operation, `noteEscapingError` can attribute it to this
+   * step. Callers in this codebase catch and recover from most step failures on purpose (poll
+   * misses, the duplicate-repo path, the non-essential finalize settings), and flagging those would
+   * label every healthy run as broken.
    */
   async time<T>(step: string, fn: () => Promise<T> | T): Promise<T> {
     const started = this.readClock();
@@ -189,7 +238,7 @@ export class StepTimings {
       result = await fn();
     } catch (error) {
       this.add(step, this.readClock() - started);
-      this.markFailed(step);
+      this.rememberThrow(step, error);
       throw error;
     }
     this.add(step, this.readClock() - started);
@@ -239,16 +288,32 @@ export class StepTimings {
     }
   }
 
-  /** Mark `step` as the one that failed. Idempotent: the FIRST failure wins. */
-  markFailed(step: string): void {
+  /**
+   * Record that `error` escaped the whole operation. Call from the operation wrapper's `catch`
+   * (before re-throwing) — that is the only place that knows an error was NOT recovered from.
+   *
+   * Attribution is by object identity against the last throw a timed step produced, so a recovered
+   * poll miss can never be mistaken for the fatal error, and an error re-thrown by the caller (e.g.
+   * `throw createErr` after inspecting it) is still attributed to the step that originally raised
+   * it. Idempotent: the first escaping error wins.
+   */
+  noteEscapingError(error: unknown): void {
     try {
-      if (this.failedStep === null) this.failedStep = step;
+      if (this.errorEscaped) return;
+      this.errorEscaped = true;
+      if (this.lastThrow && this.lastThrow.error === error) {
+        this.failedStep = this.lastThrow.step;
+      }
     } catch {
       /* instrumentation must never throw */
     }
   }
 
-  /** Current view of the timings. Safe to call at any point, including mid-operation. */
+  /**
+   * Current view of the timings. Safe to call at any point, including mid-operation: it only READS
+   * the accumulators, so taking a partial snapshot for a handled-failure Sentry capture cannot
+   * double-count a step, truncate the final line, or interfere with `finish()`.
+   */
   snapshot(): StepTimingsSnapshot {
     const steps: Record<string, number> = {};
     const repeated: Record<string, number> = {};
@@ -279,7 +344,11 @@ export class StepTimings {
       unaccounted_ms: total - accounted,
       slowest_step: slowestStep,
       slowest_ms: slowestMs,
+      error_escaped: this.errorEscaped,
       failed_step: this.failedStep,
+      // `finish()` flips `finished` BEFORE taking its snapshot, so the final line is never marked
+      // partial and every mid-operation snapshot is.
+      partial: !this.finished,
       meta: { ...this.meta }
     };
   }
@@ -312,6 +381,14 @@ export class StepTimings {
       return snapshot;
     } catch {
       return undefined;
+    }
+  }
+
+  private rememberThrow(step: string, error: unknown): void {
+    try {
+      this.lastThrow = { step, error };
+    } catch {
+      /* instrumentation must never throw */
     }
   }
 

--- a/supabase/functions/assignment-create-all-repos/index.ts
+++ b/supabase/functions/assignment-create-all-repos/index.ts
@@ -82,7 +82,7 @@ async function ensureExistingRepoCreated({
   adminSupabase,
   courseId,
   assignmentId,
-  scope,
+  scope: requestScope,
   assignmentForStrategy,
   branchProtection,
   sourceAssignmentRepos
@@ -98,6 +98,19 @@ async function ensureExistingRepoCreated({
   sourceAssignmentRepos: SourceRepoRow[];
 }) {
   const [org, repoName] = repo.repository.split("/");
+  // PER-JOB SCOPE. The caller fans this function out over every existing repo with
+  // `Promise.allSettled` + a rate limiter, up to 30 in flight, and passes the SAME request scope to
+  // all of them. Everything below writes repo-specific data to it: the `repository` and
+  // `repo_creation_error` tags here, and — since the step-timing work — a
+  // `step_timings_create_repo` context and tag set written by github.createRepo /
+  // syncRepoPermissions on completion. On one shared object those writes overwrite each other, so
+  // whichever job finished last decides what an unrelated capture reports, and a Sentry event for
+  // repo N can carry repo M's timings. Cloning per job is the same invariant the async worker
+  // already holds at github-async-worker/index.ts:613 (`_scope.clone()` per envelope), and
+  // Scope.clone() copies tags/contexts/breadcrumbs by value, so the inherited request-level context
+  // (assignment_id, course_id, github_org, ...) is preserved.
+  const scope = requestScope?.clone() ?? requestScope;
+  scope?.setTag("repository", repo.repository);
 
   try {
     // Check if the repository exists in GitHub
@@ -395,6 +408,12 @@ export async function createAllRepos(courseId: number, assignmentId: number, sco
       return;
     }
 
+    // Per-job clone, for the same reason as ensureExistingRepoCreated above: this closure is fanned
+    // out over every repo to create (up to 30 concurrent) with one shared request scope, and both
+    // the capture below and the two github.* calls write repo-specific data to whatever scope they
+    // are given.
+    const jobScope = scope?.clone() ?? scope;
+    jobScope?.setTag("repository", `${assignment.classes!.github_org!}/${repoName}`);
     const { error, data: dbRepo } = await adminSupabase
       .from("repositories")
       .insert({
@@ -409,7 +428,7 @@ export async function createAllRepos(courseId: number, assignmentId: number, sco
       .single();
     if (error) {
       console.error(error);
-      Sentry.captureException(error, scope);
+      Sentry.captureException(error, jobScope);
       throw new UserVisibleError(`Error creating repo, repo not created: ${error}`);
     }
     if (!dbRepo) {
@@ -443,14 +462,14 @@ export async function createAllRepos(courseId: number, assignmentId: number, sco
           creation_method: strategy.creationMethod,
           branch_protection: branchProtection
         },
-        scope
+        jobScope
       );
       await github.syncRepoPermissions(
         assignment.classes!.github_org!,
         repoName,
         assignment.classes!.slug!,
         github_username,
-        scope
+        jobScope
       );
       await adminSupabase
         .from("repositories")
@@ -522,12 +541,17 @@ export async function createAllRepos(courseId: number, assignmentId: number, sco
               return;
             }
 
+            // Per-job clone, same invariant as the two fan-outs above: syncRepoPermissions writes a
+            // `step_timings_sync_repo_permissions` context and tag set to whatever scope it is
+            // handed, and this map runs concurrently over every existing repo.
+            const jobScope = scope?.clone() ?? scope;
+            jobScope?.setTag("repository", repo.repository);
             const { removalsSkipped } = await github.syncRepoPermissions(
               org,
               repoName,
               assignment.classes!.slug!,
               uniqueUsernames,
-              scope
+              jobScope
             );
             // A sync that could not read the staff roster skipped every removal, so it did only half
             // the job. Leaving is_github_ready = false (with creation_error still NULL) is what keeps

--- a/supabase/functions/autograder-create-repos-for-student/index.ts
+++ b/supabase/functions/autograder-create-repos-for-student/index.ts
@@ -445,6 +445,18 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           return;
         }
         const repoName = `${c.classes!.slug}-${assignment.slug}-group-${sanitizeRepoNameComponent(group.name)}`;
+        // PER-JOB SCOPE. This closure runs concurrently over every group repo (Promise.all above)
+        // and the whole function shares ONE request scope across four such fan-outs. Everything
+        // below writes repo-specific data to whatever scope it is handed — the captures in this
+        // closure, and since the step-timing work a `step_timings_*` context and tag set written by
+        // createRepo / syncRepoPermissions on completion — so on a shared object those writes
+        // overwrite each other and a capture here can report a SIBLING repository's timings. The
+        // per-repository failures here ARE captured, so the clone is threaded into those captures
+        // too; cloning without that would move the problem rather than fix it. Same invariant the
+        // async worker holds per envelope (github-async-worker/index.ts:613), and Scope.clone()
+        // copies tags/contexts by value so inherited request context survives.
+        const jobScope = scope?.clone() ?? scope;
+        jobScope?.setTag("repository", `${c.classes!.github_org}/${repoName}`);
 
         console.log(
           `repoName: ${repoName}, template_repo: '${assignment.template_repo}', groupMembership: ${JSON.stringify(groupMembership, null, 2)}, existingRepos: ${JSON.stringify(groupMembership.assignment_groups.repositories, null, 2)}`
@@ -518,10 +530,18 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
                 .eq("id", dbRepo!.id);
               return assignment;
             }
-            const headSha = await createRepo(c.classes!.github_org!, repoName, strategy.sourceRepo, {
-              creation_method: strategy.creationMethod,
-              branch_protection: branchProtectionFromAssignment(assignment)
-            });
+            // jobScope (not the shared request scope) so this repo's step timings and github_*
+            // tags land on an object only this job writes to.
+            const headSha = await createRepo(
+              c.classes!.github_org!,
+              repoName,
+              strategy.sourceRepo,
+              {
+                creation_method: strategy.creationMethod,
+                branch_protection: branchProtectionFromAssignment(assignment)
+              },
+              jobScope
+            );
             // Sync permissions and mark ready HERE. This branch returns below without
             // reaching the existing-repo sync further down, so deferring the flag to
             // that point left every newly created group repo at is_github_ready=false
@@ -537,7 +557,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
                 .filter((m) => m.user_roles)
                 .filter((m) => m.user_roles.users.github_username)
                 .map((m) => m.user_roles.users.github_username!),
-              scope
+              jobScope
             );
             // ONE checked write for both fields. They were two writes, and the first was
             // unchecked: if it failed transiently the row still became ready, so the reconciler —
@@ -555,7 +575,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               // discarded every group push until the reconciler repaired it, with no
               // replay of what was lost.
               console.error(readyError);
-              Sentry.captureException(readyError, scope);
+              Sentry.captureException(readyError, jobScope);
               throw new UserVisibleError(
                 `Group repository ${repoName} was created but could not be marked ready ` +
                   `(${readyError.message}). Please retry: pushes to it would not be recorded until this is fixed.`
@@ -589,7 +609,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               .filter((m) => m.user_roles) // Needed to not barf when a student is removed from the class
               .filter((m) => m.user_roles.users.github_username)
               .map((m) => m.user_roles.users.github_username!),
-            scope
+            jobScope
           );
           // Only NOW is the repo genuinely usable: it exists and its members can
           // reach it. Consumers that gate on is_github_ready (including the
@@ -604,7 +624,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               `Could not resolve the repositories row for ${c.classes!.github_org!}/${repoName} (assignment ${assignment.id}); is_github_ready not set`
             );
             console.error(err);
-            Sentry.captureException(err, scope);
+            Sentry.captureException(err, jobScope);
           } else {
             // Only promote a row whose repo is known to be FULLY created. This branch runs for
             // an EXISTING is_github_ready=false row, and permission sync can succeed against a
@@ -634,7 +654,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
                 .eq("id", repoRowId)
                 .maybeSingle();
               if (pendingRow && pendingRow.synced_repo_sha === null) {
-                scope?.setTag("repo_not_promoted_incomplete_creation", String(repoRowId));
+                jobScope?.setTag("repo_not_promoted_incomplete_creation", String(repoRowId));
                 console.log(
                   `Not marking ${repoName} ready: creation has not completed (synced_repo_sha is null). ` +
                     `Leaving it for the creation worker.`
@@ -646,7 +666,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               const failure =
                 readyError ?? new Error(`No repositories row matched id=${repoRowId} when marking it ready`);
               console.error(failure);
-              Sentry.captureException(failure, scope);
+              Sentry.captureException(failure, jobScope);
               // Propagate, as the newly-created branch does. This branch is reached after
               // permissions have just been repaired on an EXISTING is_github_ready=false
               // row, so logging alone reported success while the row stayed unready — and
@@ -695,6 +715,9 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
       //Is it a group assignment?
       const courseSlug = assignment.classes!.slug;
       const repoName = `${courseSlug}-${assignment.slug}-${githubUsername}`;
+      // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above.
+      const jobScope = scope?.clone() ?? scope;
+      jobScope?.setTag("repository", `${assignment.classes!.github_org}/${repoName}`);
       if (existingRepos.find((repo) => repo.repository === `${assignment.classes!.github_org}/${repoName}`)) {
         console.log(`Repo ${repoName} already exists...`);
         return;
@@ -755,12 +778,18 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
             .eq("id", dbRepo!.id);
           return `e2e-skip-${repoName}`;
         }
-        const new_repo_sha = await createRepo(assignment.classes!.github_org!, repoName, sourceTemplateRepo, {
-          creation_method: strategy.creationMethod,
-          branch_protection: branchProtectionFromAssignment(assignment)
-        });
+        const new_repo_sha = await createRepo(
+          assignment.classes!.github_org!,
+          repoName,
+          sourceTemplateRepo,
+          {
+            creation_method: strategy.creationMethod,
+            branch_protection: branchProtectionFromAssignment(assignment)
+          },
+          jobScope
+        );
         console.log(`courseSlug: ${courseSlug}`);
-        await syncRepoPermissions(assignment.classes!.github_org!, repoName, courseSlug!, [githubUsername], scope);
+        await syncRepoPermissions(assignment.classes!.github_org!, repoName, courseSlug!, [githubUsername], jobScope);
         const { error: readyError } = await adminSupabase
           .from("repositories")
           .update({
@@ -778,7 +807,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
           // repos — so student pushes would be acknowledged and discarded until the
           // periodic reconciler repairs the row, with no replay of what was lost.
           console.error(readyError);
-          Sentry.captureException(readyError, scope);
+          Sentry.captureException(readyError, jobScope);
           throw new UserVisibleError(
             `Repository ${repoName} was created but could not be marked ready (${readyError.message}). ` +
               `Please retry: pushes to it would not be recorded until this is fixed.`
@@ -811,11 +840,14 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
       .filter((repo) => repo.repository && repo.repository.includes("/"))
       .filter((repo) => assignmentId === undefined || repo.assignment_id === assignmentId)
       .map(async (repo) => {
+        // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above.
+        const jobScope = scope?.clone() ?? scope;
+        jobScope?.setTag("repository", repo.repository);
         try {
           const [orgName, repoName] = repo.repository.split("/");
           const classSlug = classes.find((c) => c.class_id === repo.class_id)?.classes?.slug;
           if (classSlug) {
-            await syncRepoPermissions(orgName, repoName, classSlug, [githubUsername], scope);
+            await syncRepoPermissions(orgName, repoName, classSlug, [githubUsername], jobScope);
             console.log(`Synced permissions for individual repo: ${repo.repository}`);
           }
         } catch (e) {
@@ -832,6 +864,9 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
       .filter((repo) => repo.repository && repo.repository.includes("/"))
       .filter((repo) => assignmentId === undefined || repo.assignment_id === assignmentId)
       .map(async (repo) => {
+        // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above.
+        const jobScope = scope?.clone() ?? scope;
+        jobScope?.setTag("repository", repo.repository);
         try {
           const [orgName, repoName] = repo.repository.split("/");
           const classSlug = classes.find((c) => c.class_id === repo.class_id)?.classes?.slug;
@@ -846,7 +881,7 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
               .filter((m) => m.user_roles && m.user_roles.users.github_username)
               .map((m) => m.user_roles.users.github_username!);
 
-            await syncRepoPermissions(orgName, repoName, classSlug, groupMemberUsernames, scope);
+            await syncRepoPermissions(orgName, repoName, classSlug, groupMemberUsernames, jobScope);
             console.log(`Synced permissions for group repo: ${repo.repository}`);
           }
         } catch (e) {

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -23,6 +23,7 @@ import {
   getCreateContentLimiter
 } from "../_shared/GitHubWrapper.ts";
 import { beginWorkerRun } from "../_shared/workerRun.ts";
+import { resolveAsyncWorkerTuning } from "../_shared/asyncWorkerTuning.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { syncRepositoryToHandout, getFirstCommit } from "../_shared/GitHubSyncHelpers.ts";
 import { shouldSkipRealGithubForE2eFixture } from "../_shared/e2eGithubGuard.ts";
@@ -989,6 +990,20 @@ export async function processEnvelope(
         }
         Sentry.addBreadcrumb({ message: `Creating repo ${repoName} for org ${org}`, level: "info" });
         const limiter = getCreateContentLimiter(org);
+        // This one `schedule` wraps the WHOLE repo creation, and the limiter is Redis-backed —
+        // fleet-wide per org, `{ reservoir: 40, maxConcurrent: 40, refresh 40/60s }`. A create_repo
+        // measured p50 279.5s (prod, 2026-09-07, 58 messages), so each in-flight creation holds one
+        // of those 40 slots for ~4.7 minutes, and the SAME pool serves org invitations
+        // (`POST /orgs/{org}/invitations`) and sync_repo_to_handout. That is why the worker's drain
+        // concurrency is capped at 8 rather than at anything near 40 — see
+        // _shared/asyncWorkerTuning.ts.
+        //
+        // DO NOT move any limiter-scheduled call INSIDE this wrapper. Nothing inside createRepo
+        // re-enters this limiter today, which is the only reason the pattern is safe: nest a
+        // permission/invitation call in here and, once >= maxConcurrent outer jobs are running,
+        // every slot is held by an outer job waiting on an inner job that can never start — a
+        // Bottleneck deadlock. If that ever changes, the concurrency ceiling has to come DOWN.
+        //
         // createRepo patches repo settings after generate/fork (squash merge on, template flag, branch ruleset, …).
         const effectiveSource = sourceRepo ?? templateRepo;
         const headSha = await limiter.schedule(() =>
@@ -2539,17 +2554,75 @@ export async function processEnvelope(
   }
 }
 
+/**
+ * Drain tuning, resolved ONCE per isolate.
+ *
+ * Memoized rather than re-read per iteration for two reasons: the values cannot
+ * change without a pod roll (they are container env), and the issue reporting
+ * below must not repeat on every ~7 min iteration for the life of the lease —
+ * that would be a Sentry event every few minutes for a static misconfiguration.
+ */
+let cachedTuning: ReturnType<typeof resolveAsyncWorkerTuning> | null = null;
+
+function getTuning(scope: Sentry.Scope) {
+  if (cachedTuning) return cachedTuning;
+  const tuning = resolveAsyncWorkerTuning(Deno.env);
+  cachedTuning = tuning;
+
+  scope.setTag("drain_concurrency", String(tuning.drainConcurrency));
+  scope.setTag("visibility_timeout_seconds", String(tuning.visibilityTimeoutSeconds));
+
+  for (const issue of tuning.issues) {
+    console.warn(`[pgmq] worker: ${issue.message}`);
+  }
+  // Only a rejected/clamped value is worth an event: it means the configured
+  // number is NOT the one in force, which is invisible from the outside. The
+  // `invariant` issue is true of the shipped defaults (4, 300) by design, so
+  // reporting it to Sentry would page on every deployment; it stays a log line
+  // and a tag.
+  const misconfigured = tuning.issues.filter((i) => i.kind !== "invariant");
+  if (misconfigured.length > 0) {
+    const s = scope.clone();
+    s.setTag("async_worker_tuning_rejected", "true");
+    s.setContext("async_worker_tuning", {
+      drain_concurrency: tuning.drainConcurrency,
+      visibility_timeout_seconds: tuning.visibilityTimeoutSeconds,
+      issues: misconfigured.map((i) => i.message)
+    });
+    Sentry.captureMessage(
+      `github-async-worker: rejected ${misconfigured.length} configured drain tuning value(s); running on bounded values`,
+      { level: "warning" }
+    );
+  }
+  return tuning;
+}
+
 export async function processBatch(adminSupabase: SupabaseClient<Database>, scope: Sentry.Scope) {
-  // VT (sleep_seconds) needs to comfortably exceed worst-case handler runtime.
-  // sync_repo_to_handout in particular can take minutes when many files change,
-  // and a too-short VT causes a re-read storm: the message stays in q_async_calls
-  // with read_ct climbing forever and `sync_data` never updating because the
-  // Edge Function isolate is killed mid-handler. 300s is well above the Edge
-  // Function wall clock and well above observed p99 handler durations.
+  // `n` is the CONCURRENCY CEILING (the batch below runs under
+  // Promise.allSettled inside a single leaseholder isolate), and `sleep_seconds`
+  // is the pgmq visibility timeout. Both were hardcoded at 4 / 300 until the
+  // 2026-09-07 CS 4530 burst measured what that costs: 58 create_repo messages
+  // took 88 MINUTES to drain, 2-4 completing every ~7 min, and 20 of the 58 came
+  // back with read_ct > 1 (max 3) because a ~420s batch outlives a 300s VT and
+  // pgmq re-served messages that were still in flight.
+  //
+  // The comment that used to live here claimed 300s was "well above observed
+  // p99 handler durations". That is FALSE for create_repo under burst and is why
+  // this is now configurable instead of asserted.
+  //
+  // THE INVARIANT: the VT must exceed the worst case for a whole batch of `n`,
+  // NOT for one message — raising `n` without raising the VT makes the
+  // redelivery storm worse, not better. It is encoded as
+  // requiredVisibilityTimeoutSeconds(n) in _shared/asyncWorkerTuning.ts, which
+  // holds the bounds, the calibration and the full incident narrative; the chart
+  // refuses to render a raised `n` with an unraised VT. Read that file before
+  // changing either number, and do NOT put constants back here.
+  const tuning = getTuning(scope);
+
   let result = await adminSupabase.schema("pgmq_public").rpc("read", {
     queue_name: "async_calls",
-    sleep_seconds: 300,
-    n: 4
+    sleep_seconds: tuning.visibilityTimeoutSeconds,
+    n: tuning.drainConcurrency
   });
 
   if (result.error) {
@@ -2561,10 +2634,13 @@ export async function processBatch(adminSupabase: SupabaseClient<Database>, scop
   let queueName: "async_calls" | "async_calls_low_priority" = "async_calls";
 
   if (messages.length === 0) {
+    // Same tuning object as the main queue on purpose: these two call sites drifting
+    // apart is how the low-priority queue would quietly keep the 300s VT (and the
+    // re-read storm) after the main queue was fixed.
     result = await adminSupabase.schema("pgmq_public").rpc("read", {
       queue_name: "async_calls_low_priority",
-      sleep_seconds: 300,
-      n: 4
+      sleep_seconds: tuning.visibilityTimeoutSeconds,
+      n: tuning.drainConcurrency
     });
     if (result.error) {
       Sentry.captureException(result.error, scope);

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2680,24 +2680,54 @@ export async function processBatch(adminSupabase: SupabaseClient<Database>, scop
 
   await Promise.allSettled(
     messages.map(async (msg) => {
+      // ONE SCOPE PER MESSAGE, because `n` of these run CONCURRENTLY and
+      // Sentry.Scope is a mutable bag. `archiveMessage` writes to whatever scope
+      // it is handed — setContext("archive_error", { msg_id, … }) and
+      // setTag("pgmq_archive_failed", "true") — so handing it processBatch's
+      // shared scope let four concurrent archives scribble over each other:
+      // a capture could report a FOREIGN msg_id, and pgmq_archive_failed=true
+      // stuck on the shared object for the rest of the batch, so a later event
+      // for a message that archived cleanly still claimed an archive failure.
+      //
+      // NOT the same thing as processEnvelope's scope handling, and do not
+      // "fix" that by analogy: processEnvelope already clones per envelope (see
+      // `_scope?.clone()` at its top), and Scope.clone() copies context and tags
+      // BY VALUE, so its two archiveMessage call sites are already isolated and
+      // the step-timings snapshot attached inside it is already private. Adding
+      // another clone there would be harmful — see the comment on
+      // attachStepTimingsToScope in _shared/GitHubWrapper.ts. Only THIS call
+      // site was reading through to the shared object.
+      //
+      // Cloning rather than constructing fresh keeps the batch- and run-level
+      // context the shared scope carries (function, worker_run_mode, the drain
+      // tuning tags), which a `new Sentry.Scope()` would silently drop.
+      const msgScope = scope.clone();
+      msgScope.setTag("msg_id", String(msg.msg_id));
+      msgScope.setTag("queue_name", queueName);
+
       const ok = await processEnvelope(
         adminSupabase,
         msg.message,
         { msg_id: msg.msg_id, enqueued_at: msg.enqueued_at, read_ct: msg.read_ct, queue_name: queueName },
-        scope
+        msgScope
       );
       if (ok) {
-        const archived = await archiveMessage(adminSupabase, msg.msg_id, scope, queueName);
+        const archived = await archiveMessage(adminSupabase, msg.msg_id, msgScope, queueName);
         if (!archived) {
           console.error(
             `[pgmq] worker: handler returned OK but archive failed msg_id=${msg.msg_id} queue=${queueName} — message will redeliver after VT`
           );
+          // This message's scope, positionally — not an options object. The
+          // options-object form is applied to the SDK's CURRENT scope, which is
+          // not this manually-built one, so the event would arrive without the
+          // worker's own tags; and the scope it does report must be the one only
+          // this message has written to.
+          const s = msgScope.clone();
+          s.setLevel("error");
+          s.setContext("archive_failed", { msg_id: msg.msg_id, queue_name: queueName });
           Sentry.captureMessage(
             "github-async-worker: processed message but failed to archive after retries; expect redelivery",
-            {
-              level: "error",
-              extra: { msg_id: msg.msg_id, queue_name: queueName }
-            }
+            s
           );
         }
       }

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2583,15 +2583,22 @@ function getTuning(scope: Sentry.Scope) {
   const misconfigured = tuning.issues.filter((i) => i.kind !== "invariant");
   if (misconfigured.length > 0) {
     const s = scope.clone();
+    s.setLevel("warning");
     s.setTag("async_worker_tuning_rejected", "true");
     s.setContext("async_worker_tuning", {
       drain_concurrency: tuning.drainConcurrency,
       visibility_timeout_seconds: tuning.visibilityTimeoutSeconds,
       issues: misconfigured.map((i) => i.message)
     });
+    // The scope goes POSITIONALLY, and the level goes ON the scope. This worker
+    // builds its own Sentry.Scope rather than using the SDK's current scope, so
+    // an options-object second argument (`{ level: "warning" }`) is applied to
+    // the CURRENT scope and silently drops every tag and context set above —
+    // the event would arrive with only the count in its message. Same shape as
+    // the captureException/captureMessage calls elsewhere in this file.
     Sentry.captureMessage(
       `github-async-worker: rejected ${misconfigured.length} configured drain tuning value(s); running on bounded values`,
-      { level: "warning" }
+      s
     );
   }
   return tuning;

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2565,7 +2565,20 @@ export async function processEnvelope(
 let cachedTuning: ReturnType<typeof resolveAsyncWorkerTuning> | null = null;
 
 function getTuning(scope: Sentry.Scope) {
-  if (cachedTuning) return cachedTuning;
+  // TAGGING IS PER SCOPE, MEMOIZATION IS PER ISOLATE, and the two must not be
+  // conflated. runBatchHandler() builds a FRESH Sentry.Scope for every run, and
+  // in bounded mode (no Redis: each cron poke drains and returns) there are many
+  // runs per isolate. An early `return cachedTuning` before these setTag calls
+  // therefore left every run after the first with untagged batch and envelope
+  // events — the tags were on a scope that had already been discarded. So tag
+  // unconditionally, and memoize only the resolution and the one-time report
+  // below, which would otherwise be re-emitted on every poke for a static
+  // misconfiguration.
+  if (cachedTuning) {
+    scope.setTag("drain_concurrency", String(cachedTuning.drainConcurrency));
+    scope.setTag("visibility_timeout_seconds", String(cachedTuning.visibilityTimeoutSeconds));
+    return cachedTuning;
+  }
   const tuning = resolveAsyncWorkerTuning(Deno.env);
   cachedTuning = tuning;
 

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2589,10 +2589,13 @@ function getTuning(scope: Sentry.Scope) {
     console.warn(`[pgmq] worker: ${issue.message}`);
   }
   // Only a rejected/clamped value is worth an event: it means the configured
-  // number is NOT the one in force, which is invisible from the outside. The
-  // `invariant` issue is true of the shipped defaults (4, 300) by design, so
-  // reporting it to Sentry would page on every deployment; it stays a log line
-  // and a tag.
+  // number is NOT the one in force, which is invisible from the outside. That
+  // now includes the COHERENCE clamp — someone who sets concurrency 8 through a
+  // Helm-bypass path and gets 2 because the visibility timeout only covers 2
+  // needs to hear about it, since their throughput change did not happen.
+  // `invariant` issues stay log-only: the one that survives enforcement is the
+  // shipped legacy pair (4, 300), which is deliberate, so reporting it would
+  // page on every deployment.
   const misconfigured = tuning.issues.filter((i) => i.kind !== "invariant");
   if (misconfigured.length > 0) {
     const s = scope.clone();
@@ -2632,11 +2635,14 @@ export async function processBatch(adminSupabase: SupabaseClient<Database>, scop
   //
   // THE INVARIANT: the VT must exceed the worst case for a whole batch of `n`,
   // NOT for one message — raising `n` without raising the VT makes the
-  // redelivery storm worse, not better. It is encoded as
-  // requiredVisibilityTimeoutSeconds(n) in _shared/asyncWorkerTuning.ts, which
-  // holds the bounds, the calibration and the full incident narrative; the chart
-  // refuses to render a raised `n` with an unraised VT. Read that file before
-  // changing either number, and do NOT put constants back here.
+  // redelivery storm worse, not better. The same holds for the isolate lifetime.
+  // Both are encoded in _shared/asyncWorkerTuning.ts, which holds the bounds,
+  // the calibration and the full incident narrative, and which ENFORCES them:
+  // the pair below is coherent by construction, because an incoherent
+  // configuration has `n` degraded until it fits (never below 1) rather than
+  // being handed through with a warning. The chart refuses the same combinations
+  // at render time. Read that file before changing either number, and do NOT put
+  // constants back here.
   const tuning = getTuning(scope);
 
   let result = await adminSupabase.schema("pgmq_public").rpc("read", {

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -27,9 +27,7 @@ import type {
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 
 type InstructorGitHubRequest =
-  | InstructorGitHubDiagnoseRequest
-  | InstructorGitHubSyncRequest
-  | InstructorGitHubUnlinkRequest;
+  InstructorGitHubDiagnoseRequest | InstructorGitHubSyncRequest | InstructorGitHubUnlinkRequest;
 
 type AdminSupabase = ReturnType<typeof createClient<Database>>;
 
@@ -218,8 +216,21 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
           return;
         }
         const repoName = `${c.classes!.slug}-${assignment.slug}-group-${sanitizeRepoNameComponent(group.name)}`;
+        // PER-JOB SCOPE. This closure is one of four fan-outs in this function that share the single
+        // request scope, and it runs concurrently over every group repo. Everything below writes
+        // repo-specific data to whatever scope it is handed: the captures in this closure, the
+        // breadcrumbs, and — since the step-timing work — a `step_timings_*` context and tag set
+        // written by createRepo / syncRepoPermissions on completion. On one shared object those
+        // writes overwrite each other, so a capture here could report a SIBLING repository's timing
+        // breakdown. Unlike assignment-create-all-repos, the per-repository failures here ARE
+        // captured (below), so the clone has to be threaded into those captures too — otherwise the
+        // problem moves rather than goes away. Same invariant the async worker holds per envelope at
+        // github-async-worker/index.ts:613; Scope.clone() copies tags/contexts/breadcrumbs by value,
+        // so inherited request context (user_id, github_username, ...) survives.
+        const jobScope = scope?.clone() ?? scope;
+        jobScope?.setTag("repository", `${c.classes!.github_org}/${repoName}`);
 
-        Sentry.addBreadcrumb({
+        jobScope?.addBreadcrumb({
           category: "github",
           message: `repoName: ${repoName}, template_repo: '${assignment.template_repo}', groupMembership: ${JSON.stringify(groupMembership, null, 2)}, existingRepos: ${JSON.stringify(groupMembership.assignment_groups.repositories, null, 2)}`,
           level: "info"
@@ -227,7 +238,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         // Make sure that the repo exists
         if (groupMembership.assignment_groups.repositories.length === 0) {
           madeChanges = true;
-          Sentry.addBreadcrumb({
+          jobScope?.addBreadcrumb({
             category: "github",
             message: `Creating repo ${repoName}`,
             level: "info"
@@ -245,7 +256,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
             .select("id")
             .single();
           if (error) {
-            Sentry.captureException(error, scope);
+            Sentry.captureException(error, jobScope);
             throw new UserVisibleError(`Error creating repo: ${error}`);
           }
           try {
@@ -264,7 +275,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
                 .eq("id", dbRepo!.id);
               return assignment;
             }
-            const headSha = await createRepo(c.classes!.github_org!, repoName, assignment.template_repo!);
+            const headSha = await createRepo(c.classes!.github_org!, repoName, assignment.template_repo!, {}, jobScope);
             const { error: updateRepoError } = await adminSupabase
               .from("repositories")
               .update({
@@ -276,7 +287,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
               throw updateRepoError;
             }
           } catch (e) {
-            Sentry.captureException(e, scope);
+            Sentry.captureException(e, jobScope);
             // Keep the row (is_github_ready stays false) so the reconciler + self-healing createRepo
             // can auto-repair a transient failure; deleting would orphan a possibly-blank GitHub repo
             // and hide it from the reconciler. Only a terminal (non-retryable) failure records
@@ -293,7 +304,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         }
 
         try {
-          Sentry.addBreadcrumb({
+          jobScope?.addBreadcrumb({
             category: "github",
             message: `Syncing permissions for ${repoName}, groupMemberUsernames: ${group.assignment_groups_members
               .filter((m) => m.user_roles) // Needed to not barf when a student is removed from the class
@@ -310,11 +321,11 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
               .filter((m) => m.user_roles) // Needed to not barf when a student is removed from the class
               .filter((m) => m.user_roles.users.github_username)
               .map((m) => m.user_roles.users.github_username!),
-            scope
+            jobScope
           );
           madeChanges = madeChanges || madeChangesForRepo;
         } catch (e) {
-          Sentry.captureException(e, scope);
+          Sentry.captureException(e, jobScope);
           errorMessages.push(`Error syncing repo permissions for ${repoName}`);
         }
       });
@@ -344,8 +355,13 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
       //Is it a group assignment?
       const courseSlug = assignment.classes!.slug;
       const repoName = `${courseSlug}-${assignment.slug}-${githubUsername}`;
+      // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above: shared request
+      // scope + concurrent fan-out means this closure's own captures would report another
+      // repository's timings.
+      const jobScope = scope?.clone() ?? scope;
+      jobScope?.setTag("repository", `${assignment.classes!.github_org}/${repoName}`);
       if (existingRepos.find((repo) => repo.repository === `${assignment.classes!.github_org}/${repoName}`)) {
-        Sentry.addBreadcrumb({
+        jobScope?.addBreadcrumb({
           category: "github",
           message: `Repo ${repoName} already exists...`,
           level: "info"
@@ -365,12 +381,12 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         .select("id")
         .single();
       if (error) {
-        Sentry.captureException(error, scope);
+        Sentry.captureException(error, jobScope);
         throw new UserVisibleError(`Error inserting repo: ${error}`);
       }
 
       try {
-        Sentry.addBreadcrumb({
+        jobScope?.addBreadcrumb({
           category: "github",
           message: `Creating repo and syncing permissions for ${repoName}, githubUsername: ${githubUsername}`,
           level: "info"
@@ -387,8 +403,14 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
             .eq("id", dbRepo!.id);
           return `e2e-skip-${repoName}`;
         }
-        const new_repo_sha = await createRepo(assignment.classes!.github_org!, repoName, assignment.template_repo);
-        await syncRepoPermissions(assignment.classes!.github_org!, repoName, courseSlug!, [githubUsername], scope);
+        const new_repo_sha = await createRepo(
+          assignment.classes!.github_org!,
+          repoName,
+          assignment.template_repo,
+          {},
+          jobScope
+        );
+        await syncRepoPermissions(assignment.classes!.github_org!, repoName, courseSlug!, [githubUsername], jobScope);
         await adminSupabase
           .from("repositories")
           .update({
@@ -400,7 +422,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
 
         return new_repo_sha;
       } catch (e) {
-        Sentry.captureException(e, scope);
+        Sentry.captureException(e, jobScope);
         errorMessages.push(`Error creating repo: ${repoName}`);
         // Keep the row so the reconciler + self-healing createRepo can auto-repair a transient
         // failure (deleting would orphan a possibly-blank GitHub repo and hide it from the
@@ -417,11 +439,16 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   const individualRepoSyncPromises = existingIndividualRepos
     .filter((repo) => repo.repository && repo.repository.includes("/"))
     .map(async (repo) => {
+      // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above: shared request
+      // scope + concurrent fan-out means this closure's own captures would report another
+      // repository's timings.
+      const jobScope = scope?.clone() ?? scope;
+      jobScope?.setTag("repository", repo.repository);
       try {
         const [orgName, repoName] = repo.repository.split("/");
         const classSlug = classes.find((c) => c.class_id === repo.class_id)?.classes?.slug;
         if (classSlug) {
-          Sentry.addBreadcrumb({
+          jobScope?.addBreadcrumb({
             category: "github",
             message: `Syncing permissions for ${repo.repository}, githubUsername: ${githubUsername}`,
             level: "info"
@@ -431,12 +458,12 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
             repoName,
             classSlug,
             [githubUsername],
-            scope
+            jobScope
           );
           madeChanges = madeChanges || madeChangesForRepo;
         }
       } catch (e) {
-        Sentry.captureException(e, scope);
+        Sentry.captureException(e, jobScope);
         errorMessages.push(`Error syncing permissions for repo: ${repo.repository}`);
       }
     });
@@ -445,6 +472,11 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   const groupRepoSyncPromises = existingGroupRepos
     .filter((repo) => repo.repository && repo.repository.includes("/"))
     .map(async (repo) => {
+      // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above: shared request
+      // scope + concurrent fan-out means this closure's own captures would report another
+      // repository's timings.
+      const jobScope = scope?.clone() ?? scope;
+      jobScope?.setTag("repository", repo.repository);
       try {
         const [orgName, repoName] = repo.repository.split("/");
         const classSlug = classes.find((c) => c.class_id === repo.class_id)?.classes?.slug;
@@ -459,7 +491,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
             .filter((m) => m.user_roles && m.user_roles.users.github_username)
             .map((m) => m.user_roles.users.github_username!);
 
-          Sentry.addBreadcrumb({
+          jobScope?.addBreadcrumb({
             category: "github",
             message: `Syncing permissions for ${repo.repository}, groupMemberUsernames: ${groupMemberUsernames.join(", ")}`,
             level: "info"
@@ -469,12 +501,12 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
             repoName,
             classSlug,
             groupMemberUsernames,
-            scope
+            jobScope
           );
           madeChanges = madeChanges || madeChangesForRepo;
         }
       } catch (e) {
-        Sentry.captureException(e, scope);
+        Sentry.captureException(e, jobScope);
         errorMessages.push(`Error syncing permissions for repo: ${repo.repository}`);
       }
     });
@@ -638,8 +670,8 @@ async function diagnoseGitHubLinkStatus(
     currentGithubUsername,
     usernameChanged: Boolean(
       currentGithubUsername &&
-        target.users?.github_username &&
-        currentGithubUsername.toLowerCase() !== target.users.github_username.toLowerCase()
+      target.users?.github_username &&
+      currentGithubUsername.toLowerCase() !== target.users.github_username.toLowerCase()
     ),
     classOrg: githubOrg,
     studentTeamSlug,

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -27,7 +27,9 @@ import type {
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 
 type InstructorGitHubRequest =
-  InstructorGitHubDiagnoseRequest | InstructorGitHubSyncRequest | InstructorGitHubUnlinkRequest;
+  | InstructorGitHubDiagnoseRequest
+  | InstructorGitHubSyncRequest
+  | InstructorGitHubUnlinkRequest;
 
 type AdminSupabase = ReturnType<typeof createClient<Database>>;
 
@@ -670,8 +672,8 @@ async function diagnoseGitHubLinkStatus(
     currentGithubUsername,
     usernameChanged: Boolean(
       currentGithubUsername &&
-      target.users?.github_username &&
-      currentGithubUsername.toLowerCase() !== target.users.github_username.toLowerCase()
+        target.users?.github_username &&
+        currentGithubUsername.toLowerCase() !== target.users.github_username.toLowerCase()
     ),
     classOrg: githubOrg,
     studentTeamSlug,

--- a/tests/unit/async-worker-tuning.test.ts
+++ b/tests/unit/async-worker-tuning.test.ts
@@ -1,8 +1,4 @@
 /**
- * @jest-environment node
- */
-
-/**
  * The parsing/clamping rules behind the github-async-worker's pgmq drain tuning.
  *
  * These are the values that produced the 2026-09-07 incident (58 create_repo
@@ -146,8 +142,19 @@ describe("async worker drain tuning: clamping", () => {
     expect(clamped[0].message).toContain("below the minimum");
   });
 
+  // The isolate lifetime is set generously here ON PURPOSE. This test is about the
+  // MAX_DRAIN_CONCURRENCY bound, so that bound has to be the binding term; without a
+  // lifetime the resolver applies main.ts's 400s fallback and coherently returns 3
+  // (floor(400/120)), which is correct behaviour but tests the wrong ceiling. The
+  // lifetime ceiling has its own cases below.
   it("clamps an absurd concurrency down to the memory/quota ceiling instead of honouring it", () => {
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "1000", [VISIBILITY_TIMEOUT_ENV]: "1800" }));
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "1000",
+        [VISIBILITY_TIMEOUT_ENV]: "1800",
+        [ISOLATE_LIFETIME_ENV]: "1800000"
+      })
+    );
     expect(t.drainConcurrency).toBe(MAX_DRAIN_CONCURRENCY);
     expect(t.issues.some((i) => i.kind === "clamped" && i.env === DRAIN_CONCURRENCY_ENV)).toBe(true);
   });

--- a/tests/unit/async-worker-tuning.test.ts
+++ b/tests/unit/async-worker-tuning.test.ts
@@ -163,16 +163,58 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
     expect(requiredVisibilityTimeoutSeconds(4)).toBeGreaterThanOrEqual(420);
   });
 
-  it("flags a raised concurrency left against the old 300s timeout", () => {
+  it("ENFORCES a raised concurrency left against the old 300s timeout", () => {
+    // 8/300 used to be handed to processBatch unchanged with a log line: a batch
+    // modelled at 960s going visible at 300s. floor(300/120) = 2, so 2 is the
+    // most concurrency that timeout can cover.
     const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "300" }));
+    expect(t.drainConcurrency).toBe(2);
+    expect(t.visibilityTimeoutSeconds).toBe(300);
+    const clamped = t.issues.filter((i) => i.kind === "clamped");
+    expect(clamped).toHaveLength(1);
+    expect(clamped[0].env).toBe(DRAIN_CONCURRENCY_ENV);
+    expect(clamped[0].message).toContain("reduced from 8 to 2");
+    expect(clamped[0].message).toContain(VISIBILITY_TIMEOUT_ENV);
+  });
+
+  it("degrades concurrency rather than inflating the timeout", () => {
+    // The timeout the operator set is what is honoured; the throughput knob is
+    // what gives way. Inflating the VT could break the isolate-lifetime ceiling.
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "600" }));
+    expect(t.visibilityTimeoutSeconds).toBe(600);
+    expect(t.drainConcurrency).toBe(5);
+  });
+
+  it("leaves a coherent pair completely alone", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960" }));
+    expect([t.drainConcurrency, t.visibilityTimeoutSeconds]).toEqual([8, 960]);
+    expect(t.issues).toHaveLength(0);
+  });
+
+  it("lands on n=1, NEVER 0, when no concurrency is coherent", () => {
+    // floor(60/120) = 0. n=0 reads nothing at all while the lease is held and
+    // every heartbeat stays green, which is the worst outcome available.
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "60" }));
+    expect(t.drainConcurrency).toBe(1);
+    expect(t.issues.some((i) => i.message.includes("no coherent concurrency exists"))).toBe(true);
+    expect(t.issues.some((i) => i.message.includes("n=0 would drain nothing"))).toBe(true);
+  });
+
+  it("keeps the exact legacy pair 4/300 untouched, reported but not enforced", () => {
+    // Enforcing here would change production behaviour on deploy, which is the
+    // one thing this change promises not to do.
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "4", [VISIBILITY_TIMEOUT_ENV]: "300" }));
+    expect([t.drainConcurrency, t.visibilityTimeoutSeconds]).toEqual([4, 300]);
+    expect(t.issues.filter((i) => i.kind === "clamped")).toHaveLength(0);
     const invariant = t.issues.filter((i) => i.kind === "invariant");
     expect(invariant).toHaveLength(1);
-    expect(invariant[0].message).toContain("960");
+    expect(invariant[0].message).toContain("LEGACY PAIR");
   });
 
   it("stays silent once the timeout covers the batch", () => {
     const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "1200" }));
-    expect(t.issues.filter((i) => i.kind === "invariant")).toHaveLength(0);
+    expect(t.issues).toHaveLength(0);
+    expect(t.drainConcurrency).toBe(8);
   });
 
   it("leaves the whole legal concurrency range satisfiable within the timeout ceiling", () => {
@@ -181,18 +223,45 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
     expect(requiredVisibilityTimeoutSeconds(MAX_DRAIN_CONCURRENCY)).toBeLessThanOrEqual(MAX_VISIBILITY_TIMEOUT_SECONDS);
   });
 
-  it("reports the invariant against the CLAMPED concurrency, not the requested one", () => {
-    // Someone asks for 64 and gets 8; the timeout advice must be the one that
-    // matches what will actually run.
+  it("composes the bounds clamp with the coherence clamp", () => {
+    // 64 is clamped to the ceiling of 8 first, then 8 is degraded to what a 600s
+    // timeout can cover (5). Clamped inputs must not compose into an incoherent
+    // pair, which is how 8/300 used to slip through.
     const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "64", [VISIBILITY_TIMEOUT_ENV]: "600" }));
-    expect(t.drainConcurrency).toBe(8);
-    const invariant = t.issues.find((i) => i.kind === "invariant");
-    expect(invariant?.message).toContain("960");
+    expect(t.drainConcurrency).toBe(5);
+    expect(t.visibilityTimeoutSeconds * 1).toBeGreaterThanOrEqual(t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS);
   });
 });
 
 describe("the second ceiling: isolate lifetime vs concurrency (config coherence)", () => {
-  it("flags the default concurrency against the shipped 400s isolate lifetime", () => {
+  it("caps concurrency on the isolate lifetime, not just the visibility timeout", () => {
+    // VT 960 would allow 8, but a 400s isolate only covers floor(400/120) = 3.
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "960",
+        [ISOLATE_LIFETIME_ENV]: "400000"
+      })
+    );
+    expect(t.drainConcurrency).toBe(3);
+    const clamped = t.issues.filter((i) => i.kind === "clamped");
+    expect(clamped).toHaveLength(1);
+    expect(clamped[0].message).toContain(ISOLATE_LIFETIME_ENV);
+  });
+
+  it("picks the LOWER of the two ceilings as the binding one", () => {
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "240",
+        [ISOLATE_LIFETIME_ENV]: "960000"
+      })
+    );
+    expect(t.drainConcurrency).toBe(2);
+    expect(t.issues.find((i) => i.kind === "clamped")?.message).toContain(VISIBILITY_TIMEOUT_ENV);
+  });
+
+  it("reports the legacy pair against the shipped 400s isolate lifetime without enforcing", () => {
     // A coherence check, not an observation: n x 120 budgets 480s for a batch of
     // 4 while EDGE_WORKER_TIMEOUT_MS=400000 allows 400s, so the pair cannot both
     // be right. Nothing here claims isolates are actually being truncated — that
@@ -209,18 +278,23 @@ describe("the second ceiling: isolate lifetime vs concurrency (config coherence)
     expect(t.issues.filter((i) => i.env === ISOLATE_LIFETIME_ENV)).toHaveLength(0);
   });
 
-  it("scales with concurrency, and reports both ceilings independently", () => {
-    const t = resolveAsyncWorkerTuning(
-      env({
-        [DRAIN_CONCURRENCY_ENV]: "8",
-        [VISIBILITY_TIMEOUT_ENV]: "300",
-        [ISOLATE_LIFETIME_ENV]: "400000"
-      })
-    );
-    expect(t.issues.filter((i) => i.kind === "invariant").map((i) => i.env)).toEqual([
-      VISIBILITY_TIMEOUT_ENV,
-      ISOLATE_LIFETIME_ENV
-    ]);
+  it("satisfies BOTH ceilings simultaneously for every combination it returns", () => {
+    for (const n of ["1", "4", "8", "64"]) {
+      for (const vt of ["60", "300", "480", "960", "1800"]) {
+        for (const life of [undefined, "400000", "960000"]) {
+          const t = resolveAsyncWorkerTuning(
+            env({ [DRAIN_CONCURRENCY_ENV]: n, [VISIBILITY_TIMEOUT_ENV]: vt, [ISOLATE_LIFETIME_ENV]: life })
+          );
+          expect(t.drainConcurrency).toBeGreaterThanOrEqual(1);
+          const isLegacy = t.drainConcurrency === 4 && t.visibilityTimeoutSeconds === 300;
+          const needed = t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS;
+          if (!isLegacy && t.drainConcurrency > 1) {
+            expect(t.visibilityTimeoutSeconds).toBeGreaterThanOrEqual(needed);
+            if (life) expect(Math.floor(Number(life) / 1000)).toBeGreaterThanOrEqual(needed);
+          }
+        }
+      }
+    }
   });
 
   it("skips the check rather than guessing when the lifetime is absent or unparseable", () => {

--- a/tests/unit/async-worker-tuning.test.ts
+++ b/tests/unit/async-worker-tuning.test.ts
@@ -24,7 +24,8 @@ import {
   MAX_DRAIN_CONCURRENCY,
   MIN_VISIBILITY_TIMEOUT_SECONDS,
   MAX_VISIBILITY_TIMEOUT_SECONDS,
-  PER_MESSAGE_VT_BUDGET_SECONDS
+  PER_MESSAGE_VT_BUDGET_SECONDS,
+  ISOLATE_LIFETIME_ENV
 } from "@/supabase/functions/_shared/asyncWorkerTuning";
 
 function env(vars: Record<string, string | undefined>) {
@@ -187,5 +188,52 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
     expect(t.drainConcurrency).toBe(8);
     const invariant = t.issues.find((i) => i.kind === "invariant");
     expect(invariant?.message).toContain("960");
+  });
+});
+
+describe("the second ceiling: isolate lifetime vs concurrency (config coherence)", () => {
+  it("flags the default concurrency against the shipped 400s isolate lifetime", () => {
+    // A coherence check, not an observation: n x 120 budgets 480s for a batch of
+    // 4 while EDGE_WORKER_TIMEOUT_MS=400000 allows 400s, so the pair cannot both
+    // be right. Nothing here claims isolates are actually being truncated — that
+    // claim was measured and retracted (see the module header).
+    const t = resolveAsyncWorkerTuning(env({ [ISOLATE_LIFETIME_ENV]: "400000" }));
+    const lifetime = t.issues.filter((i) => i.kind === "invariant" && i.env === ISOLATE_LIFETIME_ENV);
+    expect(lifetime).toHaveLength(1);
+    expect(lifetime[0].effective).toBe(400);
+    expect(lifetime[0].message).toContain("480000");
+  });
+
+  it("stays silent once the lifetime covers the batch", () => {
+    const t = resolveAsyncWorkerTuning(env({ [ISOLATE_LIFETIME_ENV]: "480000" }));
+    expect(t.issues.filter((i) => i.env === ISOLATE_LIFETIME_ENV)).toHaveLength(0);
+  });
+
+  it("scales with concurrency, and reports both ceilings independently", () => {
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "300",
+        [ISOLATE_LIFETIME_ENV]: "400000"
+      })
+    );
+    expect(t.issues.filter((i) => i.kind === "invariant").map((i) => i.env)).toEqual([
+      VISIBILITY_TIMEOUT_ENV,
+      ISOLATE_LIFETIME_ENV
+    ]);
+  });
+
+  it("skips the check rather than guessing when the lifetime is absent or unparseable", () => {
+    for (const vars of [{}, { [ISOLATE_LIFETIME_ENV]: "" }, { [ISOLATE_LIFETIME_ENV]: "400s" }]) {
+      const t = resolveAsyncWorkerTuning(env(vars));
+      expect(t.issues.filter((i) => i.env === ISOLATE_LIFETIME_ENV)).toHaveLength(0);
+    }
+  });
+
+  it("never treats the lifetime as a knob it can change", () => {
+    const t = resolveAsyncWorkerTuning(env({ [ISOLATE_LIFETIME_ENV]: "1000" }));
+    expect(Object.keys(t)).toEqual(["drainConcurrency", "visibilityTimeoutSeconds", "issues"]);
+    expect(t.drainConcurrency).toBe(4);
+    expect(t.visibilityTimeoutSeconds).toBe(300);
   });
 });

--- a/tests/unit/async-worker-tuning.test.ts
+++ b/tests/unit/async-worker-tuning.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * The parsing/clamping rules behind the github-async-worker's pgmq drain tuning.
+ *
+ * These are the values that produced the 2026-09-07 incident (58 create_repo
+ * messages, 88 minutes, 20 of 58 re-read against a 300s visibility timeout), so
+ * the two properties worth locking down are: (a) the defaults still reproduce
+ * the pre-change hardcoded behaviour exactly, and (b) no configured value can
+ * take the worker down or silently become 0 — `n: 0` drains nothing while every
+ * liveness signal stays green.
+ */
+
+import {
+  resolveAsyncWorkerTuning,
+  requiredVisibilityTimeoutSeconds,
+  DRAIN_CONCURRENCY_ENV,
+  VISIBILITY_TIMEOUT_ENV,
+  DEFAULT_DRAIN_CONCURRENCY,
+  DEFAULT_VISIBILITY_TIMEOUT_SECONDS,
+  MIN_DRAIN_CONCURRENCY,
+  MAX_DRAIN_CONCURRENCY,
+  MIN_VISIBILITY_TIMEOUT_SECONDS,
+  MAX_VISIBILITY_TIMEOUT_SECONDS,
+  PER_MESSAGE_VT_BUDGET_SECONDS
+} from "@/supabase/functions/_shared/asyncWorkerTuning";
+
+function env(vars: Record<string, string | undefined>) {
+  return { get: (name: string) => vars[name] };
+}
+
+describe("async worker drain tuning defaults", () => {
+  it("reproduces the previously hardcoded n=4 / sleep_seconds=300 when nothing is set", () => {
+    const t = resolveAsyncWorkerTuning(env({}));
+    expect(t.drainConcurrency).toBe(4);
+    expect(t.visibilityTimeoutSeconds).toBe(300);
+    expect(DEFAULT_DRAIN_CONCURRENCY).toBe(4);
+    expect(DEFAULT_VISIBILITY_TIMEOUT_SECONDS).toBe(300);
+  });
+
+  it("treats an empty or whitespace value as unset rather than as zero", () => {
+    for (const raw of ["", "   "]) {
+      const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: raw, [VISIBILITY_TIMEOUT_ENV]: raw }));
+      expect(t.drainConcurrency).toBe(DEFAULT_DRAIN_CONCURRENCY);
+      expect(t.visibilityTimeoutSeconds).toBe(DEFAULT_VISIBILITY_TIMEOUT_SECONDS);
+      expect(t.issues.filter((i) => i.kind !== "invariant")).toHaveLength(0);
+    }
+  });
+
+  it("reports the invariant violation that the defaults themselves carry, without changing them", () => {
+    // 300 < 4 x 120. This is the measured status quo, preserved deliberately, so
+    // it must be a report and not a silent correction.
+    const t = resolveAsyncWorkerTuning(env({}));
+    const invariant = t.issues.filter((i) => i.kind === "invariant");
+    expect(invariant).toHaveLength(1);
+    expect(invariant[0].message).toContain("read_ct");
+    expect(t.visibilityTimeoutSeconds).toBe(300);
+  });
+});
+
+describe("async worker drain tuning: valid overrides", () => {
+  it("accepts an in-range pair verbatim and reports nothing", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960" }));
+    expect(t.drainConcurrency).toBe(8);
+    expect(t.visibilityTimeoutSeconds).toBe(960);
+    expect(t.issues).toHaveLength(0);
+  });
+
+  it("tolerates surrounding whitespace from a chart/secret round-trip", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: " 6 ", [VISIBILITY_TIMEOUT_ENV]: "\t720\n" }));
+    expect(t.drainConcurrency).toBe(6);
+    expect(t.visibilityTimeoutSeconds).toBe(720);
+    expect(t.issues).toHaveLength(0);
+  });
+
+  it("accepts both bounds exactly", () => {
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: String(MIN_DRAIN_CONCURRENCY),
+        [VISIBILITY_TIMEOUT_ENV]: String(MAX_VISIBILITY_TIMEOUT_SECONDS)
+      })
+    );
+    expect(t.drainConcurrency).toBe(MIN_DRAIN_CONCURRENCY);
+    expect(t.visibilityTimeoutSeconds).toBe(MAX_VISIBILITY_TIMEOUT_SECONDS);
+  });
+});
+
+describe("async worker drain tuning: malformed values fall back", () => {
+  it.each([["four"], ["4.5"], ["1e3"], ["8kB"], ["-1"], ["NaN"], ["0x4"], ["+4"]])(
+    "falls back to the default for %s and says so",
+    (raw) => {
+      const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: raw }));
+      expect(t.drainConcurrency).toBe(DEFAULT_DRAIN_CONCURRENCY);
+      const rejected = t.issues.filter((i) => i.kind === "rejected");
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].env).toBe(DRAIN_CONCURRENCY_ENV);
+      expect(rejected[0].raw).toBe(raw);
+      expect(rejected[0].effective).toBe(DEFAULT_DRAIN_CONCURRENCY);
+    }
+  );
+
+  it("never yields NaN for the visibility timeout, which pgmq would reject outright", () => {
+    const t = resolveAsyncWorkerTuning(env({ [VISIBILITY_TIMEOUT_ENV]: "five minutes" }));
+    expect(Number.isInteger(t.visibilityTimeoutSeconds)).toBe(true);
+    expect(t.visibilityTimeoutSeconds).toBe(DEFAULT_VISIBILITY_TIMEOUT_SECONDS);
+  });
+
+  it("reports each bad value independently", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "lots", [VISIBILITY_TIMEOUT_ENV]: "ages" }));
+    expect(
+      t.issues
+        .filter((i) => i.kind === "rejected")
+        .map((i) => i.env)
+        .sort()
+    ).toEqual([DRAIN_CONCURRENCY_ENV, VISIBILITY_TIMEOUT_ENV].sort());
+  });
+});
+
+describe("async worker drain tuning: clamping", () => {
+  it("never lets drain concurrency become 0 — that drains nothing and looks like a hung queue", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "0" }));
+    expect(t.drainConcurrency).toBe(MIN_DRAIN_CONCURRENCY);
+    expect(t.drainConcurrency).toBeGreaterThan(0);
+    const clamped = t.issues.filter((i) => i.kind === "clamped");
+    expect(clamped).toHaveLength(1);
+    expect(clamped[0].message).toContain("below the minimum");
+  });
+
+  it("clamps an absurd concurrency down to the memory/quota ceiling instead of honouring it", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "1000", [VISIBILITY_TIMEOUT_ENV]: "1800" }));
+    expect(t.drainConcurrency).toBe(MAX_DRAIN_CONCURRENCY);
+    expect(t.issues.some((i) => i.kind === "clamped" && i.env === DRAIN_CONCURRENCY_ENV)).toBe(true);
+  });
+
+  it("clamps the visibility timeout to both bounds", () => {
+    const low = resolveAsyncWorkerTuning(env({ [VISIBILITY_TIMEOUT_ENV]: "1" }));
+    expect(low.visibilityTimeoutSeconds).toBe(MIN_VISIBILITY_TIMEOUT_SECONDS);
+    const high = resolveAsyncWorkerTuning(env({ [VISIBILITY_TIMEOUT_ENV]: "86400" }));
+    expect(high.visibilityTimeoutSeconds).toBe(MAX_VISIBILITY_TIMEOUT_SECONDS);
+    expect(high.issues.some((i) => i.kind === "clamped" && i.env === VISIBILITY_TIMEOUT_ENV)).toBe(true);
+  });
+
+  it("keeps every resolved value inside its documented range for arbitrary garbage", () => {
+    for (const raw of ["0", "-5", "999999", "", "abc", "0.0001", "8_000"]) {
+      const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: raw, [VISIBILITY_TIMEOUT_ENV]: raw }));
+      expect(t.drainConcurrency).toBeGreaterThanOrEqual(MIN_DRAIN_CONCURRENCY);
+      expect(t.drainConcurrency).toBeLessThanOrEqual(MAX_DRAIN_CONCURRENCY);
+      expect(t.visibilityTimeoutSeconds).toBeGreaterThanOrEqual(MIN_VISIBILITY_TIMEOUT_SECONDS);
+      expect(t.visibilityTimeoutSeconds).toBeLessThanOrEqual(MAX_VISIBILITY_TIMEOUT_SECONDS);
+    }
+  });
+});
+
+describe("the visibility-timeout-vs-concurrency invariant", () => {
+  it("scales with the whole batch, not with one message", () => {
+    expect(requiredVisibilityTimeoutSeconds(4)).toBe(4 * PER_MESSAGE_VT_BUDGET_SECONDS);
+    expect(requiredVisibilityTimeoutSeconds(8)).toBe(960);
+    // The measured batch of 4 took ~420s, so the per-message budget must not be
+    // set below what was actually observed.
+    expect(requiredVisibilityTimeoutSeconds(4)).toBeGreaterThanOrEqual(420);
+  });
+
+  it("flags a raised concurrency left against the old 300s timeout", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "300" }));
+    const invariant = t.issues.filter((i) => i.kind === "invariant");
+    expect(invariant).toHaveLength(1);
+    expect(invariant[0].message).toContain("960");
+  });
+
+  it("stays silent once the timeout covers the batch", () => {
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "1200" }));
+    expect(t.issues.filter((i) => i.kind === "invariant")).toHaveLength(0);
+  });
+
+  it("leaves the whole legal concurrency range satisfiable within the timeout ceiling", () => {
+    // Otherwise the bounds would contradict each other: a legal `n` whose
+    // required timeout is above MAX would be impossible to configure correctly.
+    expect(requiredVisibilityTimeoutSeconds(MAX_DRAIN_CONCURRENCY)).toBeLessThanOrEqual(MAX_VISIBILITY_TIMEOUT_SECONDS);
+  });
+
+  it("reports the invariant against the CLAMPED concurrency, not the requested one", () => {
+    // Someone asks for 64 and gets 8; the timeout advice must be the one that
+    // matches what will actually run.
+    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "64", [VISIBILITY_TIMEOUT_ENV]: "600" }));
+    expect(t.drainConcurrency).toBe(8);
+    const invariant = t.issues.find((i) => i.kind === "invariant");
+    expect(invariant?.message).toContain("960");
+  });
+});

--- a/tests/unit/async-worker-tuning.test.ts
+++ b/tests/unit/async-worker-tuning.test.ts
@@ -25,7 +25,8 @@ import {
   MIN_VISIBILITY_TIMEOUT_SECONDS,
   MAX_VISIBILITY_TIMEOUT_SECONDS,
   PER_MESSAGE_VT_BUDGET_SECONDS,
-  ISOLATE_LIFETIME_ENV
+  ISOLATE_LIFETIME_ENV,
+  DEFAULT_ISOLATE_LIFETIME_SECONDS
 } from "@/supabase/functions/_shared/asyncWorkerTuning";
 
 function env(vars: Record<string, string | undefined>) {
@@ -55,22 +56,38 @@ describe("async worker drain tuning defaults", () => {
     // it must be a report and not a silent correction.
     const t = resolveAsyncWorkerTuning(env({}));
     const invariant = t.issues.filter((i) => i.kind === "invariant");
-    expect(invariant).toHaveLength(1);
+    expect(invariant).toHaveLength(2);
     expect(invariant[0].message).toContain("read_ct");
+    expect(invariant[1].env).toBe(ISOLATE_LIFETIME_ENV);
     expect(t.visibilityTimeoutSeconds).toBe(300);
+    expect(t.drainConcurrency).toBe(4);
   });
 });
 
 describe("async worker drain tuning: valid overrides", () => {
   it("accepts an in-range pair verbatim and reports nothing", () => {
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960" }));
+    // The isolate lifetime has to be raised too, or the assumed 400s caps this
+    // at 3 — see the isolate-lifetime describe block below.
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "960",
+        [ISOLATE_LIFETIME_ENV]: "960000"
+      })
+    );
     expect(t.drainConcurrency).toBe(8);
     expect(t.visibilityTimeoutSeconds).toBe(960);
     expect(t.issues).toHaveLength(0);
   });
 
   it("tolerates surrounding whitespace from a chart/secret round-trip", () => {
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: " 6 ", [VISIBILITY_TIMEOUT_ENV]: "\t720\n" }));
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: " 6 ",
+        [VISIBILITY_TIMEOUT_ENV]: "\t720\n",
+        [ISOLATE_LIFETIME_ENV]: " 720000 "
+      })
+    );
     expect(t.drainConcurrency).toBe(6);
     expect(t.visibilityTimeoutSeconds).toBe(720);
     expect(t.issues).toHaveLength(0);
@@ -135,9 +152,19 @@ describe("async worker drain tuning: clamping", () => {
     expect(t.issues.some((i) => i.kind === "clamped" && i.env === DRAIN_CONCURRENCY_ENV)).toBe(true);
   });
 
-  it("clamps the visibility timeout to both bounds", () => {
+  it("clamps the visibility timeout to its bounds, then to coherence", () => {
+    // 1 is raised to the 60s bound, and 60 cannot cover even one message, so the
+    // coherence floor raises the EFFECTIVE value to 120. Both steps are reported.
     const low = resolveAsyncWorkerTuning(env({ [VISIBILITY_TIMEOUT_ENV]: "1" }));
-    expect(low.visibilityTimeoutSeconds).toBe(MIN_VISIBILITY_TIMEOUT_SECONDS);
+    expect(low.visibilityTimeoutSeconds).toBe(PER_MESSAGE_VT_BUDGET_SECONDS);
+    expect(low.drainConcurrency).toBe(1);
+    expect(
+      low.issues.some(
+        (i) => i.kind === "clamped" && i.message.includes(`below the minimum ${MIN_VISIBILITY_TIMEOUT_SECONDS}`)
+      )
+    ).toBe(true);
+    expect(low.issues.some((i) => i.kind === "clamped" && i.message.includes("raised from 60s to 120s"))).toBe(true);
+
     const high = resolveAsyncWorkerTuning(env({ [VISIBILITY_TIMEOUT_ENV]: "86400" }));
     expect(high.visibilityTimeoutSeconds).toBe(MAX_VISIBILITY_TIMEOUT_SECONDS);
     expect(high.issues.some((i) => i.kind === "clamped" && i.env === VISIBILITY_TIMEOUT_ENV)).toBe(true);
@@ -180,24 +207,44 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
   it("degrades concurrency rather than inflating the timeout", () => {
     // The timeout the operator set is what is honoured; the throughput knob is
     // what gives way. Inflating the VT could break the isolate-lifetime ceiling.
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "600" }));
+    // Lifetime raised out of the way here so the VT is the binding ceiling.
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "600",
+        [ISOLATE_LIFETIME_ENV]: "960000"
+      })
+    );
     expect(t.visibilityTimeoutSeconds).toBe(600);
     expect(t.drainConcurrency).toBe(5);
   });
 
   it("leaves a coherent pair completely alone", () => {
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960" }));
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "960",
+        [ISOLATE_LIFETIME_ENV]: "960000"
+      })
+    );
     expect([t.drainConcurrency, t.visibilityTimeoutSeconds]).toEqual([8, 960]);
     expect(t.issues).toHaveLength(0);
   });
 
-  it("lands on n=1, NEVER 0, when no concurrency is coherent", () => {
+  it("lands on n=1, NEVER 0, and raises the timeout so the floored pair is coherent", () => {
     // floor(60/120) = 0. n=0 reads nothing at all while the lease is held and
-    // every heartbeat stays green, which is the worst outcome available.
+    // every heartbeat stays green, which is the worst outcome available — but
+    // flooring alone used to leave n=1 against a 60s timeout, i.e. a knowingly
+    // incoherent pair re-reading a multi-minute create_repo. The worker owns
+    // sleep_seconds on every pgmq read, so it raises the timeout to the
+    // one-message budget instead.
     const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "60" }));
     expect(t.drainConcurrency).toBe(1);
-    expect(t.issues.some((i) => i.message.includes("no coherent concurrency exists"))).toBe(true);
-    expect(t.issues.some((i) => i.message.includes("n=0 would drain nothing"))).toBe(true);
+    expect(t.visibilityTimeoutSeconds).toBe(PER_MESSAGE_VT_BUDGET_SECONDS);
+    const vtClamp = t.issues.filter((i) => i.kind === "clamped" && i.env === VISIBILITY_TIMEOUT_ENV);
+    expect(vtClamp).toHaveLength(1);
+    expect(vtClamp[0].message).toContain("raised from 60s to 120s");
+    expect(vtClamp[0].message).toContain("floored at 1");
   });
 
   it("keeps the exact legacy pair 4/300 untouched, reported but not enforced", () => {
@@ -207,12 +254,21 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
     expect([t.drainConcurrency, t.visibilityTimeoutSeconds]).toEqual([4, 300]);
     expect(t.issues.filter((i) => i.kind === "clamped")).toHaveLength(0);
     const invariant = t.issues.filter((i) => i.kind === "invariant");
-    expect(invariant).toHaveLength(1);
+    // Both ceilings are reported: 300 < 4x120, and the assumed 400s lifetime is
+    // also below 480. Reported, never enforced — that is the whole exemption.
+    expect(invariant).toHaveLength(2);
     expect(invariant[0].message).toContain("LEGACY PAIR");
+    expect(invariant[1].env).toBe(ISOLATE_LIFETIME_ENV);
   });
 
   it("stays silent once the timeout covers the batch", () => {
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "1200" }));
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "8",
+        [VISIBILITY_TIMEOUT_ENV]: "1200",
+        [ISOLATE_LIFETIME_ENV]: "1200000"
+      })
+    );
     expect(t.issues).toHaveLength(0);
     expect(t.drainConcurrency).toBe(8);
   });
@@ -227,9 +283,20 @@ describe("the visibility-timeout-vs-concurrency invariant", () => {
     // 64 is clamped to the ceiling of 8 first, then 8 is degraded to what a 600s
     // timeout can cover (5). Clamped inputs must not compose into an incoherent
     // pair, which is how 8/300 used to slip through.
-    const t = resolveAsyncWorkerTuning(env({ [DRAIN_CONCURRENCY_ENV]: "64", [VISIBILITY_TIMEOUT_ENV]: "600" }));
+    const t = resolveAsyncWorkerTuning(
+      env({
+        [DRAIN_CONCURRENCY_ENV]: "64",
+        [VISIBILITY_TIMEOUT_ENV]: "600",
+        [ISOLATE_LIFETIME_ENV]: "960000"
+      })
+    );
     expect(t.drainConcurrency).toBe(5);
-    expect(t.visibilityTimeoutSeconds * 1).toBeGreaterThanOrEqual(t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS);
+    expect(t.visibilityTimeoutSeconds).toBeGreaterThanOrEqual(t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS);
+    // ...and with only the assumed 400s lifetime, the lifetime binds instead.
+    const noLifetime = resolveAsyncWorkerTuning(
+      env({ [DRAIN_CONCURRENCY_ENV]: "64", [VISIBILITY_TIMEOUT_ENV]: "600" })
+    );
+    expect(noLifetime.drainConcurrency).toBe(3);
   });
 });
 
@@ -278,30 +345,89 @@ describe("the second ceiling: isolate lifetime vs concurrency (config coherence)
     expect(t.issues.filter((i) => i.env === ISOLATE_LIFETIME_ENV)).toHaveLength(0);
   });
 
-  it("satisfies BOTH ceilings simultaneously for every combination it returns", () => {
-    for (const n of ["1", "4", "8", "64"]) {
-      for (const vt of ["60", "300", "480", "960", "1800"]) {
-        for (const life of [undefined, "400000", "960000"]) {
+  it("satisfies the visibility-timeout ceiling for EVERY combination it returns", () => {
+    // The `> 1` escape hatch this assertion used to carry was load-bearing only
+    // because the VT inputs never forced the floor. They do now (60, 61, 119),
+    // and the floored result raises the timeout, so the ceiling holds at n=1 too
+    // and the exemption is gone. The isolate-lifetime ceiling is asserted
+    // separately below, because it is the one this module cannot always fix.
+    for (const n of ["1", "3", "4", "8", "64", "0", "abc"]) {
+      for (const vt of ["60", "61", "119", "120", "240", "300", "480", "960", "1800", "abc"]) {
+        for (const life of [undefined, "60000", "400000", "480000", "960000", "abc"]) {
           const t = resolveAsyncWorkerTuning(
             env({ [DRAIN_CONCURRENCY_ENV]: n, [VISIBILITY_TIMEOUT_ENV]: vt, [ISOLATE_LIFETIME_ENV]: life })
           );
+          const tag = `${n}/${vt}/${life}`;
           expect(t.drainConcurrency).toBeGreaterThanOrEqual(1);
+          expect(t.drainConcurrency).toBeLessThanOrEqual(MAX_DRAIN_CONCURRENCY);
           const isLegacy = t.drainConcurrency === 4 && t.visibilityTimeoutSeconds === 300;
-          const needed = t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS;
-          if (!isLegacy && t.drainConcurrency > 1) {
-            expect(t.visibilityTimeoutSeconds).toBeGreaterThanOrEqual(needed);
-            if (life) expect(Math.floor(Number(life) / 1000)).toBeGreaterThanOrEqual(needed);
+          if (!isLegacy) {
+            // `tag` is in the failure message so a sweep failure names the input.
+            expect([tag, t.visibilityTimeoutSeconds >= t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS]).toEqual([
+              tag,
+              true
+            ]);
           }
         }
       }
     }
   });
 
-  it("skips the check rather than guessing when the lifetime is absent or unparseable", () => {
-    for (const vars of [{}, { [ISOLATE_LIFETIME_ENV]: "" }, { [ISOLATE_LIFETIME_ENV]: "400s" }]) {
-      const t = resolveAsyncWorkerTuning(env(vars));
-      expect(t.issues.filter((i) => i.env === ISOLATE_LIFETIME_ENV)).toHaveLength(0);
+  it("satisfies the isolate-lifetime ceiling whenever the lifetime allows one message at all", () => {
+    for (const n of ["1", "4", "8", "64"]) {
+      for (const vt of ["60", "300", "960", "1800"]) {
+        for (const life of [undefined, "400000", "480000", "960000"]) {
+          const t = resolveAsyncWorkerTuning(
+            env({ [DRAIN_CONCURRENCY_ENV]: n, [VISIBILITY_TIMEOUT_ENV]: vt, [ISOLATE_LIFETIME_ENV]: life })
+          );
+          const lifeSec = life ? Math.floor(Number(life) / 1000) : DEFAULT_ISOLATE_LIFETIME_SECONDS;
+          const isLegacy = t.drainConcurrency === 4 && t.visibilityTimeoutSeconds === 300;
+          if (!isLegacy && lifeSec >= PER_MESSAGE_VT_BUDGET_SECONDS) {
+            expect(lifeSec).toBeGreaterThanOrEqual(t.drainConcurrency * PER_MESSAGE_VT_BUDGET_SECONDS);
+          }
+        }
+      }
     }
+  });
+
+  it("assumes main.ts's 400s fallback rather than skipping the ceiling", () => {
+    // main.ts:61 is `Number(env) || 400 * 1000`, so the runtime is not undecided
+    // about an absent value and neither is this. Skipping the ceiling used to
+    // green-light a 960s batch inside an isolate that really lives 400s.
+    expect(DEFAULT_ISOLATE_LIFETIME_SECONDS).toBe(400);
+    for (const vars of [{}, { [ISOLATE_LIFETIME_ENV]: "" }]) {
+      const t = resolveAsyncWorkerTuning(
+        env({ ...vars, [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960" })
+      );
+      expect(t.drainConcurrency).toBe(3);
+      expect(t.issues.find((i) => i.kind === "clamped")?.message).toContain(ISOLATE_LIFETIME_ENV);
+    }
+  });
+
+  it("reports a malformed lifetime separately from the clamp it causes", () => {
+    // "you typed garbage" and "your pair was reduced" are different facts and an
+    // operator needs both.
+    for (const raw of ["400s", "abc", "0", "-5"]) {
+      const t = resolveAsyncWorkerTuning(
+        env({ [DRAIN_CONCURRENCY_ENV]: "8", [VISIBILITY_TIMEOUT_ENV]: "960", [ISOLATE_LIFETIME_ENV]: raw })
+      );
+      const rejected = t.issues.filter((i) => i.kind === "rejected" && i.env === ISOLATE_LIFETIME_ENV);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0].effective).toBe(DEFAULT_ISOLATE_LIFETIME_SECONDS);
+      expect(t.issues.filter((i) => i.kind === "clamped")).toHaveLength(1);
+      expect(t.drainConcurrency).toBe(3);
+    }
+  });
+
+  it("says so, rather than pretending, when the lifetime is below even one message", () => {
+    // sleep_seconds is ours to raise; the isolate lifetime is the demuxer's.
+    const t = resolveAsyncWorkerTuning(
+      env({ [DRAIN_CONCURRENCY_ENV]: "4", [VISIBILITY_TIMEOUT_ENV]: "480", [ISOLATE_LIFETIME_ENV]: "60000" })
+    );
+    expect(t.drainConcurrency).toBe(1);
+    const unfixable = t.issues.filter((i) => i.kind === "invariant" && i.env === ISOLATE_LIFETIME_ENV);
+    expect(unfixable).toHaveLength(1);
+    expect(unfixable[0].message).toContain("cannot raise it");
   });
 
   it("never treats the lifetime as a knob it can change", () => {

--- a/tests/unit/create-repo-step-timings.test.ts
+++ b/tests/unit/create-repo-step-timings.test.ts
@@ -1,6 +1,14 @@
-/**
- * @jest-environment node
- */
+// NOTE: deliberately no jest environment pragma. These are pure-logic tests — injected clock,
+// logger and env reader, and a plain object standing in for a Sentry scope — so they need nothing
+// the default jsdom environment lacks, and there are no jest mocking APIs in the file at all.
+//
+// Naming an environment is what made suites here fragile: package.json allows `jest: ^30.1.2` so an
+// `npm install` drifts the runtime to 30.4.x, while package-lock.json still pins one hoisted
+// `jest-mock@30.0.5`. `jest-runtime@30.4.2` calls `moduleMocker.clearMocksOnScope()`, which 30.0.5
+// does not have, so a suite that pins an environment dies with
+// "TypeError: this._moduleMocker.clearMocksOnScope is not a function" before running a single test.
+// Staying on the default environment makes this suite immune to that drift, which matters now that
+// it is a gating CI job.
 
 /**
  * Tests for the step-timing collector added to chase the 2026-09-07 create_repo latency (58 prod

--- a/tests/unit/create-repo-step-timings.test.ts
+++ b/tests/unit/create-repo-step-timings.test.ts
@@ -1,0 +1,351 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Tests for the step-timing collector added to chase the 2026-09-07 create_repo latency (58 prod
+ * messages, p50 279.5s, ~275s of it unexplained — see supabase/functions/_shared/stepTimings.ts).
+ *
+ * The properties under test are the ones that make this instrumentation safe to ship into the hot
+ * path of repo creation: it records what it claims to record, it still reports the steps that DID
+ * complete when a later step throws, and it can never mask, wrap, or swallow the caller's error.
+ */
+
+import {
+  bucketDurationMs,
+  countStep,
+  STEP_TIMINGS_DEBUG_ENV_VAR,
+  STEP_TIMINGS_DEBUG_LOG_PREFIX,
+  STEP_TIMINGS_LOG_PREFIX,
+  StepTimings,
+  type StepTimingsSnapshot,
+  timeStep
+} from "@/supabase/functions/_shared/stepTimings";
+
+/** Deterministic clock: every read advances by the scripted amount. */
+function fakeClock(startAt = 1_000) {
+  let now = startAt;
+  return {
+    now: () => now,
+    advance: (ms: number) => {
+      now += ms;
+    }
+  };
+}
+
+function harness(startAt = 1_000) {
+  const clock = fakeClock(startAt);
+  const lines: string[] = [];
+  const timings = new StepTimings("create_repo", {
+    now: clock.now,
+    log: (line) => lines.push(line),
+    debug: false
+  });
+  return { clock, lines, timings };
+}
+
+function parseSummary(lines: string[]): StepTimingsSnapshot {
+  const summary = lines.filter((l) => l.startsWith(STEP_TIMINGS_LOG_PREFIX));
+  expect(summary).toHaveLength(1);
+  return JSON.parse(summary[0].slice(STEP_TIMINGS_LOG_PREFIX.length).trim()) as StepTimingsSnapshot;
+}
+
+describe("StepTimings.time", () => {
+  it("records elapsed ms per step and returns the step's value", async () => {
+    const { clock, lines, timings } = harness();
+
+    const generated = await timings.time("template_generate", () => {
+      clock.advance(4_896);
+      return Promise.resolve("head-sha");
+    });
+    await timings.time("get_head_sha", () => {
+      clock.advance(120);
+      return Promise.resolve(undefined);
+    });
+
+    expect(generated).toBe("head-sha");
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.op).toBe("create_repo");
+    expect(snapshot.steps).toEqual({ template_generate: 4_896, get_head_sha: 120 });
+    expect(snapshot.slowest_step).toBe("template_generate");
+    expect(snapshot.slowest_ms).toBe(4_896);
+    expect(snapshot.failed_step).toBeNull();
+  });
+
+  it("accumulates a step that runs more than once and reports the call count", async () => {
+    // The delete+regenerate repair path runs generate + wait-ready twice; the summary must show the
+    // TOTAL cost of the step plus the fact that it ran twice, not a silently doubled number.
+    const { clock, lines, timings } = harness();
+    for (const ms of [4_000, 5_000]) {
+      await timings.time("template_generate", () => {
+        clock.advance(ms);
+        return Promise.resolve(undefined);
+      });
+    }
+    await timings.time("post_delete_sleep", () => {
+      clock.advance(2_000);
+      return Promise.resolve(undefined);
+    });
+
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.steps.template_generate).toBe(9_000);
+    expect(snapshot.repeated).toEqual({ template_generate: 2 });
+    expect(snapshot.repeated.post_delete_sleep).toBeUndefined();
+  });
+
+  it("reports total, accounted and unaccounted time so gaps between steps are visible", async () => {
+    const { clock, lines, timings } = harness();
+    clock.advance(1_000); // time spent before any instrumented step
+    await timings.time("get_octokit", () => {
+      clock.advance(50);
+      return Promise.resolve(undefined);
+    });
+    clock.advance(30_000); // an un-instrumented stretch — exactly what we are hunting
+
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.total_ms).toBe(31_050);
+    expect(snapshot.accounted_ms).toBe(50);
+    expect(snapshot.unaccounted_ms).toBe(31_000);
+  });
+
+  it("counts poll attempts separately from elapsed time", async () => {
+    // waitForRepoReady is capped at 30 x 2000ms, so the attempt COUNT is what bounds how much of
+    // the 4.7 minutes that loop can own — elapsed time alone cannot distinguish one slow GET from
+    // 29 polls.
+    const { clock, lines, timings } = harness();
+    for (let attempt = 0; attempt < 3; attempt++) {
+      timings.count("wait_for_repo_ready_attempts");
+      await timings.time("wait_for_repo_ready_sleep", () => {
+        clock.advance(2_000);
+        return Promise.resolve(undefined);
+      });
+    }
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.counts).toEqual({ wait_for_repo_ready_attempts: 3 });
+    expect(snapshot.steps.wait_for_repo_ready_sleep).toBe(6_000);
+  });
+});
+
+describe("StepTimings failure behavior", () => {
+  it("still reports the steps that completed when a later step throws", async () => {
+    const { clock, lines, timings } = harness();
+    const boom = new Error("GitHub said no");
+
+    await timings.time("patch_repo_settings", () => {
+      clock.advance(200);
+      return Promise.resolve(undefined);
+    });
+    await expect(
+      timings.time("get_head_sha", () => {
+        clock.advance(93_000);
+        return Promise.reject(boom);
+      })
+    ).rejects.toBe(boom);
+
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.steps).toEqual({ patch_repo_settings: 200, get_head_sha: 93_000 });
+    expect(snapshot.failed_step).toBe("get_head_sha");
+  });
+
+  it("re-throws the ORIGINAL error object, unmodified", async () => {
+    const { timings } = harness();
+
+    class RepoError extends Error {
+      readonly status = 422;
+    }
+    const original = new RepoError("Name already exists on this account");
+
+    let caught: unknown;
+    try {
+      await timings.time("template_generate", () => Promise.reject(original));
+    } catch (e) {
+      caught = e;
+    }
+
+    // Identity, not just message equality: callers branch on `instanceof RequestError` and read
+    // `.status`/`.response.data.errors`, so a wrapped or re-created error would change behavior.
+    expect(caught).toBe(original);
+    expect((caught as RepoError).status).toBe(422);
+    expect((caught as Error).message).toBe("Name already exists on this account");
+  });
+
+  it("propagates a synchronous throw from the timed function", async () => {
+    const { timings } = harness();
+    const boom = new Error("sync boom");
+    await expect(
+      timings.time("get_octokit", () => {
+        throw boom;
+      })
+    ).rejects.toBe(boom);
+    expect(timings.snapshot().failed_step).toBe("get_octokit");
+  });
+
+  it("keeps the FIRST failing step when several fail", async () => {
+    const { timings } = harness();
+    await expect(timings.time("first", () => Promise.reject(new Error("a")))).rejects.toThrow("a");
+    await expect(timings.time("second", () => Promise.reject(new Error("b")))).rejects.toThrow("b");
+    expect(timings.snapshot().failed_step).toBe("first");
+  });
+});
+
+describe("StepTimings cannot break the operation it measures", () => {
+  it("swallows a throwing sink", () => {
+    const { lines, timings } = harness();
+    expect(() =>
+      timings.finish(() => {
+        throw new Error("sentry is down");
+      })
+    ).not.toThrow();
+    // The summary line is still emitted even though the Sentry attachment failed.
+    expect(parseSummary(lines).op).toBe("create_repo");
+  });
+
+  it("swallows a throwing logger", () => {
+    const timings = new StepTimings("create_repo", {
+      now: () => 0,
+      log: () => {
+        throw new Error("stdout is gone");
+      },
+      debug: false
+    });
+    const seen: StepTimingsSnapshot[] = [];
+    expect(() => timings.finish((s) => seen.push(s))).not.toThrow();
+    // The sink still ran, so Sentry gets the breakdown even when logging failed.
+    expect(seen).toHaveLength(1);
+  });
+
+  it("survives a throwing clock without throwing", async () => {
+    const timings = new StepTimings("create_repo", {
+      now: () => {
+        throw new Error("no clock");
+      },
+      log: () => {},
+      debug: false
+    });
+    await expect(timings.time("get_octokit", () => Promise.resolve("ok"))).resolves.toBe("ok");
+    expect(() => timings.finish()).not.toThrow();
+  });
+
+  it("is idempotent: a second finish() does not emit a second line", () => {
+    const { lines, timings } = harness();
+    timings.finish();
+    timings.finish();
+    expect(lines.filter((l) => l.startsWith(STEP_TIMINGS_LOG_PREFIX))).toHaveLength(1);
+  });
+
+  it("ignores non-finite and negative elapsed values", () => {
+    const { lines, timings } = harness();
+    timings.add("weird", Number.NaN);
+    timings.add("weird", -500);
+    timings.count("bad", Number.POSITIVE_INFINITY);
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.steps.weird).toBe(0);
+    expect(snapshot.counts.bad).toBeUndefined();
+  });
+});
+
+describe("per-step debug lines", () => {
+  it("emits exactly one summary line and no per-step lines by default", async () => {
+    // The whole point of the single-line format: 58 repos x ~10 steps of individual lines would be
+    // unreadable and expensive to ship.
+    const lines: string[] = [];
+    const timings = new StepTimings("create_repo", {
+      now: () => 0,
+      log: (line) => lines.push(line),
+      readEnv: () => undefined
+    });
+    await timings.time("a", () => Promise.resolve(undefined));
+    await timings.time("b", () => Promise.resolve(undefined));
+    timings.finish();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].startsWith(STEP_TIMINGS_LOG_PREFIX)).toBe(true);
+  });
+
+  it("emits per-step lines when the debug env var is set", async () => {
+    const lines: string[] = [];
+    const timings = new StepTimings("create_repo", {
+      now: () => 0,
+      log: (line) => lines.push(line),
+      readEnv: (key) => (key === STEP_TIMINGS_DEBUG_ENV_VAR ? "1" : undefined)
+    });
+    await timings.time("a", () => Promise.resolve(undefined));
+    timings.finish();
+    expect(lines.filter((l) => l.startsWith(STEP_TIMINGS_DEBUG_LOG_PREFIX))).toEqual([
+      `${STEP_TIMINGS_DEBUG_LOG_PREFIX} op=create_repo step=a ms=0`
+    ]);
+  });
+});
+
+describe("meta and snapshot shape", () => {
+  it("carries low-cardinality meta into the snapshot", () => {
+    const lines: string[] = [];
+    const timings = new StepTimings("create_repo", {
+      now: () => 0,
+      log: (line) => lines.push(line),
+      debug: false,
+      meta: { org: "khoury", creation_method: "template" }
+    });
+    timings.setMeta("repo_already_exists", true);
+    timings.finish();
+    expect(parseSummary(lines).meta).toEqual({
+      org: "khoury",
+      creation_method: "template",
+      repo_already_exists: true
+    });
+  });
+
+  it("serializes to a single greppable JSON line", () => {
+    const { lines, timings } = harness();
+    timings.finish();
+    expect(lines[0]).toMatch(/^\[step-timings\] \{.*\}$/);
+    expect(lines[0].includes("\n")).toBe(false);
+  });
+});
+
+describe("timeStep / countStep with no collector", () => {
+  it("runs the function and returns its value when timings is undefined", async () => {
+    await expect(timeStep(undefined, "anything", () => Promise.resolve(7))).resolves.toBe(7);
+    expect(() => countStep(undefined, "anything")).not.toThrow();
+  });
+
+  it("records through the collector when one is supplied", async () => {
+    const { clock, lines, timings } = harness();
+    await timeStep(timings, "ruleset_list", () => {
+      clock.advance(42);
+      return Promise.resolve(undefined);
+    });
+    countStep(timings, "collaborators_added", 3);
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.steps.ruleset_list).toBe(42);
+    expect(snapshot.counts.collaborators_added).toBe(3);
+  });
+
+  it("propagates errors unchanged with no collector", async () => {
+    const boom = new Error("nope");
+    await expect(timeStep(undefined, "anything", () => Promise.reject(boom))).rejects.toBe(boom);
+  });
+});
+
+describe("bucketDurationMs", () => {
+  it("buckets the measured incident into the 240-300s band", () => {
+    // p50 279.5s, p90 294.7s: 86% of the 58 messages fell between 260s and 300s.
+    expect(bucketDurationMs(279_500)).toBe("240-300s");
+    expect(bucketDurationMs(294_700)).toBe("240-300s");
+    expect(bucketDurationMs(304_000)).toBe("300s+");
+  });
+
+  it("buckets the fast comparators and rejects nonsense", () => {
+    expect(bucketDurationMs(1_000)).toBe("1-5s"); // sync_student_team p50
+    expect(bucketDurationMs(500)).toBe("0-1s"); // sync_staff_team p50
+    expect(bucketDurationMs(4_900)).toBe("1-5s"); // the template generate call
+    expect(bucketDurationMs(Number.NaN)).toBe("unknown");
+    expect(bucketDurationMs(-1)).toBe("unknown");
+  });
+});

--- a/tests/unit/create-repo-step-timings.test.ts
+++ b/tests/unit/create-repo-step-timings.test.ts
@@ -131,7 +131,7 @@ describe("StepTimings.time", () => {
 });
 
 describe("StepTimings failure behavior", () => {
-  it("still reports the steps that completed when a later step throws", async () => {
+  it("still reports the steps that completed when an error escapes the operation", async () => {
     const { clock, lines, timings } = harness();
     const boom = new Error("GitHub said no");
 
@@ -145,11 +145,77 @@ describe("StepTimings failure behavior", () => {
         return Promise.reject(boom);
       })
     ).rejects.toBe(boom);
+    timings.noteEscapingError(boom); // what createRepo's catch does before re-throwing
 
     timings.finish();
     const snapshot = parseSummary(lines);
     expect(snapshot.steps).toEqual({ patch_repo_settings: 200, get_head_sha: 93_000 });
+    expect(snapshot.error_escaped).toBe(true);
     expect(snapshot.failed_step).toBe("get_head_sha");
+  });
+
+  it("does NOT flag a step whose error was caught and recovered from", async () => {
+    // The shape of waitForRepoReady: a freshly generated repo 404s on the first polls, the loop
+    // swallows those and retries, and the operation succeeds. Flagging that would label every
+    // healthy create_repo as failed — which is what this instrumentation is being read to rule out.
+    const { clock, lines, timings } = harness();
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      timings.count("wait_for_repo_ready_attempts");
+      try {
+        await timings.time("wait_for_repo_ready_requests", () => {
+          clock.advance(300);
+          return Promise.reject(Object.assign(new Error("Not Found"), { status: 404 }));
+        });
+      } catch {
+        // caught and retried, exactly like the real poll loop
+      }
+    }
+    timings.count("wait_for_repo_ready_attempts");
+    await timings.time("wait_for_repo_ready_requests", () => {
+      clock.advance(250);
+      return Promise.resolve(undefined);
+    });
+
+    timings.finish();
+    const snapshot = parseSummary(lines);
+    expect(snapshot.error_escaped).toBe(false);
+    expect(snapshot.failed_step).toBeNull();
+    // The time and the attempt count are still recorded — the misses are measured, just not blamed.
+    expect(snapshot.steps.wait_for_repo_ready_requests).toBe(850);
+    expect(snapshot.counts.wait_for_repo_ready_attempts).toBe(3);
+    expect(snapshot.repeated.wait_for_repo_ready_requests).toBe(3);
+  });
+
+  it("flags an escaping error raised outside any timed step, without attributing it", async () => {
+    // waitForRepoReady's "did not become ready" UserVisibleError is thrown after its loop, not by
+    // one of the timed requests inside it. It must still be flagged; it just cannot be pinned on a
+    // step, and inventing one would be a lie.
+    const { timings } = harness();
+    await timings.time("wait_for_repo_ready_requests", () => Promise.resolve(undefined));
+    timings.noteEscapingError(new Error("Repo org/repo did not become ready in time"));
+    const snapshot = timings.snapshot();
+    expect(snapshot.error_escaped).toBe(true);
+    expect(snapshot.failed_step).toBeNull();
+  });
+
+  it("attributes an error the caller inspected and re-threw to its originating step", async () => {
+    // createRepo's catch re-throws the SAME object (`throw createErr`) after classifying it.
+    const { timings } = harness();
+    const createErr = new Error("boom");
+    await expect(timings.time("template_generate", () => Promise.reject(createErr))).rejects.toBe(createErr);
+    timings.noteEscapingError(createErr);
+    expect(timings.snapshot().failed_step).toBe("template_generate");
+  });
+
+  it("does not attribute an escaping error that a recovered step merely happens to precede", async () => {
+    const { timings } = harness();
+    const recovered = new Error("404 that was retried");
+    await expect(timings.time("wait_for_repo_ready_requests", () => Promise.reject(recovered))).rejects.toBe(recovered);
+    timings.noteEscapingError(new Error("something else entirely"));
+    const snapshot = timings.snapshot();
+    expect(snapshot.error_escaped).toBe(true);
+    expect(snapshot.failed_step).toBeNull();
   });
 
   it("re-throws the ORIGINAL error object, unmodified", async () => {
@@ -182,13 +248,20 @@ describe("StepTimings failure behavior", () => {
         throw boom;
       })
     ).rejects.toBe(boom);
+    // Not flagged yet: the caller may still recover.
+    expect(timings.snapshot().failed_step).toBeNull();
+    timings.noteEscapingError(boom);
     expect(timings.snapshot().failed_step).toBe("get_octokit");
   });
 
-  it("keeps the FIRST failing step when several fail", async () => {
+  it("keeps the FIRST escaping error when noteEscapingError is called more than once", async () => {
     const { timings } = harness();
-    await expect(timings.time("first", () => Promise.reject(new Error("a")))).rejects.toThrow("a");
-    await expect(timings.time("second", () => Promise.reject(new Error("b")))).rejects.toThrow("b");
+    const first = new Error("a");
+    const second = new Error("b");
+    await expect(timings.time("first", () => Promise.reject(first))).rejects.toThrow("a");
+    timings.noteEscapingError(first);
+    await expect(timings.time("second", () => Promise.reject(second))).rejects.toThrow("b");
+    timings.noteEscapingError(second);
     expect(timings.snapshot().failed_step).toBe("first");
   });
 });
@@ -229,6 +302,34 @@ describe("StepTimings cannot break the operation it measures", () => {
     });
     await expect(timings.time("get_octokit", () => Promise.resolve("ok"))).resolves.toBe("ok");
     expect(() => timings.finish()).not.toThrow();
+  });
+
+  it("supports a partial snapshot mid-operation without disturbing the final one", async () => {
+    // What a handled-failure Sentry capture attaches: Sentry applies scope data at capture time, so
+    // patch_repo_settings / enable_actions / ruleset events need the breakdown as it stands then.
+    const { clock, lines, timings } = harness();
+    await timings.time("template_generate", () => {
+      clock.advance(4_896);
+      return Promise.resolve(undefined);
+    });
+
+    const partial = timings.snapshot();
+    expect(partial.partial).toBe(true);
+    expect(partial.steps).toEqual({ template_generate: 4_896 });
+    expect(lines).toHaveLength(0); // a partial snapshot logs nothing
+
+    await timings.time("get_head_sha", () => {
+      clock.advance(390);
+      return Promise.resolve(undefined);
+    });
+    timings.finish();
+
+    const final = parseSummary(lines);
+    expect(final.partial).toBe(false);
+    // Not double-counted and not truncated by the partial read.
+    expect(final.steps).toEqual({ template_generate: 4_896, get_head_sha: 390 });
+    expect(final.repeated).toEqual({});
+    expect(final.total_ms).toBe(5_286);
   });
 
   it("is idempotent: a second finish() does not emit a second line", () => {

--- a/tests/unit/create-repo-step-timings.test.ts
+++ b/tests/unit/create-repo-step-timings.test.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  attachSnapshotToScope,
   bucketDurationMs,
   countStep,
   STEP_TIMINGS_DEBUG_ENV_VAR,
@@ -448,5 +449,164 @@ describe("bucketDurationMs", () => {
     expect(bucketDurationMs(4_900)).toBe("1-5s"); // the template generate call
     expect(bucketDurationMs(Number.NaN)).toBe("unknown");
     expect(bucketDurationMs(-1)).toBe("unknown");
+  });
+});
+
+/**
+ * Stand-in for a Sentry.Scope. `attachSnapshotToScope` takes the scope structurally precisely so
+ * this is possible, which is what lets these tests assert the scope-isolation property directly
+ * rather than by inspection.
+ */
+function fakeScope() {
+  const tags: Record<string, string | number | boolean> = {};
+  const contexts: Record<string, unknown> = {};
+  const breadcrumbs: Record<string, unknown>[] = [];
+  return {
+    tags,
+    contexts,
+    breadcrumbs,
+    setTag: (key: string, value: string | number | boolean) => {
+      tags[key] = value;
+    },
+    setContext: (key: string, context: Record<string, unknown>) => {
+      contexts[key] = context;
+    },
+    addBreadcrumb: (breadcrumb: Record<string, unknown>) => {
+      breadcrumbs.push(breadcrumb);
+    }
+  };
+}
+
+describe("scope isolation between concurrent operations", () => {
+  // WHY: processBatch runs drainConcurrency (default 4) envelopes concurrently under
+  // Promise.allSettled and shares one Sentry.Scope across them; processEnvelope clones it per
+  // envelope before any handler sees it. Timings must therefore ride on the scope OBJECT they were
+  // given and never on a module-level/global sink, or one repo's breakdown lands on another repo's
+  // event and we chase the wrong step.
+  it("two operations running concurrently each report only their own steps and counters", async () => {
+    const lines: string[] = [];
+    let clockA = 1_000;
+    let clockB = 500_000;
+    const a = new StepTimings("create_repo", {
+      now: () => clockA,
+      log: (line) => lines.push(line),
+      debug: false,
+      meta: { repo_name: "hw2-alice" }
+    });
+    const b = new StepTimings("create_repo", {
+      now: () => clockB,
+      log: (line) => lines.push(line),
+      debug: false,
+      meta: { repo_name: "hw2-bob" }
+    });
+
+    // Interleaved, the way two awaited operations in one isolate actually run.
+    const opA = a.time("template_generate", async () => {
+      clockA += 4_896;
+      await Promise.resolve();
+      a.count("wait_for_repo_ready_attempts", 3);
+    });
+    const opB = b.time("template_generate", async () => {
+      clockB += 12_000;
+      await Promise.resolve();
+      b.count("wait_for_repo_ready_attempts", 29);
+    });
+    await Promise.all([opA, opB]);
+
+    const scopeA = fakeScope();
+    const scopeB = fakeScope();
+    a.finish((snapshot) => attachSnapshotToScope(snapshot, scopeA));
+    b.finish((snapshot) => attachSnapshotToScope(snapshot, scopeB));
+
+    const [snapA, snapB] = lines
+      .filter((l) => l.startsWith(STEP_TIMINGS_LOG_PREFIX))
+      .map((l) => JSON.parse(l.slice(STEP_TIMINGS_LOG_PREFIX.length).trim()) as StepTimingsSnapshot);
+    expect(snapA.steps.template_generate).toBe(4_896);
+    expect(snapB.steps.template_generate).toBe(12_000);
+    expect(snapA.counts.wait_for_repo_ready_attempts).toBe(3);
+    expect(snapB.counts.wait_for_repo_ready_attempts).toBe(29);
+    expect(snapA.meta.repo_name).toBe("hw2-alice");
+    expect(snapB.meta.repo_name).toBe("hw2-bob");
+
+    // And nothing bled across the two scopes.
+    expect(scopeA.tags["step_timings_create_repo_wait_for_repo_ready_attempts"]).toBe("3");
+    expect(scopeB.tags["step_timings_create_repo_wait_for_repo_ready_attempts"]).toBe("29");
+    expect((scopeA.contexts["step_timings_create_repo"] as StepTimingsSnapshot).meta.repo_name).toBe("hw2-alice");
+    expect((scopeB.contexts["step_timings_create_repo"] as StepTimingsSnapshot).meta.repo_name).toBe("hw2-bob");
+    expect(scopeA.breadcrumbs).toHaveLength(1);
+    expect(scopeB.breadcrumbs).toHaveLength(1);
+  });
+
+  it("a failure in one operation does not stamp failed_step onto the other", async () => {
+    const boom = new Error("message 3 of 4 blew up");
+    const failing = new StepTimings("create_repo", { now: () => 0, log: () => {}, debug: false });
+    const healthy = new StepTimings("create_repo", { now: () => 0, log: () => {}, debug: false });
+
+    await expect(failing.time("get_head_sha", () => Promise.reject(boom))).rejects.toBe(boom);
+    failing.noteEscapingError(boom);
+    await healthy.time("get_head_sha", () => Promise.resolve(undefined));
+
+    const failingScope = fakeScope();
+    const healthyScope = fakeScope();
+    attachSnapshotToScope(failing.snapshot(), failingScope);
+    attachSnapshotToScope(healthy.snapshot(), healthyScope);
+
+    expect(failing.snapshot().failed_step).toBe("get_head_sha");
+    expect(healthy.snapshot().failed_step).toBeNull();
+    expect(failingScope.tags["step_timings_create_repo_failed_step"]).toBe("get_head_sha");
+    expect(failingScope.tags["step_timings_create_repo_error_escaped"]).toBe("true");
+    // The healthy operation's scope must carry NO failure tag at all, not even a "false" one for
+    // failed_step — an error event for a sibling message must not look like this repo failed.
+    expect(healthyScope.tags["step_timings_create_repo_failed_step"]).toBeUndefined();
+    expect(healthyScope.tags["step_timings_create_repo_error_escaped"]).toBe("false");
+  });
+});
+
+describe("attachSnapshotToScope", () => {
+  it("namespaces tags per operation so two operations on ONE scope do not overwrite each other", () => {
+    // A single create_repo MESSAGE runs createRepo and then syncRepoPermissions against the same
+    // envelope scope. Unprefixed tag keys meant the second one silently clobbered the first.
+    const scope = fakeScope();
+    const create = new StepTimings("create_repo", { now: () => 0, log: () => {}, debug: false });
+    create.add("template_generate", 4_896);
+    create.count("wait_for_repo_ready_attempts", 7);
+    const sync = new StepTimings("sync_repo_permissions", { now: () => 0, log: () => {}, debug: false });
+    sync.add("list_collaborators", 1_200);
+    sync.count("collaborators_added", 1);
+
+    attachSnapshotToScope(create.snapshot(), scope);
+    attachSnapshotToScope(sync.snapshot(), scope);
+
+    expect(scope.tags["step_timings_create_repo_slowest_step"]).toBe("template_generate");
+    expect(scope.tags["step_timings_sync_repo_permissions_slowest_step"]).toBe("list_collaborators");
+    expect(scope.tags["step_timings_create_repo_wait_for_repo_ready_attempts"]).toBe("7");
+    expect(scope.tags["step_timings_sync_repo_permissions_collaborators_added"]).toBe("1");
+    expect(Object.keys(scope.contexts).sort()).toEqual([
+      "step_timings_create_repo",
+      "step_timings_sync_repo_permissions"
+    ]);
+  });
+
+  it("tags the coarse duration bucket and the partial flag", () => {
+    const scope = fakeScope();
+    const timings = new StepTimings("create_repo", { now: () => 0, log: () => {}, debug: false });
+    timings.add("patch_repo_settings", 279_500);
+    attachSnapshotToScope(timings.snapshot(), scope);
+    expect(scope.tags["step_timings_create_repo_partial"]).toBe("true");
+    timings.finish();
+    attachSnapshotToScope(timings.snapshot(), scope);
+    expect(scope.tags["step_timings_create_repo_partial"]).toBe("false");
+  });
+
+  it("is a no-op with no scope and swallows a throwing scope", () => {
+    const timings = new StepTimings("create_repo", { now: () => 0, log: () => {}, debug: false });
+    expect(() => attachSnapshotToScope(timings.snapshot(), undefined)).not.toThrow();
+    expect(() =>
+      attachSnapshotToScope(timings.snapshot(), {
+        setTag: () => {
+          throw new Error("sentry is down");
+        }
+      })
+    ).not.toThrow();
   });
 });

--- a/tests/unit/create-repo-step-timings.test.ts
+++ b/tests/unit/create-repo-step-timings.test.ts
@@ -610,3 +610,43 @@ describe("attachSnapshotToScope", () => {
     ).not.toThrow();
   });
 });
+
+describe("stepForError (handled-failure attribution)", () => {
+  // WHY: applyBranchProtectionRuleset wraps BOTH the rulesets list and the ruleset detail request
+  // in one try/catch. Labelling that catch's Sentry tag `ruleset_list` meant a failed DETAIL
+  // request was indexed as a failed LIST request, contradicting the timing context attached beside
+  // it and pointing endpoint-level filtering at the wrong GitHub call.
+  it("names the step that raised THIS error, not the catch's coarse label", async () => {
+    const { timings } = harness();
+    const detailErr = Object.assign(new Error("Internal Server Error"), { status: 500 });
+
+    await timings.time("ruleset_list", () => Promise.resolve(["existing"]));
+    await expect(timings.time("ruleset_detail", () => Promise.reject(detailErr))).rejects.toBe(detailErr);
+
+    expect(timings.stepForError(detailErr)).toBe("ruleset_detail");
+  });
+
+  it("returns null for an error that did not come from a timed step, so callers can fall back", async () => {
+    const { timings } = harness();
+    await timings.time("ruleset_list", () => Promise.resolve(undefined));
+    expect(timings.stepForError(new Error("raised between steps"))).toBeNull();
+    expect(timings.stepForError(undefined)).toBeNull();
+  });
+
+  it("returns null when no step has thrown at all", () => {
+    const { timings } = harness();
+    expect(timings.stepForError(new Error("anything"))).toBeNull();
+  });
+
+  it("does not flag the operation as failed — attribution is read-only", async () => {
+    // A handled failure must not turn into `failed_step`/`error_escaped`; that pair is reserved for
+    // an error that escaped the whole operation.
+    const { timings } = harness();
+    const handled = new Error("handled and recovered");
+    await expect(timings.time("ruleset_detail", () => Promise.reject(handled))).rejects.toBe(handled);
+    expect(timings.stepForError(handled)).toBe("ruleset_detail");
+    const snapshot = timings.snapshot();
+    expect(snapshot.error_escaped).toBe(false);
+    expect(snapshot.failed_step).toBeNull();
+  });
+});


### PR DESCRIPTION
## The incident

Khoury prod, 2026-09-07. CS 4530 released an assignment, enqueueing 58 `create_repo` messages at 04:01:00. The last drained at 05:37:28.

| | |
|---|---|
| Drain time | **88 minutes for 58 messages** |
| Avg time in queue | 3,230s (54 min) |
| Worst | 5,788s (96 min) |
| `PawtograderQueueOldestMessageAging` | fired for >1h, **true positive** |
| Outcome | correct — 58/58 provisioned, no duplicates, empty DLQ |

Fall classes start **2026-09-09** and CS 2000 has ~585 pending enrollments, so the drain rate matters now.

## Part 1 — the two hardcoded values become tunable

`processBatch` read `{ n: 4, sleep_seconds: 300 }` at two call sites. **`n` is the real concurrency ceiling** — the leaseholder already runs 4 messages concurrently via `Promise.allSettled`, and 4-per-~7min matches the measured drain. The Redis lease is *not* the constraint and is untouched, as is the cron spawn count.

```
GITHUB_ASYNC_WORKER_DRAIN_CONCURRENCY            1..8,     default 4
GITHUB_ASYNC_WORKER_VISIBILITY_TIMEOUT_SECONDS   60..1800, default 300
```

**Defaults reproduce today's behaviour exactly**, so deploying the chart changes nothing until someone sets a value. Verified: rendering against the real `values-prod.yaml` gives `"4"` / `"300"`.

The `n` ceiling of **8** comes from the content limiter, not memory. The handler wraps the whole `github.createRepo` in `getCreateContentLimiter(org).schedule()`, which is Redis-backed and therefore fleet-wide per org at `{reservoir: 40, maxConcurrent: 40, 40/60s}`. At p50 279.5s, each in-flight creation holds a slot **and** a token for ~4.7 minutes, and the same pool serves `POST /orgs/{org}/invitations`. 8 is 20% of the pool, so all 8 held for the full 280s still leaves 32 for invitations. A deadlock warning is recorded in three places: **do not move limiter-scheduled calls inside the `createRepo` wrapper** — with `maxConcurrent` outer jobs holding every slot, inner jobs could never start.

VT and `n` are coupled by `requiredVisibilityTimeoutSeconds(n) = n * 120`, because **the VT must cover a whole batch, not one message.** Enforced at render time — `helm template` is refused for `drainConcurrency > 4` unless the VT covers the batch:

```
drainConcurrency=8 requires visibilityTimeoutSeconds >= 960 (8 x 120s/message),
but it is 300. ... measured 2026-09-07: ~420s for a batch of 4, which already
re-read 20 of 58 messages against a 300s timeout.
```

This also corrects a now-falsified comment claiming 300s is "well above observed p99 handler durations". Raising the VT removes the `read_ct` climb for this failure mode (20 of 58 were re-read), leaving `read_ct` to advance only on a genuine isolate death — which is what the poison-pill threshold is for.

> **Honest limit:** at `n=8` the drain is ~1.2 msg/min, so a 585-message burst is still **~8 hours**. This halves an 88-minute drain and stops mid-flight redeliveries; **it does not solve CS 2000.** That needs more than one concurrent leaseholder, flagged in code as a separate design change rather than a bigger number.

## Part 2 — instrumentation, because the latency is still unexplained

`create_repo` takes ~280s (p50 279.5, **86% inside a 40s band**, max 304) while `sync_student_team` on the same pods in the same batches is **p50 1.0s**.

Ruled out by measurement rather than inspection:

- **Retry backoff** — zero retry log lines in the window; the ladders (worst case 144s) never fired.
- **The content limiter** — 4 concurrent against 40 slots doesn't queue.
- **Network/infra** — GitHub API latency from inside the cluster is **18–219ms, avg ~80ms**.
- **`getOctoKit` cold start** — only 14 installations.
- **The template generate itself** — logged at ~5s.

That leaves ~275s inside a stretch with **no instrumentation at all**. So: one greppable `[step-timings] {json}` line per repo, covering `get_octokit`, `template_generate`/`create_fork`, `wait_for_repo_ready` (requests *and* sleep, plus the **attempt count**), the delete+regenerate repair path, the finalize writes, the ruleset calls, and `syncRepoPermissions` as its own op. `unaccounted_ms` says outright whether the missing time is even inside an instrumented call.

Diagnostic only — no retry parameter, timeout, `maxAttempts`, limiter config or ordering changed. Timing records in both success and catch paths, re-throws the identical error object (tested by identity, since callers branch on `instanceof RequestError`), and a throwing clock/logger/sink cannot turn a successful creation into a failure.

### Two things this uncovered and deliberately did not change

1. **The pgmq-derived 280s is not `createRepo`'s duration.** `syncRepoPermissions` runs after it in the same message and makes more GitHub calls, several paginated by roster size. Instrumented separately.
2. **`@octokit/plugin-throttling` 11.0.3 awaits `groups.write` (`maxConcurrent: 1, minTime: 1000`) before every non-GET**, and `GitHubWrapper` backs it with the shared Redis connection under one id — so *all* mutating GitHub requests across every replica and every org serialize at **one per second**. GETs bypass it (`octokit-global`, `maxConcurrent: 10`), which is why GET-heavy methods stayed at 1.0s. This is a real **cross-org** constraint worth addressing on its own merits. But note the incident was a **single org** (all 58 were `neu-cs4530`), so it cannot be the dominant term here: 4 concurrent messages sharing one 1/s FIFO would need ~70 writes per repo to explain 280s. Left alone pending the timings.

For context on why this regressed: the pre-May tree (`d5bbfe0b`, the supabase.com era) had **0** occurrences of `waitForRepoReady` and **0** of `applyBranchProtectionRuleset`, and **24** mutating `octokit.request` calls vs **34** today. `waitForRepoReady` arrived 2026-05-22 in #698/#699/#700.

## Verification

- `render-guardrails.sh` — **passes**, with 14 new assertions (defaults render; both settable; raising `n` alone refused; partially-raised VT refused; `n=0`, `n=16`, VT=30, VT=3600, `n=four` all refused).
- `helm lint` — clean, including against the real `prod-charts/values/values-prod.yaml`.
- `prettier` clean. `eslint` and `deno check` both match their HEAD baselines exactly — one type error *was* introduced and fixed (a closure discarded an `if` narrowing).

> ⚠️ **Unit tests (18 + 22) could not run under the repo's own Jest.** The shared install has `jest-runtime@30.4.2` beside a hoisted `jest-mock@30.0.5` (`clearMocksOnScope is not a function`), reproducible on untouched test files. Both sets were run 1:1 through a private runner instead (18 and 22 passing). **CI is the first run under the repo's configured runner.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)