### PR TITLE
fix(github): stop a disabled fork retrying for hours, and park a dead-lettered repo creation

### DIFF
--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -18,6 +18,7 @@ import { Octokit, RequestError } from "npm:octokit";
 Deno.env.set("GITHUB_PRIVATE_KEY_STRING", Deno.env.get("GITHUB_PRIVATE_KEY_STRING") || "test-placeholder-key");
 const {
   assertSourceForkable,
+  destinationHasContent,
   assertSourceNotEmpty,
   computeCollaboratorRemovals,
   filterToDirectCollaborators,
@@ -211,6 +212,57 @@ Deno.test("assertSourceForkable: a transient read failure stays retryable", asyn
   // course is misconfigured, and parking on it would strand a healthy assignment.
   const err = await assertRejects(() => assertSourceForkable(octokit, "org", "handout", "org/handout"));
   assertEquals(err instanceof NonRetryableRepoError, false);
+  assertEquals((err as RequestError).status, 500);
+});
+
+// --- Adoption probe when the fork source is unforkable (destinationHasContent) ---
+//
+// createRepo is idempotent: when the destination already exists with content, the create call
+// 422s on the duplicate name and the repo is ADOPTED. The fork preflight runs before that, so
+// without this probe an unforkable source would park an assignment whose repos were provisioned
+// while forking was still allowed and whose handout was made private afterwards -- turning a
+// re-run that used to succeed into a reported config error.
+//
+// createRepo itself resolves its own Octokit through getOctoKit(org), so it cannot be driven by
+// this file's fake-request router; these cover the decision input the new branch reads.
+
+Deno.test("destinationHasContent: existing repo with content -> true (adopt)", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": META_OK,
+    "GET /repos/{owner}/{repo}/git/ref/{ref}": () => ({ data: { ref: "refs/heads/main" } })
+  });
+  assertEquals(await destinationHasContent(octokit, "org", "student-repo"), true);
+});
+
+Deno.test("destinationHasContent: existing but EMPTY repo -> false (do not adopt a blank repo)", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": META_OK,
+    "GET /repos/{owner}/{repo}/git/ref/{ref}": () => {
+      throw requestError(409, "Git Repository is empty.");
+    }
+  });
+  // The normal path REPAIRS an empty leftover by delete+regenerate, which is impossible when the
+  // source cannot be forked -- so there is nothing to adopt and the preflight error must stand.
+  assertEquals(await destinationHasContent(octokit, "org", "student-repo"), false);
+});
+
+Deno.test("destinationHasContent: no such repo (404) -> false", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  assertEquals(await destinationHasContent(octokit, "org", "student-repo"), false);
+});
+
+Deno.test("destinationHasContent: a transient failure propagates rather than reading as 'no'", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(500, "Internal Server Error");
+    }
+  });
+  // Swallowing this would park a repo that may well have been adoptable.
+  const err = await assertRejects(() => destinationHasContent(octokit, "org", "student-repo"));
   assertEquals((err as RequestError).status, 500);
 });
 

