### PR TITLE
fix(github): stop handout creation 500ing when a course team doesn't exist yet

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -27,6 +27,7 @@ const {
   NonRetryableRepoError,
   publicSupabaseUrl,
   resolveExistingTeamSlug,
+  resolveTeamSlugIfExists,
   TeamMembersUnreadableError,
   TeamNotFoundError,
   toPublicSupabaseUrl
@@ -261,6 +262,65 @@ Deno.test("resolveExistingTeamSlug: 404 then normalized slug in org list -> retu
     "GET /orgs/{org}/teams": () => [{ id: 2, slug: "cs-101-students", name: "cs101-students" }]
   });
   assertEquals(await resolveExistingTeamSlug("org-b", "cs101-students", octokit), "cs-101-students");
+});
+
+// --- Absence-reporting slug resolution (resolveTeamSlugIfExists) ---
+// `resolveExistingTeamSlug` echoes the requested slug back when the team does not exist, which made
+// "resolved" and "absent" indistinguishable — and every caller then fed that slug to a team endpoint
+// that 404s. These pin the distinction that `syncRepoPermissions` now branches on.
+
+Deno.test("resolveTeamSlugIfExists: team exists -> returns its actual slug", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": (p) => ({ data: { id: 1, slug: p.team_slug } })
+  });
+  assertEquals(await resolveTeamSlugIfExists("org-exists", "cs101-staff", octokit), "cs101-staff");
+});
+
+Deno.test("resolveTeamSlugIfExists: team absent -> null, NOT the requested slug", async () => {
+  // The whole point: an absent team must not come back as a usable-looking slug. This is the
+  // neu-cs4535/fa26-students case that 500'd handout creation for a course with nobody enrolled.
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /orgs/{org}/teams": () => []
+  });
+  assertEquals(await resolveTeamSlugIfExists("org-absent", "fa26-students", octokit), null);
+});
+
+Deno.test("resolveTeamSlugIfExists: 404 then normalized slug in org list -> returns normalized slug", async () => {
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /orgs/{org}/teams": () => [{ id: 2, slug: "cs-101-students", name: "cs101-students" }]
+  });
+  assertEquals(await resolveTeamSlugIfExists("org-norm", "cs101-students", octokit), "cs-101-students");
+});
+
+Deno.test("resolveTeamSlugIfExists: a null result is not cached, so a later create is picked up", async () => {
+  let teamExists = false;
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": (p) => {
+      if (teamExists) return { data: { id: 3, slug: p.team_slug } };
+      throw requestError(404, "Not Found");
+    },
+    "GET /orgs/{org}/teams": () => (teamExists ? [{ id: 3, slug: "fa26-students", name: "fa26-students" }] : [])
+  });
+  assertEquals(await resolveTeamSlugIfExists("org-uncached", "fa26-students", octokit), null);
+  teamExists = true;
+  assertEquals(await resolveTeamSlugIfExists("org-uncached", "fa26-students", octokit), "fa26-students");
+});
+
+Deno.test("resolveTeamSlugIfExists: non-404 error -> rethrows rather than reporting absence", async () => {
+  // A 500 or a rate limit is "we do not know", and must not be read as "the team is gone" — that
+  // would silently skip a staff grant on a repo whose team is fine.
+  const octokit = fakeOctokit({
+    "GET /orgs/{org}/teams/{team_slug}": () => {
+      throw requestError(500, "Server Error");
+    }
+  });
+  await assertRejects(() => resolveTeamSlugIfExists("org-5xx", "cs101-staff", octokit), RequestError);
 });
 
 Deno.test("resolveExistingTeamSlug: 404 and no match -> falls back to requested slug, not cached", async () => {

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2455,7 +2455,7 @@ export async function getTeamAndCreateIfNeeded(org: string, team_slug: string, o
   }
 }
 
-const teamSlugCache = new Map<string, Promise<string>>();
+const teamSlugCache = new Map<string, Promise<string | null>>();
 
 /**
  * Resolve a team's actual GitHub slug, tolerating the case where GitHub normalized the team's slug
@@ -2471,6 +2471,29 @@ const teamSlugCache = new Map<string, Promise<string>>();
  * the miss would keep every retry hitting the wrong slug until cold start.
  */
 export async function resolveExistingTeamSlug(org: string, team_slug: string, octokit: Octokit): Promise<string> {
+  return (await resolveTeamSlugIfExists(org, team_slug, octokit)) ?? team_slug;
+}
+
+/**
+ * Same resolution as {@link resolveExistingTeamSlug}, but reports ABSENCE as `null` instead of
+ * echoing back the requested slug.
+ *
+ * The fallback in `resolveExistingTeamSlug` makes "resolved to a real team" and "this team does not
+ * exist" indistinguishable to the caller, and every team endpoint below takes a slug — so a caller
+ * that only wanted a spelling correction would happily go on to PUT against a team that isn't
+ * there. That 404s, and because it happens inside `syncRepoPermissions`, it took down
+ * assignment-create-handout-repo for every brand-new course: the `<slug>-students` team is created
+ * lazily by the student-team sync, so a course with nothing enrolled yet has no students team at
+ * all, and mode-2 handout creation failed with a bare "Not Found" AFTER the repo was already made.
+ *
+ * Callers that must not create a team can now branch on the absence; the one caller that genuinely
+ * requires the team (a mode-2 handout grant) creates it explicitly.
+ */
+export async function resolveTeamSlugIfExists(
+  org: string,
+  team_slug: string,
+  octokit: Octokit
+): Promise<string | null> {
   // JSON tuple, not `org + "-" + team_slug`: string concat is ambiguous (org "a-b"/slug "c" would
   // collide with org "a"/slug "b-c") and could reuse one course's resolved slug for another.
   const cacheKey = JSON.stringify([org, team_slug]);
@@ -2479,12 +2502,10 @@ export async function resolveExistingTeamSlug(org: string, team_slug: string, oc
     return cached;
   }
   const pending = (async () => {
-    let slug = team_slug;
-    let resolved = false;
+    let slug: string | null = null;
     try {
       const team = await octokit.request("GET /orgs/{org}/teams/{team_slug}", { org, team_slug });
       slug = team.data.slug ?? team_slug;
-      resolved = true;
     } catch (e) {
       if (!(e instanceof RequestError && e.status === 404)) {
         throw e;
@@ -2493,11 +2514,10 @@ export async function resolveExistingTeamSlug(org: string, team_slug: string, oc
       const match = teams.find((t) => t.slug === team_slug || t.name === team_slug);
       if (match?.slug) {
         slug = match.slug;
-        resolved = true;
       }
     }
-    // Don't retain a no-match fallback so a retry re-checks once the team exists.
-    if (!resolved) {
+    // Don't retain a no-match so a retry re-checks once the team exists.
+    if (slug === null) {
       teamSlugCache.delete(cacheKey);
     }
     return slug;
@@ -3166,9 +3186,12 @@ async function syncRepoPermissionsInstrumented(
   // Resolve to the team's real GitHub slug: if the team was created out-of-band and GitHub
   // normalized its slug differently from `${courseSlug}-staff`, the literal would 404 on the
   // members/repo-access endpoints below, silently leaving repos without staff access.
-  const team_slug = await timeStep(timings, "resolve_staff_team_slug", () =>
-    resolveExistingTeamSlug(org, `${courseSlug}-staff`, octokit)
+  const resolvedStaffTeamSlug = await timeStep(timings, "resolve_staff_team_slug", () =>
+    resolveTeamSlugIfExists(org, `${courseSlug}-staff`, octokit)
   );
+  // Keep the derived name as the slug we *use*, so the members read below still produces the
+  // TeamNotFoundError the degradation path downstream is written against.
+  const team_slug = resolvedStaffTeamSlug ?? `${courseSlug}-staff`;
   // JSON tuple, not `org + "-" + courseSlug`, for the same reason as teamSlugCache above: string
   // concat is ambiguous and could serve one course's staff roster to another.
   const staffCacheKey = JSON.stringify([org, courseSlug]);
@@ -3259,7 +3282,14 @@ async function syncRepoPermissionsInstrumented(
       repo
     })
   );
-  if (!teamsWithAccess.length || !teamsWithAccess.some((t) => t.slug === team_slug)) {
+  // `resolvedStaffTeamSlug === null` means the course has no staff team on GitHub. Reading its
+  // roster already degrades to "remove nobody" a few lines up (see the TeamNotFoundError catch);
+  // this grant did not, and PUT-ing to a team that does not exist 404s and takes the whole sync —
+  // and its caller — down. Skip it for the same reason: a course that legitimately has no staff
+  // team must not be broken by it, and the staff-team sync is what owns creating one.
+  if (resolvedStaffTeamSlug === null) {
+    scope?.setTag("staff_team_grant", "skipped_absent");
+  } else if (!teamsWithAccess.length || !teamsWithAccess.some((t) => t.slug === team_slug)) {
     madeChanges = true;
     await timeStep(timings, "grant_staff_team", () =>
       octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
@@ -3273,25 +3303,45 @@ async function syncRepoPermissionsInstrumented(
   }
   // Optionally grant the students team read access (mode 2 handout repos). Resolve the real slug for
   // the same reason as the staff team above, so grant/revoke hit the correct team endpoint.
-  const studentsTeamSlug = await timeStep(timings, "resolve_students_team_slug", () =>
-    resolveExistingTeamSlug(org, `${courseSlug}-students`, octokit)
+  let studentsTeamSlug = await timeStep(timings, "resolve_students_team_slug", () =>
+    resolveTeamSlugIfExists(org, `${courseSlug}-students`, octokit)
   );
-  if (options.studentTeamPermission) {
-    // Bound to a local so the narrowing survives into the closure below: TypeScript discards the
+  // The students team is created LAZILY, by the student-team sync, the first time somebody is
+  // enrolled. A mode-2 handout is normally created before that has ever run — a brand-new course
+  // has nobody enrolled — so the team the grant below needs does not exist yet, and the grant 404s
+  // AFTER the handout repo has already been created but before `template_repo` is persisted. That
+  // is a 500 on every first mode-2 handout of a new course, and a retry hits it again.
+  //
+  // Create it here rather than skipping, because `studentTeamPermission` is only ever set by the
+  // mode-2 handout path, which REQUIRES students to be able to read the handout. Skipping would
+  // let creation report success while leaving the repo unreadable, and nothing revisits the
+  // handout's team grants once the team later appears. Creating an empty `<slug>-students` team is
+  // exactly what the student-team sync would do on the next enrollment anyway.
+  if (options.studentTeamPermission && studentsTeamSlug === null) {
+    const created = await timeStep(timings, "create_students_team", () =>
+      getTeamAndCreateIfNeeded(org, `${courseSlug}-students`, octokit)
+    );
+    studentsTeamSlug = created.data.slug ?? `${courseSlug}-students`;
+    scope?.setTag("students_team_created", "true");
+  }
+  if (options.studentTeamPermission && studentsTeamSlug) {
+    // Bound to locals so the narrowing survives into the closure below: TypeScript discards the
     // `if (options.studentTeamPermission)` narrowing inside a callback (options is a mutable
     // parameter), so passing `options.studentTeamPermission` there would widen back to
     // `"pull" | null | undefined`. Same value, same request — this is a typing artifact of wrapping
-    // the call in a timing closure, not a behavior change.
+    // the call in a timing closure, not a behavior change. `studentsTeamSlug` needs the same
+    // treatment now that it is a mutable `string | null`.
     const studentTeamPermission = options.studentTeamPermission;
+    const studentsTeam = studentsTeamSlug;
     const hasStudentsTeam = teamsWithAccess.some(
-      (t) => t.slug === studentsTeamSlug && t.permission === studentTeamPermission
+      (t) => t.slug === studentsTeam && t.permission === studentTeamPermission
     );
     if (!hasStudentsTeam) {
       madeChanges = true;
       await timeStep(timings, "grant_students_team", () =>
         octokit.request("PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
           org,
-          team_slug: studentsTeamSlug,
+          team_slug: studentsTeam,
           owner: org,
           repo,
           permission: studentTeamPermission
@@ -3299,26 +3349,29 @@ async function syncRepoPermissionsInstrumented(
       );
       scope?.addBreadcrumb({
         category: "github",
-        message: `${org}/${repo} granted ${studentsTeamSlug} team ${options.studentTeamPermission}`,
+        message: `${org}/${repo} granted ${studentsTeam} team ${options.studentTeamPermission}`,
         level: "info"
       });
     }
-  } else {
-    // No student access desired — revoke any stale students-team grant.
-    const hasStudentsTeamAccess = teamsWithAccess.some((t) => t.slug === studentsTeamSlug);
+  } else if (studentsTeamSlug) {
+    // No student access desired — revoke any stale students-team grant. Guarded on the team
+    // existing: with no students team there is no grant to revoke, and `teamsWithAccess` could
+    // never match an absent team anyway.
+    const studentsTeam = studentsTeamSlug;
+    const hasStudentsTeamAccess = teamsWithAccess.some((t) => t.slug === studentsTeam);
     if (hasStudentsTeamAccess) {
       madeChanges = true;
       await timeStep(timings, "revoke_students_team", () =>
         octokit.request("DELETE /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}", {
           org,
-          team_slug: studentsTeamSlug,
+          team_slug: studentsTeam,
           owner: org,
           repo
         })
       );
       scope?.addBreadcrumb({
         category: "github",
-        message: `${org}/${repo} removed ${studentsTeamSlug} team access`,
+        message: `${org}/${repo} removed ${studentsTeam} team access`,
         level: "info"
       });
     }


### PR DESCRIPTION
## The bug

`assignment-create-handout-repo` returns a bare 500 for the first mode-2 handout of any brand-new course. Hit in prod on `neu-cs4535` / `fa26`:

```
[step-timings] {"op":"sync_repo_permissions", ..., "error_escaped":true, "failed_step":"grant_students_team"}
[Error] HttpError: Not Found
  PUT /orgs/neu-cs4535/teams/fa26-students/repos/neu-cs4535/fa26-handout-hw1-onboarding
```

`resolveExistingTeamSlug` echoes the **requested** slug back when no team matches, so "resolved to a real team" and "this team does not exist" are indistinguishable to callers. Every team endpoint takes a slug, so `syncRepoPermissions` went on to PUT against a team that isn't there.

The `<slug>-students` team is created **lazily**, by the student-team sync, the first time somebody is enrolled. A brand-new course has nobody enrolled, so its first mode-2 handout always hit this.

The failure mode is nasty: the 404 escapes **after** `createRepo` succeeds but **before** `template_repo` is persisted. The repo exists on GitHub, nothing in the DB points at it, and the retry fails identically. Three orphaned repos in `neu-cs4535` from this.

The staff team has the same hole. Reading its roster already degrades to "remove nobody" (the `TeamNotFoundError` catch), so a course with no staff team is *explicitly* supported — but the grant right below it didn't degrade, and 404'd the same way. That was the first failure of this incident, before `fa26-staff` was created.

## The fix

`supabase/functions/_shared/GitHubWrapper.ts`:

- **New `resolveTeamSlugIfExists`** reports absence as `null`. A non-404 still throws — "we could not ask" must not be read as "the team is gone", or a rate limit would silently skip a grant on a repo whose team is fine. `resolveExistingTeamSlug` becomes a one-line wrapper over it, so its other callers are unchanged.
- **Staff grant** skips when the team is absent, tagging `staff_team_grant=skipped_absent`. Creating one here would contradict the deliberate degradation above; the staff-team sync owns that.
- **Students grant** *creates* the team when absent rather than skipping. `studentTeamPermission` is only ever set by the mode-2 handout path (`assignment-create-handout-repo` and its `github-async-worker` twin), which **requires** students to read the handout — skipping would report success on a repo they can't see, and nothing revisits handout grants once the team later appears. An empty `<slug>-students` team is exactly what the next enrollment would have created. Adds a `create_students_team` step timing.
- Revoke branch guarded on the team existing; `studentsTeamSlug` bound to consts so narrowing survives the timing closures (same artifact the existing `studentTeamPermission` comment describes).

## Testing

- 5 new tests pinning the resolved/absent distinction, including the non-404-rethrows case.
- `deno test _shared/` — 336 passed, 0 failed.
- `deno check` reports the same 6 errors as `staging`; all pre-existing, none in the changed regions.
- Prettier clean.

Prod was unblocked by hand (creating `fa26-staff` and `fa26-students`); this stops the next new course from hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository permission syncing when GitHub teams are missing or have normalized slugs.
  - Prevented handout repository setup from failing when a student team does not yet exist; the team is now created when required.
  - Avoided granting permissions to unavailable staff teams.
  - Ensured student-team permission revocation only occurs when the team is successfully resolved.
  - Improved handling of transient team availability and non-404 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->