### PR TITLE
fix(chart): give the azure provider a redirect URI, so Microsoft sign-in can work

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.21
+version: 0.3.22
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -482,7 +482,12 @@ id/secret (stored in the `pawtograder-web` Secret). `github`, `azure`, and
 auth:
   external:
     github: { enabled: true } # reads GITHUB_OAUTH_CLIENT_ID / _SECRET
-    azure: { enabled: true } # reads AZURE_OAUTH_CLIENT_ID / _SECRET
+    azure:
+      enabled: true # reads AZURE_OAUTH_CLIENT_ID / _SECRET
+      # Optional: pin sign-in to one Entra directory. Unset, GoTrue talks to
+      # login.microsoftonline.com/common and accepts an ID token from any
+      # issuer — including personal Microsoft accounts.
+      url: https://login.microsoftonline.com/<tenant-id>
   externalProviders:
     - name: google # -> GOTRUE_EXTERNAL_GOOGLE_*
       enabled: true # reads GOOGLE_OAUTH_CLIENT_ID / _SECRET from the web Secret
@@ -501,7 +506,10 @@ Each enabled provider's redirect URI defaults to the API gateway origin +
   `https://<hostname>/auth/v1/callback`
 
 Register that exact URL in the provider's OAuth app (override per provider with
-`redirectUri` if your topology differs). Put the client id/secret in the
+`redirectUri` if your topology differs). Microsoft/Entra matches it
+character-for-character and rejects a mismatch with `AADSTS50011` at the
+*consent* screen — after the client id has already been accepted — so a wrong
+value here looks like a working button that dead-ends on Microsoft's side. Put the client id/secret in the
 `pawtograder-web` Secret under the `<NAME>_OAUTH_CLIENT_ID` /
 `<NAME>_OAUTH_CLIENT_SECRET` keys (e.g. `GOOGLE_OAUTH_CLIENT_ID`). A complete
 worked example (Google + Microsoft + GitHub) is in

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -146,14 +146,26 @@ auth:
     github:
       enabled: true
       redirectUri: https://api.staging.pawtograder.net/auth/v1/callback
-    # Microsoft (Entra ID), multi-tenant — GoTrue uses the common endpoint,
-    # so any Microsoft account can sign in. Creds come from the
-    # pawtograder-web Secret keys AZURE_OAUTH_CLIENT_ID /
-    # AZURE_OAUTH_CLIENT_SECRET (synced from kv/apps/pawtograder-staging/web).
-    # Redirect URI registered in Azure:
-    #   https://api.staging.pawtograder.net/auth/v1/callback
+    # Microsoft (Entra ID). Creds come from the pawtograder-web Secret keys
+    # AZURE_OAUTH_CLIENT_ID / AZURE_OAUTH_CLIENT_SECRET, synced from
+    # kv/apps/pawtograder-staging/web — populate them with
+    # k8s/apps/pawtograder-staging/setup-azure.sh, which also registers the
+    # redirect URI expectation below and restarts auth.
+    #
+    # redirectUri is spelled out rather than left to the chart default because
+    # it has to match the Entra app registration's "Web" redirect URI
+    # character-for-character; having it in one visible place makes the two
+    # easy to diff when sign-in starts failing with AADSTS50011.
+    #
+    # `url` is intentionally unset: staging runs against the common endpoint so
+    # any Microsoft account can sign in, which is what we want for testing with
+    # non-NU accounts. The trade-off is that a non-Northeastern account gets no
+    # employeeId from Microsoft Graph, so user-fetch-azure-profile leaves
+    # sis_user_id NULL. To restrict staging to the NU directory, set
+    #   url: https://login.microsoftonline.com/<northeastern-tenant-id>
     azure:
       enabled: true
+      redirectUri: https://api.staging.pawtograder.net/auth/v1/callback
     # GitHub + Discord OAuth (sign-in / identity-linking). Client id+secret are
     # read from the pawtograder-web Secret as {GITHUB,DISCORD}_OAUTH_CLIENT_ID /
     # _CLIENT_SECRET (synced from kv/apps/pawtograder-staging/web). GitHub reuses

--- a/charts/pawtograder/templates/auth.yaml
+++ b/charts/pawtograder/templates/auth.yaml
@@ -174,6 +174,12 @@ spec:
             {{- if .Values.auth.external.azure.enabled }}
             - name: GOTRUE_EXTERNAL_AZURE_ENABLED
               value: "true"
+            # REQUIRED, not optional: GoTrue's ValidateOAuth rejects a provider
+            # with an empty RedirectURI ("missing redirect URI") before it ever
+            # talks to Microsoft, so omitting this makes /authorize?provider=azure
+            # 400 even with a valid client id + secret.
+            - name: GOTRUE_EXTERNAL_AZURE_REDIRECT_URI
+              value: {{ default (printf "%s/auth/v1/callback" (include "pawtograder.api.url" .)) .Values.auth.external.azure.redirectUri | quote }}
             - name: GOTRUE_EXTERNAL_AZURE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -186,6 +192,15 @@ spec:
                   name: {{ .Values.secrets.names.web }}
                   key: AZURE_OAUTH_CLIENT_SECRET
                   optional: true
