### PR TITLE
fix(github): stop one deleted repo from throttling permission sync for a whole org

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -299,6 +299,64 @@ Deno.test(
   }
 );
 
+Deno.test(
+  "listCollaboratorsOrThrowMissing: parking requires the scope to still be all-repos after the probe",
+  async () => {
+    // The TOCTOU: scope read as "all" before the probe, narrowed by an admin, so a live but
+    // newly-deselected repo 404s. Confirming after the 404 catches it and refuses to park.
+    const selections: Array<"all" | "selected"> = ["all", "selected"];
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}/collaborators": () => {
+        throw requestError(404, "Not Found");
+      },
+      "GET /repos/{owner}/{repo}": () => {
+        throw requestError(404, "Not Found");
+      }
+    });
+    const err = await assertRejects(
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => selections.shift()),
+      RepositoryUnreadableError
+    );
+    assertEquals(err instanceof RepositoryMissingError, false);
+  }
+);
+
+Deno.test("listCollaboratorsOrThrowMissing: scope unreadable on confirmation -> rethrows, parks nothing", async () => {
+  // Second read failed. We had one "all" and one shrug, which is not proof.
+  const selections: Array<"all" | undefined> = ["all", undefined];
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  const err = await assertRejects(
+    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => selections.shift()),
+    RequestError
+  );
+  assertEquals(err.status, 404);
+});
+
+Deno.test("listCollaboratorsOrThrowMissing: a rate-limited probe propagates, so the worker can back off", async () => {
+  // Not "unknown": flattening it would strip Retry-After before detectRateLimitType sees it, and
+  // the job would surface as a generic failure that opens the org circuit.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(429, "Too Many Requests");
+    }
+  });
+  const err = await assertRejects(
+    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all"),
+    RequestError
+  );
+  assertEquals(err.status, 429);
+});
+
 Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never on the happy path", async () => {
   // The resolver hits GitHub, so it must not be called when the collaborator read succeeds.
   let resolverCalls = 0;

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -376,6 +376,41 @@ Deno.test("listCollaboratorsOrThrowMissing: a 404 whose repo is PRESENT is passe
   assertEquals(err instanceof RepositoryUnreadableError, false);
 });
 
+Deno.test("listCollaboratorsOrThrowMissing: passes affiliation through, and still classifies its 404", async () => {
+  // The direct-collaborator read is the sync's second retry ladder; it needs the same in-band
+  // classification, so the helper has to carry `affiliation` without losing that behaviour.
+  let seenAffiliation: unknown = "unset";
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": (params) => {
+      seenAffiliation = params.affiliation;
+      throw requestError(404, "Not Found");
+    },
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  await assertRejects(
+    () =>
+      listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all", {
+        affiliation: "direct"
+      }),
+    RepositoryMissingError
+  );
+  assertEquals(seenAffiliation, "direct");
+});
+
+Deno.test("listCollaboratorsOrThrowMissing: omits affiliation when not asked for", async () => {
+  let seenAffiliation: unknown = "unset";
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": (params) => {
+      seenAffiliation = params.affiliation;
+      return [];
+    }
+  });
+  await listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all");
+  assertEquals(seenAffiliation, undefined);
+});
+
 Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never on the happy path", async () => {
   // The resolver hits GitHub, so it must not be called when the collaborator read succeeds.
   let resolverCalls = 0;

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -26,11 +26,11 @@ const {
   isRepoEmpty,
   isTeamAlreadyExistsError,
   isValidRepoFullName,
+  classifyRepoPresence,
   listCollaboratorsOrThrowMissing,
   NonRetryableGitHubError,
   NonRetryableRepoError,
   publicSupabaseUrl,
-  repoExists,
   RepositoryMissingError,
   resolveExistingTeamSlug,
   resolveTeamSlugIfExists,
@@ -151,36 +151,58 @@ Deno.test("assertSourceNotEmpty: missing source (404 on repo) -> NonRetryableRep
 // (worth the 93s retry ladder) or a repo that is gone (where the ladder buys nothing and the
 // escaping RequestError trips the org's method circuit). These pin the classification.
 
-Deno.test("repoExists: repo present -> true", async () => {
+Deno.test("classifyRepoPresence: repo readable -> present", async () => {
   const octokit = fakeOctokit({ "GET /repos/{owner}/{repo}": META_OK });
-  assertEquals(await repoExists(octokit, "org", "repo"), true);
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "present");
 });
 
-Deno.test("repoExists: 404 -> false", async () => {
+Deno.test("classifyRepoPresence: 404 on an all-repos installation -> absent", async () => {
+  // Only here is a 404 proof: the installation can see every repo in the org, so there was
+  // nothing to hide.
   const octokit = fakeOctokit({
     "GET /repos/{owner}/{repo}": () => {
       throw requestError(404, "Not Found");
     }
   });
-  assertEquals(await repoExists(octokit, "org", "repo"), false);
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "absent");
 });
 
-Deno.test("repoExists: non-404 rethrows rather than reporting absence", async () => {
-  // "We could not find out" must never be recorded as "the repo is gone" — that would clear
-  // is_github_ready on live repos during a GitHub outage.
+Deno.test("classifyRepoPresence: 404 on a selected-repos installation -> inaccessible, NOT absent", async () => {
+  // A repo we were never granted 404s exactly like a deleted one. Calling this "absent" would
+  // park a LIVE repo and skip it forever after access was restored.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "selected"), "inaccessible");
+});
+
+Deno.test("classifyRepoPresence: 404 with unknown installation scope -> inaccessible", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", undefined), "inaccessible");
+});
+
+Deno.test("classifyRepoPresence: non-404 -> inaccessible, never absent", async () => {
+  // "We could not find out" must never be recorded as "the repo is gone" — that would park live
+  // repos during a GitHub outage.
   const octokit = fakeOctokit({
     "GET /repos/{owner}/{repo}": () => {
       throw requestError(500, "Server Error");
     }
   });
-  await assertRejects(() => repoExists(octokit, "org", "repo"), RequestError);
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "inaccessible");
 });
 
 Deno.test("listCollaboratorsOrThrowMissing: happy path returns the collaborator list", async () => {
   const octokit = fakeOctokit({
     "GET /repos/{owner}/{repo}/collaborators": () => [{ login: "student", role_name: "write" }]
   });
-  const got = await listCollaboratorsOrThrowMissing(octokit, "org", "repo");
+  const got = await listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all");
   assertEquals(got.length, 1);
 });
 
@@ -193,7 +215,7 @@ Deno.test(
       },
       "GET /repos/{owner}/{repo}": META_OK
     });
-    const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo"), RequestError);
+    const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"), RequestError);
     assertEquals(err.status, 404);
   }
 );
@@ -210,12 +232,33 @@ Deno.test(
       }
     });
     const err = await assertRejects(
-      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo"),
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"),
       RepositoryMissingError
     );
     assertEquals(err.fullName, "org/repo");
     // The worker branches on this to keep the failure per-row instead of tripping the org circuit.
     assertEquals(err instanceof NonRetryableGitHubError, true);
+  }
+);
+
+Deno.test(
+  "listCollaboratorsOrThrowMissing: 404 everywhere but a selected-repos install -> rethrows, does NOT park",
+  async () => {
+    // The case that would park a live repo if presence were read as a boolean: both endpoints 404
+    // because the installation was never granted this repo, not because it was deleted.
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}/collaborators": () => {
+        throw requestError(404, "Not Found");
+      },
+      "GET /repos/{owner}/{repo}": () => {
+        throw requestError(404, "Not Found");
+      }
+    });
+    const err = await assertRejects(
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "selected"),
+      RequestError
+    );
+    assertEquals(err.status, 404);
   }
 );
 
@@ -227,7 +270,7 @@ Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existe
       throw requestError(403, "Forbidden");
     }
   });
-  const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo"), RequestError);
+  const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"), RequestError);
   assertEquals(err.status, 403);
 });
 

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -179,6 +179,30 @@ Deno.test("classifyRepoPresence: 404 on a selected-repos installation -> inacces
   assertEquals(await classifyRepoPresence(octokit, "org", "repo", "selected"), "inaccessible");
 });
 
+Deno.test(
+  'classifyRepoPresence: a statusless error whose message says "Not Found" -> unknown, never absent',
+  async () => {
+    // isGitHubNotFoundError has a `message.includes("Not Found")` fallback, so a transport/proxy
+    // error or a wrapped 5xx carrying that text would otherwise be read as proof of deletion and
+    // park a repo whose existence was never confirmed. This classification uses status only.
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}": () => {
+        throw new Error("socket hang up: Not Found");
+      }
+    });
+    assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "unknown");
+  }
+);
+
+Deno.test("classifyRepoPresence: a wrapped 5xx mentioning Not Found -> unknown, never absent", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(502, "Bad Gateway: Not Found");
+    }
+  });
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "unknown");
+});
+
 Deno.test("classifyRepoPresence: 404 with an undetermined installation scope -> unknown, so it retries", async () => {
   // undefined scope means the lookup failed, not that the install is "selected". Terminating here
   // would discard a permission sync (or leave a missing row unparked) because an auxiliary lookup

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -26,8 +26,12 @@ const {
   isRepoEmpty,
   isTeamAlreadyExistsError,
   isValidRepoFullName,
+  listCollaboratorsOrThrowMissing,
+  NonRetryableGitHubError,
   NonRetryableRepoError,
   publicSupabaseUrl,
+  repoExists,
+  RepositoryMissingError,
   resolveExistingTeamSlug,
   resolveTeamSlugIfExists,
   TeamMembersUnreadableError,
@@ -139,6 +143,92 @@ Deno.test("assertSourceNotEmpty: missing source (404 on repo) -> NonRetryableRep
     NonRetryableRepoError
   );
   assertEquals(err.message.includes("not found"), true);
+});
+
+// --- Telling "not yet" from "never again" on the collaborator read ---
+//
+// A 404 from the collaborators endpoint is ambiguous: read-after-create lag on a repo that exists
+// (worth the 93s retry ladder) or a repo that is gone (where the ladder buys nothing and the
+// escaping RequestError trips the org's method circuit). These pin the classification.
+
+Deno.test("repoExists: repo present -> true", async () => {
+  const octokit = fakeOctokit({ "GET /repos/{owner}/{repo}": META_OK });
+  assertEquals(await repoExists(octokit, "org", "repo"), true);
+});
+
+Deno.test("repoExists: 404 -> false", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  assertEquals(await repoExists(octokit, "org", "repo"), false);
+});
+
+Deno.test("repoExists: non-404 rethrows rather than reporting absence", async () => {
+  // "We could not find out" must never be recorded as "the repo is gone" — that would clear
+  // is_github_ready on live repos during a GitHub outage.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(500, "Server Error");
+    }
+  });
+  await assertRejects(() => repoExists(octokit, "org", "repo"), RequestError);
+});
+
+Deno.test("listCollaboratorsOrThrowMissing: happy path returns the collaborator list", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => [{ login: "student", role_name: "write" }]
+  });
+  const got = await listCollaboratorsOrThrowMissing(octokit, "org", "repo");
+  assertEquals(got.length, 1);
+});
+
+Deno.test(
+  "listCollaboratorsOrThrowMissing: 404 on a repo that EXISTS -> rethrows, so the ladder still retries",
+  async () => {
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}/collaborators": () => {
+        throw requestError(404, "Not Found");
+      },
+      "GET /repos/{owner}/{repo}": META_OK
+    });
+    const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo"), RequestError);
+    assertEquals(err.status, 404);
+  }
+);
+
+Deno.test(
+  "listCollaboratorsOrThrowMissing: 404 on a repo that is GONE -> terminal RepositoryMissingError",
+  async () => {
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}/collaborators": () => {
+        throw requestError(404, "Not Found");
+      },
+      "GET /repos/{owner}/{repo}": () => {
+        throw requestError(404, "Not Found");
+      }
+    });
+    const err = await assertRejects(
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo"),
+      RepositoryMissingError
+    );
+    assertEquals(err.fullName, "org/repo");
+    // The worker branches on this to keep the failure per-row instead of tripping the org circuit.
+    assertEquals(err instanceof NonRetryableGitHubError, true);
+  }
+);
+
+Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existence probe", async () => {
+  // No "GET /repos/{owner}/{repo}" handler: fakeOctokit throws on an unexpected route, so this
+  // fails loudly if a 403 ever starts costing an extra request.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => {
+      throw requestError(403, "Forbidden");
+    }
+  });
+  const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo"), RequestError);
+  assertEquals(err.status, 403);
 });
 
 // --- Idempotent team creation (getTeamAndCreateIfNeeded) ---

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -32,6 +32,7 @@ const {
   NonRetryableRepoError,
   publicSupabaseUrl,
   RepositoryMissingError,
+  RepositoryUnreadableError,
   resolveExistingTeamSlug,
   resolveTeamSlugIfExists,
   TeamMembersUnreadableError,
@@ -187,7 +188,7 @@ Deno.test("classifyRepoPresence: 404 with unknown installation scope -> inaccess
   assertEquals(await classifyRepoPresence(octokit, "org", "repo", undefined), "inaccessible");
 });
 