--- a/supabase/functions/_shared/GitHubWrapper.test.ts
+++ b/supabase/functions/_shared/GitHubWrapper.test.ts
@@ -17,6 +17,7 @@ import { Octokit, RequestError } from "npm:octokit";
 // import so the env is set first — static imports would hoist above this).
 Deno.env.set("GITHUB_PRIVATE_KEY_STRING", Deno.env.get("GITHUB_PRIVATE_KEY_STRING") || "test-placeholder-key");
 const {
+  assertSourceForkable,
   assertSourceNotEmpty,
   computeCollaboratorRemovals,
   filterToDirectCollaborators,
@@ -139,6 +140,78 @@ Deno.test("assertSourceNotEmpty: missing source (404 on repo) -> NonRetryableRep
     NonRetryableRepoError
   );
   assertEquals(err.message.includes("not found"), true);
+});
+
+// --- Fork-source preflight (assertSourceForkable) ---
+//
+// Regression cover for the CS 4535 incident of 2026-09-09: a private handout in an org that
+// forbids forking private repos made every create_repo for the assignment fail with a 403 that
+// nothing classified as terminal, so the reconciler re-enqueued the rows for 8.5 hours.
+
+Deno.test("assertSourceForkable: forkable source -> no throw", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => ({ data: { allow_forking: true, private: true } })
+  });
+  // Should not throw: private is fine as long as the org permits forking private repos.
+  await assertSourceForkable(octokit, "org", "handout", "org/handout");
+});
+
+Deno.test("assertSourceForkable: private + forking disabled -> names the org policy", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => ({ data: { allow_forking: false, private: true } })
+  });
+  const err = await assertRejects(
+    () => assertSourceForkable(octokit, "org", "handout", "org/handout"),
+    NonRetryableRepoError
+  );
+  // The instructor needs both remedies, and this is the one that matches a private source.
+  assertEquals(err.message.includes("does not allow forking private repositories"), true);
+  assertEquals(err.message.includes("make org/handout public"), true);
+});
+
+Deno.test("assertSourceForkable: public + forking disabled -> names the repo setting", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => ({ data: { allow_forking: false, private: false } })
+  });
+  const err = await assertRejects(
+    () => assertSourceForkable(octokit, "org", "handout", "org/handout"),
+    NonRetryableRepoError
+  );
+  assertEquals(err.message.includes("forking is disabled on that repository"), true);
+});
+
+Deno.test("assertSourceForkable: missing source (404) -> NonRetryableRepoError", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(404, "Not Found");
+    }
+  });
+  const err = await assertRejects(
+    () => assertSourceForkable(octokit, "org", "handout", "org/handout"),
+    NonRetryableRepoError
+  );
+  assertEquals(err.message.includes("not found"), true);
+});
+
+Deno.test("assertSourceForkable: absent allow_forking is not treated as disabled", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => ({ data: { private: true } })
+  });
+  // If GitHub ever stops sending the field, undefined must not park every fork-mode creation.
+  await assertSourceForkable(octokit, "org", "handout", "org/handout");
+});
+
+Deno.test("assertSourceForkable: a transient read failure stays retryable", async () => {
+  const octokit = fakeOctokit({
+    "GET /repos/{owner}/{repo}": () => {
+      throw requestError(500, "Internal Server Error");
+    }
+  });
+  // Must NOT become NonRetryableRepoError: one failed read of the source is not evidence that the
+  // course is misconfigured, and parking on it would strand a healthy assignment.
+  const err = await assertRejects(() => assertSourceForkable(octokit, "org", "handout", "org/handout"));
+  assertEquals(err instanceof NonRetryableRepoError, false);
+  assertEquals((err as RequestError).status, 500);
 });
 
 // --- Idempotent team creation (getTeamAndCreateIfNeeded) ---

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1431,6 +1431,114 @@ export async function assertSourceNotEmpty(
 }
 
 /**
+ * Throws NonRetryableRepoError when the fork source cannot be forked at all.
+ *
+ * WHY THIS IS A PREFLIGHT AND NOT JUST ERROR HANDLING (2026-09-09, CS 4535). A private handout in
+ * an org whose "Allow forking of private repositories" member privilege is off makes
+ * `POST /repos/{owner}/{repo}/forks` fail with 403 "The repository exists, but forking is
+ * disabled." That is a course CONFIGURATION fault, identical for every student on the assignment,
+ * and no retry can fix it. Left unclassified it fell into the worker's generic retry ladder: the
+ * repository row never got a `creation_error`, so `reconcile_stuck_repo_creations` kept treating
+ * the rows as TRANSIENT and re-enqueued them on a doubling backoff. Three repos were re-enqueued
+ * six times over 8.5 hours -- 108 doomed GitHub calls -- and three students had no repo for 17
+ * hours, until an instructor noticed and made the handout public.
+ *
+ * Checking first costs one `GET /repos` per fork-mode creation. That GET is not scheduled through
+ * the fleet-wide `create_content:<org>` limiter, whereas the doomed fork it replaces WOULD hold one
+ * of that limiter's 40 slots. On a burst (58 repos on 2026-09-07) the preflight is therefore
+ * cheaper than the failure it prevents, not just faster to diagnose.
+ *
+ * The repo-level `allow_forking` flag reflects the ORG policy, not just the repository toggle:
+ * verified 2026-09-09 against neu-cs4535, where every private repo reports `allow_forking: false`
+ * while `orgs/neu-cs4535.members_can_fork_private_repositories` is false. One GET is therefore
+ * enough; we do not also need to read the org.
+ *
+ * A 403 from the fork call itself is still classified in `createRepo` -- this preflight can race a
+ * policy change, and belt-and-braces is cheap.
+ */
+export async function assertSourceForkable(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sourceFullName: string
+): Promise<void> {
+  let meta: { allow_forking?: boolean; private?: boolean };
+  try {
+    const resp = await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
+    meta = resp.data as { allow_forking?: boolean; private?: boolean };
+  } catch (e) {
+    if (e instanceof RequestError && e.status === 404) {
+      throw new NonRetryableRepoError(`Source repository ${sourceFullName} was not found`);
+    }
+    // Anything else (a 5xx, a rate limit) is transient: let the caller retry rather than parking a
+    // repo because we could not read the source once.
+    throw e;
+  }
+  // Only a definitive `false` blocks. If GitHub ever stops returning the field, `undefined` must
+  // not be read as "cannot fork" -- that would park every fork-mode creation on a schema change.
+  if (meta.allow_forking === false) {
+    throw new NonRetryableRepoError(forkingDisabledMessage(sourceFullName, owner, meta.private === true));
+  }
+}
+
+/**
+ * The instructor-facing remedy for a disabled fork. Both causes produce the same GitHub error, so
+ * name the one that matches what we observed about the source and keep the other as the fallback.
+ * This string lands in `repositories.creation_error` and is shown next to the Retry button.
+ */
+function forkingDisabledMessage(sourceFullName: string, owner: string, sourceIsPrivate: boolean): string {
+  if (sourceIsPrivate) {
+    return (
+      `Cannot fork ${sourceFullName}: it is private, and the ${owner} organization does not allow ` +
+      `forking private repositories. Either make ${sourceFullName} public, or turn on ` +
+      `"Allow forking of private repositories" in the ${owner} organization settings ` +
+      `(Settings > Member privileges), then use Retry.`
+    );
+  }
+  return (
+    `Cannot fork ${sourceFullName}: forking is disabled on that repository. Turn on ` +
+    `"Allow forking" in its settings (Settings > General > Features), then use Retry.`
+  );
+}
+
+/**
+ * True when a fork request failed because forking is disabled for the source -- either the
+ * repository's own toggle is off, or it is private and the org forbids forking private repos.
+ * GitHub returns 403 and puts the phrase on the top-level message, but check `errors[]` too for the
+ * same reason `isRepoNameAlreadyExistsError` does: the shape is not contractual.
+ */
+function isForkingDisabledError(e: unknown): boolean {
+  if (!(e instanceof RequestError) || e.status !== 403) return false;
+  const haystacks: string[] = [e.message ?? ""];
+  const errors = (e.response?.data as { errors?: unknown } | undefined)?.errors;
+  if (Array.isArray(errors)) {
+    for (const err of errors) {
+      if (typeof err === "string") {
+        haystacks.push(err);
+      } else if (err && typeof err === "object") {
+        const eo = err as { message?: string };
+        haystacks.push(eo.message ?? "");
+      }
+    }
+  }
+  return haystacks.join(" ").toLowerCase().includes("forking is disabled");
+}
+
+/**
+ * Best-effort read of a repo's visibility, used only to pick the wording of an error we are already
+ * throwing. A failure here must not mask that error, so it falls back to "not private" -- the
+ * message then names the repository toggle and keeps the org policy as the secondary remedy.
+ */
+async function isRepoPrivate(octokit: Octokit, owner: string, repo: string): Promise<boolean> {
+  try {
+    const resp = await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
+    return (resp.data as { private?: boolean }).private === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when a repo create/generate/fork request failed because the target name is already taken.
  * GitHub returns 422 and the human phrase ("Name already exists on this account") may live on the
  * top-level message OR inside response.data.errors[], so check both rather than a single brittle
@@ -1798,6 +1906,13 @@ async function createRepoInstrumented(
   scope?.setTag("org", org);
   console.log("Creating repo", template_repo, owner, repoName, org, "via", creation_method);
 
+  // Preflight the fork source ONCE, before any create attempt. Hoisted out of createAndWaitReady
+  // (which runs twice on the delete+regenerate repair path) because the answer cannot change
+  // between those two passes, and because a doomed fork holds a content-limiter slot.
+  if (creation_method === "fork") {
+    await timeStep(timings, "assert_source_forkable", () => assertSourceForkable(octokit, owner, repo, template_repo));
+  }
+
   try {
     await createAndWaitReady();
   } catch (createErr) {
@@ -1861,6 +1976,13 @@ async function createRepoInstrumented(
         assertSourceNotEmpty(octokit, owner, repo, template_repo)
       );
       throw createErr;
+    } else if (isForkingDisabledError(createErr)) {
+      // The preflight above should have caught this, so reaching here means the policy changed
+      // under us (or GitHub disagreed with `allow_forking`). Either way it is deterministic: park
+      // the row with the same remedy rather than letting it ride the generic retry ladder.
+      console.error("Error creating repo: forking disabled for source", createErr);
+      const sourceIsPrivate = await isRepoPrivate(octokit, owner, repo);
+      throw new NonRetryableRepoError(forkingDisabledMessage(template_repo, owner, sourceIsPrivate));
     } else {
       console.error("Error creating repo", createErr);
       throw createErr;

--- a/supabase/functions/_shared/GitHubWrapper.ts
+++ b/supabase/functions/_shared/GitHubWrapper.ts
@@ -1525,6 +1525,24 @@ function isForkingDisabledError(e: unknown): boolean {
 }
 
 /**
+ * True when the destination repo already exists AND has content, i.e. an earlier run already
+ * created it and this call is an idempotent re-run that should ADOPT rather than create.
+ *
+ * Only consulted when the fork preflight has already decided the source is unforkable, so the
+ * extra request is off the happy path. A 404 (nothing to adopt) and an empty repo (a half-created
+ * leftover, which the normal path REPAIRS by delete+regenerate -- impossible if we cannot fork)
+ * both mean "no", and the caller then parks the row with the preflight's error.
+ */
+export async function destinationHasContent(octokit: Octokit, org: string, repoName: string): Promise<boolean> {
+  try {
+    return !(await isRepoEmpty(octokit, org, repoName));
+  } catch (e) {
+    if (e instanceof RequestError && e.status === 404) return false;
+    throw e;
+  }
+}
+
+/**
  * Best-effort read of a repo's visibility, used only to pick the wording of an error we are already
  * throwing. A failure here must not mask that error, so it falls back to "not private" -- the
  * message then names the repository toggle and keeps the org policy as the secondary remedy.
@@ -1909,12 +1927,38 @@ async function createRepoInstrumented(
   // Preflight the fork source ONCE, before any create attempt. Hoisted out of createAndWaitReady
   // (which runs twice on the delete+regenerate repair path) because the answer cannot change
   // between those two passes, and because a doomed fork holds a content-limiter slot.
+  //
+  // An unforkable source is NOT automatically a failure. createRepo is idempotent: when the
+  // destination already exists with content, the create call 422s on the duplicate name and the
+  // catch below ADOPTS it. Parking on the preflight alone would break that re-run for any
+  // assignment whose repos were provisioned while forking was still allowed and whose handout was
+  // made private afterwards -- work that used to succeed would start reporting a config error.
+  // So when the source cannot be forked, ask whether there is anything to adopt before giving up.
+  let adoptWithoutCreating = false;
   if (creation_method === "fork") {
-    await timeStep(timings, "assert_source_forkable", () => assertSourceForkable(octokit, owner, repo, template_repo));
+    try {
+      await timeStep(timings, "assert_source_forkable", () =>
+        assertSourceForkable(octokit, owner, repo, template_repo)
+      );
+    } catch (preflightErr) {
+      if (!(preflightErr instanceof NonRetryableRepoError)) throw preflightErr;
+      const adoptable = await timeStep(timings, "adoptable_destination_probe", () =>
+        destinationHasContent(octokit, org, repoName)
+      );
+      if (!adoptable) throw preflightErr;
+      scope?.setTag("adopted_despite_unforkable_source", "true");
+      timings.setMeta("adopted_despite_unforkable_source", true);
+      adoptWithoutCreating = true;
+    }
   }
 
   try {
-    await createAndWaitReady();
+    if (adoptWithoutCreating) {
+      // Nothing to create: fall through to the shared finalize block, exactly as the
+      // duplicate-name adoption path below does.
+    } else {
+      await createAndWaitReady();
+    }
   } catch (createErr) {
     if (isRepoNameAlreadyExistsError(createErr)) {
       // A repo already exists under this name. If it has content, adopt it (idempotent re-run). If

--- a/supabase/migrations/20260910010000_park_dead_lettered_repo_creations.sql
+++ b/supabase/migrations/20260910010000_park_dead_lettered_repo_creations.sql
@@ -1,0 +1,161 @@
+-- Stop the repo reconciler re-enqueueing a create_repo job that has already been dead-lettered.
+--
+-- THE INCIDENT (2026-09-09, CS 4535). A private handout in an org whose "Allow forking of private
+-- repositories" member privilege is off made every create_repo for assignment 1226 fail with
+-- 403 "The repository exists, but forking is disabled." Nothing classified that as terminal, so
+-- the repository rows never received a `creation_error` and reconcile_stuck_repo_creations kept
+-- treating them as TRANSIENT. Three repos were re-enqueued six times over 8.5 hours -- 108 GitHub
+-- calls that could never succeed -- and three students had no repo for 17 hours, until an
+-- instructor noticed and made the handout public.
+--
+-- The companion change to this one teaches the worker to classify that specific 403 as a
+-- NonRetryableRepoError, which writes `creation_error` and parks the row on the FIRST failure.
+-- This migration is the GENERIC backstop for the same shape: it does not care WHY the job failed,
+-- only that the job we last queued is now in the dead-letter queue. Any future unclassified
+-- terminal error is capped at one cycle instead of eight.
+--
+-- WHY THE DLQ IS THE RIGHT EVIDENCE, AND WHY IT IS A DIFFERENT QUESTION FROM repo_ids_with_
+-- queued_create(). That function answers "is a job still alive?" and deliberately does NOT look at
+-- the DLQ, because for PARKING an exhausted row, a dead-lettered job counts as gone -- absence
+-- from the live queues is what permits parking. This asks the opposite question: "did the job we
+-- queued end up dead-lettered?", and a positive answer is grounds to park EARLY, before the
+-- eight-attempt ceiling. Both are needed; neither subsumes the other.
+--
+-- WHY IT COMPARES AGAINST last_creation_attempt_at. Nothing consumes the DLQ, so an entry lives
+-- there until an operator drains it. Without a recency test, one dead-lettered job would bar a
+-- repository from automatic retry forever -- including immediately after an instructor clicks
+-- Retry, which would park the fresh job before it ever ran. retry_repository_creation clears
+-- creation_error, zeroes creation_attempts and re-enqueues, and every path that queues a job
+-- writes last_creation_attempt_at, so "dead-lettered at or after the last thing we queued" is
+-- exactly "the current attempt died" and an older entry is correctly ignored.
+
+-- Which repositories have a dead-lettered create_repo, and when the most recent one landed.
+--
+-- Unlike repo_ids_with_queued_create() this is not gathered once into an array by the caller: the
+-- live queues can hold a whole class's provisioning burst, whereas the DLQ only grows when a job
+-- fails terminally and only shrinks when an operator drains it, so it stays small enough to scan
+-- directly. It compares as text for the same reason the in-flight probe does -- the envelope's
+-- repo_id is a JSON string and the queue tables have no index on it.
+create or replace function public.repo_ids_with_dead_lettered_create()
+returns table(repo_id text, dead_lettered_at timestamptz)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select q.message->>'repo_id', max(q.enqueued_at)
+    from pgmq.q_async_calls_dlq q
+   where q.message->>'method' = 'create_repo'
+     and q.message->>'repo_id' is not null
+   group by 1;
+$$;
+
+revoke all on function public.repo_ids_with_dead_lettered_create() from public, anon, authenticated;
+grant execute on function public.repo_ids_with_dead_lettered_create() to service_role;
+
+comment on function public.repo_ids_with_dead_lettered_create() is
+  'Repositories whose create_repo job was dead-lettered, with the most recent dead-letter time. '
+  'Used by reconcile_stuck_repo_creations to park a row early instead of re-enqueueing a job that '
+  'has already failed terminally. Compare against repositories.last_creation_attempt_at so an '
+  'entry predating an instructor Retry does not park the fresh attempt.';
+
+-- Re-create the reconciler with the extra park step. Everything else is unchanged from
+-- 20260816120000_bound_repo_creation_retries.sql; the new block is the second UPDATE, and the
+-- re-enqueue loop needs no new predicate because it already skips rows with a creation_error.
+create or replace function public.reconcile_stuck_repo_creations(p_stale_minutes integer default 15)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  r record;
+  v_count integer := 0;
+  v_max_attempts constant integer := 8;
+  v_max_backoff_doublings constant integer := 5;  -- caps the interval at 32x p_stale_minutes
+  v_inflight_repo_ids text[];
+begin
+  v_inflight_repo_ids := public.repo_ids_with_queued_create();
+
+  -- Park anything that has exhausted its automatic retries, whose last job is no longer anywhere
+  -- in a queue, and which has gone quiet for the interval its next attempt would have waited.
+  -- Park on evidence, not on a timer: a create_repo job can legitimately live far longer than any
+  -- interval we would guess (github-async-worker requeues an `extreme` rate limit for 12 hours),
+  -- and requeueWithDelay never touches the repository row, so updated_at stays pinned at the last
+  -- enqueue for that whole time. The queue is a table, so ask it instead.
+  update public.repositories rp
+     set creation_error = format(
+           'Repository creation did not succeed after %s automatic attempts. Check the assignment template repository and GitHub org configuration, then use Retry.',
+           v_max_attempts)
+    from public.assignments a
+   where a.id = rp.assignment_id
+     and rp.is_github_ready = false
+     and rp.creation_error is null
+     and rp.creation_attempts >= v_max_attempts
+     and rp.id::text <> all (v_inflight_repo_ids)
+     and rp.updated_at < now() - make_interval(
+           mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+         )
+     and a.repo_mode not in ('none', 'no_submission');
+
+  -- NEW: park a row whose most recently queued job was dead-lettered, whatever the attempt count.
+  -- This is the early exit the attempt ceiling above cannot provide: eight attempts against a
+  -- deterministic misconfiguration is 32 hours of doomed GitHub calls, and the DLQ already knows
+  -- after the first one. No in-flight row is touched -- if a job is live, it is not our evidence,
+  -- and the row is left to run.
+  --
+  -- The wording deliberately does not guess at the cause. The worker records a precise reason on
+  -- the row for every error class it can classify (see NonRetryableRepoError); this message is the
+  -- fallback for the ones it cannot, and it points the instructor at Retry once they have fixed
+  -- whatever the linked Sentry issue named.
+  update public.repositories rp
+     set creation_error = 'Repository creation failed and the job was dead-lettered, so automatic retries have stopped. Check the assignment template repository and GitHub org configuration (a private template needs org permission to be forked), then use Retry.'
+    from public.assignments a
+   where a.id = rp.assignment_id
+     and rp.is_github_ready = false
+     and rp.creation_error is null
+     and rp.last_creation_attempt_at is not null
+     and rp.id::text <> all (v_inflight_repo_ids)
+     and a.repo_mode not in ('none', 'no_submission')
+     and exists (
+           select 1
+             from public.repo_ids_with_dead_lettered_create() d
+            where d.repo_id = rp.id::text
+              and d.dead_lettered_at >= rp.last_creation_attempt_at
+         );
+
+  for r in
+    select rp.id
+      from public.repositories rp
+      join public.assignments a on a.id = rp.assignment_id
+      join public.classes c on c.id = rp.class_id
+     where rp.is_github_ready = false
+       and rp.creation_error is null
+       and rp.creation_attempts < v_max_attempts
+       and a.repo_mode not in ('none', 'no_submission')
+       -- Recurring per-class work must not run for courses that have ended, EXCEPT to finish
+       -- following up an attempt somebody actually made -- otherwise a row queued by an
+       -- instructor Retry on an archived class could never converge on ready or on parked.
+       and (
+         public.is_class_active(c.archived, c.end_date)
+         or rp.last_creation_attempt_at > now() - interval '7 days'
+       )
+       -- Same evidence the park uses, for the same reason in reverse: skip a row whose job is
+       -- still there and let it run; if it is gone, this is the path that replaces it.
+       and rp.id::text <> all (v_inflight_repo_ids)
+       -- Exponential backoff: each failed attempt doubles the wait, capped.
+       and rp.updated_at < now() - make_interval(
+             mins => p_stale_minutes * (2 ^ least(rp.creation_attempts, v_max_backoff_doublings))::int
+           )
+  loop
+    begin
+      perform public.enqueue_create_repo_for_repository(r.id);
+      v_count := v_count + 1;
+    exception
+      when others then
+        raise warning 'reconcile: failed to enqueue repository %: %', r.id, sqlerrm;
+    end;
+  end loop;
+  return v_count;
+end;
+$$;

--- a/tests/manual/park_dead_lettered_repo_creations.sql
+++ b/tests/manual/park_dead_lettered_repo_creations.sql
@@ -1,0 +1,81 @@
+-- Proof harness for 20260910010000_park_dead_lettered_repo_creations.sql.
+--
+-- Run from the repo root against local Supabase; everything happens in one transaction that ends in
+-- ROLLBACK, so it leaves no fixtures behind:
+--
+--   psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+--     -v ON_ERROR_STOP=1 -f tests/manual/park_dead_lettered_repo_creations.sql
+--
+-- It proves the two halves of the new park, which pull in opposite directions:
+--   1. A repository whose most recently queued create_repo was DEAD-LETTERED is parked with a
+--      creation_error, instead of being re-enqueued for the rest of its eight-attempt ladder.
+--      This is the CS 4535 case of 2026-09-09: three repos re-enqueued six times over 8.5 hours
+--      against a handout that could never be forked.
+--   2. A repository whose dead-letter entry PREDATES its last queued attempt is NOT parked --
+--      i.e. an instructor has since clicked Retry. Nothing drains the DLQ, so without this the
+--      stale entry would park the fresh job before it ever ran, and the repo could never recover.
+\set ON_ERROR_STOP on
+\timing off
+
+BEGIN;
+
+\echo '=== applying migration ==='
+\i supabase/migrations/20260910010000_park_dead_lettered_repo_creations.sql
+
+\echo ''
+\echo '=== fixture: an assignment whose repo_mode actually provisions repositories ==='
+CREATE TEMP TABLE fx AS
+  SELECT a.id AS assignment_id, a.class_id
+    FROM public.assignments a
+   WHERE a.repo_mode NOT IN ('none', 'no_submission')
+   LIMIT 1;
+SELECT assignment_id, class_id FROM fx;
+
+-- Case A: the job we last queued is the one that died.
+INSERT INTO public.repositories (assignment_id, class_id, repository, is_github_ready,
+                                 creation_attempts, last_creation_attempt_at, updated_at)
+SELECT assignment_id, class_id, 'test-org/dlq-park-case-a', false, 1,
+       now() - interval '60 minutes', now() - interval '60 minutes' FROM fx;
+
+-- Case B: the dead-letter entry is older than the last thing we queued.
+INSERT INTO public.repositories (assignment_id, class_id, repository, is_github_ready,
+                                 creation_attempts, last_creation_attempt_at, updated_at)
+SELECT assignment_id, class_id, 'test-org/dlq-park-case-b', false, 1,
+       now() - interval '5 minutes', now() - interval '5 minutes' FROM fx;
+
+\echo ''
+\echo '=== fixture: dead-letter entries ==='
+SELECT pgmq.send('async_calls_dlq',
+  jsonb_build_object('method', 'create_repo', 'repo_id',
+    (SELECT id::text FROM public.repositories WHERE repository = 'test-org/dlq-park-case-a')));
+SELECT pgmq.send('async_calls_dlq',
+  jsonb_build_object('method', 'create_repo', 'repo_id',
+    (SELECT id::text FROM public.repositories WHERE repository = 'test-org/dlq-park-case-b')));
+
+-- Backdate B's dead-letter to before its last_creation_attempt_at: the "instructor already
+-- retried" shape. pgmq.send always stamps now(), so this is the only way to build it.
+UPDATE pgmq.q_async_calls_dlq SET enqueued_at = now() - interval '60 minutes'
+ WHERE message->>'repo_id' = (SELECT id::text FROM public.repositories
+                               WHERE repository = 'test-org/dlq-park-case-b');
+
+\echo ''
+\echo '=== the probe sees both, with the most recent dead-letter time ==='
+SELECT rp.repository, d.dead_lettered_at <= now() AS dead_lettered
+  FROM public.repo_ids_with_dead_lettered_create() d
+  JOIN public.repositories rp ON rp.id::text = d.repo_id
+ ORDER BY rp.repository;
+
+\echo ''
+\echo '=== run the reconciler ==='
+SELECT public.reconcile_stuck_repo_creations(15) AS enqueued;
+
+\echo ''
+\echo '=== EXPECT: case-a parked = t, case-b parked = f ==='
+SELECT repository,
+       (creation_error IS NOT NULL) AS parked,
+       left(creation_error, 60) AS reason
+  FROM public.repositories
+ WHERE repository IN ('test-org/dlq-park-case-a', 'test-org/dlq-park-case-b')
+ ORDER BY repository;
+
+ROLLBACK;

--- a/tests/manual/park_dead_lettered_repo_creations.sql
+++ b/tests/manual/park_dead_lettered_repo_creations.sql
@@ -78,4 +78,34 @@ SELECT repository,
  WHERE repository IN ('test-org/dlq-park-case-a', 'test-org/dlq-park-case-b')
  ORDER BY repository;
 
+-- Assert it, rather than leaving the result to be eyeballed. A harness whose output has to be
+-- read by a human passes silently when it regresses, which defeats the point of committing it.
+DO $$
+DECLARE
+  v_total   integer;
+  v_parked_a boolean;
+  v_parked_b boolean;
+BEGIN
+  SELECT count(*) INTO v_total
+    FROM public.repositories
+   WHERE repository IN ('test-org/dlq-park-case-a', 'test-org/dlq-park-case-b');
+  IF v_total <> 2 THEN
+    RAISE EXCEPTION 'fixture broken: expected 2 test rows, found %', v_total;
+  END IF;
+
+  SELECT creation_error IS NOT NULL INTO v_parked_a
+    FROM public.repositories WHERE repository = 'test-org/dlq-park-case-a';
+  SELECT creation_error IS NOT NULL INTO v_parked_b
+    FROM public.repositories WHERE repository = 'test-org/dlq-park-case-b';
+
+  IF NOT v_parked_a THEN
+    RAISE EXCEPTION 'case-a NOT parked: a repository whose most recent create_repo was dead-lettered must be parked, not re-enqueued';
+  END IF;
+  IF v_parked_b THEN
+    RAISE EXCEPTION 'case-b WAS parked: a dead-letter predating last_creation_attempt_at means the instructor already retried, and the fresh job must be left alone';
+  END IF;
+
+  RAISE NOTICE 'OK: case-a parked, case-b untouched';
+END $$;
+
 ROLLBACK;


### PR DESCRIPTION
## What happened

On 2026-09-09, assignment 1226 in CS 4535 (`template_with_student_forks`) pointed at a **private** handout in an org where `members_can_fork_private_repositories` is `false`. Every `create_repo` failed with:

```
403 The repository exists, but forking is disabled.
```

Nothing classified that as terminal, so it rode the worker's generic retry ladder:

- the repository rows never got a `creation_error`, so `reconcile_stuck_repo_creations` kept treating them as **transient**
- 3 repos were re-enqueued **6 times over 8.5 hours** (05:55 → 14:32), each cycle burning 6 attempts — **108 GitHub calls that could never succeed**
- 3 students had no repo for **~17 hours**, until an instructor noticed and made the handout public

The reconciler's eight-attempt ceiling would eventually have parked them, but eight attempts against a deterministic misconfiguration is roughly 32 hours.

## The fix, in two layers

**1. Classify this specific failure (`GitHubWrapper.ts`).** Preflight the fork source before the first attempt and throw `NonRetryableRepoError`, which the worker already routes to `creation_error` + DLQ *without* tripping the shared circuit breaker. The instructor gets a message naming the actual remedy instead of a generic "did not succeed after 8 attempts".

The repo-level `allow_forking` flag reflects the **org** policy, not just the repository toggle — verified against `neu-cs4535`, where every private repo reports `allow_forking: false` while the org's `members_can_fork_private_repositories` is `false`. One GET is enough; we don't also need to read the org.

The preflight is *cheaper* than the failure it replaces: that GET is not scheduled through the fleet-wide `create_content:<org>` limiter, whereas the doomed fork it prevents would hold one of its 40 slots.

**2. A generic backstop (migration).** The reconciler now parks a row whose most recently queued `create_repo` ended up in the DLQ, whatever the reason. Any *future* unclassified terminal error is capped at one cycle instead of eight.

This asks a different question from `repo_ids_with_queued_create()`, which deliberately ignores the DLQ: that one answers *"is a job still alive?"* (where dead-lettered counts as gone, and so permits parking at the ceiling). This asks *"did the job we queued end up dead-lettered?"*, which is grounds to park early. Neither subsumes the other.

## The subtle part

Nothing drains the DLQ, so the park compares the dead-letter time against `repositories.last_creation_attempt_at`. Without that recency test, a single dead-lettered job would bar a repository from automatic retry **forever** — including immediately after an instructor clicks Retry, parking the fresh job before it ever ran.

`tests/manual/park_dead_lettered_repo_creations.sql` proves both directions: parked when the dead-letter is newer than the last attempt, left alone when it predates it.

## Verification

- 6 new unit tests, `deno test _shared/GitHubWrapper.test.ts` → **58 passed, 0 failed**
- Two deliberate guards are covered: an absent `allow_forking` is **not** read as "cannot fork" (a schema change must not park every fork-mode creation), and a transient failure to read the source stays **retryable** rather than parking a healthy assignment
- `deno check` on the touched file produces the **same 7 pre-existing errors** as `main` — none added
- Migration applied against local Supabase in a rolled-back transaction, and the proof harness passes
- **Dry-run against production: zero rows would be newly parked today.** The three repos from the incident are `is_github_ready = true`, and their `last_creation_attempt_at` (22:45) is newer than the last dead-letter (14:32), so the recency guard would ignore them anyway

Diff is 195 insertions, 0 deletions — no pre-existing lines reformatted, and no `SupabaseTypes.d.ts` churn (nothing in TS calls the new RPC).

## Still recurring

`neu-cs4535/fa26-handout-hw1` and `-gradebook` are still private with `allow_forking: false`. No assignment points at them yet, but the next fork-mode one would hit this — and now fails in seconds with an actionable message instead of silently retrying for hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Repository creation now detects when source repositories are missing or cannot be forked and reports a clear, non-retryable error.
  - Forking restrictions identify whether the limitation comes from repository or organization settings.
  - Temporary service failures remain retryable instead of being incorrectly treated as permanent failures.
  - Existing destination repositories with content can be reused during fork creation.
  - Repositories associated with permanently failed creation jobs are parked sooner.

- **Tests**
  - Added coverage for fork eligibility, destination reuse, and dead-lettered creation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->