### PR TITLE
perf(github): stop permission sync doing 80s of work that changes nothing

### DIFF
--- a/app/admin/github-orgs/[org]/page.tsx
+++ b/app/admin/github-orgs/[org]/page.tsx
@@ -45,6 +45,9 @@ export default function GitHubOrgDetailPage() {
   // for half-typed or not-yet-saved repos.
   const [savedHandout, setSavedHandout] = useState("");
   const [savedSolution, setSavedSolution] = useState("");
+  // Held as the raw text the admin typed, not as a parsed array, so a half-typed entry doesn't
+  // vanish from the box while they're still writing it. Parsed on save.
+  const [exemptUsers, setExemptUsers] = useState("");
   const [courses, setCourses] = useState<OrgCourse[]>([]);
 
   const load = useCallback(async () => {
@@ -64,6 +67,7 @@ export default function GitHubOrgDetailPage() {
       setSolution(loadedSolution);
       setSavedHandout(loadedHandout);
       setSavedSolution(loadedSolution);
+      setExemptUsers((thisOrg?.permission_sync_exempt_users ?? []).join(", "));
       setCourses((orgCourses ?? []) as OrgCourse[]);
     } catch (err) {
       toaster.error({ title: "Failed to load org", description: (err as Error).message });
@@ -83,7 +87,13 @@ export default function GitHubOrgDetailPage() {
       const { error } = await supabase.rpc("admin_upsert_github_org", {
         p_org_name: orgName,
         p_handout: handout.trim() === "" ? undefined : handout.trim(),
-        p_solution: solution.trim() === "" ? undefined : solution.trim()
+        p_solution: solution.trim() === "" ? undefined : solution.trim(),
+        // Always sent, including as an empty array: `undefined` means "leave as-is" to the RPC, so
+        // omitting it when the box is cleared would make clearing the list impossible.
+        p_permission_sync_exempt_users: exemptUsers
+          .split(/[\s,]+/)
+          .map((u) => u.trim())
+          .filter((u) => u !== "")
       });
       if (error) throw error;
       toaster.success({ title: "Org defaults saved" });
@@ -96,7 +106,7 @@ export default function GitHubOrgDetailPage() {
     } finally {
       setSaving(false);
     }
-  }, [orgName, handout, solution, load, revalidateServerCaches]);
+  }, [orgName, handout, solution, exemptUsers, load, revalidateServerCaches]);
 
   // A course in this org gives the edge function a valid auth/ownership context for editing the
   // org's template repos. (Writes are restricted to the course's own org.) Prefer a non-archived
@@ -140,6 +150,17 @@ export default function GitHubOrgDetailPage() {
             </Field>
             <Field label="Default solution (grader) template repository">
               <Input value={solution} onChange={(e) => setSolution(e.target.value)} fontFamily="mono" />
+            </Field>
+            <Field
+              label="Permission sync exemptions"
+              helperText="GitHub usernames, comma separated. Repository permission sync removes anyone who is not on the course roster or the staff team; these accounts are left alone. Use for access that is intentional but that the roster cannot explain — institutional IT, an integration account, or faculty carried on repos directly."
+            >
+              <Input
+                value={exemptUsers}
+                onChange={(e) => setExemptUsers(e.target.value)}
+                fontFamily="mono"
+                placeholder="octocat, some-ops-account"
+              />
             </Field>
             <Button colorPalette="green" alignSelf="flex-start" onClick={handleSave} loading={saving}>
               Save defaults

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -25,6 +25,7 @@ const {
   getTeamMembers,
   isRepoEmpty,
   isTeamAlreadyExistsError,
+  isValidRepoFullName,
   NonRetryableRepoError,
   publicSupabaseUrl,
   resolveExistingTeamSlug,
@@ -599,4 +600,46 @@ Deno.test("computeCollaboratorRemovals: keeps desired, staff and excluded admins
     }),
     ["stale"]
   );
+});
+
+// --- Repository names the GitHub helpers can act on (isValidRepoFullName) ---
+// getOctoKit / getFileFromRepo / getDefaultBranchHeadSha all take the first two slash-separated
+// components and hand them to the API, so "contains a slash" is not the same question as "names a
+// repository". github-repo-configure-webhook takes this value straight from an instructor's form.
+
+Deno.test("isValidRepoFullName: owner/name is valid", () => {
+  assertEquals(isValidRepoFullName("neu-cs4530/fa26-handout-ip2"), true);
+  assertEquals(isValidRepoFullName("a/b"), true);
+});
+
+Deno.test("isValidRepoFullName: a missing component is not a repository", () => {
+  // `autograder.grader_repo` is NULL exactly when solution-repo creation never finished; the empty
+  // string is what a cleared form field sends.
+  assertEquals(isValidRepoFullName(null), false);
+  assertEquals(isValidRepoFullName(undefined), false);
+  assertEquals(isValidRepoFullName(""), false);
+  assertEquals(isValidRepoFullName("no-slash"), false);
+  assertEquals(isValidRepoFullName("/"), false);
+  assertEquals(isValidRepoFullName("owner/"), false);
+  assertEquals(isValidRepoFullName("/repo"), false);
+});
+
+Deno.test("isValidRepoFullName: extra components are rejected rather than truncated", () => {
+  // The dangerous one: the helpers would drop "/extra" and act on owner/repo, a repository the
+  // instructor did not name.
+  assertEquals(isValidRepoFullName("owner/repo/extra"), false);
+  assertEquals(isValidRepoFullName("https://github.com/owner/repo"), false);
+});
+
+Deno.test("isValidRepoFullName: whitespace is rejected", () => {
+  // Matches the "owner/repo" validation admin_upsert_github_org applies to template repo defaults:
+  // a pasted value with a stray space is a typo, not a repository.
+  assertEquals(isValidRepoFullName("owner /repo"), false);
+  assertEquals(isValidRepoFullName(" owner/repo"), false);
+  assertEquals(isValidRepoFullName("owner/repo "), false);
+});
+
+Deno.test("isValidRepoFullName: non-strings are rejected", () => {
+  assertEquals(isValidRepoFullName(42), false);
+  assertEquals(isValidRepoFullName({ owner: "a", repo: "b" }), false);
 });

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -19,6 +19,7 @@ Deno.env.set("GITHUB_PRIVATE_KEY_STRING", Deno.env.get("GITHUB_PRIVATE_KEY_STRIN
 const {
   assertSourceNotEmpty,
   computeCollaboratorRemovals,
+  filterToDirectCollaborators,
   getGitHubUserIfExists,
   getTeamAndCreateIfNeeded,
   getTeamMembers,
@@ -536,6 +537,32 @@ Deno.test("getTeamMembers: a 404 is not remembered as an empty roster", async ()
   });
   await assertRejects(() => getTeamMembers("org", "course-staff", octokit), TeamNotFoundError);
   assertEquals(await getTeamMembers("org", "course-staff", octokit), ["alice"]);
+});
+
+// --- Removals that can actually take effect (filterToDirectCollaborators) ---
+// DELETE /repos/.../collaborators/{username} only revokes a DIRECT grant. Access held through a
+// team or through org ownership survives it, and GitHub still answers 2xx — so every such
+// "removal" was a request that changed nothing, issued serially, once per sync.
+
+Deno.test("filterToDirectCollaborators: keeps direct collaborators", () => {
+  assertEquals(filterToDirectCollaborators(["alice", "bob"], ["alice", "bob", "carol"]), ["alice", "bob"]);
+});
+
+Deno.test("filterToDirectCollaborators: drops candidates whose access is not direct", () => {
+  // The measured prod case: a fresh handout repo listed 37 collaborators, none of them direct.
+  // Every removal the sync computed was unremovable, and attempting them cost 63.6 seconds.
+  assertEquals(filterToDirectCollaborators(["org-owner", "staff-via-team"], []), []);
+});
+
+Deno.test("filterToDirectCollaborators: compares case-insensitively", () => {
+  // GitHub reports logins in display casing; the sync works in lowercase. A case mismatch here
+  // would silently drop a real removal and let a dropped student keep write access.
+  assertEquals(filterToDirectCollaborators(["alice"], ["Alice"]), ["alice"]);
+  assertEquals(filterToDirectCollaborators(["Bob"], ["bob"]), ["Bob"]);
+});
+
+Deno.test("filterToDirectCollaborators: no candidates -> no removals", () => {
+  assertEquals(filterToDirectCollaborators([], ["alice"]), []);
 });
 
 Deno.test("computeCollaboratorRemovals: an unknown roster removes nobody", () => {

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2782,6 +2782,67 @@ export async function reinviteToOrgTeam(
 }
 const staffTeamCache = new Map<string, Promise<string[]>>();
 const orgMembershipCache = new Map<string, Promise<Endpoints["GET /orgs/{org}/members"]["response"]["data"][]>>();
+// `null` in the cached value means the org has no row / an empty list; a READ FAILURE is not cached
+// at all, so a retry re-asks rather than inheriting a wrong answer for the isolate's lifetime.
+const orgExemptionCache = new Map<string, Promise<string[]>>();
+
+/**
+ * Per-org allowlist of GitHub logins that permission sync must never remove.
+ *
+ * Some accounts hold access the course roster cannot explain and should keep it — institutional IT,
+ * an integration account, faculty carried on a repo directly rather than through the staff team.
+ * That used to be `adminsThatShouldNotBeListedAsAdmins`: five names hardcoded here, applied to every
+ * org, invisible to the admins who know who those people actually are, and changeable only by a
+ * deploy. `github_orgs.permission_sync_exempt_users` is the same decision moved to the per-org
+ * config admins already manage; the constant stays as a global backstop so nothing regresses.
+ *
+ * Returns `null` when the list could not be READ, which is distinct from an empty list. Callers must
+ * treat unknown as "remove nobody" — see the identical argument for an unreadable staff roster. An
+ * exemption that silently reads as absent is how a protected account gets stripped off a repo.
+ */
+async function getOrgPermissionSyncExemptions(org: string, scope?: Sentry.Scope): Promise<string[] | null> {
+  try {
+    return await readOrgPermissionSyncExemptions(org);
+  } catch (err) {
+    // Report and return unknown rather than throwing: a config read that failed must not take down
+    // repo creation, and `null` already means the caller removes nobody this run. The next sync
+    // re-reads (the failure is not cached) and performs any removals then.
+    scope?.setTag("org_permission_exemptions", "unavailable");
+    Sentry.captureException(err, scope);
+    return null;
+  }
+}
+
+function readOrgPermissionSyncExemptions(org: string): Promise<string[]> {
+  const cached = orgExemptionCache.get(org);
+  if (cached) {
+    return cached;
+  }
+  const pending = (async () => {
+    const adminSupabase = createClient<Database>(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    );
+    const { data, error } = await adminSupabase
+      .from("github_orgs")
+      .select("permission_sync_exempt_users")
+      .eq("org_name", org)
+      .maybeSingle();
+    // maybeSingle: an org with no configuration row is `null` with no error, and that is a real
+    // answer (no exemptions). Only a genuine error is unknown.
+    if (error) {
+      throw error;
+    }
+    // Lowercased on write by admin_upsert_github_org, and again here: a row edited directly with
+    // SQL would otherwise never match the lowercased logins the sync compares against.
+    return (data?.permission_sync_exempt_users ?? []).map((u) => u.toLowerCase());
+  })().catch((err) => {
+    orgExemptionCache.delete(org);
+    throw err;
+  });
+  orgExemptionCache.set(org, pending);
+  return pending;
+}
 /**
  * The team does not exist on GitHub at all.
  *
@@ -2895,6 +2956,34 @@ export function computeCollaboratorRemovals({
   return existingUsernames.filter(
     (u) => !desiredUsernames.includes(u) && !staffRoster.includes(u) && !adminExclusions.includes(u)
   );
+}
+
+/**
+ * Narrow removal candidates to the ones a removal can actually act on.
+ *
+ * `DELETE /repos/{owner}/{repo}/collaborators/{username}` removes a DIRECT collaborator grant. It
+ * cannot revoke access someone holds through a team or through org ownership — GitHub accepts the
+ * call, reports success, and the person keeps their access. `GET .../collaborators` defaults to
+ * `affiliation=all`, so the candidate list it feeds contains all three kinds mixed together, and
+ * every team-derived or owner-derived entry became one serial DELETE that changed nothing.
+ *
+ * Measured on a real course org: a freshly created handout repo listed 37 collaborators, of which
+ * ZERO were direct (org `default_repository_permission` is `none`; all 37 came from the staff team
+ * plus org owners). The sync issued 22 removals, took 63.6s doing it, revoked nothing, and would
+ * have repeated the same 63.6s on every subsequent sync of that repo. That is what pushed handout
+ * creation past 95s and made the browser give up before the chained solution-repo call.
+ *
+ * Filtering here rather than fetching only `affiliation=direct` in the first place: the unfiltered
+ * list is still the right input for the "already has access, do not re-add" check, since access via
+ * a team is real access and a redundant direct grant would be wrong.
+ *
+ * The hardcoded `adminsThatShouldNotBeListedAsAdmins` allowlist is the same problem patched by hand
+ * for five specific people; this covers every org owner without naming them, and that list stays as
+ * a backstop.
+ */
+export function filterToDirectCollaborators(candidates: string[], directUsernames: string[]): string[] {
+  const direct = new Set(directUsernames.map((u) => u.toLowerCase()));
+  return candidates.filter((u) => direct.has(u.toLowerCase()));
 }
 async function getOrgMembers(
   org: string,
@@ -3238,19 +3327,29 @@ async function syncRepoPermissionsInstrumented(
     });
     console.error(`Could not read staff team for ${org}/${courseSlug}; not removing any collaborators`, err);
   }
-  if (!orgMembershipCache.has(org)) {
-    orgMembershipCache.set(
-      org,
-      getOrgMembers(org, octokit).catch((err) => {
-        orgMembershipCache.delete(org);
-        throw err;
-      })
-    );
+  // The org roster answers exactly one question — "is this person I am about to ADD already in the
+  // org?" — so with nobody to add it is pure cost. Handout and solution repo creation both pass an
+  // empty username list, and on a large org this paginated read took 18.8s of the 95.6s that made
+  // handout creation outlive the browser's patience. Both consumers below are optional-chained, so
+  // leaving it undefined is the same code path as a failed lookup.
+  let allOrgMembers: string[] | undefined;
+  if (githubUsernames.length === 0) {
+    scope?.setTag("org_members_skipped", "no_desired_users");
+  } else {
+    if (!orgMembershipCache.has(org)) {
+      orgMembershipCache.set(
+        org,
+        getOrgMembers(org, octokit).catch((err) => {
+          orgMembershipCache.delete(org);
+          throw err;
+        })
+      );
+    }
+    // Same promise-cache note as the staff roster above. On a cold isolate this is a PAGINATED list
+    // of every member of the org, which for a large course org is many sequential requests.
+    const orgMembers = await timeStep(timings, "org_members", () => orgMembershipCache.get(org));
+    allOrgMembers = orgMembers?.map((u) => u.login.toLowerCase());
   }
-  // Same promise-cache note as the staff roster above. On a cold isolate this is a PAGINATED list
-  // of every member of the org, which for a large course org is many sequential requests.
-  const orgMembers = await timeStep(timings, "org_members", () => orgMembershipCache.get(org));
-  const allOrgMembers = orgMembers?.map((u) => u.login.toLowerCase());
   // maxRetries 5 / baseDelayMs 3000 — the same 93s worst-case ladder as get_head_sha. No retry
   // lines appear in the 2026-09-07 logs, so it did not fire; timed so we can say that from data.
   const existingAccess = await timeStep(timings, "list_collaborators", () =>
@@ -3466,12 +3565,49 @@ async function syncRepoPermissionsInstrumented(
   const newAccess = githubUsernames.filter(
     (u) => !existingUsernames.includes(u) && verifiedOrgMembers.has(u.toLowerCase())
   );
-  const removeAccess = computeCollaboratorRemovals({
-    existingUsernames,
-    desiredUsernames: githubUsernames,
-    staffRoster: staffTeamUsernames,
-    adminExclusions: adminsThatShouldNotBeListedAsAdmins
-  });
+  // Read BEFORE computing removals, and fail closed when it is unknown, for the same reason the
+  // staff roster does: a removal made against an incomplete exemption list is not recoverable by
+  // the next sync — the access is already gone.
+  const orgExemptions = await timeStep(timings, "org_permission_exemptions", () =>
+    getOrgPermissionSyncExemptions(org, scope)
+  );
+  const removalCandidates =
+    orgExemptions === null
+      ? []
+      : computeCollaboratorRemovals({
+          existingUsernames,
+          desiredUsernames: githubUsernames,
+          staffRoster: staffTeamUsernames,
+          // Per-org config first, then the legacy global constant as a backstop. Once every org
+          // that needs one has a row, the constant can be deleted.
+          adminExclusions: [...adminsThatShouldNotBeListedAsAdmins, ...orgExemptions]
+        });
+  // Only ask for the direct-collaborator list when something might actually be removed, so the
+  // common no-op sync keeps costing exactly the requests it costs today.
+  let removeAccess: string[] = [];
+  if (removalCandidates.length > 0) {
+    const directAccess = await timeStep(timings, "list_direct_collaborators", () =>
+      retryWithBackoff(
+        () =>
+          octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
+            owner: org,
+            repo,
+            affiliation: "direct",
+            per_page: 100
+          }),
+        5,
+        3000,
+        scope
+      )
+    );
+    removeAccess = filterToDirectCollaborators(
+      removalCandidates,
+      directAccess.map((c) => c.login)
+    );
+    // The gap between these two is the futile work this guard removes. Counted so a regression
+    // shows up as a number rather than as latency somebody has to go and explain.
+    countStep(timings, "removals_skipped_not_direct", removalCandidates.length - removeAccess.length);
+  }
   for (const username of newAccess) {
     madeChanges = true;
     // Accumulated across the loop, with a counter for how many writes were actually issued. One
@@ -3524,7 +3660,9 @@ async function syncRepoPermissionsInstrumented(
   // dropped from the course keeps push access and reconcile_stuck_repo_creations, which scans only
   // is_github_ready = false, never revisits it. That is the outcome the TeamNotFoundError comment
   // above rejects for a 403; the flag is what stops it happening for a 404.
-  return { madeChanges, removalsSkipped: staffTeamUsernames === null };
+  // Either unknown input means the additive half ran and the removal half did not, which is exactly
+  // what this flag exists to tell the caller.
+  return { madeChanges, removalsSkipped: staffTeamUsernames === null || orgExemptions === null };
 }
 /**
  * Mark the user_role row for a specific (org, team_slug) as github_org_confirmed = true.

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -376,6 +376,21 @@ export async function getOrgId(org: string, scope?: Sentry.Scope): Promise<numbe
   }
 }
 
+/**
+ * Is this a repository name the GitHub helpers here can actually use — exactly `owner/name`?
+ *
+ * `getOctoKit`, `getFileFromRepo` and `getDefaultBranchHeadSha` all take the first two
+ * slash-separated components and pass them straight to the API, so `owner/name/extra` silently
+ * targets `owner/name`, and `/name`, `owner/` or `/` build a request with an empty owner or repo.
+ * A merely-present slash (the check this replaces at the callers) accepts all four.
+ *
+ * Same shape as the "owner/repo" validation `admin_upsert_github_org` applies to the template repo
+ * defaults, deliberately: these values come from the same kind of admin-typed form field.
+ */
+export function isValidRepoFullName(repo: unknown): repo is string {
+  return typeof repo === "string" && /^[^/\s]+\/[^/\s]+$/.test(repo);
+}
+
 export async function getOctoKitAndInstallationID(repoOrOrgName: string, scope?: Sentry.Scope) {
   const org = repoOrOrgName.includes("/") ? repoOrOrgName.split("/")[0] : repoOrOrgName;
   const octokit = await getOctoKit(repoOrOrgName, scope);
@@ -2782,9 +2797,15 @@ export async function reinviteToOrgTeam(
 }
 const staffTeamCache = new Map<string, Promise<string[]>>();
 const orgMembershipCache = new Map<string, Promise<Endpoints["GET /orgs/{org}/members"]["response"]["data"][]>>();
-// `null` in the cached value means the org has no row / an empty list; a READ FAILURE is not cached
-// at all, so a retry re-asks rather than inheriting a wrong answer for the isolate's lifetime.
-const orgExemptionCache = new Map<string, Promise<string[]>>();
+// A READ FAILURE is not cached at all, so a retry re-asks rather than inheriting a wrong answer.
+//
+// Bounded, unlike the staff-team and org-membership caches above, because this list is edited in the
+// admin UI and nothing invalidates a warm isolate: an unbounded entry means an exemption added right
+// after a sync does not apply until that isolate is recycled, which can be hours. The TTL is short
+// enough that an admin edit takes effect on the next sync but still collapses the burst that matters
+// — assignment-create-all-repos syncs every repo in a course back to back against the same org.
+const ORG_EXEMPTION_CACHE_TTL_MS = 60_000;
+const orgExemptionCache = new Map<string, { readAt: number; users: Promise<string[]> }>();
 
 /**
  * Per-org allowlist of GitHub logins that permission sync must never remove.
@@ -2796,27 +2817,28 @@ const orgExemptionCache = new Map<string, Promise<string[]>>();
  * deploy. `github_orgs.permission_sync_exempt_users` is the same decision moved to the per-org
  * config admins already manage; the constant stays as a global backstop so nothing regresses.
  *
- * Returns `null` when the list could not be READ, which is distinct from an empty list. Callers must
- * treat unknown as "remove nobody" — see the identical argument for an unreadable staff roster. An
- * exemption that silently reads as absent is how a protected account gets stripped off a repo.
+ * THROWS when the list could not be read, which is distinct from an empty list — and aborts the
+ * sync, exactly as an unreadable staff roster does. Degrading instead would finish the run having
+ * performed only the additive half, and the callers that ignore `removalsSkipped` (both repo
+ * creation paths, github-user-sync, the async worker) would record the repo as ready: a student
+ * dropped from the course keeps write access and nothing retries. An exemption list that silently
+ * reads as absent is the other half of the same failure — it strips a protected account off a repo.
  */
-async function getOrgPermissionSyncExemptions(org: string, scope?: Sentry.Scope): Promise<string[] | null> {
+async function getOrgPermissionSyncExemptions(org: string, scope?: Sentry.Scope): Promise<string[]> {
   try {
     return await readOrgPermissionSyncExemptions(org);
   } catch (err) {
-    // Report and return unknown rather than throwing: a config read that failed must not take down
-    // repo creation, and `null` already means the caller removes nobody this run. The next sync
-    // re-reads (the failure is not cached) and performs any removals then.
+    // Tagged before rethrowing so the abort is attributable to the config read rather than looking
+    // like a GitHub failure. The failure is not cached, so the retry re-asks.
     scope?.setTag("org_permission_exemptions", "unavailable");
-    Sentry.captureException(err, scope);
-    return null;
+    throw err;
   }
 }
 
 function readOrgPermissionSyncExemptions(org: string): Promise<string[]> {
   const cached = orgExemptionCache.get(org);
-  if (cached) {
-    return cached;
+  if (cached && Date.now() - cached.readAt < ORG_EXEMPTION_CACHE_TTL_MS) {
+    return cached.users;
   }
   const pending = (async () => {
     const adminSupabase = createClient<Database>(
@@ -2840,7 +2862,7 @@ function readOrgPermissionSyncExemptions(org: string): Promise<string[]> {
     orgExemptionCache.delete(org);
     throw err;
   });
-  orgExemptionCache.set(org, pending);
+  orgExemptionCache.set(org, { readAt: Date.now(), users: pending });
   return pending;
 }
 /**
@@ -3565,23 +3587,22 @@ async function syncRepoPermissionsInstrumented(
   const newAccess = githubUsernames.filter(
     (u) => !existingUsernames.includes(u) && verifiedOrgMembers.has(u.toLowerCase())
   );
-  // Read BEFORE computing removals, and fail closed when it is unknown, for the same reason the
-  // staff roster does: a removal made against an incomplete exemption list is not recoverable by
-  // the next sync — the access is already gone.
+  // Read BEFORE computing removals, and it THROWS rather than degrading when the read fails, for
+  // the same reason the staff roster aborts on a 403: a removal made against an incomplete
+  // exemption list is not recoverable by the next sync — the access is already gone — and a run
+  // that quietly skipped the removal half would be recorded as complete by the callers that do not
+  // inspect `removalsSkipped`.
   const orgExemptions = await timeStep(timings, "org_permission_exemptions", () =>
     getOrgPermissionSyncExemptions(org, scope)
   );
-  const removalCandidates =
-    orgExemptions === null
-      ? []
-      : computeCollaboratorRemovals({
-          existingUsernames,
-          desiredUsernames: githubUsernames,
-          staffRoster: staffTeamUsernames,
-          // Per-org config first, then the legacy global constant as a backstop. Once every org
-          // that needs one has a row, the constant can be deleted.
-          adminExclusions: [...adminsThatShouldNotBeListedAsAdmins, ...orgExemptions]
-        });
+  const removalCandidates = computeCollaboratorRemovals({
+    existingUsernames,
+    desiredUsernames: githubUsernames,
+    staffRoster: staffTeamUsernames,
+    // Per-org config first, then the legacy global constant as a backstop. Once every org that
+    // needs one has a row, the constant can be deleted.
+    adminExclusions: [...adminsThatShouldNotBeListedAsAdmins, ...orgExemptions]
+  });
   // Only ask for the direct-collaborator list when something might actually be removed, so the
   // common no-op sync keeps costing exactly the requests it costs today.
   let removeAccess: string[] = [];
@@ -3660,9 +3681,10 @@ async function syncRepoPermissionsInstrumented(
   // dropped from the course keeps push access and reconcile_stuck_repo_creations, which scans only
   // is_github_ready = false, never revisits it. That is the outcome the TeamNotFoundError comment
   // above rejects for a 403; the flag is what stops it happening for a 404.
-  // Either unknown input means the additive half ran and the removal half did not, which is exactly
-  // what this flag exists to tell the caller.
-  return { madeChanges, removalsSkipped: staffTeamUsernames === null || orgExemptions === null };
+  //
+  // The staff roster is the only input that can be unknown here: an unreadable exemption list
+  // throws out of this function rather than reaching this line.
+  return { madeChanges, removalsSkipped: staffTeamUsernames === null };
 }
 /**
  * Mark the user_role row for a specific (org, team_slug) as github_org_confirmed = true.

--- a/supabase/functions/_shared/HandlerUtils.test.ts
+++ b/supabase/functions/_shared/HandlerUtils.test.ts
@@ -8,12 +8,13 @@
  *
  * Run from supabase/functions:  deno test --no-check --allow-env _shared/HandlerUtils.test.ts
  */
-import { assertEquals, assertThrows } from "jsr:@std/assert@^1";
+import { assertEquals, assertRejects, assertThrows } from "jsr:@std/assert@^1";
 import {
   assertAuthLookupSucceeded,
   assertRoleLookupSucceeded,
   IllegalArgumentError,
   NotFoundError,
+  readJsonObjectBody,
   SecurityError,
   UserVisibleError,
   wrapRequestHandler
@@ -140,4 +141,58 @@ Deno.test("wrapRequestHandler: typed errors keep their own statuses", async () =
 Deno.test("wrapRequestHandler: a successful handler is still 200", async () => {
   const res = await wrapRequestHandler(post(), () => Promise.resolve({ ok: true }));
   assertEquals(res.status, 200);
+});
+
+// --- Request bodies that are not objects (readJsonObjectBody) ---------------
+//
+// Every handler here does `const { a, b } = await req.json()`. A malformed body throws a
+// SyntaxError out of `req.json()`, and a body of JSON `null` or a bare scalar throws a TypeError on
+// the destructuring. Neither is a typed error, so the ladder above turns both into a 500 "Internal
+// Server Error" AND captures them to Sentry: a caller sending a bad body pages us and is told
+// nothing about what was wrong with their request.
+//
+// Driven through wrapRequestHandler with real Requests, because the status is the thing being
+// pinned down — a helper that throws the right class but still comes back as a 500 has fixed
+// nothing.
+
+function postBody(body: string): Request {
+  return new Request("https://example.test/fn", { method: "POST", body });
+}
+
+Deno.test("readJsonObjectBody: an object body passes through with its fields intact", async () => {
+  const body = await readJsonObjectBody(postBody(JSON.stringify({ assignment_id: 7, new_repo: "org/repo" })));
+  assertEquals(body.assignment_id, 7);
+  assertEquals(body.new_repo, "org/repo");
+});
+
+Deno.test("readJsonObjectBody: malformed JSON is a 400, not a 500", async () => {
+  const res = await wrapRequestHandler(postBody("{not json"), async (req) => await readJsonObjectBody(req));
+  assertEquals(res.status, 400);
+});
+
+Deno.test("readJsonObjectBody: an empty body is a 400", async () => {
+  // `req.json()` on zero bytes is the same SyntaxError as malformed input.
+  const res = await wrapRequestHandler(postBody(""), async (req) => await readJsonObjectBody(req));
+  assertEquals(res.status, 400);
+});
+
+Deno.test("readJsonObjectBody: a JSON null body is a 400, not a 500", async () => {
+  // Valid JSON, so it survives req.json() and only fails at the destructuring — which is why this
+  // one reached the caller as an unexplained 500 rather than as a parse error.
+  const res = await wrapRequestHandler(postBody("null"), async (req) => await readJsonObjectBody(req));
+  assertEquals(res.status, 400);
+});
+
+Deno.test("readJsonObjectBody: scalars and arrays are not objects to destructure", async () => {
+  // An array would destructure without throwing and hand every named field back as `undefined` —
+  // reported as a missing-field problem rather than as the wrong shape of body.
+  for (const body of ["42", '"a string"', "true", "[]", '[{"assignment_id":1}]']) {
+    const res = await wrapRequestHandler(postBody(body), async (req) => await readJsonObjectBody(req));
+    assertEquals(res.status, 400, body);
+  }
+});
+
+Deno.test("readJsonObjectBody: the thrown error is a 400 UserVisibleError", async () => {
+  const e = await assertRejects(() => readJsonObjectBody(postBody("null")), UserVisibleError);
+  assertEquals((e as UserVisibleError).status, 400);
 });

--- a/supabase/functions/_shared/HandlerUtils.ts
+++ b/supabase/functions/_shared/HandlerUtils.ts
@@ -289,6 +289,36 @@ export async function assertUserIsInCourse(courseId: number, authHeader: string)
   return { supabase, enrollment };
 }
 
+/**
+ * Read a request body as a JSON object, or fail with a 400 the caller can act on.
+ *
+ * `await req.json()` throws a SyntaxError on a malformed body, and destructuring its result throws
+ * a TypeError when the body is JSON `null` or a bare scalar. Neither is one of the typed errors
+ * {@link wrapRequestHandler} classifies, so both came back as a 500 "Internal Server Error" AND
+ * were captured to Sentry: a caller sending a bad body paged us and learned nothing about what was
+ * wrong with their request.
+ *
+ * Arrays are rejected alongside `null`, because every handler here destructures named fields off
+ * this value and an array would quietly produce `undefined` for all of them — the same shape as a
+ * body that omitted everything, reported as if it were a missing-field problem.
+ *
+ * Returns `Record<string, unknown>` deliberately: the body is a claim about the caller, so the
+ * fields still have to be checked one by one. This only establishes that there is an object to
+ * check them on.
+ */
+export async function readJsonObjectBody(req: Request): Promise<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = await req.json();
+  } catch {
+    throw new UserVisibleError("Request body must be valid JSON", 400);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new UserVisibleError("Request body must be a JSON object", 400);
+  }
+  return parsed as Record<string, unknown>;
+}
+
 export async function wrapRequestHandler(
   req: Request,
   handler: (req: Request, scope: Sentry.Scope) => Promise<unknown>,

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -3543,6 +3543,7 @@ export type Database = {
           default_handout_template_repo: string;
           default_solution_template_repo: string;
           org_name: string;
+          permission_sync_exempt_users: string[];
           updated_at: string;
           updated_by: string | null;
         };
@@ -3552,6 +3553,7 @@ export type Database = {
           default_handout_template_repo?: string;
           default_solution_template_repo?: string;
           org_name: string;
+          permission_sync_exempt_users?: string[];
           updated_at?: string;
           updated_by?: string | null;
         };
@@ -3561,6 +3563,7 @@ export type Database = {
           default_handout_template_repo?: string;
           default_solution_template_repo?: string;
           org_name?: string;
+          permission_sync_exempt_users?: string[];
           updated_at?: string;
           updated_by?: string | null;
         };
@@ -11981,6 +11984,7 @@ export type Database = {
           default_solution_template_repo: string;
           is_configured: boolean;
           org_name: string;
+          permission_sync_exempt_users: string[];
           updated_at: string;
         }[];
       };
@@ -12102,7 +12106,12 @@ export type Database = {
         Returns: boolean;
       };
       admin_upsert_github_org: {
-        Args: { p_handout?: string; p_org_name: string; p_solution?: string };
+        Args: {
+          p_handout?: string;
+          p_org_name: string;
+          p_permission_sync_exempt_users?: string[];
+          p_solution?: string;
+        };
         Returns: undefined;
       };
       admin_upsert_lti_platform: {

--- a/supabase/functions/github-repo-configure-webhook/index.ts
+++ b/supabase/functions/github-repo-configure-webhook/index.ts
@@ -9,7 +9,7 @@ import {
   getDefaultBranchHeadSha,
   isValidRepoFullName
 } from "../_shared/GitHubWrapper.ts";
-import { UserVisibleError, SecurityError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
+import { UserVisibleError, SecurityError, wrapRequestHandler, readJsonObjectBody } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { parse } from "jsr:@std/yaml";
 import { PawtograderConfig } from "../_shared/PawtograderYml.d.ts";
@@ -48,15 +48,12 @@ export const GITHUB_APP_WEBHOOK_EVENTS = [
   "organization",
   "deployment_status"
 ] as const;
-// `unknown`, not a shape: this is a request body, so a declared type would be a claim about the
-// caller rather than a guarantee. Narrowed by the guards at the top of handleRequest.
-type RequestBody = {
-  new_repo?: unknown;
-  assignment_id?: unknown;
-  watch_type?: unknown;
-};
 async function handleRequest(req: Request, scope: Sentry.Scope) {
-  const { assignment_id, new_repo, watch_type }: RequestBody = await req.json();
+  // Not `await req.json()` destructured directly: malformed JSON throws a SyntaxError and a body of
+  // JSON `null` throws a TypeError on the destructuring itself, and neither is a typed error, so
+  // both came back as a 500 and paged us. No declared body shape either — this is a request body,
+  // so a type would be a claim about the caller rather than a guarantee. Every field is checked.
+  const { assignment_id, new_repo, watch_type } = await readJsonObjectBody(req);
   scope?.setTag("function", "github-repo-configure-webhook");
 
   // Validated BEFORE the Sentry tags: `assignment_id.toString()` on a missing or null id threw

--- a/supabase/functions/github-repo-configure-webhook/index.ts
+++ b/supabase/functions/github-repo-configure-webhook/index.ts
@@ -3,7 +3,12 @@
  */
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
-import { getFileFromRepo, updateAutograderWorkflowHash, getDefaultBranchHeadSha } from "../_shared/GitHubWrapper.ts";
+import {
+  getFileFromRepo,
+  updateAutograderWorkflowHash,
+  getDefaultBranchHeadSha,
+  isValidRepoFullName
+} from "../_shared/GitHubWrapper.ts";
 import { UserVisibleError, SecurityError, wrapRequestHandler } from "../_shared/HandlerUtils.ts";
 import { Database } from "../_shared/SupabaseTypes.d.ts";
 import { parse } from "jsr:@std/yaml";
@@ -43,18 +48,28 @@ export const GITHUB_APP_WEBHOOK_EVENTS = [
   "organization",
   "deployment_status"
 ] as const;
+// `unknown`, not a shape: this is a request body, so a declared type would be a claim about the
+// caller rather than a guarantee. Narrowed by the guards at the top of handleRequest.
 type RequestBody = {
-  // Typed non-null, but this is a request body: the type is a claim about the caller, not a
-  // guarantee. See the guard in handleRequest.
-  new_repo: string;
-  assignment_id: number;
-  watch_type: "grader_solution" | "template_repo";
+  new_repo?: unknown;
+  assignment_id?: unknown;
+  watch_type?: unknown;
 };
 async function handleRequest(req: Request, scope: Sentry.Scope) {
   const { assignment_id, new_repo, watch_type }: RequestBody = await req.json();
   scope?.setTag("function", "github-repo-configure-webhook");
+
+  // Validated BEFORE the Sentry tags: `assignment_id.toString()` on a missing or null id threw
+  // outside any UserVisibleError, so wrapRequestHandler classified it as unexpected and answered
+  // 500 — the same "An unknown error occurred" this function is being fixed to stop producing.
+  if (typeof assignment_id !== "number" || !Number.isFinite(assignment_id)) {
+    throw new UserVisibleError("assignment_id is required", 400);
+  }
+  if (watch_type !== "grader_solution" && watch_type !== "template_repo") {
+    throw new UserVisibleError("watch_type must be either grader_solution or template_repo", 400);
+  }
   scope?.setTag("assignment_id", assignment_id.toString());
-  scope?.setTag("new_repo", new_repo);
+  scope?.setTag("new_repo", typeof new_repo === "string" ? new_repo : String(new_repo));
 
   // The autograder page sends `new_repo: values.grader_repo` straight from the form, and
   // `autograder.grader_repo` is NULL whenever solution-repo creation never completed — which is
@@ -64,8 +79,11 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
   // a 500 with "An unknown error occurred" — no indication that the fix is to create the repo.
   //
   // Checked here rather than at the getFileFromRepo call, so the template_repo branch is covered
-  // by the same guard and neither branch can grow a new unchecked use.
-  if (typeof new_repo !== "string" || !new_repo.includes("/")) {
+  // by the same guard and neither branch can grow a new unchecked use. Full `owner/name` rather
+  // than "contains a slash": the helpers downstream take the first two components, so `owner/` and
+  // `/name` reach GitHub as a request with an empty field and `owner/name/extra` quietly acts on a
+  // repository the instructor did not name.
+  if (!isValidRepoFullName(new_repo)) {
     throw new UserVisibleError(
       `This assignment has no ${watch_type === "grader_solution" ? "grader" : "handout"} repository ` +
         `configured yet, so there is nothing to read its configuration from. This usually means ` +
@@ -308,11 +326,10 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
         );
       }
     }
-  } else {
-    return {
-      message: "Webhook already configured"
-    };
   }
+  // No trailing `else`: watch_type is validated at the top of the function, so the three branches
+  // above are exhaustive. The branch that used to be here answered 200 "Webhook already configured"
+  // to anything else, telling the caller the work had been done when nothing had run at all.
 }
 Deno.serve(async (req) => {
   return await wrapRequestHandler(req, handleRequest);

--- a/supabase/functions/github-repo-configure-webhook/index.ts
+++ b/supabase/functions/github-repo-configure-webhook/index.ts
@@ -44,6 +44,8 @@ export const GITHUB_APP_WEBHOOK_EVENTS = [
   "deployment_status"
 ] as const;
 type RequestBody = {
+  // Typed non-null, but this is a request body: the type is a claim about the caller, not a
+  // guarantee. See the guard in handleRequest.
   new_repo: string;
   assignment_id: number;
   watch_type: "grader_solution" | "template_repo";
@@ -53,6 +55,24 @@ async function handleRequest(req: Request, scope: Sentry.Scope) {
   scope?.setTag("function", "github-repo-configure-webhook");
   scope?.setTag("assignment_id", assignment_id.toString());
   scope?.setTag("new_repo", new_repo);
+
+  // The autograder page sends `new_repo: values.grader_repo` straight from the form, and
+  // `autograder.grader_repo` is NULL whenever solution-repo creation never completed — which is
+  // exactly the state a failed or abandoned assignment-create-solution-repo leaves behind. The
+  // value then flowed unchecked into getFileFromRepo -> getOctoKit, where `repo.includes("/")`
+  // threw `TypeError: Cannot read properties of null (reading 'includes')` and the instructor got
+  // a 500 with "An unknown error occurred" — no indication that the fix is to create the repo.
+  //
+  // Checked here rather than at the getFileFromRepo call, so the template_repo branch is covered
+  // by the same guard and neither branch can grow a new unchecked use.
+  if (typeof new_repo !== "string" || !new_repo.includes("/")) {
+    throw new UserVisibleError(
+      `This assignment has no ${watch_type === "grader_solution" ? "grader" : "handout"} repository ` +
+        `configured yet, so there is nothing to read its configuration from. This usually means ` +
+        `repository creation did not finish — re-save the assignment to retry it.`,
+      400
+    );
+  }
   scope?.setTag("watch_type", watch_type);
   //Validate that the user is an instructor
   const supabase = createClient<Database>(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_ANON_KEY")!, {

--- a/supabase/migrations/20260908120000_github_org_permission_sync_exemptions.sql
+++ b/supabase/migrations/20260908120000_github_org_permission_sync_exemptions.sql
@@ -1,0 +1,165 @@
+-- Per-org allowlist of GitHub users that repo permission sync must never remove.
+--
+-- `syncRepoPermissions` reconciles a repo's collaborators against the course roster plus the staff
+-- team, and removes everyone else. Some accounts legitimately hold access that the roster cannot
+-- explain — an institution's IT or ops account, a long-lived integration user, a co-teaching
+-- faculty member carried on the repo directly rather than through the staff team.
+--
+-- That was previously handled by `adminsThatShouldNotBeListedAsAdmins`, a five-name array hardcoded
+-- in GitHubWrapper.ts. It is invisible to the admins who actually know who those people are, it
+-- applies to EVERY org rather than the one org it was added for, and changing it needs a code
+-- change and a deploy. This moves the decision to the per-org config that admins already manage,
+-- and keeps the constant only as a global backstop so nothing regresses on deploy.
+
+ALTER TABLE public.github_orgs
+    ADD COLUMN IF NOT EXISTS permission_sync_exempt_users text[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN public.github_orgs.permission_sync_exempt_users IS
+    'GitHub logins (lowercased) that repo permission sync must never remove from repos in this org. '
+    'For access that the course roster and staff team cannot explain but which is intentional. '
+    'Additive to the global backstop list in GitHubWrapper.ts.';
+
+----------------------------------------------------------------------------------------
+-- admin_get_github_orgs: expose the new column
+----------------------------------------------------------------------------------------
+
+-- DROP before CREATE: changing a function's RETURNS TABLE shape is not a replace, and
+-- CREATE OR REPLACE would fail rather than migrate it.
+DROP FUNCTION IF EXISTS public.admin_get_github_orgs();
+
+CREATE OR REPLACE FUNCTION public.admin_get_github_orgs()
+RETURNS TABLE (
+    org_name text,
+    default_handout_template_repo text,
+    default_solution_template_repo text,
+    permission_sync_exempt_users text[],
+    course_count bigint,
+    is_configured boolean,
+    created_at timestamptz,
+    updated_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF NOT public.authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    RETURN QUERY
+    WITH orgs AS (
+        SELECT go.org_name FROM public.github_orgs go
+        UNION
+        SELECT DISTINCT c.github_org AS org_name FROM public.classes c WHERE c.github_org IS NOT NULL
+    )
+    SELECT
+        o.org_name,
+        COALESCE(go.default_handout_template_repo, 'pawtograder/template-assignment-handout'),
+        COALESCE(go.default_solution_template_repo, 'pawtograder/template-assignment-grader'),
+        COALESCE(go.permission_sync_exempt_users, '{}'::text[]),
+        (SELECT COUNT(*) FROM public.classes c WHERE c.github_org = o.org_name)::bigint,
+        (go.org_name IS NOT NULL) AS is_configured,
+        go.created_at,
+        go.updated_at
+    FROM orgs o
+    LEFT JOIN public.github_orgs go ON go.org_name = o.org_name
+    ORDER BY o.org_name;
+END;
+$$;
+
+----------------------------------------------------------------------------------------
+-- admin_upsert_github_org: accept the new column
+----------------------------------------------------------------------------------------
+
+-- Adding a parameter creates an OVERLOAD rather than replacing, and two candidates with the same
+-- name leave PostgREST unable to choose. Drop the old arity explicitly.
+DROP FUNCTION IF EXISTS public.admin_upsert_github_org(text, text, text);
+
+CREATE OR REPLACE FUNCTION public.admin_upsert_github_org(
+    p_org_name text,
+    p_handout text DEFAULT NULL,
+    p_solution text DEFAULT NULL,
+    p_permission_sync_exempt_users text[] DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_exempt text[];
+    v_login text;
+BEGIN
+    IF NOT public.authorize_for_admin() THEN
+        RAISE EXCEPTION 'Access denied: Admin role required';
+    END IF;
+
+    IF p_org_name IS NULL OR trim(p_org_name) = '' THEN
+        RAISE EXCEPTION 'Org name is required';
+    END IF;
+
+    -- A non-empty default must be exactly "owner/repo" (NULL/empty falls back to the constant).
+    IF NULLIF(trim(p_handout), '') IS NOT NULL AND trim(p_handout) !~ '^[^/[:space:]]+/[^/[:space:]]+$' THEN
+        RAISE EXCEPTION 'Invalid handout template repo "%": expected "owner/repo"', p_handout;
+    END IF;
+    IF NULLIF(trim(p_solution), '') IS NOT NULL AND trim(p_solution) !~ '^[^/[:space:]]+/[^/[:space:]]+$' THEN
+        RAISE EXCEPTION 'Invalid solution template repo "%": expected "owner/repo"', p_solution;
+    END IF;
+
+    -- Normalize to lowercase and drop blanks/duplicates: the sync compares lowercased logins, so an
+    -- entry typed with GitHub's display casing would silently never match and the exemption would
+    -- appear configured while doing nothing.
+    IF p_permission_sync_exempt_users IS NULL THEN
+        v_exempt := NULL;
+    ELSE
+        SELECT COALESCE(array_agg(DISTINCT lower(trim(u)) ORDER BY lower(trim(u))), '{}'::text[])
+        INTO v_exempt
+        FROM unnest(p_permission_sync_exempt_users) AS u
+        WHERE NULLIF(trim(u), '') IS NOT NULL;
+
+        FOREACH v_login IN ARRAY v_exempt LOOP
+            -- GitHub logins: alphanumeric with single internal hyphens, 39 chars max. Rejecting the
+            -- obviously-wrong shapes here stops "owner/repo" or an email being pasted in and then
+            -- never matching anything.
+            IF v_login !~ '^[a-z0-9](?:[a-z0-9]|-[a-z0-9]){0,38}$' THEN
+                RAISE EXCEPTION 'Invalid GitHub login "%": expected a GitHub username', v_login;
+            END IF;
+        END LOOP;
+    END IF;
+
+    INSERT INTO public.github_orgs (
+        org_name,
+        default_handout_template_repo,
+        default_solution_template_repo,
+        permission_sync_exempt_users,
+        created_by,
+        updated_by
+    ) VALUES (
+        trim(p_org_name),
+        COALESCE(NULLIF(trim(p_handout), ''), 'pawtograder/template-assignment-handout'),
+        COALESCE(NULLIF(trim(p_solution), ''), 'pawtograder/template-assignment-grader'),
+        COALESCE(v_exempt, '{}'::text[]),
+        auth.uid(),
+        auth.uid()
+    )
+    ON CONFLICT (org_name) DO UPDATE SET
+        default_handout_template_repo = COALESCE(NULLIF(trim(p_handout), ''), 'pawtograder/template-assignment-handout'),
+        default_solution_template_repo = COALESCE(NULLIF(trim(p_solution), ''), 'pawtograder/template-assignment-grader'),
+        -- NULL means "not supplied by this caller", so the existing list survives a save from a
+        -- client that only knows about the template fields. Clearing is an explicit empty array.
+        permission_sync_exempt_users = COALESCE(v_exempt, public.github_orgs.permission_sync_exempt_users),
+        updated_by = auth.uid(),
+        updated_at = now();
+END;
+$$;
+
+----------------------------------------------------------------------------------------
+-- Grants (the DROPs above took the old ones with them)
+----------------------------------------------------------------------------------------
+
+REVOKE EXECUTE ON FUNCTION public.admin_get_github_orgs() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.admin_upsert_github_org(text, text, text, text[]) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.admin_get_github_orgs() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.admin_upsert_github_org(text, text, text, text[]) TO authenticated, service_role;

--- a/supabase/migrations/20260908120000_github_org_permission_sync_exemptions.sql
+++ b/supabase/migrations/20260908120000_github_org_permission_sync_exemptions.sql
@@ -55,8 +55,15 @@ BEGIN
     )
     SELECT
         o.org_name,
-        COALESCE(go.default_handout_template_repo, 'pawtograder/template-assignment-handout'),
-        COALESCE(go.default_solution_template_repo, 'pawtograder/template-assignment-grader'),
+        -- Through resolve_effective_template_repo, NOT a bare COALESCE to the constant: an org with
+        -- no row must still report the deployment's app.settings default (20260715120000), or a
+        -- self-hosted site sees pawtograder/* here and materializes it on the next save.
+        public.resolve_effective_template_repo(
+            NULL, go.default_handout_template_repo,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            NULL, go.default_solution_template_repo,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         COALESCE(go.permission_sync_exempt_users, '{}'::text[]),
         (SELECT COUNT(*) FROM public.classes c WHERE c.github_org = o.org_name)::bigint,
         (go.org_name IS NOT NULL) AS is_configured,
@@ -122,7 +129,12 @@ BEGIN
             -- GitHub logins: alphanumeric with single internal hyphens, 39 chars max. Rejecting the
             -- obviously-wrong shapes here stops "owner/repo" or an email being pasted in and then
             -- never matching anything.
-            IF v_login !~ '^[a-z0-9](?:[a-z0-9]|-[a-z0-9]){0,38}$' THEN
+            --
+            -- The length is checked separately because the pattern cannot express it: the repeated
+            -- alternative consumes TWO characters on every '-[a-z0-9]' branch, so it accepts up to
+            -- 77 characters and an over-long login would be stored as a configured exemption that
+            -- can never match a real account.
+            IF length(v_login) > 39 OR v_login !~ '^[a-z0-9](?:[a-z0-9]|-[a-z0-9]){0,38}$' THEN
                 RAISE EXCEPTION 'Invalid GitHub login "%": expected a GitHub username', v_login;
             END IF;
         END LOOP;
@@ -137,15 +149,27 @@ BEGIN
         updated_by
     ) VALUES (
         trim(p_org_name),
-        COALESCE(NULLIF(trim(p_handout), ''), 'pawtograder/template-assignment-handout'),
-        COALESCE(NULLIF(trim(p_solution), ''), 'pawtograder/template-assignment-grader'),
+        -- A blank template field means "use the site default", which is the GUC tier, not the
+        -- constant. Writing the constant instead would override the operator's configured default
+        -- for every future assignment in this org — including when the admin only came here to
+        -- edit the exemption list and left the template boxes untouched.
+        public.resolve_effective_template_repo(
+            NULLIF(trim(p_handout), ''), NULL,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        public.resolve_effective_template_repo(
+            NULLIF(trim(p_solution), ''), NULL,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         COALESCE(v_exempt, '{}'::text[]),
         auth.uid(),
         auth.uid()
     )
     ON CONFLICT (org_name) DO UPDATE SET
-        default_handout_template_repo = COALESCE(NULLIF(trim(p_handout), ''), 'pawtograder/template-assignment-handout'),
-        default_solution_template_repo = COALESCE(NULLIF(trim(p_solution), ''), 'pawtograder/template-assignment-grader'),
+        default_handout_template_repo = public.resolve_effective_template_repo(
+            NULLIF(trim(p_handout), ''), NULL,
+            'app.settings.default_handout_template_repo', 'pawtograder/template-assignment-handout'),
+        default_solution_template_repo = public.resolve_effective_template_repo(
+            NULLIF(trim(p_solution), ''), NULL,
+            'app.settings.default_solution_template_repo', 'pawtograder/template-assignment-grader'),
         -- NULL means "not supplied by this caller", so the existing list survives a save from a
         -- client that only knows about the template fields. Clearing is an explicit empty array.
         permission_sync_exempt_users = COALESCE(v_exempt, public.github_orgs.permission_sync_exempt_users),

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -3543,6 +3543,7 @@ export type Database = {
           default_handout_template_repo: string;
           default_solution_template_repo: string;
           org_name: string;
+          permission_sync_exempt_users: string[];
           updated_at: string;
           updated_by: string | null;
         };
@@ -3552,6 +3553,7 @@ export type Database = {
           default_handout_template_repo?: string;
           default_solution_template_repo?: string;
           org_name: string;
+          permission_sync_exempt_users?: string[];
           updated_at?: string;
           updated_by?: string | null;
         };
@@ -3561,6 +3563,7 @@ export type Database = {
           default_handout_template_repo?: string;
           default_solution_template_repo?: string;
           org_name?: string;
+          permission_sync_exempt_users?: string[];
           updated_at?: string;
           updated_by?: string | null;
         };
@@ -11981,6 +11984,7 @@ export type Database = {
           default_solution_template_repo: string;
           is_configured: boolean;
           org_name: string;
+          permission_sync_exempt_users: string[];
           updated_at: string;
         }[];
       };
@@ -12102,7 +12106,12 @@ export type Database = {
         Returns: boolean;
       };
       admin_upsert_github_org: {
-        Args: { p_handout?: string; p_org_name: string; p_solution?: string };
+        Args: {
+          p_handout?: string;
+          p_org_name: string;
+          p_permission_sync_exempt_users?: string[];
+          p_solution?: string;
+        };
         Returns: undefined;
       };
       admin_upsert_lti_platform: {


### PR DESCRIPTION
Follow-up to #959, on the same code path but a different mechanism.

## The incident

Handout creation for a large course org took **95.6 seconds** and outlived the browser waiting on it. The UI chains handout → solution repo creation, so when the first promise rejected the second never fired — leaving the assignment with a handout repo and no grader repo. Observed on `neu-cs4530/fa26`:

```
edge:  POST /assignment-create-handout-repo              -> 200 95585ms
kong:  POST /functions/v1/assignment-create-handout-repo -> 499     (~30s in)
       ...no assignment-create-solution-repo call ever follows
```

`fa26-handout-ip2` exists on GitHub. `fa26-solution-ip2` does not.

Nearly all 95 seconds was work that **could not have had an effect**.

## 1. Removals GitHub cannot perform — 63.6s

`DELETE /repos/{owner}/{repo}/collaborators/{username}` revokes a **direct** collaborator grant. It cannot revoke access held through a team or through org ownership: GitHub accepts the call, answers 2xx, and the person keeps their access. `GET .../collaborators` defaults to `affiliation=all`, so the candidate list mixed all three kinds together and every team- or owner-derived entry became one serial DELETE that did nothing.

Measured on that repo:

| affiliation | count |
|---|---|
| `all` | 37 |
| `direct` | **0** |
| `outside` | 0 |

Org `default_repository_permission` is `none` — all 37 came from the `fa26-staff` team plus org owners. The sync attempted 22 removals, spent 63.6s, and revoked nothing; `robsimmons` still has `admin` on the repo afterwards. The same 63.6s would be spent again on every subsequent sync.

Removal candidates are now filtered to direct collaborators, with a `removals_skipped_not_direct` counter so a regression reads as a number rather than as latency somebody has to go and explain.

## 2. An org roster nobody asked about — 18.8s

`allOrgMembers` answers exactly one question: *is this person I am about to ADD already in the org?* Handout and solution repo creation both pass an empty username list, so the paginated read of every org member fed nothing. Skipped when there's nobody to add — both consumers were already optional-chained, so this is the same code path as a failed lookup.

## 3. Exemptions become per-org config

`adminsThatShouldNotBeListedAsAdmins` is a hardcoded array of five logins in `GitHubWrapper.ts` — the same problem patched by hand. It applies to every org rather than the one it was added for, it's invisible to the admins who know who those people are, and changing it needs a deploy.

Adds `github_orgs.permission_sync_exempt_users`, surfaced on the existing per-org admin page. `admin_upsert_github_org` lowercases, dedupes, and enforces GitHub-login shape, so an entry can't be saved in a casing that silently never matches the lowercased logins the sync compares against.

An **unreadable** exemption list aborts the sync, which is what the staff-roster read already does for the same class of failure: a wrong removal isn't recoverable by the next sync, because the access is already gone. Degrading instead would report it through `removalsSkipped`, and only one of the twelve callers reads that flag — the other eleven would record the repo as ready and a dropped student would keep write access with nothing to retry it.

The list is cached per isolate for 60s, not for the isolate's lifetime. It's admin-editable safety config and nothing invalidates a warm isolate, so an unbounded entry means an exemption added right after a sync doesn't apply for hours. The TTL still collapses the burst the cache is for — `assignment-create-all-repos` syncs every repo in a course back to back against the same org.

The constant stays as a global backstop, so this deploy changes no behavior. **It can be deleted once the orgs that need entries have them — I don't know which org those five names belong to.** Say the word and I'll migrate them and drop the constant.

## 4. `github-repo-configure-webhook` no longer 500s on a bad request body

The autograder page sends `new_repo: values.grader_repo` straight from the form, and `autograder.grader_repo` is NULL exactly when solution-repo creation never finished — the state §1 leaves behind. It flowed unchecked into `getFileFromRepo` → `getOctoKit`:

```
[fn=github-repo-configure-webhook] Getting autograder config from repo null
TypeError: Cannot read properties of null (reading 'includes')
```

The instructor got a 500 reading "An unknown error occurred", with no hint that the fix is to create the repo. Now a 400 that says so. Four of these in 24h of prod logs.

The whole body is validated up front, since three more shapes produced the same unexplained 500. Malformed JSON throws a SyntaxError out of `req.json()`, and a body of JSON `null` or a bare scalar survives parsing and throws a TypeError on the destructuring — neither is a typed error, so both answered 500 *and* paged us. `readJsonObjectBody` (in `_shared/HandlerUtils.ts`, since `const { a, b } = await req.json()` is how nearly every function here reads its body) makes those a 400. Then `assignment_id.toString()` ran before any guard, so a missing id threw outside `UserVisibleError` the same way. And `new_repo` must now be a full `owner/name` (`isValidRepoFullName`, next to the helpers that do the splitting) rather than merely containing a slash: `getOctoKit`, `getFileFromRepo` and `getDefaultBranchHeadSha` all take the first two components, so `owner/repo/extra` didn't fail — it acted on `owner/repo`, a repository the instructor never named.

## Expected effect

For the `fa26-handout-ip2` case: `create_repo` 10.6s + sync ~2s ≈ **13s**, down from 95.6s.

## Testing

- 4 new tests on `filterToDirectCollaborators`, including case-insensitivity — a mismatch there would silently drop a *real* removal and let a dropped student keep write access.
- 5 new tests on `isValidRepoFullName`, covering the boundaries that used to pass: `/`, `owner/`, `/repo`, `owner/repo/extra`, a pasted GitHub URL, whitespace, and non-strings.
- 6 new tests on `readJsonObjectBody`, driven through `wrapRequestHandler` with real `Request`s rather than asserting on the thrown class — a helper that throws the right error but still answers 500 would have fixed nothing.
- `deno test _shared/` — 351 passed, 0 failed (re-run after rebasing onto `staging`).
- Migration applied against a local Supabase under `--single-transaction`, matching how `migrate.sh` runs it: clean, exactly one `admin_upsert_github_org` left (no overload), normalization and login-shape validation verified — including that a 41-character login is rejected and a 39-character one is not, and that with `app.settings.default_*_template_repo` set, a save with blank template fields materializes the site default rather than the `pawtograder/*` constant.
- `deno check` reports the same 6 errors as base — all pre-existing, none in changed regions. `tsc --noEmit` and `eslint` show nothing in any changed file.
- `SupabaseTypes.d.ts` updated by hand to exactly the generator's output for this change. A full regen also pulled in unrelated drift (the committed types are stale vs. the `20260827`/`20260904` migrations), which didn't belong in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can configure GitHub usernames exempt from organization permission-sync removals.
  * Exemptions are normalized, validated, and persisted per organization.
  * Permission synchronization avoids removing exempt users and indirect or ownership-based access.

* **Bug Fixes**
  * Invalid repository configuration now returns a clear client-facing error instead of a generic server error.
  * Invalid webhook request values are rejected with appropriate client errors.

* **Tests**
  * Added coverage for collaborator filtering, case-insensitive matching, indirect access, empty inputs, and repository-name validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