-Deno.test("classifyRepoPresence: non-404 -> inaccessible, never absent", async () => {
+Deno.test("classifyRepoPresence: probe itself fails (non-404) -> unknown, never absent", async () => {
   // "We could not find out" must never be recorded as "the repo is gone" — that would park live
   // repos during a GitHub outage.
   const octokit = fakeOctokit({
@@ -195,7 +196,7 @@ Deno.test("classifyRepoPresence: non-404 -> inaccessible, never absent", async (
       throw requestError(500, "Server Error");
     }
   });
-  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "inaccessible");
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", "all"), "unknown");
 });
 
 Deno.test("listCollaboratorsOrThrowMissing: happy path returns the collaborator list", async () => {
@@ -245,10 +246,12 @@ Deno.test(
 );
 
 Deno.test(
-  "listCollaboratorsOrThrowMissing: 404 everywhere but a selected-repos install -> rethrows, does NOT park",
+  "listCollaboratorsOrThrowMissing: 404 on a selected-repos install -> RepositoryUnreadableError, terminal but not proof",
   async () => {
-    // The case that would park a live repo if presence were read as a boolean: both endpoints 404
-    // because the installation was never granted this repo, not because it was deleted.
+    // Both endpoints 404 because the installation was never granted this repo, not because it was
+    // deleted. This must be terminal — retrying cannot make an ungranted repo readable, and letting
+    // a bare 404 escape would spend the ladder and then trip the ORG-WIDE circuit over one repo —
+    // while still not being proof of anything about the row.
     const octokit = fakeOctokit({
       "GET /repos/{owner}/{repo}/collaborators": () => {
         throw requestError(404, "Not Found");
@@ -259,9 +262,13 @@ Deno.test(
     });
     const err = await assertRejects(
       () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "selected"),
-      RequestError
+      RepositoryUnreadableError
     );
-    assertEquals(err.status, 404);
+    assertEquals(err.fullName, "org/repo");
+    // Non-retryable, so the worker keeps it off the shared circuit and out of the error threshold.
+    assertEquals(err instanceof NonRetryableGitHubError, true);
+    // But NOT the parking error: only proven-absent repos may touch the database.
+    assertEquals(err instanceof RepositoryMissingError, false);
   }
 );
 
@@ -278,7 +285,7 @@ Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never 
   assertEquals(resolverCalls, 0);
 });
 
-Deno.test("listCollaboratorsOrThrowMissing: a resolver that cannot answer -> inaccessible, does NOT park", async () => {
+Deno.test("listCollaboratorsOrThrowMissing: a resolver that cannot answer -> unreadable, never missing", async () => {
   // fetchRepositorySelection returns undefined when it cannot read the installation. Unknown scope
   // must never be treated as proof of deletion.
   const octokit = fakeOctokit({
@@ -291,9 +298,9 @@ Deno.test("listCollaboratorsOrThrowMissing: a resolver that cannot answer -> ina
   });
   const err = await assertRejects(
     () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => undefined),
-    RequestError
+    RepositoryUnreadableError
   );
-  assertEquals(err.status, 404);
+  assertEquals(err instanceof RepositoryMissingError, false);
 });
 
 Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existence probe", async () => {

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -179,13 +179,16 @@ Deno.test("classifyRepoPresence: 404 on a selected-repos installation -> inacces
   assertEquals(await classifyRepoPresence(octokit, "org", "repo", "selected"), "inaccessible");
 });
 
-Deno.test("classifyRepoPresence: 404 with unknown installation scope -> inaccessible", async () => {
+Deno.test("classifyRepoPresence: 404 with an undetermined installation scope -> unknown, so it retries", async () => {
+  // undefined scope means the lookup failed, not that the install is "selected". Terminating here
+  // would discard a permission sync (or leave a missing row unparked) because an auxiliary lookup
+  // hit a 5xx or a rate limit.
   const octokit = fakeOctokit({
     "GET /repos/{owner}/{repo}": () => {
       throw requestError(404, "Not Found");
     }
   });
-  assertEquals(await classifyRepoPresence(octokit, "org", "repo", undefined), "inaccessible");
+  assertEquals(await classifyRepoPresence(octokit, "org", "repo", undefined), "unknown");
 });
 
 Deno.test("classifyRepoPresence: probe itself fails (non-404) -> unknown, never absent", async () => {
@@ -285,23 +288,27 @@ Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never 
   assertEquals(resolverCalls, 0);
 });
 
-Deno.test("listCollaboratorsOrThrowMissing: a resolver that cannot answer -> unreadable, never missing", async () => {
-  // fetchRepositorySelection returns undefined when it cannot read the installation. Unknown scope
-  // must never be treated as proof of deletion.
-  const octokit = fakeOctokit({
-    "GET /repos/{owner}/{repo}/collaborators": () => {
-      throw requestError(404, "Not Found");
-    },
-    "GET /repos/{owner}/{repo}": () => {
-      throw requestError(404, "Not Found");
-    }
-  });
-  const err = await assertRejects(
-    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => undefined),
-    RepositoryUnreadableError
-  );
-  assertEquals(err instanceof RepositoryMissingError, false);
-});
+Deno.test(
+  "listCollaboratorsOrThrowMissing: a resolver that cannot answer -> rethrows, terminates nothing",
+  async () => {
+    // fetchRepositorySelection returns undefined when it cannot read the installation — a transient
+    // 5xx or rate limit. That must stay retryable: it is neither proof of deletion nor proof of a
+    // selected-repos install, so it may neither park the row nor discard the job.
+    const octokit = fakeOctokit({
+      "GET /repos/{owner}/{repo}/collaborators": () => {
+        throw requestError(404, "Not Found");
+      },
+      "GET /repos/{owner}/{repo}": () => {
+        throw requestError(404, "Not Found");
+      }
+    });
+    const err = await assertRejects(
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => undefined),
+      RequestError
+    );
+    assertEquals(err.status, 404);
+  }
+);
 
 Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existence probe", async () => {
   // No "GET /repos/{owner}/{repo}" handler: fakeOctokit throws on an unexpected route, so this

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -357,6 +357,25 @@ Deno.test("listCollaboratorsOrThrowMissing: a rate-limited probe propagates, so 
   assertEquals(err.status, 429);
 });
 
+Deno.test("listCollaboratorsOrThrowMissing: a 404 whose repo is PRESENT is passed through untouched", async () => {
+  // The invariant that lets the whole-sync backstop be applied broadly: a 404 that was never about
+  // the repo (e.g. a deleted GitHub account on a collaborator PUT) must not be reinterpreted as a
+  // missing repo, or a live repo gets parked because a student deleted their account.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /repos/{owner}/{repo}": META_OK
+  });
+  const err = await assertRejects(
+    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all"),
+    RequestError
+  );
+  assertEquals(err.status, 404);
+  assertEquals(err instanceof RepositoryMissingError, false);
+  assertEquals(err instanceof RepositoryUnreadableError, false);
+});
+
 Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never on the happy path", async () => {
   // The resolver hits GitHub, so it must not be called when the collaborator read succeeds.
   let resolverCalls = 0;

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -202,7 +202,7 @@ Deno.test("listCollaboratorsOrThrowMissing: happy path returns the collaborator 
   const octokit = fakeOctokit({
     "GET /repos/{owner}/{repo}/collaborators": () => [{ login: "student", role_name: "write" }]
   });
-  const got = await listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all");
+  const got = await listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all");
   assertEquals(got.length, 1);
 });
 
@@ -215,7 +215,10 @@ Deno.test(
       },
       "GET /repos/{owner}/{repo}": META_OK
     });
-    const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"), RequestError);
+    const err = await assertRejects(
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all"),
+      RequestError
+    );
     assertEquals(err.status, 404);
   }
 );
@@ -232,7 +235,7 @@ Deno.test(
       }
     });
     const err = await assertRejects(
-      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"),
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all"),
       RepositoryMissingError
     );
     assertEquals(err.fullName, "org/repo");
@@ -255,12 +258,43 @@ Deno.test(
       }
     });
     const err = await assertRejects(
-      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "selected"),
+      () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "selected"),
       RequestError
     );
     assertEquals(err.status, 404);
   }
 );
+
+Deno.test("listCollaboratorsOrThrowMissing: selection is resolved lazily, never on the happy path", async () => {
+  // The resolver hits GitHub, so it must not be called when the collaborator read succeeds.
+  let resolverCalls = 0;
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => [{ login: "student", role_name: "write" }]
+  });
+  await listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => {
+    resolverCalls++;
+    return "all";
+  });
+  assertEquals(resolverCalls, 0);
+});
+
+Deno.test("listCollaboratorsOrThrowMissing: a resolver that cannot answer -> inaccessible, does NOT park", async () => {
+  // fetchRepositorySelection returns undefined when it cannot read the installation. Unknown scope
+  // must never be treated as proof of deletion.
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}/collaborators": () => {
+      throw requestError(404, "Not Found");
+    },
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  const err = await assertRejects(
+    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => undefined),
+    RequestError
+  );
+  assertEquals(err.status, 404);
+});
 
 Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existence probe", async () => {
   // No "GET /repos/{owner}/{repo}" handler: fakeOctokit throws on an unexpected route, so this
@@ -270,7 +304,10 @@ Deno.test("listCollaboratorsOrThrowMissing: non-404 propagates without an existe
       throw requestError(403, "Forbidden");
     }
   });
-  const err = await assertRejects(() => listCollaboratorsOrThrowMissing(octokit, "org", "repo", "all"), RequestError);
+  const err = await assertRejects(
+    () => listCollaboratorsOrThrowMissing(octokit, "org", "repo", async () => "all"),
+    RequestError
+  );
   assertEquals(err.status, 403);
 });
 

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -350,10 +350,6 @@ const installations: {
   orgName: string;
   id: number;
   octokit: Octokit;
-  // "all" | "selected" — whether this installation can see every repo in the org. Kept because it
-  // is the only thing that makes a 404 legible: on a "selected" installation a repo we were never
-  // granted 404s exactly like one that was deleted. See classifyRepoPresence.
-  repositorySelection: "all" | "selected" | undefined;
 }[] = [];
 const MyOctokit = Octokit.plugin(throttling);
 