+            {{- with .Values.auth.external.azure.url }}
+            # Tenant pinning. Unset, GoTrue uses login.microsoftonline.com/common
+            # and accepts an ID token from ANY issuer (any Microsoft account,
+            # personal ones included). Set to https://login.microsoftonline.com/<tenant-id>
+            # and GoTrue both routes the authorize/token calls at that tenant and
+            # requires the ID token's `iss` to match it.
+            - name: GOTRUE_EXTERNAL_AZURE_URL
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- if .Values.auth.external.discord.enabled }}
             - name: GOTRUE_EXTERNAL_DISCORD_ENABLED

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -655,8 +655,18 @@ auth:
     github:
       enabled: false
       redirectUri: "" # default: https://<hostname>/auth/v1/callback
+    # Microsoft / Entra ID. Reads AZURE_OAUTH_CLIENT_ID / _CLIENT_SECRET from
+    # the web Secret.
     azure:
       enabled: false
+      redirectUri: "" # default: https://api.<hostname>/auth/v1/callback
+      # Tenant pinning. Empty = login.microsoftonline.com/common: any Microsoft
+      # account signs in, including personal (outlook.com) ones. Set to
+      # https://login.microsoftonline.com/<tenant-id> to restrict sign-in to a
+      # single directory — GoTrue then also verifies the ID token's issuer
+      # against it. Required if your Entra app registration is single-tenant
+      # AND you want that enforced on our side rather than only Microsoft's.
+      url: ""
     discord:
       enabled: false
       redirectUri: "" # default: https://<hostname>/auth/v1/callback


### PR DESCRIPTION
## Why

Microsoft sign-in on staging is dead, and there are **two** reasons — fixing either alone leaves it broken.

`https://api.staging.pawtograder.net/auth/v1/authorize?provider=azure` currently answers:

```
400 {"error_code":"validation_failed","msg":"Unsupported provider: missing OAuth client ID"}
```

1. **No credentials.** `kv/apps/pawtograder-staging/web` holds the GitHub and Discord OAuth pairs but never got `AZURE_OAUTH_CLIENT_ID` / `AZURE_OAUTH_CLIENT_SECRET`. The chart reads both `optional: true`, so the provider reports as enabled and fails at login rather than at startup. Credentials aren't in this PR — they're provisioned by the new `k8s/apps/pawtograder-staging/setup-azure.sh`.

2. **The chart never set `GOTRUE_EXTERNAL_AZURE_REDIRECT_URI`** — which is what this PR fixes. GoTrue's `ValidateOAuth` rejects any external provider whose `RedirectURI` is empty, *before* it contacts Microsoft:

   ```go
   if o.RedirectURI == "" {
       return errors.New("missing redirect URI")
   }
   ```
   (`internal/conf/configuration.go`, v2.186.0 — the pinned gotrue tag)

   There is no per-provider default anywhere in `ApplyDefaults`, and the `github` and `discord` blocks immediately beside `azure` have always set theirs. So landing only the credentials would have moved the failure from `missing OAuth client ID` to `missing redirect URI` — same 400, new message.

## What changed

- `templates/auth.yaml`: azure now renders `GOTRUE_EXTERNAL_AZURE_REDIRECT_URI`, defaulting to the API gateway origin + `/auth/v1/callback`, exactly like github/discord.
- New optional `auth.external.azure.url` → `GOTRUE_EXTERNAL_AZURE_URL`, for tenant pinning. Unset (the default, and what staging keeps), GoTrue talks to `login.microsoftonline.com/common` and accepts an ID token from **any** issuer, personal Microsoft accounts included. Set to `https://login.microsoftonline.com/<tenant-id>` and it pins both the authorize/token endpoints and the expected `iss`.
- `examples/values-staging.yaml`: spells the redirect URI out rather than inheriting the default. It has to match the Entra app registration character-for-character, and a mismatch surfaces as `AADSTS50011` on Microsoft's consent screen — well past the point where our config is in the picture — so having it in one visible place makes the two diffable.
- `values.yaml` + chart README document both knobs.
- Chart `0.3.21` → `0.3.22`.

Staging stays multi-tenant on purpose: testing with non-NU accounts is useful, and the only cost is that such accounts return no `employeeId` from Graph, so `user-fetch-azure-profile` leaves `sis_user_id` NULL.

## Verification

`helm template` against `values-staging.yaml` renders the new env, and `helm lint` passes:

```
- name: GOTRUE_EXTERNAL_AZURE_REDIRECT_URI
  value: "https://api.staging.pawtograder.net/auth/v1/callback"
```

Diffed the full rendered manifest against the live release (`helm get manifest`): the only changes are the azure env block and the `helm.sh/chart` version label. `examples/values-tartangrader.yaml`, the other consumer of the azure provider, still templates clean.

## Rollout

Merging deploys this via `deploy-staging`. It must land **before** the credentials go in, or `setup-azure.sh --check` will just report the redirect-URI failure instead. After that: create the staging Entra app registration (redirect URI `https://api.staging.pawtograder.net/auth/v1/callback`, Graph delegated `User.Read`), then run `k8s/apps/pawtograder-staging/setup-azure.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgc41kZHjnQZRGqooUCMvy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Microsoft Entra configuration for custom OAuth callback URLs.
  * Added optional tenant-specific sign-in URLs to restrict authentication to a selected directory.
  * Azure OAuth deployments now consistently provide the configured callback URL.

* **Documentation**
  * Expanded Azure SSO guidance, including tenant restrictions and exact redirect URI requirements.
  * Documented common Microsoft OAuth behavior, account limitations, credential sources, and related configuration errors.

* **Chores**
  * Updated the Helm chart version to 0.3.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->