### PR TITLE
fix(gradebook): keep an assignment's gradebook column named after the assignment (#891)

### DIFF
--- a/supabase/migrations/20260909120000_sync_gradebook_column_name_on_assignment_rename.sql
+++ b/supabase/migrations/20260909120000_sync_gradebook_column_name_on_assignment_rename.sql
@@ -1,0 +1,47 @@
+-- Keep an assignment's auto-created gradebook column named after the assignment (#891).
+--
+-- create_gradebook_column_for_assignment copies assignments.title into
+-- gradebook_columns.name once, on INSERT. Nothing propagated a later rename, so
+-- the gradebook header kept showing whatever the assignment was first called.
+-- total_points already had an AFTER UPDATE sync (update_gradebook_column_max_score);
+-- this folds the name into the same trigger rather than adding a second one.
+--
+-- The rename is skipped when the column's name no longer equals the assignment's
+-- previous title: an instructor who deliberately gave the column its own name keeps
+-- it. That also means no backfill -- existing drift may be intentional, and there
+-- is no way to tell from the data.
+
+CREATE OR REPLACE FUNCTION public.sync_gradebook_column_from_assignment()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+    IF NEW.gradebook_column_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF OLD.total_points IS DISTINCT FROM NEW.total_points THEN
+        UPDATE public.gradebook_columns
+        SET max_score = NEW.total_points
+        WHERE id = NEW.gradebook_column_id;
+    END IF;
+
+    IF OLD.title IS DISTINCT FROM NEW.title THEN
+        UPDATE public.gradebook_columns
+        SET name = NEW.title
+        WHERE id = NEW.gradebook_column_id
+          AND name = OLD.title;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS update_gradebook_column_max_score_trigger ON public.assignments;
+DROP FUNCTION IF EXISTS public.update_gradebook_column_max_score();
+
+CREATE TRIGGER sync_gradebook_column_from_assignment_trigger
+AFTER UPDATE OF title, total_points ON public.assignments
+FOR EACH ROW EXECUTE FUNCTION public.sync_gradebook_column_from_assignment();

--- a/tests/manual/gradebook_column_name_sync.sql
+++ b/tests/manual/gradebook_column_name_sync.sql
@@ -1,0 +1,49 @@
+-- Proof harness for 20260909120000_sync_gradebook_column_name_on_assignment_rename.sql (#891).
+--
+-- Run from the repo root against local Supabase; one transaction ending in ROLLBACK, so the shared
+-- dev DB is untouched:
+--
+--   psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -f tests/manual/gradebook_column_name_sync.sql
+--
+-- Scenarios (each SELECT prints pass/fail):
+--   1. rename an assignment              -> its gradebook column follows
+--   2. rename again after the column was hand-renamed -> column keeps the hand-picked name
+--   3. change total_points               -> max_score still follows (the old trigger's job)
+--   4. the superseded trigger and function are gone
+--
+-- Uses the lowest-id assignment that has a gradebook column; needs `npm run seed` fixtures.
+\set ON_ERROR_STOP on
+\timing off
+BEGIN;
+
+\i supabase/migrations/20260909120000_sync_gradebook_column_name_on_assignment_rename.sql
+
+CREATE TEMP TABLE fixture AS
+SELECT a.id AS assignment_id, a.gradebook_column_id, a.title, a.total_points
+FROM public.assignments a
+WHERE a.gradebook_column_id IS NOT NULL
+ORDER BY a.id LIMIT 1;
+
+\echo '=== 1. rename assignment -> column follows ==='
+UPDATE public.assignments SET title = 'Renamed Once' WHERE id = (SELECT assignment_id FROM fixture);
+SELECT CASE WHEN name = 'Renamed Once' THEN 'pass' ELSE 'FAIL: ' || name END AS scenario_1
+FROM public.gradebook_columns WHERE id = (SELECT gradebook_column_id FROM fixture);
+
+\echo '=== 2. hand-renamed column is left alone ==='
+UPDATE public.gradebook_columns SET name = 'Custom Header' WHERE id = (SELECT gradebook_column_id FROM fixture);
+UPDATE public.assignments SET title = 'Renamed Twice' WHERE id = (SELECT assignment_id FROM fixture);
+SELECT CASE WHEN name = 'Custom Header' THEN 'pass' ELSE 'FAIL: ' || name END AS scenario_2
+FROM public.gradebook_columns WHERE id = (SELECT gradebook_column_id FROM fixture);
+
+\echo '=== 3. total_points still syncs max_score ==='
+UPDATE public.assignments SET total_points = 12345 WHERE id = (SELECT assignment_id FROM fixture);
+SELECT CASE WHEN max_score = 12345 THEN 'pass' ELSE 'FAIL: ' || max_score END AS scenario_3
+FROM public.gradebook_columns WHERE id = (SELECT gradebook_column_id FROM fixture);
+
+\echo '=== 4. old trigger/function removed ==='
+SELECT CASE WHEN count(*) = 0 THEN 'pass' ELSE 'FAIL' END AS scenario_4
+FROM pg_trigger WHERE tgname = 'update_gradebook_column_max_score_trigger';
+SELECT CASE WHEN count(*) = 0 THEN 'pass' ELSE 'FAIL' END AS scenario_4b
+FROM pg_proc WHERE proname = 'update_gradebook_column_max_score';
+
+ROLLBACK;


### PR DESCRIPTION
Fixes #891.

## The bug

Renaming an assignment leaves its gradebook column header showing the old name.

`create_gradebook_column_for_assignment` copies `assignments.title` into `gradebook_columns.name` once, on `INSERT`. The only `AFTER UPDATE` sync on assignments, `update_gradebook_column_max_score`, propagates `total_points` to `max_score` and nothing else. So the column name is frozen at whatever the assignment was first called.

## The fix

One migration, `20260909120000_sync_gradebook_column_name_on_assignment_rename.sql`:

- **`sync_gradebook_column_from_assignment` replaces `update_gradebook_column_max_score`.** It keeps the `max_score` sync unchanged and adds the title sync, so there is one trigger doing "keep the auto-created column in step with its assignment" rather than two. The trigger is `AFTER UPDATE OF title, total_points`, so unrelated assignment updates skip it.
- **A hand-renamed column is left alone.** The rename only applies when `gradebook_columns.name` still equals `OLD.title`. An instructor who deliberately gave the column its own header keeps it. The reporter in #891 was relying on exactly that, so clobbering it would trade one bug for another.
- **No backfill.** Existing drift can be either accidental or deliberate, and the data cannot distinguish them. New renames sync from here on.

## Testing

`tests/manual/gradebook_column_name_sync.sql` follows the existing proof-harness pattern in that directory. It runs in one transaction that ends in `ROLLBACK`:

```
psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -f tests/manual/gradebook_column_name_sync.sql
```

| Scenario | Result |
| --- | --- |
| Rename assignment, column follows | pass |
| Rename again after hand-renaming the column, column keeps its custom name | pass |
| Change `total_points`, `max_score` still follows | pass |
| Old trigger and function are gone | pass |

Also applied through `supabase migration up` on a fresh local database seeded with `npm run seed`; the new trigger is the only gradebook sync trigger left on `public.assignments`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Assignment title changes now automatically update linked gradebook column names.
  - Assignment point-value changes continue to synchronize the gradebook column’s maximum score.
  - Custom gradebook column names are preserved when they have been intentionally changed.
  - Assignments without linked gradebook columns are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->