@@ -441,7 +437,6 @@ export async function getOctoKit(repoOrOrgName: string, scope?: Sentry.Scope) {
       installations.push({
         orgName: orgLogin,
         id: i.id,
-        repositorySelection: i.repository_selection,
         octokit: new MyOctokit({
           authStrategy: createAppAuth,
           auth: {
@@ -2260,11 +2255,32 @@ function isGitHubNotFoundError(error: unknown): boolean {
 }
 
 /**
- * Whether the installation's repo selection lets us read a 404 as proof of deletion.
- * Reads the cache `getOctoKit` populates, so callers must have obtained an octokit first.
+ * Read the org installation's repo selection ("all" | "selected") STRAIGHT FROM GitHub.
+ *
+ * Deliberately not cached, and deliberately not taken from the `installations` array: that array
+ * is filled once per isolate and only refilled while empty, so a value read from it is arbitrarily
+ * stale. An installation narrowed from "All repositories" to "Only select repositories" would keep
+ * reporting "all" for the life of the isolate, and the first live repo dropped from the selection
+ * would be read as deleted and durably parked — the exact failure the selection check exists to
+ * prevent. Proof has to be fresh to be proof.
+ *
+ * Costs one app-authenticated request, and only on the 404 path (see
+ * `listCollaboratorsOrThrowMissing`), never on the happy path. `undefined` on any failure: unknown
+ * scope must degrade to "cannot prove deletion", not to "all".
  */
-export function installationRepositorySelection(org: string): "all" | "selected" | undefined {
-  return installations.find((i) => i.orgName === org)?.repositorySelection;
+export async function fetchRepositorySelection(org: string): Promise<"all" | "selected" | undefined> {
+  try {
+    const resp = await app.octokit.request("GET /orgs/{org}/installation", { org });
+    return resp.data.repository_selection;
+  } catch (error) {
+    Sentry.addBreadcrumb({
+      category: "github",
+      message: `Could not read installation repo selection for ${org}; treating repo presence as unprovable`,
+      level: "warning",
+      data: { error: error instanceof Error ? error.message : String(error) }
+    });
+    return undefined;
+  }
 }
 
 /**
@@ -2320,17 +2336,18 @@ export async function classifyRepoPresence(
  * `inaccessible` -> rethrow the original 404 so the ladder still covers the lag it was written for,
  * and so a repo merely hidden from a selected-repos installation is never parked.
  *
- * `repositorySelection` is a parameter rather than a lookup inside this function on purpose: it
- * comes from the module-level installation cache, and reading it here would make the "repo is
- * gone" branch untestable — a cold cache reports `undefined`, which correctly degrades to
- * `inaccessible`, so the one case that must be proven right would silently never be exercised.
- * Callers pass `installationRepositorySelection(org)`; by then `getOctoKit` has warmed the cache.
+ * `resolveRepositorySelection` is a thunk, not a value, for two reasons: it is only needed on the
+ * 404 path so the happy path pays nothing for it, and passing it in keeps this function testable —
+ * an earlier version read the module-level installation cache directly, and a unit test caught that
+ * a cold cache reports `undefined`, degrades to `inaccessible`, and would have left the one branch
+ * that must be provably correct never exercised. Production passes
+ * `() => fetchRepositorySelection(owner)`, which asks GitHub rather than trusting a cache.
  */
 export async function listCollaboratorsOrThrowMissing(
   octokit: Octokit,
   owner: string,
   repo: string,
-  repositorySelection: "all" | "selected" | undefined
+  resolveRepositorySelection: () => Promise<"all" | "selected" | undefined>
 ) {
   try {
     return await octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
@@ -2340,7 +2357,7 @@ export async function listCollaboratorsOrThrowMissing(
     });
   } catch (error) {
     if (isGitHubNotFoundError(error)) {
-      const presence = await classifyRepoPresence(octokit, owner, repo, repositorySelection);
+      const presence = await classifyRepoPresence(octokit, owner, repo, await resolveRepositorySelection());
       if (presence === "absent") {
         throw new RepositoryMissingError(`${owner}/${repo}`);
       }
@@ -3492,7 +3509,7 @@ async function syncRepoPermissionsInstrumented(
   // ladder on it; see that function for what the ambiguity used to cost.
   const existingAccess = await timeStep(timings, "list_collaborators", () =>
     retryWithBackoff(
-      () => listCollaboratorsOrThrowMissing(octokit, org, repo, installationRepositorySelection(org)),
+      () => listCollaboratorsOrThrowMissing(octokit, org, repo, () => fetchRepositorySelection(org)),
       5,
       3000,
       scope

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2379,6 +2379,15 @@ export async function classifyRepoPresence(
     await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
     return "present";
   } catch (error) {
+    // A rate-limited probe is not "unknown", it is "ask again later", and only the caller's caller
+    // knows how to wait. Flattening it here would strip the response and its Retry-After before
+    // the worker's detectRateLimitType could see them, so the job would surface as a generic
+    // failure — ladder, org-method circuit, error threshold — instead of a backoff. Same reasoning
+    // as fetchRepositorySelection; propagating still cannot classify the repo as absent, because
+    // this throws instead of returning.
+    if (carriesRateLimitSignal(error)) {
+      throw error;
+    }
     // Status, NOT `isGitHubNotFoundError`. That helper falls back to `message.includes("Not Found")`
     // so that callers doing benign things still recognise a 404 behind a wrapper — but here the
     // answer can DELETE a row's readiness, and a statusless transport/proxy error or a wrapped 5xx
@@ -2440,9 +2449,26 @@ export async function listCollaboratorsOrThrowMissing(
     if (isGitHubNotFoundError(error)) {
       const presence = await classifyRepoPresence(octokit, owner, repo, await resolveRepositorySelection());
       if (presence === "absent") {
-        throw new RepositoryMissingError(`${owner}/${repo}`);
-      }
-      if (presence === "inaccessible") {
+        // `absent` rests on the scope having been "all", read BEFORE the probe. If an admin narrows
+        // the installation in between, a live repo dropped from the selection 404s and this stale
+        // "all" would write it off — the very failure the fresh lookup exists to prevent, moved
+        // inside a single call. So confirm the scope again, now that the 404 is in hand.
+        //
+        // Re-ordering alone would not help: reading only AFTER the probe just inverts the race (a
+        // widening between probe and read would mislead us identically). Requiring "all" on BOTH
+        // sides is what raises the bar from one administrative change mid-request to two in
+        // opposite directions, which is not a thing that happens. Costs one request, and only on
+        // the path where we are about to write to the database.
+        const confirmed = await resolveRepositorySelection();
+        if (confirmed === "all") {
+          throw new RepositoryMissingError(`${owner}/${repo}`);
+        }
+        // Scope changed under us. "selected" means the 404 is now unattributable; anything else
+        // means we no longer know, so fall through and let the original 404 be retried.
+        if (confirmed === "selected") {
+          throw new RepositoryUnreadableError(`${owner}/${repo}`);
+        }
+      } else if (presence === "inaccessible") {
         throw new RepositoryUnreadableError(`${owner}/${repo}`);
       }
     }

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2466,34 +2466,53 @@ export async function listCollaboratorsOrThrowMissing(
       per_page: 100
     });
   } catch (error) {
-    if (isGitHubNotFoundError(error)) {
-      const presence = await classifyRepoPresence(octokit, owner, repo, await resolveRepositorySelection());
-      if (presence === "absent") {
-        // `absent` rests on the scope having been "all", read BEFORE the probe. If an admin narrows
-        // the installation in between, a live repo dropped from the selection 404s and this stale
-        // "all" would write it off — the very failure the fresh lookup exists to prevent, moved
-        // inside a single call. So confirm the scope again, now that the 404 is in hand.
-        //
-        // Re-ordering alone would not help: reading only AFTER the probe just inverts the race (a
-        // widening between probe and read would mislead us identically). Requiring "all" on BOTH
-        // sides is what raises the bar from one administrative change mid-request to two in
-        // opposite directions, which is not a thing that happens. Costs one request, and only on
-        // the path where we are about to write to the database.
-        const confirmed = await resolveRepositorySelection();
-        if (confirmed === "all") {
-          throw new RepositoryMissingError(`${owner}/${repo}`);
-        }
-        // Scope changed under us. "selected" means the 404 is now unattributable; anything else
-        // means we no longer know, so fall through and let the original 404 be retried.
-        if (confirmed === "selected") {
-          throw new RepositoryUnreadableError(`${owner}/${repo}`);
-        }
-      } else if (presence === "inaccessible") {
-        throw new RepositoryUnreadableError(`${owner}/${repo}`);
-      }
-    }
+    const reinterpreted = await reinterpretRepoNotFound(octokit, owner, repo, error, resolveRepositorySelection);
+    if (reinterpreted) throw reinterpreted;
     throw error;
   }
+}
+
+/**
+ * Given an error from a repo-scoped call, decide whether it should be re-reported as a per-repo
+ * terminal condition, and which one. Returns undefined to mean "leave this error exactly as it is".
+ *
+ * Shared by the collaborator read and by the whole-sync backstop, so the "when may we conclude the
+ * repo is gone" rule lives in one place. Verifying rather than assuming is what makes the backstop
+ * safe to apply broadly: a 404 from
+ * `PUT /repos/{owner}/{repo}/collaborators/{username}` can mean the USERNAME does not exist, and
+ * treating that as a missing repo would park a live repo because a student deleted their GitHub
+ * account. Since this probes the repo before concluding anything, that case comes back `present`
+ * and the original error is passed through untouched.
+ */
+async function reinterpretRepoNotFound(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  error: unknown,
+  resolveRepositorySelection: () => Promise<"all" | "selected" | undefined>
+): Promise<RepositoryMissingError | RepositoryUnreadableError | undefined> {
+  if (!isGitHubNotFoundError(error)) return undefined;
+  const presence = await classifyRepoPresence(octokit, owner, repo, await resolveRepositorySelection());
+  if (presence === "inaccessible") {
+    return new RepositoryUnreadableError(`${owner}/${repo}`);
+  }
+  if (presence !== "absent") {
+    // present -> the 404 was about something else (a user, a team); unknown -> we have no grounds.
+    return undefined;
+  }
+  // `absent` rests on the scope having been "all", read BEFORE the probe. If an admin narrows the
+  // installation in between, a live repo dropped from the selection 404s and that stale "all"
+  // would write it off — the failure the fresh lookup exists to prevent, moved inside one call.
+  // So confirm the scope again, now that the 404 is in hand.
+  //
+  // Re-ordering alone would not help: reading only AFTER the probe inverts the race, since a
+  // widening between probe and read misleads us identically. Requiring "all" on BOTH sides raises
+  // the bar from one administrative change mid-request to two in opposite directions. Costs one
+  // request, and only on the path about to write to the database.
+  const confirmed = await resolveRepositorySelection();
+  if (confirmed === "all") return new RepositoryMissingError(`${owner}/${repo}`);
+  if (confirmed === "selected") return new RepositoryUnreadableError(`${owner}/${repo}`);
+  return undefined;
 }
 
 export async function archiveRepoAndLock(org: string, repo: string, scope?: Sentry.Scope) {
@@ -3514,6 +3533,39 @@ export async function syncRepoPermissions(
     // Same reasoning as createRepo: flag only what escapes. This path recovers from a missing staff
     // team on purpose (TeamNotFoundError degrades to "do not remove anyone" and carries on).
     timings.noteEscapingError(error);
+    // Backstop for every OTHER repo-scoped call in the sync. The collaborator read classifies its
+    // own 404 because it sits inside the retry ladder and has to short-circuit those 93 seconds,
+    // but the sync goes on to read the repo's teams and to add/remove collaborators — and this
+    // function has been measured at 94 seconds, so a repo deleted part-way through is not
+    // hypothetical. During the 2026-09-09 sp26 cleanup an instructor deleted 146 repos by hand;
+    // any one of those could have landed mid-sync. Without this, such a 404 escapes bare and the
+    // worker reads it as systemic, opening the org-wide circuit — the original incident, entered
+    // through a different call.
+    //
+    // Safe to apply this broadly precisely because it verifies instead of assuming: a 404 that was
+    // never about the repo (a deleted GitHub account on a collaborator PUT) probes back `present`
+    // and is rethrown untouched.
+    try {
+      const [owner, repoName] = repo.includes("/") ? repo.split("/") : [org, repo];
+      const octokit = await getOctoKit(owner, _scope);
+      if (octokit) {
+        const reinterpreted = await reinterpretRepoNotFound(octokit, owner, repoName, error, () =>
+          fetchRepositorySelection(owner)
+        );
+        if (reinterpreted) throw reinterpreted;
+      }
+    } catch (reinterpretError) {
+      // Only the reinterpretation may replace the original; a failure while trying to reinterpret
+      // must not mask what actually went wrong.
+      if (reinterpretError instanceof RepositoryMissingError || reinterpretError instanceof RepositoryUnreadableError) {
+        throw reinterpretError;
+      }
+      Sentry.addBreadcrumb({
+        category: "github",
+        message: `Could not classify the 404 escaping sync for ${org}/${repo}; reporting the original error`,
+        level: "warning"
+      });
+    }
     throw error;
   } finally {
     timings.finish((snapshot) => attachStepTimingsToScope(snapshot, _scope));

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -3545,27 +3545,38 @@ export async function syncRepoPermissions(
     // Safe to apply this broadly precisely because it verifies instead of assuming: a 404 that was
     // never about the repo (a deleted GitHub account on a collaborator PUT) probes back `present`
     // and is rethrown untouched.
+    let reinterpreted: RepositoryMissingError | RepositoryUnreadableError | undefined;
     try {
       const [owner, repoName] = repo.includes("/") ? repo.split("/") : [org, repo];
       const octokit = await getOctoKit(owner, _scope);
       if (octokit) {
-        const reinterpreted = await reinterpretRepoNotFound(octokit, owner, repoName, error, () =>
+        reinterpreted = await reinterpretRepoNotFound(octokit, owner, repoName, error, () =>
           fetchRepositorySelection(owner)
         );
-        if (reinterpreted) throw reinterpreted;
       }
     } catch (reinterpretError) {
-      // Only the reinterpretation may replace the original; a failure while trying to reinterpret
-      // must not mask what actually went wrong.
-      if (reinterpretError instanceof RepositoryMissingError || reinterpretError instanceof RepositoryUnreadableError) {
+      // A rate limit hit WHILE classifying outranks the 404 that prompted the classification: it is
+      // the actionable one, it carries Retry-After, and the worker has real backoff for it. Losing
+      // it here would report the 404 instead and open the org circuit — the same mistake this
+      // function exists to prevent, one level up. (classifyRepoPresence and
+      // fetchRepositorySelection both rethrow rate limits, so they can reach this catch.)
+      if (carriesRateLimitSignal(reinterpretError)) {
         throw reinterpretError;
       }
+      // Anything else is just a failed attempt to explain the original error, and must not mask it.
       Sentry.addBreadcrumb({
         category: "github",
         message: `Could not classify the 404 escaping sync for ${org}/${repo}; reporting the original error`,
-        level: "warning"
+        level: "warning",
+        data: {
+          classify_error: reinterpretError instanceof Error ? reinterpretError.message : String(reinterpretError)
+        }
       });
     }
+    // Thrown OUTSIDE the try on purpose: the previous shape threw here from inside it, so my own
+    // intended throw landed in my own catch and had to be fished back out by instanceof — which is
+    // exactly how the rate-limit case came to be swallowed.
+    if (reinterpreted) throw reinterpreted;
     throw error;
   } finally {
     timings.finish((snapshot) => attachStepTimingsToScope(snapshot, _scope));

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2395,6 +2395,26 @@ export async function classifyRepoPresence(
     // one place in the file where the loose check is unsafe, so require the real thing.
     const isRealNotFound = error instanceof RequestError && error.status === 404;
     if (!isRealNotFound) {
+      // A 5xx, transport error, or non-rate-limited 403 leaves the caller holding the original 404,
+      // which the ladder then retries — deliberately. Propagating the probe error instead would be
+      // worse, not better: retryWithBackoff only retries 404 / "git repository is empty", so a
+      // 5xx would get ZERO retries and land on the worker's generic path, opening the org-method
+      // circuit on the first transient blip. Retrying the 404 re-runs this probe too, which is the
+      // thing most likely to clear it.
+      //
+      // Rate limits are the deliberate exception above, because there the worker genuinely knows
+      // better than the ladder does: it has Retry-After and a real backoff. For a 5xx it has
+      // neither, so the ladder is the better handler. What IS lost is attribution — the escaping
+      // error says 404 when the proximate cause was a 500 — so leave the real reason behind.
+      Sentry.addBreadcrumb({
+        category: "github",
+        message: `Presence probe for ${owner}/${repo} failed; repo presence unknown, retrying the original 404`,
+        level: "warning",
+        data: {
+          probe_status: error instanceof RequestError ? error.status : "none",
+          probe_error: error instanceof Error ? error.message : String(error)
+        }
+      });
       return "unknown";
     }
     if (repositorySelection === "all") return "absent";

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2457,13 +2457,15 @@ export async function listCollaboratorsOrThrowMissing(
   octokit: Octokit,
   owner: string,
   repo: string,
-  resolveRepositorySelection: () => Promise<"all" | "selected" | undefined>
+  resolveRepositorySelection: () => Promise<"all" | "selected" | undefined>,
+  options: { affiliation?: "direct" | "outside" | "all" } = {}
 ) {
   try {
     return await octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
       owner,
       repo,
-      per_page: 100
+      per_page: 100,
+      ...(options.affiliation ? { affiliation: options.affiliation } : {})
     });
   } catch (error) {
     const reinterpreted = await reinterpretRepoNotFound(octokit, owner, repo, error, resolveRepositorySelection);
@@ -3928,14 +3930,16 @@ async function syncRepoPermissionsInstrumented(
   // common no-op sync keeps costing exactly the requests it costs today.
   let removeAccess: string[] = [];
   if (removalCandidates.length > 0) {
+    // Same classification as the first collaborator read, and for the same reason: this is the
+    // sync's OTHER retry ladder, and the whole-sync backstop sits outside it. Left bare, a repo
+    // deleted between the two reads would spend a second 93-second ladder here before the backstop
+    // ever saw the error. The two ladders are the only places that need in-band classification;
+    // every other repo-scoped call in this function fails fast and the backstop catches it.
     const directAccess = await timeStep(timings, "list_direct_collaborators", () =>
       retryWithBackoff(
         () =>
-          octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
-            owner: org,
-            repo,
-            affiliation: "direct",
-            per_page: 100
+          listCollaboratorsOrThrowMissing(octokit, org, repo, () => fetchRepositorySelection(org), {
+            affiliation: "direct"
           }),
         5,
         3000,

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2298,6 +2298,14 @@ export async function fetchRepositorySelection(org: string): Promise<"all" | "se
     const resp = await app.octokit.request("GET /orgs/{org}/installation", { org });
     return resp.data.repository_selection;
   } catch (error) {
+    // One failure must NOT be flattened into undefined: a rate limit. Swallowing it here loses the
+    // response and its Retry-After before the worker's detectRateLimitType ever sees them, so the
+    // job comes back as a generic failure — opening the org-method circuit and counting toward the
+    // eight-hour threshold — when the correct answer was "back off for N seconds and try again".
+    // Propagate it and let the worker's rate-limit handling do its job.
+    if (carriesRateLimitSignal(error)) {
+      throw error;
+    }
     Sentry.addBreadcrumb({
       category: "github",
       message: `Could not read installation repo selection for ${org}; treating repo presence as unprovable`,
@@ -2306,6 +2314,31 @@ export async function fetchRepositorySelection(org: string): Promise<"all" | "se
     });
     return undefined;
   }
+}
+
+/**
+ * Does this error carry the rate-limit signal the async worker keys off?
+ *
+ * Mirrors the INPUTS of github-async-worker's `detectRateLimitType` (the two rate-limit error
+ * classes, a 429, or a 403 carrying Retry-After / an exhausted x-ratelimit-remaining) rather than
+ * its decision tree, because all we need here is "is this worth preserving for that function to
+ * classify". Erring either way is survivable and neither is silent: a false positive propagates an
+ * error the worker then declines to treat as a rate limit, and a false negative just falls back to
+ * the `unknown` path, which retries.
+ *
+ * A plain 403 with no rate-limit headers is deliberately NOT a match — that is a permission
+ * problem, and propagating it would trip the org circuit over a lookup we can simply do without.
+ */
+function carriesRateLimitSignal(error: unknown): boolean {
+  if (error instanceof SecondaryRateLimitError || error instanceof PrimaryRateLimitError) return true;
+  const status = error instanceof RequestError ? error.status : undefined;
+  if (status === 429) return true;
+  if (status !== 403) return false;
+  const raw = (error as { response?: { headers?: Record<string, unknown> } })?.response?.headers;
+  if (!raw) return false;
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) headers[k.toLowerCase()] = String(v);
+  return headers["retry-after"] !== undefined || headers["x-ratelimit-remaining"] === "0";
 }
 
 /**
@@ -2346,7 +2379,13 @@ export async function classifyRepoPresence(
     await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
     return "present";
   } catch (error) {
-    if (!isGitHubNotFoundError(error)) {
+    // Status, NOT `isGitHubNotFoundError`. That helper falls back to `message.includes("Not Found")`
+    // so that callers doing benign things still recognise a 404 behind a wrapper — but here the
+    // answer can DELETE a row's readiness, and a statusless transport/proxy error or a wrapped 5xx
+    // whose body happens to carry "Not Found" would then be read as proof of deletion. This is the
+    // one place in the file where the loose check is unsafe, so require the real thing.
+    const isRealNotFound = error instanceof RequestError && error.status === 404;
+    if (!isRealNotFound) {
       return "unknown";
     }
     if (repositorySelection === "all") return "absent";

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -73,6 +73,27 @@ export class RepositoryMissingError extends NonRetryableGitHubError {
 }
 
 /**
+ * The repo 404s and we cannot attribute it: the installation is scoped to selected repositories, so
+ * this is either a deleted repo or a live one we were never granted. Sibling of
+ * RepositoryMissingError, and the distinction is exactly what we are allowed to DO about it.
+ *
+ * Both are per-repo failures, so neither should trip the org-wide circuit breaker or spend the
+ * retry ladder — nothing about one repo says the org is unhealthy. Only RepositoryMissingError
+ * carries proof of deletion, so only it may park the row; this one leaves `repositories` untouched,
+ * because the row may be perfectly correct and the problem ours.
+ */
+export class RepositoryUnreadableError extends NonRetryableGitHubError {
+  readonly fullName: string;
+  constructor(fullName: string) {
+    super(
+      `Repository ${fullName} returned 404 and this installation is scoped to selected repositories, so it is either deleted or not granted to us. Cannot sync it, and cannot safely conclude it is gone.`
+    );
+    this.name = "RepositoryUnreadableError";
+    this.fullName = fullName;
+  }
+}
+
+/**
  * The GitHub login we have on file for a user doesn't exist, and we couldn't recover a current one
  * from the numeric account id we stored when they linked their account (see
  * `reresolveMissingGitHubLogin`). Either the account was deleted or the username was never really
@@ -2284,24 +2305,26 @@ export async function fetchRepositorySelection(org: string): Promise<"all" | "se
 }
 
 /**
- * Three states, because a 404 on `GET /repos/{owner}/{repo}` has two very different causes and
- * only one of them is actionable:
+ * Four states, because the caller has to make two independent decisions from one 404 — may we keep
+ * retrying, and may we write the row off — and collapsing them gets one of the two wrong:
  *
- *   present      — 200. The repo is there.
+ *   present      — 200. The repo is there, so the collaborators 404 was replication lag. Retry.
+ *   unknown      — the probe ITSELF failed (403, 5xx, network). We learned nothing, so this says
+ *                  nothing about the repo and nothing about the row. Retry.
  *   absent       — 404, AND this installation can see every repo in the org, so there was nothing
- *                  to hide: the repo really is gone.
+ *                  to hide: the repo really is gone. Terminal, and provably so — safe to park.
  *   inaccessible — 404, but the installation is scoped to SELECTED repos (or we don't know its
- *                  scope), so a repo we were never granted 404s identically to a deleted one. Also
- *                  any non-404 failure: 403, 5xx, network.
+ *                  scope), so a live repo we were never granted 404s identically to a deleted one.
+ *                  Terminal for this job — retrying cannot make an ungranted repo readable — but
+ *                  NOT proof of anything about the row.
  *
- * That middle distinction is the whole point. `github-check-app-installation` already reads a repo
- * 404 as "installed in the org but not granted access to this repo", and if we collapsed that into
- * "deleted" we would park a LIVE repo — clearing `is_github_ready`, writing a creation_error, and
- * having every later permission sync skip it even after access was restored. "We could not find
- * out" must never be recorded as "the repo is gone", so anything short of proof lands on
- * `inaccessible` and the caller leaves the row alone.
+ * `github-check-app-installation` already reads a repo 404 as "installed in the org but not granted
+ * access to this repo". Collapsing that into "deleted" would park a LIVE repo; collapsing it into
+ * "retry" would spend the 93s ladder and then let a bare 404 escape and trip the org-wide circuit,
+ * throttling every other class over one repo. Hence two terminal states rather than one: both stop
+ * the work, only `absent` is allowed to change the database.
  */
-export type RepoPresence = "present" | "absent" | "inaccessible";
+export type RepoPresence = "present" | "unknown" | "absent" | "inaccessible";
 
 export async function classifyRepoPresence(
   octokit: Octokit,
@@ -2314,7 +2337,7 @@ export async function classifyRepoPresence(
     return "present";
   } catch (error) {
     if (!isGitHubNotFoundError(error)) {
-      return "inaccessible";
+      return "unknown";
     }
     return repositorySelection === "all" ? "absent" : "inaccessible";
   }
@@ -2331,10 +2354,17 @@ export async function classifyRepoPresence(
  * by opening the `<org>:sync_repo_permissions` circuit, throttling that method for every other
  * class in the org over one dead row.
  *
- * So ask instead of guessing. One extra request, only on the error path, and we act only on proof:
- * `absent` -> RepositoryMissingError (terminal, not retried, handled per-row). `present` or
- * `inaccessible` -> rethrow the original 404 so the ladder still covers the lag it was written for,
- * and so a repo merely hidden from a selected-repos installation is never parked.
+ * So ask instead of guessing, and answer the two questions separately:
+ *
+ *   absent       -> RepositoryMissingError. Terminal AND provable: park the row.
+ *   inaccessible -> RepositoryUnreadableError. Terminal but unprovable: stop, touch nothing.
+ *   present      -> rethrow the original 404; the ladder covers the lag it was written for.
+ *   unknown      -> rethrow too. The probe failed, so we have no grounds to terminate.
+ *
+ * Both terminal cases are NonRetryableGitHubError, which is what keeps a single dead or ungranted
+ * repo out of the org-wide circuit breaker and out of the error-threshold counter. Returning a
+ * bare 404 for the inaccessible case instead would spend the full ladder and then be read as a
+ * systemic failure — the original incident, just narrowed to selected-repos installations.
  *
  * `resolveRepositorySelection` is a thunk, not a value, for two reasons: it is only needed on the
  * 404 path so the happy path pays nothing for it, and passing it in keeps this function testable —
@@ -2360,6 +2390,9 @@ export async function listCollaboratorsOrThrowMissing(
       const presence = await classifyRepoPresence(octokit, owner, repo, await resolveRepositorySelection());
       if (presence === "absent") {
         throw new RepositoryMissingError(`${owner}/${repo}`);
+      }
+      if (presence === "inaccessible") {
+        throw new RepositoryUnreadableError(`${owner}/${repo}`);
       }
     }
     throw error;

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -54,6 +54,25 @@ export class NonRetryableRepoError extends NonRetryableGitHubError {
 }
 
 /**
+ * The repository we were asked to operate on is not on GitHub at all. Distinct from a bare 404,
+ * which on a freshly-created repo usually means read-after-create replication lag and IS worth
+ * retrying: this error is only raised once a direct `GET /repos/{owner}/{repo}` has confirmed the
+ * repo is really gone. Someone deleted it out of band, or the row was left behind when the repo was
+ * renamed. Either way the row no longer describes anything, so the worker records the reason and
+ * clears `is_github_ready` rather than retrying.
+ */
+export class RepositoryMissingError extends NonRetryableGitHubError {
+  readonly fullName: string;
+  constructor(fullName: string) {
+    super(
+      `Repository ${fullName} does not exist on GitHub. It was deleted or renamed outside Pawtograder, so there is nothing to sync.`
+    );
+    this.name = "RepositoryMissingError";
+    this.fullName = fullName;
+  }
+}
+
+/**
  * The GitHub login we have on file for a user doesn't exist, and we couldn't recover a current one
  * from the numeric account id we stored when they linked their account (see
  * `reresolveMissingGitHubLogin`). Either the account was deleted or the username was never really
@@ -2235,6 +2254,57 @@ function isGitHubNotFoundError(error: unknown): boolean {
   );
 }
 
+/**
+ * Does this repo exist right now? Used to tell a 404 that means "not yet" from one that means
+ * "never again" — see `listCollaboratorsOrThrowMissing` for why that distinction is worth a
+ * request.
+ *
+ * A 404 here is the answer, not a failure. Anything else (403, 5xx, network) is NOT: propagate it,
+ * because "we could not find out" must not be recorded as "the repo is gone" — that would clear
+ * `is_github_ready` on a live repo during an outage.
+ */
+export async function repoExists(octokit: Octokit, owner: string, repo: string): Promise<boolean> {
+  try {
+    await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
+    return true;
+  } catch (error) {
+    if (isGitHubNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * List a repo's collaborators, distinguishing the two things a 404 can mean.
+ *
+ * The caller wraps this in `retryWithBackoff`, whose 404 ladder exists for read-after-create lag:
+ * syncRepoPermissions runs immediately after createRepo in the same worker message, and the
+ * collaborators endpoint can 404 briefly on a repo that does exist. A repo that is GONE returns
+ * exactly the same 404, and paying the ladder for it costs 93 seconds of a worker slot and then
+ * escapes as a bare RequestError — which the async worker reads as a systemic failure and answers
+ * by opening the `<org>:sync_repo_permissions` circuit, throttling that method for every other
+ * class in the org over one dead row.
+ *
+ * So ask instead of guessing. One extra request, only on the error path, converts the ambiguous
+ * 404 into an answer: missing -> RepositoryMissingError (terminal, not retried, handled per-row),
+ * present -> rethrow the original so the ladder still covers the lag it was written for.
+ */
+export async function listCollaboratorsOrThrowMissing(octokit: Octokit, owner: string, repo: string) {
+  try {
+    return await octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
+      owner,
+      repo,
+      per_page: 100
+    });
+  } catch (error) {
+    if (isGitHubNotFoundError(error) && !(await repoExists(octokit, owner, repo))) {
+      throw new RepositoryMissingError(`${owner}/${repo}`);
+    }
+    throw error;
+  }
+}
+
 export async function archiveRepoAndLock(org: string, repo: string, scope?: Sentry.Scope) {
   scope?.setTag("github_operation", "archive_repo");
   scope?.setTag("org", org);
@@ -3372,20 +3442,12 @@ async function syncRepoPermissionsInstrumented(
     const orgMembers = await timeStep(timings, "org_members", () => orgMembershipCache.get(org));
     allOrgMembers = orgMembers?.map((u) => u.login.toLowerCase());
   }
-  // maxRetries 5 / baseDelayMs 3000 — the same 93s worst-case ladder as get_head_sha. No retry
-  // lines appear in the 2026-09-07 logs, so it did not fire; timed so we can say that from data.
+  // maxRetries 5 / baseDelayMs 3000 — the same 93s worst-case ladder as get_head_sha, and still
+  // the right ladder for the read-after-create lag it was written for. A repo that is GONE 404s
+  // identically, so `listCollaboratorsOrThrowMissing` classifies the 404 before we spend the
+  // ladder on it; see that function for what the ambiguity used to cost.
   const existingAccess = await timeStep(timings, "list_collaborators", () =>
-    retryWithBackoff(
-      () =>
-        octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
-          owner: org,
-          repo,
-          per_page: 100
-        }),
-      5,
-      3000,
-      scope
-    )
+    retryWithBackoff(() => listCollaboratorsOrThrowMissing(octokit, org, repo), 5, 3000, scope)
   );
   const existingUsernames = existingAccess
     .filter((c) => c.role_name === "admin" || c.role_name === "write" || c.role_name === "maintain")

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -350,6 +350,10 @@ const installations: {
   orgName: string;
   id: number;
   octokit: Octokit;
+  // "all" | "selected" — whether this installation can see every repo in the org. Kept because it
+  // is the only thing that makes a 404 legible: on a "selected" installation a repo we were never
+  // granted 404s exactly like one that was deleted. See classifyRepoPresence.
+  repositorySelection: "all" | "selected" | undefined;
 }[] = [];
 const MyOctokit = Octokit.plugin(throttling);
 
@@ -437,6 +441,7 @@ export async function getOctoKit(repoOrOrgName: string, scope?: Sentry.Scope) {
       installations.push({
         orgName: orgLogin,
         id: i.id,
+        repositorySelection: i.repository_selection,
         octokit: new MyOctokit({
           authStrategy: createAppAuth,
           auth: {
@@ -2255,23 +2260,47 @@ function isGitHubNotFoundError(error: unknown): boolean {
 }
 
 /**
- * Does this repo exist right now? Used to tell a 404 that means "not yet" from one that means
- * "never again" — see `listCollaboratorsOrThrowMissing` for why that distinction is worth a
- * request.
- *
- * A 404 here is the answer, not a failure. Anything else (403, 5xx, network) is NOT: propagate it,
- * because "we could not find out" must not be recorded as "the repo is gone" — that would clear
- * `is_github_ready` on a live repo during an outage.
+ * Whether the installation's repo selection lets us read a 404 as proof of deletion.
+ * Reads the cache `getOctoKit` populates, so callers must have obtained an octokit first.
  */
-export async function repoExists(octokit: Octokit, owner: string, repo: string): Promise<boolean> {
+export function installationRepositorySelection(org: string): "all" | "selected" | undefined {
+  return installations.find((i) => i.orgName === org)?.repositorySelection;
+}
+
+/**
+ * Three states, because a 404 on `GET /repos/{owner}/{repo}` has two very different causes and
+ * only one of them is actionable:
+ *
+ *   present      — 200. The repo is there.
+ *   absent       — 404, AND this installation can see every repo in the org, so there was nothing
+ *                  to hide: the repo really is gone.
+ *   inaccessible — 404, but the installation is scoped to SELECTED repos (or we don't know its
+ *                  scope), so a repo we were never granted 404s identically to a deleted one. Also
+ *                  any non-404 failure: 403, 5xx, network.
+ *
+ * That middle distinction is the whole point. `github-check-app-installation` already reads a repo
+ * 404 as "installed in the org but not granted access to this repo", and if we collapsed that into
+ * "deleted" we would park a LIVE repo — clearing `is_github_ready`, writing a creation_error, and
+ * having every later permission sync skip it even after access was restored. "We could not find
+ * out" must never be recorded as "the repo is gone", so anything short of proof lands on
+ * `inaccessible` and the caller leaves the row alone.
+ */
+export type RepoPresence = "present" | "absent" | "inaccessible";
+
+export async function classifyRepoPresence(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  repositorySelection: "all" | "selected" | undefined
+): Promise<RepoPresence> {
   try {
     await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
-    return true;
+    return "present";
   } catch (error) {
-    if (isGitHubNotFoundError(error)) {
-      return false;
+    if (!isGitHubNotFoundError(error)) {
+      return "inaccessible";
     }
-    throw error;
+    return repositorySelection === "all" ? "absent" : "inaccessible";
   }
 }
 
@@ -2286,11 +2315,23 @@ export async function repoExists(octokit: Octokit, owner: string, repo: string):
  * by opening the `<org>:sync_repo_permissions` circuit, throttling that method for every other
  * class in the org over one dead row.
  *
- * So ask instead of guessing. One extra request, only on the error path, converts the ambiguous
- * 404 into an answer: missing -> RepositoryMissingError (terminal, not retried, handled per-row),
- * present -> rethrow the original so the ladder still covers the lag it was written for.
+ * So ask instead of guessing. One extra request, only on the error path, and we act only on proof:
+ * `absent` -> RepositoryMissingError (terminal, not retried, handled per-row). `present` or
+ * `inaccessible` -> rethrow the original 404 so the ladder still covers the lag it was written for,
+ * and so a repo merely hidden from a selected-repos installation is never parked.
+ *
+ * `repositorySelection` is a parameter rather than a lookup inside this function on purpose: it
+ * comes from the module-level installation cache, and reading it here would make the "repo is
+ * gone" branch untestable — a cold cache reports `undefined`, which correctly degrades to
+ * `inaccessible`, so the one case that must be proven right would silently never be exercised.
+ * Callers pass `installationRepositorySelection(org)`; by then `getOctoKit` has warmed the cache.
  */
-export async function listCollaboratorsOrThrowMissing(octokit: Octokit, owner: string, repo: string) {
+export async function listCollaboratorsOrThrowMissing(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  repositorySelection: "all" | "selected" | undefined
+) {
   try {
     return await octokit.paginate("GET /repos/{owner}/{repo}/collaborators", {
       owner,
@@ -2298,8 +2339,11 @@ export async function listCollaboratorsOrThrowMissing(octokit: Octokit, owner: s
       per_page: 100
     });
   } catch (error) {
-    if (isGitHubNotFoundError(error) && !(await repoExists(octokit, owner, repo))) {
-      throw new RepositoryMissingError(`${owner}/${repo}`);
+    if (isGitHubNotFoundError(error)) {
+      const presence = await classifyRepoPresence(octokit, owner, repo, repositorySelection);
+      if (presence === "absent") {
+        throw new RepositoryMissingError(`${owner}/${repo}`);
+      }
     }
     throw error;
   }
@@ -3447,7 +3491,12 @@ async function syncRepoPermissionsInstrumented(
   // identically, so `listCollaboratorsOrThrowMissing` classifies the 404 before we spend the
   // ladder on it; see that function for what the ambiguity used to cost.
   const existingAccess = await timeStep(timings, "list_collaborators", () =>
-    retryWithBackoff(() => listCollaboratorsOrThrowMissing(octokit, org, repo), 5, 3000, scope)
+    retryWithBackoff(
+      () => listCollaboratorsOrThrowMissing(octokit, org, repo, installationRepositorySelection(org)),
+      5,
+      3000,
+      scope
+    )
   );
   const existingUsernames = existingAccess
     .filter((c) => c.role_name === "admin" || c.role_name === "write" || c.role_name === "maintain")

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -2286,8 +2286,12 @@ function isGitHubNotFoundError(error: unknown): boolean {
  * prevent. Proof has to be fresh to be proof.
  *
  * Costs one app-authenticated request, and only on the 404 path (see
- * `listCollaboratorsOrThrowMissing`), never on the happy path. `undefined` on any failure: unknown
- * scope must degrade to "cannot prove deletion", not to "all".
+ * `listCollaboratorsOrThrowMissing`), never on the happy path.
+ *
+ * Returns `undefined` on ANY failure, meaning strictly "could not find out" — never "all" and never
+ * "selected". `classifyRepoPresence` maps that to its retryable `unknown` state, so a 5xx or rate
+ * limit from this auxiliary lookup cannot terminate a job. Reading it as "selected" would be just
+ * as wrong as reading it as "all": one discards a live sync, the other parks a live repo.
  */
 export async function fetchRepositorySelection(org: string): Promise<"all" | "selected" | undefined> {
   try {
@@ -2309,14 +2313,20 @@ export async function fetchRepositorySelection(org: string): Promise<"all" | "se
  * retrying, and may we write the row off — and collapsing them gets one of the two wrong:
  *
  *   present      — 200. The repo is there, so the collaborators 404 was replication lag. Retry.
- *   unknown      — the probe ITSELF failed (403, 5xx, network). We learned nothing, so this says
- *                  nothing about the repo and nothing about the row. Retry.
+ *   unknown      — we learned nothing, from either input: the probe ITSELF failed (403, 5xx,
+ *                  network), or the installation scope came back undefined because THAT lookup
+ *                  failed. Says nothing about the repo and nothing about the row. Retry.
  *   absent       — 404, AND this installation can see every repo in the org, so there was nothing
  *                  to hide: the repo really is gone. Terminal, and provably so — safe to park.
- *   inaccessible — 404, but the installation is scoped to SELECTED repos (or we don't know its
- *                  scope), so a live repo we were never granted 404s identically to a deleted one.
- *                  Terminal for this job — retrying cannot make an ungranted repo readable — but
- *                  NOT proof of anything about the row.
+ *   inaccessible — 404, AND the installation is confirmed scoped to SELECTED repos, so a live repo
+ *                  we were never granted 404s identically to a deleted one. Terminal for this job
+ *                  — retrying cannot make an ungranted repo readable — but NOT proof about the row.
+ *
+ * `undefined` scope means "we could not find out", and it has to land on `unknown` rather than on
+ * `inaccessible`: a transient 5xx or rate limit from the scope lookup would otherwise be
+ * indistinguishable from a confirmed selected-repos installation, and would terminate the job —
+ * permanently discarding a permission sync, or leaving a genuinely missing row unparked, because
+ * an auxiliary lookup blipped. Ignorance is never grounds to stop.
  *
  * `github-check-app-installation` already reads a repo 404 as "installed in the org but not granted
  * access to this repo". Collapsing that into "deleted" would park a LIVE repo; collapsing it into
@@ -2339,7 +2349,9 @@ export async function classifyRepoPresence(
     if (!isGitHubNotFoundError(error)) {
       return "unknown";
     }
-    return repositorySelection === "all" ? "absent" : "inaccessible";
+    if (repositorySelection === "all") return "absent";
+    if (repositorySelection === "selected") return "inaccessible";
+    return "unknown";
   }
 }
 

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -20,6 +20,7 @@ import {
   NonRetryableGitHubError,
   NonRetryableRepoError,
   NonRetryableUserError,
+  RepositoryMissingError,
   getCreateContentLimiter
 } from "../_shared/GitHubWrapper.ts";
 import { beginWorkerRun } from "../_shared/workerRun.ts";
@@ -1159,10 +1160,22 @@ export async function processEnvelope(
         //Otherwise we might race against a createRepo, and end up overwriting to the wrong githubUsernames.
         const { data: repository } = await adminSupabase
           .from("repositories")
-          .select("is_github_ready")
+          .select("is_github_ready, creation_error")
           .eq("repository", `${org}/${repoName}`)
           .maybeSingle();
         if (!repository?.is_github_ready) {
+          // "Not ready" covers two states that deserve opposite answers. With no creation_error the
+          // repo is still on its way — requeue and let it land, which is what this gate was written
+          // for. With one recorded, the row is parked: creation failed for good, or the repo turned
+          // out to be missing (RepositoryMissingError, handled below). Requeueing that is pure
+          // waste — nothing will change it, and the message just redelivers every visibility
+          // timeout until read_ct trips the poison-pill limit ~50 minutes later. Archive it and
+          // say why.
+          if (repository?.creation_error) {
+            console.log(`repo is parked, dropping permission sync: ${org}/${repoName} — ${repository.creation_error}`);
+            scope.setTag("permission_sync_skipped", "repo_parked");
+            return true;
+          }
           console.log("repo is not ready", `${org}/${repoName}`);
           return false;
         }
@@ -2258,6 +2271,11 @@ export async function processEnvelope(
       // one issue per method is enough. The offending login is on the tag and in the message.
       scope.setFingerprint(["github-non-retryable-user", envelope.method]);
       scope.setTag("github_username", error.githubUsername);
+    } else if (error instanceof RepositoryMissingError) {
+      // Deleting an assignment's repos by hand turns up dozens of these at once (146 rows for one
+      // sp26 assignment on 2026-09-09). Group them; the repo is on the tag and in the message.
+      scope.setFingerprint(["github-repository-missing", envelope.method]);
+      scope.setTag("missing_repository", error.fullName);
     }
 
     const errorId = Sentry.captureException(error, scope);
@@ -2294,16 +2312,36 @@ export async function processEnvelope(
           scope.setTag("non_retryable_repo_error", "true");
         }
         const reason = error.message;
+        // A repo that is gone is not just "this job failed" — the ROW is wrong, and every future
+        // job derived from it will fail the same way. Clearing is_github_ready parks the row, so
+        // the sync_repo_permissions pre-flight gate drops the duplicates already queued for it
+        // (see that gate) instead of each one paying for its own discovery, and the row stops
+        // silently claiming a working repo.
+        //
+        // Safe to pair with creation_error and only with it: reconcile_stuck_repo_creations
+        // re-enqueues create_repo for rows with `is_github_ready = false AND creation_error IS
+        // NULL`, so clearing the flag on its own would hand a deleted repo to the reconciler and
+        // have it recreated. Setting both in one update keeps the row parked.
+        const repoUpdate =
+          error instanceof RepositoryMissingError
+            ? { creation_error: reason, is_github_ready: false }
+            : { creation_error: reason };
         try {
           if (envelope.repo_id) {
-            await adminSupabase.from("repositories").update({ creation_error: reason }).eq("id", envelope.repo_id);
+            await adminSupabase.from("repositories").update(repoUpdate).eq("id", envelope.repo_id);
           } else if (envelope.method === "create_repo" && envelope.class_id) {
             const { org: eo, repoName: ern } = envelope.args as CreateRepoArgs;
             await adminSupabase
               .from("repositories")
-              .update({ creation_error: reason })
+              .update(repoUpdate)
               .eq("class_id", envelope.class_id)
               .eq("repository", `${eo}/${ern}`);
+          } else if (error instanceof RepositoryMissingError) {
+            // sync_repo_permissions envelopes carry no repo_id (enqueue_github_sync_repo_permissions
+            // takes org + repo, not a row id), so match on the full name the error actually
+            // confirmed missing. Not scoped by class_id: `repository` is the unique handle here and
+            // the envelope's class_id is absent on some paths.
+            await adminSupabase.from("repositories").update(repoUpdate).eq("repository", error.fullName);
           }
         } catch (markErr) {
           console.error("Failed to record creation_error on repository row:", markErr);

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -21,6 +21,7 @@ import {
   NonRetryableRepoError,
   NonRetryableUserError,
   RepositoryMissingError,
+  RepositoryUnreadableError,
   getCreateContentLimiter
 } from "../_shared/GitHubWrapper.ts";
 import { beginWorkerRun } from "../_shared/workerRun.ts";
@@ -2318,6 +2319,12 @@ export async function processEnvelope(
       // sp26 assignment on 2026-09-09). Group them; the repo is on the tag and in the message.
       scope.setFingerprint(["github-repository-missing", envelope.method]);
       scope.setTag("missing_repository", error.fullName);
+    } else if (error instanceof RepositoryUnreadableError) {
+      // Narrowing an installation's repo selection would produce one of these per affected repo at
+      // once, so group them the same way. Kept separate from the missing case because the operator
+      // action differs: re-grant access, versus accept that the repo is gone.
+      scope.setFingerprint(["github-repository-unreadable", envelope.method]);
+      scope.setTag("unreadable_repository", error.fullName);
     }
 
     const errorId = Sentry.captureException(error, scope);
@@ -2385,7 +2392,13 @@ export async function processEnvelope(
         // redelivery is the only thing that gets us another attempt.
         let parked = true;
         try {
-          if (envelope.repo_id) {
+          if (error instanceof RepositoryUnreadableError) {
+            // Terminal for this job, but it says nothing about the row: the repo may be alive and
+            // simply not granted to this installation. Recording a creation_error here would put a
+            // failure in front of an instructor for a repo that is fine, and the cause is on our
+            // side of the fence. Stop the work, leave the data alone.
+            scope.setTag("repository_unreadable", error.fullName);
+          } else if (envelope.repo_id) {
             const { data: rows, error: e } = await adminSupabase
               .from("repositories")
               .update(repoUpdate)

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -2368,36 +2368,62 @@ export async function processEnvelope(
           error instanceof RepositoryMissingError
             ? { creation_error: reason, is_github_ready: false }
             : { creation_error: reason };
-        // postgrest-js RESOLVES with `{ error }` instead of throwing, so a failed write here is
-        // invisible to the catch below. That matters more than it used to: parking is what stops
-        // the next job repeating this failure, and DLQing while the row still says
-        // is_github_ready = true would throw the durable state away and leave the loop intact. So
-        // inspect the result, and treat a failed park as a reason NOT to archive — leaving the
-        // message for redelivery is the only thing that gets us another attempt at parking.
+        // Two ways this write can fail without throwing, both of which would leave us believing a
+        // row was parked when it was not:
+        //
+        //   1. postgrest-js RESOLVES with `{ error }` rather than throwing, so a PostgREST or
+        //      database failure is invisible to the catch below.
+        //   2. An UPDATE that matches ZERO rows is a success in both Postgres and PostgREST. The
+        //      by-name fallback is the exposed one: `.eq("repository", ...)` is case-sensitive
+        //      while GitHub treats owner/repo case-insensitively, so an envelope whose casing
+        //      differs from the stored value silently parks nothing — as would a row already
+        //      deleted.
+        //
+        // Parking is what stops the next job repeating this failure, so "we think we parked it"
+        // has to mean a row actually changed. `.select("id")` makes the affected rows observable;
+        // zero of them is a failed park, and a failed park means do not archive, because
+        // redelivery is the only thing that gets us another attempt.
         let parked = true;
         try {
           if (envelope.repo_id) {
-            const { error: e } = await adminSupabase.from("repositories").update(repoUpdate).eq("id", envelope.repo_id);
+            const { data: rows, error: e } = await adminSupabase
+              .from("repositories")
+              .update(repoUpdate)
+              .eq("id", envelope.repo_id)
+              .select("id");
             if (e) throw e;
+            if (!rows?.length) throw new Error(`no repositories row matched id ${envelope.repo_id}`);
           } else if (envelope.method === "create_repo" && envelope.class_id) {
             const { org: eo, repoName: ern } = envelope.args as CreateRepoArgs;
-            const { error: e } = await adminSupabase
+            const { data: rows, error: e } = await adminSupabase
               .from("repositories")
               .update(repoUpdate)
               .eq("class_id", envelope.class_id)
-              .eq("repository", `${eo}/${ern}`);
+              .eq("repository", `${eo}/${ern}`)
+              .select("id");
             if (e) throw e;
+            if (!rows?.length)
+              throw new Error(`no repositories row matched ${eo}/${ern} in class ${envelope.class_id}`);
           } else if (error instanceof RepositoryMissingError) {
             // sync_repo_permissions envelopes carry no repo_id (enqueue_github_sync_repo_permissions
             // takes org + repo, not a row id), so match on the full name the error actually
             // confirmed missing. Not scoped by class_id: `repository` carries a UNIQUE index
             // (unique_repo_name), so this touches at most one row, and the envelope's class_id is
             // absent on some paths.
-            const { error: e } = await adminSupabase
+            const { data: rows, error: e } = await adminSupabase
               .from("repositories")
               .update(repoUpdate)
-              .eq("repository", error.fullName);
+              .eq("repository", error.fullName)
+              .select("id");
             if (e) throw e;
+            if (!rows?.length) {
+              // Most likely an owner/repo casing difference between the envelope and the stored
+              // value, since GitHub is case-insensitive here and this filter is not. Naming it
+              // explicitly beats a silent no-op that reports success.
+              throw new Error(
+                `no repositories row matched ${error.fullName} (casing mismatch, or row already deleted)`
+              );
+            }
           }
         } catch (markErr) {
           parked = false;

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -1174,6 +1174,23 @@ export async function processEnvelope(
           if (repository?.creation_error) {
             console.log(`repo is parked, dropping permission sync: ${org}/${repoName} — ${repository.creation_error}`);
             scope.setTag("permission_sync_skipped", "repo_parked");
+            // Close out the api_gateway_calls row this envelope opened. enqueue_* inserts it with
+            // status_code = 0, and returning true archives the message — so without this the row
+            // stays pending forever and every dropped duplicate inflates the call totals with no
+            // completion status or latency. 422: the job was well-formed but can never succeed,
+            // matching the non-retryable path below.
+            recordMetric(
+              adminSupabase,
+              {
+                method: envelope.method,
+                status_code: 422,
+                class_id: envelope.class_id,
+                debug_id: envelope.debug_id,
+                enqueued_at: meta.enqueued_at,
+                log_id: envelope.log_id
+              },
+              scope
+            );
             return true;
           }
           console.log("repo is not ready", `${org}/${repoName}`);
@@ -2326,26 +2343,52 @@ export async function processEnvelope(
           error instanceof RepositoryMissingError
             ? { creation_error: reason, is_github_ready: false }
             : { creation_error: reason };
+        // postgrest-js RESOLVES with `{ error }` instead of throwing, so a failed write here is
+        // invisible to the catch below. That matters more than it used to: parking is what stops
+        // the next job repeating this failure, and DLQing while the row still says
+        // is_github_ready = true would throw the durable state away and leave the loop intact. So
+        // inspect the result, and treat a failed park as a reason NOT to archive — leaving the
+        // message for redelivery is the only thing that gets us another attempt at parking.
+        let parked = true;
         try {
           if (envelope.repo_id) {
-            await adminSupabase.from("repositories").update(repoUpdate).eq("id", envelope.repo_id);
+            const { error: e } = await adminSupabase.from("repositories").update(repoUpdate).eq("id", envelope.repo_id);
+            if (e) throw e;
           } else if (envelope.method === "create_repo" && envelope.class_id) {
             const { org: eo, repoName: ern } = envelope.args as CreateRepoArgs;
-            await adminSupabase
+            const { error: e } = await adminSupabase
               .from("repositories")
               .update(repoUpdate)
               .eq("class_id", envelope.class_id)
               .eq("repository", `${eo}/${ern}`);
+            if (e) throw e;
           } else if (error instanceof RepositoryMissingError) {
             // sync_repo_permissions envelopes carry no repo_id (enqueue_github_sync_repo_permissions
             // takes org + repo, not a row id), so match on the full name the error actually
-            // confirmed missing. Not scoped by class_id: `repository` is the unique handle here and
-            // the envelope's class_id is absent on some paths.
-            await adminSupabase.from("repositories").update(repoUpdate).eq("repository", error.fullName);
+            // confirmed missing. Not scoped by class_id: `repository` carries a UNIQUE index
+            // (unique_repo_name), so this touches at most one row, and the envelope's class_id is
+            // absent on some paths.
+            const { error: e } = await adminSupabase
+              .from("repositories")
+              .update(repoUpdate)
+              .eq("repository", error.fullName);
+            if (e) throw e;
           }
         } catch (markErr) {
+          parked = false;
           console.error("Failed to record creation_error on repository row:", markErr);
           Sentry.captureException(markErr, scope);
+        }
+        // Only for a missing repo, where the park IS the fix. Every other non-retryable error is
+        // already terminal on its own and has always gone to the DLQ regardless of this write —
+        // holding those back on a transient DB blip would be a new way to wedge the queue.
+        if (!parked && error instanceof RepositoryMissingError) {
+          scope.setTag("park_failed", "true");
+          Sentry.captureMessage(
+            `Could not park ${error.fullName}; leaving msg ${meta.msg_id} unarchived to retry the park`,
+            scope
+          );
+          return false;
         }
         recordMetric(
           adminSupabase,

--- a/supabase/functions/github-async-worker/index.ts
+++ b/supabase/functions/github-async-worker/index.ts
@@ -1175,7 +1175,7 @@ export async function processEnvelope(
             console.log(`repo is parked, dropping permission sync: ${org}/${repoName} — ${repository.creation_error}`);
             scope.setTag("permission_sync_skipped", "repo_parked");
             // Close out the api_gateway_calls row this envelope opened. enqueue_* inserts it with
-            // status_code = 0, and returning true archives the message — so without this the row
+            // status_code = 0, and archiving the message ends its life — so without this the row
             // stays pending forever and every dropped duplicate inflates the call totals with no
             // completion status or latency. 422: the job was well-formed but can never succeed,
             // matching the non-retryable path below.
@@ -1191,6 +1191,31 @@ export async function processEnvelope(
               },
               scope
             );
+            // DLQ before archiving, rather than just dropping the message.
+            //
+            // The subtle case this protects: when the error path below parks the row but its own
+            // sendToDeadLetterQueue call fails, it deliberately leaves the message UNARCHIVED so
+            // that write can be retried. That redelivered message arrives back here, and it is
+            // indistinguishable from a duplicate — so simply archiving would consume the very
+            // retry the error path was preserving, and the terminal failure would vanish from DLQ
+            // tracking during exactly the transient outage the retry exists for.
+            //
+            // Routing every parked message through the DLQ makes both cases correct without having
+            // to tell them apart, and matches the handler's convention that terminal work leaves a
+            // DLQ record. It does mean a genuine duplicate also lands there, which is the intended
+            // trade: a redundant DLQ row is recoverable, a lost one is not.
+            const dlqSuccess = await sendToDeadLetterQueue(
+              adminSupabase,
+              envelope,
+              meta,
+              new Error(`Repository is parked and cannot be synced: ${repository.creation_error}`),
+              scope
+            );
+            if (!dlqSuccess) {
+              // Leave it unarchived so the DLQ write is retried; read_ct's poison limit bounds this.
+              console.error(`Failed to DLQ parked permission sync for ${org}/${repoName}, leaving unarchived`);
+              return false;
+            }
             return true;
           }
           console.log("repo is not ready", `${org}/${repoName}`);

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -113,7 +113,11 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
     .select(
       // "*"
       // "class_id, classes(slug, github_org), profiles!private_profile_id(id, name, sortable_name, repositories(*), assignment_groups_members!assignment_groups_members_profile_id_fkey(*,assignments(*), assignment_groups(*,repositories(*)), user_roles(users(github_username)))))",
-      "class_id, github_org_confirmed, classes(slug, github_org, time_zone), profiles!private_profile_id(id, name, sortable_name, repositories(*), assignment_groups_members!assignment_groups_members_profile_id_fkey(*, assignments(*), assignment_groups(*, repositories(*), assignment_groups_members(*, user_roles(users(github_username))))))"
+      // `repositories(*, assignments(archived_at))`: the repo rows carry no assignment data of their
+      // own, and both permission-sync fan-outs below have to skip repos whose assignment has been
+      // archived. Unambiguous embed — repositories has exactly one FK to assignments
+      // (repositories_assignment_id_fkey).
+      "class_id, github_org_confirmed, classes(slug, github_org, time_zone), profiles!private_profile_id(id, name, sortable_name, repositories(*, assignments(archived_at)), assignment_groups_members!assignment_groups_members_profile_id_fkey(*, assignments(*), assignment_groups(*, repositories(*, assignments(archived_at)), assignment_groups_members(*, user_roles(users(github_username))))))"
     )
     .eq("disabled", false)
     .eq("role", "student")
@@ -170,6 +174,23 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
     c!.profiles!.assignment_groups_members!.flatMap((g) => g.assignment_groups.repositories)
   );
 
+  // An archived assignment is over: its repos need no collaborator reconciliation, and if the
+  // instructor deleted them on GitHub when they abandoned the assignment then syncing is not just
+  // pointless but noisy — every one 404s, and this is the user-facing "Fix GitHub" path, so the
+  // student is shown `Error syncing permissions for <repo>` about something that is not their
+  // problem and cannot fix. Two abandoned sp26 assignments left 192 such rows in neu-cs2100.
+  // Mirrors the trigger-path filter in
+  // 20260909170000_org_join_sync_skips_archived_assignments.sql.
+  //
+  // Deliberately NOT applied to `existingRepos` below. That list answers "does a repo already
+  // exist for this assignment?", which decides whether to CREATE one — a different question, and
+  // one where dropping archived rows would conclude "missing" and manufacture a fresh repo for a
+  // retired assignment. Existence is unconditional; only syncing is filtered.
+  const isForLiveAssignment = (repo: { assignments?: { archived_at: string | null } | null }) =>
+    !repo.assignments?.archived_at;
+  const individualReposToSync = existingIndividualRepos.filter(isForLiveAssignment);
+  const groupReposToSync = existingGroupRepos.filter(isForLiveAssignment);
+
   const existingRepos = [...existingIndividualRepos, ...existingGroupRepos];
   //Find all assignments that the student is enrolled in that have been released
   const { data: allAssignments, error: assignmentsError } = await adminSupabase
@@ -182,6 +203,11 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
       classes!.map((c) => c!.class_id)
     )
     .eq("classes.user_roles.user_id", userID)
+    // Never create a repo for a retired assignment. Same reasoning as the sync filter above, and
+    // the same predicate the migration adds to create_repos_for_student — this function is the
+    // TypeScript twin of that path, so a student pressing "Fix GitHub" must not manufacture repos
+    // the instructor has archived.
+    .is("archived_at", null)
     .not("template_repo", "is", "null")
     .not("template_repo", "eq", "")
     .lte("release_date", TZDate.tz(classes[0].classes.time_zone!).toISOString())
@@ -438,7 +464,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
   await Promise.all(requests);
 
   // Sync permissions for existing individual repos
-  const individualRepoSyncPromises = existingIndividualRepos
+  const individualRepoSyncPromises = individualReposToSync
     .filter((repo) => repo.repository && repo.repository.includes("/"))
     .map(async (repo) => {
       // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above: shared request
@@ -471,7 +497,7 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
     });
 
   // Sync permissions for existing group repos
-  const groupRepoSyncPromises = existingGroupRepos
+  const groupRepoSyncPromises = groupReposToSync
     .filter((repo) => repo.repository && repo.repository.includes("/"))
     .map(async (repo) => {
       // PER-JOB SCOPE, for the reason spelled out on the group-repo fan-out above: shared request

--- a/supabase/functions/github-user-sync/index.ts
+++ b/supabase/functions/github-user-sync/index.ts
@@ -243,6 +243,13 @@ async function ensureAllReposExist(userID: string, githubUsername: string, scope
         if (!assignment.template_repo?.includes("/")) {
           return;
         }
+        // This fan-out CREATES a repo whenever the group has none, and it reads its assignment from
+        // its own embed rather than from `allAssignments` — so the `archived_at` filter on that
+        // query does not reach here. Without this guard, "Fix GitHub" would still manufacture a
+        // fresh group repo for an assignment the instructor has retired.
+        if (assignment.archived_at) {
+          return;
+        }
         const repoName = `${c.classes!.slug}-${assignment.slug}-group-${sanitizeRepoNameComponent(group.name)}`;
         // PER-JOB SCOPE. This closure is one of four fan-outs in this function that share the single
         // request scope, and it runs concurrently over every group repo. Everything below writes

--- a/supabase/migrations/20260909170000_org_join_sync_skips_archived_assignments.sql
+++ b/supabase/migrations/20260909170000_org_join_sync_skips_archived_assignments.sql
@@ -151,3 +151,142 @@ $$;
 revoke all on function public.sync_repo_permissions_for_student(uuid, integer) from public;
 grant execute on function public.sync_repo_permissions_for_student(uuid, integer) to postgres;
 grant execute on function public.sync_repo_permissions_for_student(uuid, integer) to service_role;
+
+-- ---------------------------------------------------------------------------
+-- The creation path needs the same exclusion, or archival is only half honoured.
+-- ---------------------------------------------------------------------------
+-- `sync_github_teams_on_role_change` fires BOTH functions on the same
+-- github_org_confirmed false->true transition: create_repos_for_student first, then the permission
+-- sync above (20260728010000_include_admin_in_staff_github_team_sync.sql:82-93). Filtering only
+-- the rows that already exist therefore leaves a gap — for a released-but-archived assignment
+-- whose repository row was deleted or never created, an org confirmation still enqueues a
+-- create_repo job and manufactures fresh work for an assignment the instructor has retired. It
+-- would then be a brand-new repo that nothing wants, and the permission-sync filter above would
+-- (correctly) never touch it again.
+--
+-- Body is otherwise verbatim from the live definition, itself last set by
+-- 20260530120200_assignment-repo-config.sql; the only change is the added `a.archived_at is null`
+-- predicate in the assignment loop.
+-- (generated from pg_get_functiondef; see the note above)
+CREATE OR REPLACE FUNCTION public.create_repos_for_student(user_id uuid, class_id integer DEFAULT NULL::integer, p_force boolean DEFAULT false)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_username text;
+  v_user_id uuid := user_id;
+  v_class_id integer := class_id;
+  r_assignment_id bigint;
+  r_assignment_slug text;
+  r_template_repo text;
+  r_course_id bigint;
+  r_course_slug text;
+  r_github_org text;
+  r_latest_template_sha text;
+  r_profile_id uuid;
+  r_repo_mode public.assignment_repo_mode;
+  r_source_assignment_id bigint;
+  r_branch_protection jsonb;
+  r_creation_method text;
+  r_source_repo text;
+begin
+  if user_id is null then
+    raise warning 'create_repos_for_student called with NULL user_id, skipping';
+    return;
+  end if;
+
+  select u.github_username into v_username from public.users u where u.user_id = v_user_id;
+  if v_username is null or v_username = '' then
+    raise exception 'User % has no GitHub username linked', user_id;
+  end if;
+
+  if p_force then
+    if auth.uid() is not null then
+      if class_id is null then
+        raise exception 'Force create for all classes requires service role';
+      end if;
+      if not exists (
+        select 1 from public.user_privileges up
+        where up.user_id = auth.uid()
+          and (up.role = 'admin' or (up.class_id = v_class_id::bigint and up.role = 'instructor'))
+      ) then
+        raise exception 'Access denied: Only instructors can force-create repos for class %', class_id;
+      end if;
+    end if;
+  end if;
+
+  for r_assignment_id, r_assignment_slug, r_template_repo, r_course_id, r_course_slug, r_github_org,
+      r_latest_template_sha, r_profile_id, r_repo_mode, r_source_assignment_id, r_branch_protection in
+    select a.id, a.slug, a.template_repo, c.id, c.slug, c.github_org, a.latest_template_sha,
+           ur.private_profile_id, a.repo_mode, a.source_assignment_id,
+           jsonb_build_object(
+             'blockForcePush', coalesce(a.protect_block_force_push, true),
+             'requirePullRequest', coalesce(a.protect_require_pull_request, false),
+             'requiredReviewers', coalesce(a.protect_required_reviewers, 0)
+           )
+    from public.assignments a
+    join public.classes c on c.id = a.class_id
+    join public.user_roles ur on ur.class_id = c.id
+    where ur.user_id = v_user_id
+      and ur.private_profile_id is not null                  -- safety check for NULL profiles
+      and ur.disabled = false                                -- skip disabled/dropped students
+      and (v_class_id is null or c.id = v_class_id)
+      and c.github_org is not null and c.github_org <> ''    -- skip classes with no GitHub org configured
+      and a.release_date is not null and a.release_date <= now()  -- only create repos for released assignments
+      and a.archived_at is null                              -- an archived assignment is over; do not create repos for it
+      and a.repo_mode not in ('none', 'no_submission')
+      and a.group_config <> 'groups'
+      and (
+        a.repo_mode = 'fork_from_prior_assignment'
+        or (a.template_repo is not null and a.template_repo <> '')
+      )
+      and (
+        p_force
+        or not exists (
+          select 1 from public.repositories r
+          where r.assignment_id = a.id and r.profile_id = ur.private_profile_id
+        )
+      )
+  loop
+    if r_repo_mode = 'fork_from_prior_assignment' then
+      select r.repository into r_source_repo
+        from public.repositories r
+       where r.assignment_id = r_source_assignment_id
+         and r.profile_id = r_profile_id
+       limit 1;
+      if r_source_repo is null then
+        raise warning 'No source repository for profile % on assignment %; skipping', r_profile_id, r_source_assignment_id;
+        continue;
+      end if;
+      r_creation_method := 'fork';
+    elsif r_repo_mode = 'template_with_student_forks' then
+      r_source_repo := r_template_repo;
+      r_creation_method := 'fork';
+    else
+      r_source_repo := r_template_repo;
+      r_creation_method := 'template';
+    end if;
+
+    perform public.enqueue_github_create_repo(
+      r_course_id,
+      r_github_org,
+      r_course_slug || '-' || r_assignment_slug || '-' || v_username,
+      coalesce(r_template_repo, r_source_repo),
+      r_course_slug,
+      array[v_username],
+      false,
+      null,
+      r_assignment_id,
+      r_profile_id,
+      null,
+      r_latest_template_sha,
+      r_creation_method,
+      r_source_repo,
+      r_branch_protection,
+      null
+    );
+  end loop;
+end;
+$function$;

--- a/supabase/migrations/20260909170000_org_join_sync_skips_archived_assignments.sql
+++ b/supabase/migrations/20260909170000_org_join_sync_skips_archived_assignments.sql
@@ -1,0 +1,153 @@
+-- Stop the org-join permission sync from queueing work for archived assignments.
+--
+-- `sync_repo_permissions_for_student` fires from the user_roles trigger on the
+-- github_org_confirmed false->true transition, and enqueues one sync per repository row the
+-- student owns in that class. It has never filtered on the assignment: an archived assignment's
+-- rows are still selected, still enqueued, and — if the instructor deleted the GitHub repos when
+-- they abandoned the assignment — still 404.
+--
+-- What that cost in production (2026-09-09, neu-cs2100): sp26 assignments hw6 and lab6 were
+-- replaced mid-term by hw6-real / lab6-real and their repos deleted by hand, leaving 192 rows
+-- pointing at repos that no longer exist. Every student whose sp26 enrollment got re-confirmed
+-- queued two doomed syncs, and each one burned the 93-second 404 retry ladder in
+-- syncRepoPermissions and then opened the `neu-cs2100:sync_repo_permissions` circuit — throttling
+-- that method for every other class in the org.
+--
+-- Archiving an assignment is the instructor's own signal that it is over. Honour it here: no repo
+-- of an archived assignment needs its collaborators reconciled, whether or not the repo still
+-- exists. The GitHubWrapper/worker change that ships with this migration handles the repos that
+-- are missing for other reasons (deleted from a LIVE assignment, or left behind by an out-of-band
+-- rename); this one keeps the queue from filling with work that was never worth doing.
+--
+-- Body is otherwise verbatim from 20260108100000_sync_repo_permissions_on_org_join.sql.
+create or replace function public.sync_repo_permissions_for_student(
+  p_user_id uuid,
+  p_class_id integer
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_github_username text;
+  v_course_slug text;
+  v_github_org text;
+  v_repo_record record;
+  v_github_usernames text[];
+  v_repo_name text;
+  v_org_name text;
+begin
+  if p_user_id is null then
+    raise warning 'sync_repo_permissions_for_student called with NULL user_id, skipping';
+    return;
+  end if;
+
+  -- Get the user's GitHub username
+  select github_username into v_github_username
+  from public.users
+  where user_id = p_user_id;
+
+  if v_github_username is null or v_github_username = '' then
+    raise warning 'User % has no GitHub username, skipping repo permission sync', p_user_id;
+    return;
+  end if;
+
+  -- Get class information
+  select slug, github_org into v_course_slug, v_github_org
+  from public.classes
+  where id = p_class_id;
+
+  if v_github_org is null or v_github_org = '' then
+    raise warning 'Class % has no GitHub org configured, skipping repo permission sync', p_class_id;
+    return;
+  end if;
+
+  -- Get the user's profile for this class
+  declare
+    v_profile_id uuid;
+  begin
+    select private_profile_id into v_profile_id
+    from public.user_roles
+    where user_id = p_user_id
+      and class_id = p_class_id
+      and role = 'student';
+
+    if v_profile_id is null then
+      raise warning 'No profile found for user % in class %, skipping', p_user_id, p_class_id;
+      return;
+    end if;
+
+    -- Sync permissions for individual repos belonging to this student
+    for v_repo_record in
+      select r.repository
+      from public.repositories r
+      join public.assignments a on a.id = r.assignment_id
+      where r.profile_id = v_profile_id
+        and r.class_id = p_class_id
+        and a.archived_at is null
+        and r.repository is not null
+        and r.repository != ''
+        and position('/' in r.repository) > 0
+    loop
+      v_org_name := split_part(v_repo_record.repository, '/', 1);
+      v_repo_name := split_part(v_repo_record.repository, '/', 2);
+
+      perform public.enqueue_github_sync_repo_permissions(
+        p_class_id::bigint,
+        v_org_name,
+        v_repo_name,
+        v_course_slug,
+        array[v_github_username],
+        'org-join-sync-' || p_user_id::text
+      );
+    end loop;
+
+    -- Sync permissions for group repos the student is a member of
+    for v_repo_record in
+      select r.repository, r.assignment_group_id
+      from public.assignment_groups_members agm
+      join public.assignment_groups ag on ag.id = agm.assignment_group_id
+      join public.repositories r on r.assignment_group_id = ag.id
+      join public.assignments a on a.id = r.assignment_id
+      where agm.profile_id = v_profile_id
+        and r.class_id = p_class_id
+        and a.archived_at is null
+        and r.repository is not null
+        and r.repository != ''
+        and position('/' in r.repository) > 0
+    loop
+      v_org_name := split_part(v_repo_record.repository, '/', 1);
+      v_repo_name := split_part(v_repo_record.repository, '/', 2);
+
+      -- Get all group members' GitHub usernames
+      select array_remove(array_agg(u.github_username), null)
+      into v_github_usernames
+      from public.assignment_groups_members agm
+      join public.user_roles ur on ur.private_profile_id = agm.profile_id
+      join public.users u on u.user_id = ur.user_id
+      where agm.assignment_group_id = v_repo_record.assignment_group_id
+        and ur.class_id = p_class_id
+        and ur.role = 'student'
+        and ur.github_org_confirmed = true
+        and u.github_username is not null;
+
+      if v_github_usernames is not null and array_length(v_github_usernames, 1) > 0 then
+        perform public.enqueue_github_sync_repo_permissions(
+          p_class_id::bigint,
+          v_org_name,
+          v_repo_name,
+          v_course_slug,
+          v_github_usernames,
+          'org-join-sync-group-' || p_user_id::text
+        );
+      end if;
+    end loop;
+  end;
+end;
+$$;
+
+-- Unchanged from the original definition; restated because CREATE OR REPLACE does not reset them
+-- and a future reader should not have to go back two migrations to see what may call this.
+revoke all on function public.sync_repo_permissions_for_student(uuid, integer) from public;
+grant execute on function public.sync_repo_permissions_for_student(uuid, integer) to postgres;
+grant execute on function public.sync_repo_permissions_for_student(uuid, integer) to service_role;


### PR DESCRIPTION
## What broke

A `sync_repo_permissions` job for a repo that no longer exists on GitHub cost **94 seconds** and took the org's permission sync down with it.

Observed in prod on 2026-09-09 (`neu-cs2100`, release `main-20260909-400bbf28`). Three students each queued two such jobs; each one:

1. spent the full 404 retry ladder in `syncRepoPermissions` — 3+6+12+24+48 = **93s** of a worker slot — because `retryWithBackoff` retries 404;
2. escaped as a bare `RequestError`, which the worker's generic error path reads as a *systemic* failure and answers by opening the `neu-cs2100:sync_repo_permissions` circuit — pausing that method for **every other class in the org**;
3. requeued and repeated until it hit the DLQ.

Evidence: 24 `github_async_errors` rows between 15:31 and 19:24 UTC, 4 messages in `async_calls_dlq`, and `github_circuit_breakers` showing `org_method / neu-cs2100:sync_repo_permissions` opened at 19:24:09.

## Why it happened

The 404 ladder isn't wrong. `syncRepoPermissions` runs immediately after `createRepo` in the same message, and the collaborators endpoint really does 404 briefly on a repo that exists. The bug is that a repo which is **gone** 404s identically — and we were guessing which case we had.

**So ask instead of guessing.** On a 404, `listCollaboratorsOrThrowMissing` issues one `GET /repos/{owner}/{repo}` (only ever on the error path) and turns the ambiguity into an answer:

- still there → replication lag, keep the ladder;
- absent → `RepositoryMissingError`, a `NonRetryableGitHubError`, which the worker already knows to record per-row and to keep **away** from the shared circuit breaker;
- non-404 (403, 5xx, network) → propagate unchanged. "We could not find out" must never be recorded as "the repo is gone", or a GitHub outage would clear `is_github_ready` across live repos.

## Also in here

- **The worker clears `is_github_ready` alongside `creation_error`** for a missing repo — only ever *together*: `reconcile_stuck_repo_creations` re-enqueues `create_repo` for rows with `is_github_ready = false AND creation_error IS NULL`, so clearing the flag alone would have the reconciler recreate a deleted repo. `sync_repo_permissions` envelopes carry no `repo_id`, so the row is matched by the full name the error confirmed missing.
- **The pre-flight gate now distinguishes "not ready yet" (requeue, as before) from "parked with a `creation_error`" (archive).** Requeueing a parked row is waste — nothing will change it, and the message redelivered every visibility timeout until `read_ct` tripped the poison-pill limit ~50 minutes later.
- **`sync_repo_permissions_for_student` skips archived assignments.** The org-join trigger that enqueued all of this never filtered on the assignment, so an archived assignment's rows were still selected and still synced. That's what turned two abandoned sp26 assignments (`hw6`/`lab6`, replaced mid-term by `hw6-real`/`lab6-real`, repos then deleted by hand) into 192 landmines. Archiving is the instructor's own signal that the assignment is over; both loops now honour it.

## Scope note

258 rows in `neu-cs2100` currently point at repos that aren't on GitHub. 234 are the three hand-cleaned assignments (`sp26 hw6` 146, `sp26 lab6` 46, `f25 lab9` 42). The other **24 were renamed, not deleted** — `archiveRepoAndLock` renames to `archived-<ts>-<name>` and never updates the row. All but one date from 2026-01-10..21, and the current group-dissolve path *does* delete the row, so that's legacy residue rather than a live bug; I deliberately left `archiveRepoAndLock` alone. The `RepositoryMissingError` path parks those rows instead of retrying them forever.

## Testing

- 7 new unit tests pin the classification: present, absent, inconclusive, and that a non-404 costs no extra request (the fake Octokit throws on unexpected routes, so a regression there fails loudly).
- `npm run test:functions`: **377 passed, 0 failed**.
- The migration was applied and rolled back against a local database to confirm it parses, resolves, and plans — `EXPLAIN` shows the `archived_at IS NULL` filter in effect.
- Not covered by automated tests: the worker's row-parking write and the pre-flight gate change (no test harness exists for `processEnvelope`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository synchronization when GitHub repositories are missing or unreadable.
  * Missing repositories are now parked without unnecessary retries, while unreadable repositories remain unchanged for review.
  * Improved error handling and status updates when synchronization cannot be completed.
  * Prevented archived assignments from triggering repository creation or permission synchronization.

* **Reliability**
  * Preserved retry signals for temporary GitHub and rate-limit failures.
  * Improved recovery when recording a missing repository fails, allowing the operation to be retried safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->