### PR TITLE
fix(discord): give channels a repair path, and stop paying twice for the same member lookup

### DIFF
--- a/components/discord/reinvite-button.tsx
+++ b/components/discord/reinvite-button.tsx
@@ -96,8 +96,21 @@ export default function DiscordReinviteButton({
       // RETURNS TABLE, so PostgREST sends a one-row array.
       const queued = data?.[0]?.queued ?? 0;
       const rolesRepaired = data?.[0]?.roles_repaired ?? 0;
+      const channelsRepaired = data?.[0]?.channels_repaired ?? 0;
 
-      if (rolesRepaired > 0) {
+      if (channelsRepaired > 0 && rolesRepaired === 0) {
+        // Channels are reported on their own only when the roles were fine, because the two failure
+        // modes read differently to an instructor. Missing roles block the sync -- nothing can be
+        // queued until they exist. Missing #scheduling / #operations block nothing; they are where
+        // the course's own notifications go, so the honest message is "this is being fixed", not
+        // "retry in a minute". When both are missing the role message below covers the press, and
+        // this repair rides along with it.
+        toaster.create({
+          title: "Re-creating this course's Discord channels",
+          description: `${channelsRepaired} missing ${channelsRepaired === 1 ? "channel was" : "channels were"} never created. They should appear in the server shortly.`,
+          type: "warning"
+        });
+      } else if (rolesRepaired > 0) {
         // The class was missing the Discord roles the sync assigns, which is the state a class is
         // left in when its role creation failed. Nothing could have been queued for those students
         // until the roles exist, so this is reported as its own outcome rather than folded into a

--- a/supabase/functions/_shared/DiscordAsyncTypes.ts
+++ b/supabase/functions/_shared/DiscordAsyncTypes.ts
@@ -172,6 +172,20 @@ export type DiscordAsyncEnvelope = {
   debug_id?: string;
   log_id?: number;
   retry_count?: number;
+  /**
+   * When the enqueuer last saw this user in the guild, as an ISO timestamp.
+   *
+   * Set only by the batch role sync, which reads `GET /guilds/{g}/members/{u}` for every candidate
+   * and then enqueues an `add_member_role` whose handler used to read the very same endpoint again
+   * about a second later. Two identical calls per user is what exhausted the per-route bucket: the
+   * 429s all landed on the second one. The handler skips its own lookup while this is fresh (see
+   * MEMBERSHIP_HINT_TTL_MS).
+   *
+   * Deliberately a timestamp rather than a boolean, so an envelope that sat in the queue -- retried,
+   * delayed by backoff, redelivered after a visibility timeout -- falls back to checking rather than
+   * trusting an observation of unknown age.
+   */
+  membership_verified_at?: string;
   // For message tracking
   discord_message_id?: string; // For update_message, the message ID to update
   discord_channel_id?: string; // For send_message, store the channel ID

--- a/supabase/functions/_shared/DiscordMembershipHint.test.ts
+++ b/supabase/functions/_shared/DiscordMembershipHint.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the add_member_role membership hint.
+ *
+ * The timestamps below are the shape enqueue_discord_role_sync() actually writes -- UTC, millisecond
+ * precision, trailing Z -- because the SQL side formats the string by hand rather than relying on a
+ * timestamptz cast. If that format changes these tests are what notices.
+ *
+ * Run from supabase/functions:  deno test --no-check _shared/DiscordMembershipHint.test.ts
+ */
+import { assert, assertEquals } from "jsr:@std/assert@^1";
+import { freshMembershipHintAgeMs, MEMBERSHIP_HINT_TTL_MS } from "./DiscordMembershipHint.ts";
+
+/** The exact format the migration's to_char() produces. */
+const asEnqueuerWrites = (d: Date) => d.toISOString().replace(/Z$/, "Z");
+
+Deno.test("freshMembershipHintAgeMs: a hint written moments ago is trusted", () => {
+  const age = freshMembershipHintAgeMs(asEnqueuerWrites(new Date(Date.now() - 1_200)));
+  assert(age !== undefined, "a 1.2s-old hint should be trusted");
+  // Bounded rather than exact: the clock advances between constructing the string and reading it.
+  assert(age >= 1_000 && age < 5_000, `expected roughly 1200ms, got ${age}`);
+});
+
+Deno.test("freshMembershipHintAgeMs: no hint means look it up", () => {
+  assertEquals(freshMembershipHintAgeMs(undefined), undefined);
+  assertEquals(freshMembershipHintAgeMs(null), undefined);
+  assertEquals(freshMembershipHintAgeMs(""), undefined);
+});
+
+Deno.test("freshMembershipHintAgeMs: an unparseable hint means look it up, not throw", () => {
+  assertEquals(freshMembershipHintAgeMs("not a timestamp"), undefined);
+  assertEquals(freshMembershipHintAgeMs("2026-13-45T99:99:99Z"), undefined);
+});
+
+// The case the TTL exists for: an envelope that was requeued with backoff, or redelivered after its
+// visibility timeout, carries an observation far too old to stand in for a fresh lookup.
+Deno.test("freshMembershipHintAgeMs: an expired hint means look it up", () => {
+  const stale = new Date(Date.now() - MEMBERSHIP_HINT_TTL_MS - 1_000);
+  assertEquals(freshMembershipHintAgeMs(asEnqueuerWrites(stale)), undefined);
+});
+
+Deno.test("freshMembershipHintAgeMs: the TTL boundary is inclusive", () => {
+  // Just inside the window is trusted; a second past it is not. Pinned because the whole point of the
+  // bound is that it is checked, and `>` vs `>=` here is a silent one-line regression.
+  const justInside = new Date(Date.now() - (MEMBERSHIP_HINT_TTL_MS - 5_000));
+  assert(freshMembershipHintAgeMs(asEnqueuerWrites(justInside)) !== undefined);
+});
+
+// Clock skew between the enqueuer's database and this isolate is the only way to produce a future
+// timestamp. Trusting it would extend the window by the size of the skew, so it is refused outright.
+Deno.test("freshMembershipHintAgeMs: a hint from the future is refused", () => {
+  const future = new Date(Date.now() + 30_000);
+  assertEquals(freshMembershipHintAgeMs(asEnqueuerWrites(future)), undefined);
+});

--- a/supabase/functions/_shared/DiscordMembershipHint.ts
+++ b/supabase/functions/_shared/DiscordMembershipHint.ts
@@ -1,0 +1,41 @@
+/**
+ * The membership hint an enqueuer can attach to an `add_member_role` envelope.
+ *
+ * processBatchRoleSync() reads `GET /guilds/{g}/members/{u}` for every candidate and then enqueues an
+ * add_member_role whose handler used to read the very same endpoint again about a second later. Two
+ * identical calls per user, the second wave four-wide in parallel, is what emptied Discord's
+ * per-route bucket -- the 429s all landed on the second call, with `remaining: 0` and a sub-second
+ * reset. That is a route bucket, which the shared 50/s global limiter cannot see, so the fix is to
+ * stop making the duplicate call rather than to throttle harder.
+ *
+ * Kept out of the worker so it can be tested without standing up the whole handler.
+ */
+
+/**
+ * How long an enqueuer's observation is worth trusting.
+ *
+ * The batch sync enqueues and the worker picks the message up on its next iteration, normally within
+ * a second or two, so this only has to cover a healthy hand-off -- not a message that was retried,
+ * delayed by backoff, or redelivered after its visibility timeout. Two minutes is generous for the
+ * first and far short of the second.
+ */
+export const MEMBERSHIP_HINT_TTL_MS = 120_000;
+
+/**
+ * Age of a usable membership hint, or undefined when there is none worth trusting.
+ *
+ * Undefined for absent, unparseable and expired alike: every one of them means "look it up", and
+ * collapsing them here keeps the call site from having to care which.
+ *
+ * A timestamp from the future is refused rather than clamped. Clock skew between the enqueuer and
+ * this isolate is the only thing that produces one, and accepting it would extend the trust window
+ * by the size of the skew -- silently, and by an amount nothing here can measure.
+ */
+export function freshMembershipHintAgeMs(verifiedAt: string | undefined | null): number | undefined {
+  if (!verifiedAt) return undefined;
+  const observedMs = Date.parse(verifiedAt);
+  if (Number.isNaN(observedMs)) return undefined;
+  const ageMs = Date.now() - observedMs;
+  if (ageMs < 0 || ageMs > MEMBERSHIP_HINT_TTL_MS) return undefined;
+  return ageMs;
+}

--- a/supabase/functions/_shared/DiscordWrapper.ts
+++ b/supabase/functions/_shared/DiscordWrapper.ts
@@ -29,6 +29,22 @@ import {
 /** Default timeout for Discord API fetch calls (15 seconds) */
 const DISCORD_FETCH_TIMEOUT_MS = 15_000;
 
+/**
+ * Longest `retry_after` this will wait out in place rather than propagating.
+ *
+ * Discord's per-route buckets are small and refill on a sub-second cadence, so brushing one costs a
+ * `retry_after` in the tens of milliseconds. Propagating those was a 200x amplification: the worker
+ * rounds the delay up to a whole second, applies a five-second floor, requeues the message and files
+ * an error-level Sentry event -- all to avoid a 26ms wait. Waiting is also the behaviour Discord's own
+ * documentation asks for.
+ *
+ * The bound is what keeps this from becoming a hidden stall. A genuine sustained limit -- the global
+ * 50/s ceiling, or a route parked for seconds -- still propagates, so the queue's backoff and the
+ * circuit breaker keep seeing it. One second is above every per-route reset observed in production
+ * and far below the visibility timeout the message is holding.
+ */
+const SHORT_RATE_LIMIT_WAIT_MS = 1_000;
+
 const globalLimiters = new Map<string, Bottleneck>();
 const channelLimiters = new Map<string, Bottleneck>();
 
@@ -135,69 +151,116 @@ async function discordRequest(
   const globalLimiter = getGlobalLimiter();
 
   return await globalLimiter.schedule(async () => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), DISCORD_FETCH_TIMEOUT_MS);
+    // Attempted at most twice, and only for a 429 short enough to wait out (see
+    // SHORT_RATE_LIMIT_WAIT_MS). The retry stays inside the limiter slot on purpose: releasing it to
+    // sleep would let the next queued call take the slot and hit the same exhausted bucket, which is
+    // the pile-up this is meant to stop.
+    for (let attempt = 0; ; attempt++) {
+      const result = await attemptDiscordRequest(url, method, endpoint, token, body, scope);
+      if (result.kind === "response") return result.response;
 
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        method,
-        headers: {
-          Authorization: `Bot ${token}`,
-          "Content-Type": "application/json",
-          "User-Agent": "Pawtograder-Discord-Bot/1.0"
-        },
-        body: body ? JSON.stringify(body) : undefined,
-        signal: controller.signal
-      });
-    } catch (fetchError) {
-      clearTimeout(timer);
-      // Convert AbortError into a descriptive timeout error
-      if (fetchError instanceof DOMException && fetchError.name === "AbortError") {
-        const msg = `Discord API timeout after ${DISCORD_FETCH_TIMEOUT_MS}ms: ${method} ${endpoint}`;
-        console.error(`[discordRequest] ${msg}`);
-        scope?.setContext("discord_timeout", { endpoint, method, timeout_ms: DISCORD_FETCH_TIMEOUT_MS });
-        Sentry.addBreadcrumb({ message: msg, level: "error" });
-        throw new Error(msg);
+      // Rate limited. Wait it out once if it is brief, otherwise hand it to the caller's backoff.
+      if (attempt === 0 && result.retryAfterMs <= SHORT_RATE_LIMIT_WAIT_MS) {
+        console.log(
+          `[discordRequest] Rate limited on ${method} ${endpoint}, waiting ${result.retryAfterMs}ms and retrying once`
+        );
+        Sentry.addBreadcrumb({
+          message: `Discord rate limit waited out: ${endpoint}`,
+          level: "info",
+          data: { retry_after_ms: result.retryAfterMs, remaining: result.remaining }
+        });
+        await new Promise((resolve) => setTimeout(resolve, result.retryAfterMs));
+        continue;
       }
-      throw fetchError;
-    } finally {
-      clearTimeout(timer);
-    }
 
-    // Check rate limit headers
-    const remaining = response.headers.get("X-RateLimit-Remaining");
-    const resetAfter = response.headers.get("X-RateLimit-Reset-After");
-
-    if (response.status === 429) {
-      // Rate limited
-      const retryAfter = resetAfter ? parseFloat(resetAfter) * 1000 : 1000; // Convert to ms
       scope?.setContext("discord_rate_limit", {
         endpoint,
-        retry_after_ms: retryAfter,
-        remaining: remaining
+        retry_after_ms: result.retryAfterMs,
+        remaining: result.remaining,
+        waited_out: attempt > 0
       });
       Sentry.addBreadcrumb({
         message: `Discord rate limit hit: ${endpoint}`,
         level: "warning",
-        data: { retry_after_ms: retryAfter, remaining }
+        data: { retry_after_ms: result.retryAfterMs, remaining: result.remaining }
       });
-      throw new Error(`Discord rate limit: retry after ${retryAfter}ms`);
+      throw new Error(`Discord rate limit: retry after ${result.retryAfterMs}ms`);
     }
-
-    if (!response.ok) {
-      const errorText = await response.text().catch(() => "Unknown error");
-      scope?.setContext("discord_api_error", {
-        endpoint,
-        status: response.status,
-        status_text: response.statusText,
-        error: errorText
-      });
-      throw new Error(`Discord API error: ${response.status} ${response.statusText} - ${errorText}`);
-    }
-
-    return response;
   });
+}
+
+/** A 429 the caller has to decide about, rather than a response. */
+type RateLimited = { kind: "rate_limited"; retryAfterMs: number; remaining: string | null };
+
+/**
+ * One attempt at a Discord call. Separated from discordRequest so the 429 path can be retried without
+ * re-entering the limiter, and so the retry decision lives in one place instead of being duplicated.
+ */
+async function attemptDiscordRequest(
+  url: string,
+  method: string,
+  endpoint: string,
+  token: string,
+  body: unknown,
+  scope?: Sentry.Scope
+): Promise<{ kind: "response"; response: Response } | RateLimited> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DISCORD_FETCH_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bot ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "Pawtograder-Discord-Bot/1.0"
+      },
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal
+    });
+  } catch (fetchError) {
+    clearTimeout(timer);
+    // Convert AbortError into a descriptive timeout error
+    if (fetchError instanceof DOMException && fetchError.name === "AbortError") {
+      const msg = `Discord API timeout after ${DISCORD_FETCH_TIMEOUT_MS}ms: ${method} ${endpoint}`;
+      console.error(`[discordRequest] ${msg}`);
+      scope?.setContext("discord_timeout", { endpoint, method, timeout_ms: DISCORD_FETCH_TIMEOUT_MS });
+      Sentry.addBreadcrumb({ message: msg, level: "error" });
+      throw new Error(msg);
+    }
+    throw fetchError;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // Check rate limit headers
+  const remaining = response.headers.get("X-RateLimit-Remaining");
+  const resetAfter = response.headers.get("X-RateLimit-Reset-After");
+
+  if (response.status === 429) {
+    // Rate limited
+    const retryAfter = resetAfter ? parseFloat(resetAfter) * 1000 : 1000; // Convert to ms
+    // Drained before returning. The caller may sleep for the retry window and issue a second
+    // request, and an unread body holds its connection out of the pool for that whole wait --
+    // exactly when the pool is under pressure. Deno also warns about bodies that were never
+    // consumed.
+    await response.body?.cancel().catch(() => {});
+    return { kind: "rate_limited", retryAfterMs: retryAfter, remaining };
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "Unknown error");
+    scope?.setContext("discord_api_error", {
+      endpoint,
+      status: response.status,
+      status_text: response.statusText,
+      error: errorText
+    });
+    throw new Error(`Discord API error: ${response.status} ${response.statusText} - ${errorText}`);
+  }
+
+  return { kind: "response", response };
 }
 
 /**

--- a/supabase/functions/_shared/SupabaseTypes.d.ts
+++ b/supabase/functions/_shared/SupabaseTypes.d.ts
@@ -12780,6 +12780,7 @@ export type Database = {
         Args: {
           p_action?: string;
           p_class_id: number;
+          p_membership_verified_at?: string;
           p_role: Database["public"]["Enums"]["app_role"];
           p_user_id: string;
         };
@@ -13834,6 +13835,7 @@ export type Database = {
       request_discord_reinvite: {
         Args: { p_class_id: number; p_user_id?: string };
         Returns: {
+          channels_repaired: number;
           queued: number;
           roles_repaired: number;
         }[];

--- a/supabase/functions/discord-async-worker/index.ts
+++ b/supabase/functions/discord-async-worker/index.ts
@@ -27,6 +27,7 @@ import {
   parseDiscordApiError,
   DISCORD_UNKNOWN_GUILD
 } from "../_shared/DiscordErrorClassification.ts";
+import { freshMembershipHintAgeMs } from "../_shared/DiscordMembershipHint.ts";
 import { discordApiBase, isDiscordApiMocked } from "../_shared/DiscordApiBase.ts";
 import type { Database } from "../_shared/SupabaseTypes.d.ts";
 import { waitUntilWithSentryFlush } from "../_shared/SentryInit.ts";
@@ -1698,11 +1699,16 @@ async function processBatchRoleSync(
     if (membership.result === "member") {
       // User is in guild, enqueue role sync
       try {
+        // The membership this loop just established is handed to the envelope, so the
+        // add_member_role handler does not re-read the same guild member endpoint a second later.
+        // That duplicate pair -- one lookup here, an identical one from the handler, 4-wide in
+        // parallel -- is what emptied the per-route bucket and produced the 429s.
         const { error: syncError } = await adminSupabase.rpc("enqueue_discord_role_sync", {
           p_user_id: record.user_id,
           p_class_id: record.class_id,
           p_role: record.role,
-          p_action: "add"
+          p_action: "add",
+          p_membership_verified_at: new Date().toISOString()
         });
 
         if (syncError) {
@@ -2767,10 +2773,29 @@ export async function processEnvelope(
         }
 
         try {
-          // First check if user is in the guild
-          const member = await discord.getGuildMember(args.guild_id, args.user_id, scope);
+          // First check if the user is in the guild -- unless the enqueuer just did, and said so.
+          //
+          // The result is only ever read as a presence check, so a boolean is what this needs; the
+          // hint can answer it without inventing a member object the rest of the branch would then
+          // have to be trusted not to look inside.
+          //
+          // Safe because a hint is only ever written after a 200, so the user was in the guild
+          // moments ago. If they left in between, the add_member_role below 404s -- which
+          // classifyDiscordError already treats as terminal. The alternative failure, wrongly taking
+          // the `!inGuild` branch, is the expensive one: it records the student as not joined and
+          // mints an invite they do not need.
+          const hintAgeMs = freshMembershipHintAgeMs(envelope.membership_verified_at);
+          let inGuild: boolean;
+          if (hintAgeMs !== undefined) {
+            console.log(
+              `[processEnvelope] Skipping guild member lookup for ${args.user_id}; verified ${hintAgeMs}ms ago by the enqueuer`
+            );
+            inGuild = true;
+          } else {
+            inGuild = (await discord.getGuildMember(args.guild_id, args.user_id, scope)) !== null;
+          }
 
-          if (!member) {
+          if (!inGuild) {
             // The user has not joined the server. That is a permanent state until the user acts, so
             // this operation is finished either way — the invite below is a courtesy, and its failure
             // is recorded rather than retried.
@@ -3195,6 +3220,12 @@ export async function processEnvelope(
     const rt = detectRateLimit(error);
     console.log(`[processEnvelope] Rate limit detected: ${rt.isRateLimit}, retry_after: ${rt.retryAfter}`);
     scope.setTag("rate_limit", rt.isRateLimit ? "true" : "false");
+    // A rate limit that reaches here is backpressure, not a fault: the envelope is requeued below and
+    // the operation still happens. Filing it at `error` put a self-correcting 429 in the same bucket
+    // as a lost message and made the Discord worker look like it was failing when it was waiting.
+    // Still captured -- a sustained limit is worth seeing, and DiscordWrapper only propagates the ones
+    // too long to wait out -- but at a level that does not page.
+    if (rt.isRateLimit) scope.setLevel("warning");
     const errorId = Sentry.captureException(error, scope);
     console.log(`[processEnvelope] Recorded error with Sentry ID: ${errorId}`);
 

--- a/supabase/migrations/20260910010000_discord_channel_repair_and_membership_hint.sql
+++ b/supabase/migrations/20260910010000_discord_channel_repair_and_membership_hint.sql
@@ -1,0 +1,471 @@
+-- Give Discord channels a repair path, and stop the batch role sync paying for the same guild
+-- member lookup twice.
+--
+-- Two independent problems, both observed in production on 2026-09-09/10 against class 636.
+--
+-- 1. A class's #scheduling and #operations channels had no way back once their create_channel
+--    envelopes failed. All five of the class's connect-time envelopes -- three create_role, two
+--    create_channel -- died together on `403 Missing Permissions` when the bot was connected without
+--    Manage Roles or Manage Channels. isBotPermissionProblem() classifies that as terminal, so they
+--    dead-lettered at retry_count 0 rather than retrying. Once permissions were fixed, the three
+--    roles came back and the two channels did not:
+--
+--      - request_discord_reinvite() repairs missing ROLES class-wide (the v_missing_roles phase
+--        below) and has no channel equivalent, so the retry button rebuilt half the class.
+--      - trigger_discord_create_roles_on_server_connect is AFTER UPDATE OF discord_server_id, so it
+--        cannot re-fire for a guild that never changed.
+--      - claim_discord_guild() on a same-guild refresh only clears the circuit breaker.
+--
+--    Nothing else enqueues them. The channels stayed missing until they were re-driven by hand, and
+--    would have stayed missing all semester -- silently, because the enqueuers that post to them
+--    read the channel back with a non-STRICT SELECT and simply find nothing.
+--
+--    Repair covers 'scheduling' and 'operations' only: exactly what the connect trigger creates.
+--    'general' and 'regrades' are the other resource-less types, but they are created lazily by
+--    their own enqueuers on first use, and eagerly creating them here would put channels in guilds
+--    that never asked for one.
+--
+-- 2. add_member_role re-read a guild member the enqueuer had just read. processBatchRoleSync() calls
+--    GET /guilds/{g}/members/{u} for every candidate, then enqueues an add_member_role whose handler
+--    opened by calling the identical endpoint about a second later -- and the worker processes those
+--    four-wide in parallel. Discord's per-route bucket for that endpoint is small, so the second wave
+--    is where the 429s landed: `remaining: 0` with a sub-second reset, which is a route bucket and
+--    not the global 50/s ceiling the shared limiter covers. Halving the traffic is the fix; the
+--    limiter cannot see a per-route bucket.
+--
+--    enqueue_discord_role_sync() grows an optional p_membership_verified_at, stamped into the
+--    envelope. The worker trusts it for a short TTL (MEMBERSHIP_HINT_TTL_MS) and otherwise looks the
+--    member up as before, so every other caller -- the user_roles trigger, the interactions route,
+--    a manual retry -- is unchanged.
+
+-- Recreated rather than replaced: adding a defaulted parameter changes the signature, and leaving
+-- the four-argument version in place would make every existing PERFORM ambiguous ("function is not
+-- unique") rather than resolving to the new default.
+DROP FUNCTION IF EXISTS public.enqueue_discord_role_sync(uuid, bigint, public.app_role, text);
+
+CREATE FUNCTION public.enqueue_discord_role_sync(
+  p_user_id uuid,
+  p_class_id bigint,
+  p_role public.app_role,
+  p_action text DEFAULT 'add'::text,
+  -- When the caller last saw this user in the guild. Only processBatchRoleSync passes it, and only
+  -- immediately after a 200 from the member endpoint. NULL -- every other caller -- leaves the
+  -- worker's own lookup exactly as it was.
+  p_membership_verified_at timestamptz DEFAULT NULL
+)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_guild_id text;
+  v_discord_user_id text;
+  v_discord_role_id text;
+  v_class_slug text;
+BEGIN
+  -- Get Discord server info from class
+  SELECT c.discord_server_id, c.slug
+  INTO v_guild_id, v_class_slug
+  FROM public.classes c
+  WHERE c.id = p_class_id;
+
+  -- Skip if no Discord server configured
+  IF v_guild_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Get user's Discord ID
+  SELECT u.discord_id INTO v_discord_user_id
+  FROM public.users u
+  WHERE u.user_id = p_user_id;
+
+  -- Skip if user doesn't have Discord linked
+  IF v_discord_user_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Note: We don't check if user is in server here - the async worker will handle that
+  -- and create an invite if needed. This allows the role sync to be queued even if
+  -- the user isn't in the server yet.
+
+  -- Get Discord role ID for this class and role type
+  SELECT dr.discord_role_id INTO v_discord_role_id
+  FROM public.discord_roles dr
+  WHERE dr.class_id = p_class_id
+    AND dr.role_type = p_role::text;
+
+  -- Skip if role doesn't exist yet (will be created when server is connected)
+  IF v_discord_role_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- Enqueue role add/remove operation
+  IF p_action = 'add' THEN
+    PERFORM pgmq_public.send(
+      queue_name := 'discord_async_calls',
+      message := jsonb_strip_nulls(
+        jsonb_build_object(
+          'method', 'add_member_role',
+          'args', jsonb_build_object(
+            'guild_id', v_guild_id,
+            'user_id', v_discord_user_id,
+            'role_id', v_discord_role_id
+          ),
+          'class_id', p_class_id,
+          -- Stripped when NULL by the wrapper above, so an envelope from any other caller is byte
+          -- for byte what it was before this migration.
+          'membership_verified_at', to_char(
+            p_membership_verified_at AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          )
+        )
+      )
+    );
+  ELSIF p_action = 'remove' THEN
+    -- No hint on this path. remove_member_role does not look the member up at all, so there is
+    -- nothing for one to save.
+    PERFORM pgmq_public.send(
+      queue_name := 'discord_async_calls',
+      message := jsonb_build_object(
+        'method', 'remove_member_role',
+        'args', jsonb_build_object(
+          'guild_id', v_guild_id,
+          'user_id', v_discord_user_id,
+          'role_id', v_discord_role_id
+        ),
+        'class_id', p_class_id
+      )
+    );
+  END IF;
+END;
+$function$
+;
+
+COMMENT ON FUNCTION public.enqueue_discord_role_sync(uuid, bigint, public.app_role, text, timestamptz) IS
+  'Queue an add/remove of a class Discord role for one user. p_membership_verified_at lets a caller that has just confirmed the user is in the guild say so, which spares the worker an identical member lookup; leave it NULL and the worker checks for itself.';
+
+REVOKE ALL ON FUNCTION public.enqueue_discord_role_sync(uuid, bigint, public.app_role, text, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.enqueue_discord_role_sync(uuid, bigint, public.app_role, text, timestamptz) TO service_role;
+
+-- Recreated rather than replaced: the return type gains a column, which CREATE OR REPLACE cannot do.
+DROP FUNCTION IF EXISTS public.request_discord_reinvite(bigint, uuid);
+
+CREATE FUNCTION public.request_discord_reinvite(
+  p_class_id bigint,
+  p_user_id uuid DEFAULT NULL
+)
+RETURNS TABLE (queued integer, roles_repaired integer, channels_repaired integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_caller uuid := auth.uid();
+  v_is_staff boolean;
+  v_guild_id text;
+  v_queued integer := 0;
+  v_repaired integer := 0;
+  v_channels_repaired integer := 0;
+  v_missing_roles text[] := ARRAY[]::text[];
+  v_role_type text;
+  v_missing_channels text[] := ARRAY[]::text[];
+  v_channel_type text;
+  v_row record;
+  -- Self-service daily budget, read and written only on the student path below.
+  v_self_window timestamptz;
+  v_self_count integer;
+BEGIN
+  IF v_caller IS NULL THEN
+    RAISE EXCEPTION 'Access denied: authentication required';
+  END IF;
+
+  v_is_staff := public.authorizeforclassgrader(p_class_id::bigint);
+
+  -- A student may retry their own membership -- that is the self-service half of the
+  -- GitHub pattern, where the resend banner is rendered to the student themselves. Acting
+  -- on anyone else, or on the whole class, is a staff action.
+  IF NOT v_is_staff THEN
+    IF p_user_id IS NULL OR p_user_id <> v_caller THEN
+      RAISE EXCEPTION 'Access denied: must be a grader or instructor for this class';
+    END IF;
+
+    -- Passing your own id is not on its own a claim on this class. Without this an
+    -- authenticated user could name any class id, satisfy the check above, and reach the
+    -- role-repair phase below -- which scans the class independently of the membership loop
+    -- and would enqueue create_role against a Discord server they have nothing to do with.
+    IF NOT EXISTS (
+      SELECT 1 FROM public.user_roles ur
+      WHERE ur.class_id = p_class_id AND ur.user_id = v_caller AND ur.disabled = false
+    ) THEN
+      RAISE EXCEPTION 'Access denied: no active enrollment in this class';
+    END IF;
+  END IF;
+
+  SELECT c.discord_server_id INTO v_guild_id
+  FROM public.classes c
+  WHERE c.id = p_class_id;
+
+  -- Nothing to retry against. Reported as zero rather than as an error: the caller is a
+  -- button on a roster page, and a class with no Discord server is a configuration state,
+  -- not a failure of this request.
+  IF v_guild_id IS NULL THEN
+    RETURN QUERY SELECT 0, 0, 0;
+    RETURN;
+  END IF;
+
+  -- Serialize the whole retry per class, for the rest of this transaction.
+  --
+  -- Every phase below is read-then-write. The throttle predicate reads
+  -- last_retry_requested_at and the loop body writes it, so two staff pressing the button at
+  -- the same moment both saw an unthrottled row and both enqueued add_member_role for the
+  -- same users. The worker handles those messages in parallel and creates a Discord invite
+  -- per message before upserting the one tracking row, so the loser's invite stays live in
+  -- Discord with no record of it -- the orphan-invite shape this branch has been removing
+  -- everywhere else. A class-scoped lock is the right grain: this function is a per-class
+  -- operation, and it also covers the role- and channel-repair phases further down.
+  PERFORM pg_advisory_xact_lock(hashtext('discord_reinvite:' || p_class_id::text));
+
+  -- A student's own retries are capped per day, on top of the five-minute throttle below.
+  --
+  -- The throttle alone bounds a held-down button, not a determined one: five minutes apart is 288
+  -- presses a day, each of which costs a Discord member lookup and possibly an invite creation. That
+  -- is a rate-limit problem the guild's other students then share, since Discord's limits are
+  -- per-bot. A handful a day is all a student can act on -- the failures that survive more than one
+  -- retry need an instructor, not another press.
+  --
+  -- Staff are exempt. A class-wide retry is the documented way out of a guild-level failure, and
+  -- rationing it would leave a broken class unfixable.
+  --
+  -- Read before the loop rather than inside it, because the budget belongs to the caller, not to
+  -- each row: the student path only ever touches its own row, and reading it here means the refusal
+  -- happens before any work is queued.
+  IF NOT v_is_staff THEN
+    SELECT dms.self_retry_window_started_at, dms.self_retry_count
+    INTO v_self_window, v_self_count
+    FROM public.discord_membership_status dms
+    WHERE dms.class_id = p_class_id
+      AND dms.user_id = v_caller
+      AND dms.guild_id = v_guild_id;
+
+    -- A window older than a day is spent; the next press starts a fresh one. Rolling from the first
+    -- press of the window rather than at a fixed hour, so the budget cannot be doubled by pressing
+    -- either side of a midnight boundary.
+    IF v_self_window IS NULL OR v_self_window < now() - INTERVAL '24 hours' THEN
+      v_self_window := now();
+      v_self_count := 0;
+    END IF;
+
+    IF COALESCE(v_self_count, 0) >= 5 THEN
+      RAISE EXCEPTION
+        'Discord role sync limit reached: this can be requested at most 5 times a day. If your roles are still missing, contact your instructors.'
+        USING ERRCODE = '53400';
+    END IF;
+  END IF;
+
+  FOR v_row IN
+    SELECT ur.user_id, ur.role, dms.id AS status_id,
+           EXISTS (
+             SELECT 1 FROM public.discord_roles dr
+             WHERE dr.class_id = p_class_id AND dr.role_type = ur.role::text
+           ) AS role_exists
+    FROM public.user_roles ur
+    JOIN public.users u ON u.user_id = ur.user_id
+    LEFT JOIN public.discord_membership_status dms
+      ON dms.class_id = ur.class_id
+     AND dms.user_id = ur.user_id
+     AND dms.guild_id = v_guild_id
+    WHERE ur.class_id = p_class_id
+      AND ur.disabled = false
+      -- Without a linked Discord account there is no member to look up and no invite that
+      -- would reach anyone. enqueue_discord_role_sync would return silently; skipping here
+      -- keeps the returned count honest.
+      AND u.discord_id IS NOT NULL
+      AND (p_user_id IS NULL OR ur.user_id = p_user_id)
+      -- A class-wide retry targets everyone not recorded as being in the server, which
+      -- includes users with no row at all. Requiring a row excluded exactly the students the
+      -- sync has never reached -- and for a class outside the active-class window that is
+      -- permanent, because the hourly batch will never create one, while the settings page
+      -- reported there was nothing to queue. A retry aimed at a single user runs whatever
+      -- their state is, including none, because that is the case it exists for.
+      AND (p_user_id IS NOT NULL OR dms.id IS NULL OR dms.state <> 'in_guild')
+      -- Throttle. The work this queues is one Discord member lookup plus, at most, an
+      -- invite creation, so the window only has to stop a button being held down; it is
+      -- not the five-day email throttle the GitHub resend banner needs.
+      AND (dms.last_retry_requested_at IS NULL OR dms.last_retry_requested_at < now() - INTERVAL '5 minutes')
+    -- Deterministic, so a class-wide retry that is interrupted repeats in the same order.
+    ORDER BY ur.user_id
+  LOOP
+    -- The class's Discord role for this user's role type does not exist, so
+    -- enqueue_discord_role_sync would return without queueing anything. Repair that first
+    -- and leave the user un-stamped and uncounted: they are not throttled for a retry that
+    -- never happened, and the count stays true.
+    IF NOT v_row.role_exists THEN
+      CONTINUE;
+    END IF;
+
+    -- No membership hint: this path has not looked the user up, which is the whole reason it is
+    -- queueing the work.
+    PERFORM public.enqueue_discord_role_sync(v_row.user_id, p_class_id, v_row.role, 'add');
+
+    IF v_row.status_id IS NOT NULL THEN
+      UPDATE public.discord_membership_status
+      SET last_retry_requested_at = now()
+      WHERE id = v_row.status_id;
+    END IF;
+
+    -- Deliberately no row is created for a user who has none. Seeding one meant choosing a state
+    -- before anything had been observed, and `not_joined` is what the alerts read as "an invite is
+    -- waiting on their dashboard, no action needed" -- false the moment it is written, and false
+    -- indefinitely if the worker never gets there. The enum has no value for "queued, not yet
+    -- checked", and inventing one would have to reach the roster column and its filter as well.
+    --
+    -- The cost is that such a user is not throttled until the worker records their first real
+    -- outcome, about a minute later. Pressing again before then re-enqueues an add_member_role,
+    -- which is idempotent at the Discord end and can no longer mint a duplicate invite now that
+    -- claim_discord_invite() decides that centrally. A brief unthrottled window is the cheaper error
+    -- than telling staff an invite exists when none does.
+
+    v_queued := v_queued + 1;
+  END LOOP;
+
+  -- Spend a day's budget only when the press actually queued something. A press that queued nothing
+  -- -- inside the five-minute throttle, already in_guild, or the class's roles missing -- cost no
+  -- Discord work, so charging for it would let a student burn the day's allowance on presses that
+  -- never reached Discord.
+  --
+  -- UPDATE, never INSERT. request_discord_reinvite deliberately creates no membership row (see the
+  -- comment in the loop above), and that carries here: a student with no row yet is not counted,
+  -- exactly as they are not throttled. The row is written when their invite is minted, about a
+  -- minute later, so the uncounted window is small and self-closing.
+  IF NOT v_is_staff AND v_queued > 0 THEN
+    UPDATE public.discord_membership_status
+    SET self_retry_window_started_at = v_self_window,
+        self_retry_count = COALESCE(v_self_count, 0) + 1
+    WHERE class_id = p_class_id
+      AND user_id = v_caller
+      AND guild_id = v_guild_id;
+  END IF;
+
+  -- Which of the class's Discord roles are missing, computed independently of anyone's
+  -- membership state.
+  --
+  -- Deliberately not derived from the loop above. That loop only sees users who need a
+  -- membership retry, so a class where role creation failed but everyone has since joined the
+  -- server produced no candidates, no repair, and no way to ever create the role -- and the
+  -- batch worker records in_guild even when enqueue_discord_role_sync silently finds no role,
+  -- so nothing anywhere said the roles were missing.
+  --
+  -- Restricted to the role types discord_roles accepts. app_role also has 'admin', which
+  -- discord_roles_role_type_check rejects, so enqueueing it would have Discord create a role
+  -- the insert then refuses to track -- an orphan in the guild, re-created on every retry.
+  -- Staff only, as a second boundary. Repair is class-wide work: it enqueues Discord mutations
+  -- for a whole guild, which is not something a student's retry of their own membership should
+  -- ever reach, whatever the enrollment check above concluded. A student in a class whose roles
+  -- are missing gets queued 0 and repaired 0, which is accurate -- their retry cannot succeed
+  -- until staff restore the roles.
+  IF NOT v_is_staff THEN
+    RETURN QUERY SELECT v_queued, 0, 0;
+    RETURN;
+  END IF;
+
+  --
+  -- All three supported types, not just the ones currently enrolled.
+  -- trigger_sync_existing_users_on_role_creation only calls sync_existing_users_after_roles_created
+  -- when COUNT(DISTINCT role_type) = 3, so repairing a class with no grader would create student and
+  -- instructor, never reach three, and never fire the sync that assigns roles to the users already
+  -- in the guild. Creating an unused role costs nothing -- the class-connect flow creates all three
+  -- unconditionally -- and it is what makes the repair actually finish.
+  SELECT COALESCE(array_agg(rt.role_type), ARRAY[]::text[])
+  INTO v_missing_roles
+  FROM unnest(ARRAY['student', 'grader', 'instructor']) AS rt(role_type)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.discord_roles dr
+    WHERE dr.class_id = p_class_id AND dr.role_type = rt.role_type
+  );
+
+  -- Re-create them. The worker writes the discord_roles row when it succeeds, so the next
+  -- press of the button finds the role and queues the users skipped above.
+  FOREACH v_role_type IN ARRAY v_missing_roles LOOP
+    -- Users are left un-stamped on the missing-role path, so nothing throttles a second press
+    -- while the worker is still working. This is what stops that becoming a second Discord
+    -- role: create_role is not idempotent at the Discord end -- it creates the role and only
+    -- then inserts the row, while discord_roles allows one row per (class_id, role_type) -- so
+    -- a duplicate leaves an untracked role in the guild that nothing refers to again.
+    -- Concurrent callers are handled by the class-scoped lock taken above.
+    IF EXISTS (
+      SELECT 1
+      FROM pgmq.q_discord_async_calls q
+      WHERE q.message ->> 'method' = 'create_role'
+        AND (q.message ->> 'class_id')::bigint = p_class_id
+        AND q.message ->> 'role_type' = v_role_type
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    PERFORM public.enqueue_discord_role_creation(p_class_id, v_role_type, v_guild_id);
+    v_repaired := v_repaired + 1;
+  END LOOP;
+
+  -- The channel half of the same repair, and the reason this migration exists.
+  --
+  -- Exactly the two types trigger_discord_create_roles_on_server_connect creates. The other two
+  -- resource-less types are deliberately excluded: 'general' and 'regrades' are created lazily by
+  -- their own enqueuers the first time something needs to post to them, so a class that has never
+  -- had a regrade request is *correctly* without a #regrades channel and creating one here would put
+  -- an unused channel in every connected guild.
+  --
+  -- Resource-scoped channels -- per assignment, per lab section, per help queue -- are also out of
+  -- scope. They are created by triggers on their own rows, there can be dozens of them, and a repair
+  -- that enqueued the missing ones would turn one button press into an unbounded burst against the
+  -- per-guild channel-creation limit. This restores the class-level channels the connect flow
+  -- promises; the rest stay with the triggers that own them.
+  SELECT COALESCE(array_agg(ct.channel_type), ARRAY[]::text[])
+  INTO v_missing_channels
+  FROM unnest(ARRAY['scheduling', 'operations']) AS ct(channel_type)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.discord_channels dc
+    WHERE dc.class_id = p_class_id
+      AND dc.channel_type = ct.channel_type::public.discord_channel_type
+      -- resource_id IS NULL is what makes this a class-level channel; the unique constraint on
+      -- (class_id, channel_type, resource_id) is NULLS NOT DISTINCT, so there is at most one.
+      AND dc.resource_id IS NULL
+  );
+
+  FOREACH v_channel_type IN ARRAY v_missing_channels LOOP
+    -- Same reasoning as the role loop: create_channel is not idempotent at the Discord end. It
+    -- creates the channel and only then tries to store the row, and store_discord_channel_if_current
+    -- reports the duplicate rather than preventing it -- by which point the extra channel is already
+    -- in the guild, visible to students, and referenced by nothing. A press while the previous
+    -- press's envelope is still queued must therefore enqueue nothing.
+    IF EXISTS (
+      SELECT 1
+      FROM pgmq.q_discord_async_calls q
+      WHERE q.message ->> 'method' = 'create_channel'
+        AND (q.message ->> 'class_id')::bigint = p_class_id
+        AND q.message ->> 'channel_type' = v_channel_type
+    ) THEN
+      CONTINUE;
+    END IF;
+
+    -- Name passed explicitly to match what the connect trigger sends, rather than relying on the
+    -- enqueuer's default for these two types.
+    PERFORM public.enqueue_discord_channel_creation(
+      p_class_id,
+      v_channel_type::public.discord_channel_type,
+      NULL,
+      v_channel_type,
+      v_guild_id
+    );
+    v_channels_repaired := v_channels_repaired + 1;
+  END LOOP;
+
+  RETURN QUERY SELECT v_queued, v_repaired, v_channels_repaired;
+END;
+$$;
+
+COMMENT ON FUNCTION public.request_discord_reinvite(bigint, uuid) IS
+  'Re-queue the Discord membership check for one user, or for every user in the class not recorded as in_guild. The way out of a recorded cannot_invite once the underlying problem is fixed. A student retrying their own membership is capped at five a day on top of the five-minute throttle; staff are uncapped. Returns the number of users queued, the number of missing class Discord roles re-created, and the number of missing class-level channels (#scheduling, #operations) re-created.';
+
+REVOKE ALL ON FUNCTION public.request_discord_reinvite(bigint, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.request_discord_reinvite(bigint, uuid) TO authenticated, service_role;

--- a/utils/supabase/SupabaseTypes.d.ts
+++ b/utils/supabase/SupabaseTypes.d.ts
@@ -12780,6 +12780,7 @@ export type Database = {
         Args: {
           p_action?: string;
           p_class_id: number;
+          p_membership_verified_at?: string;
           p_role: Database["public"]["Enums"]["app_role"];
           p_user_id: string;
         };
@@ -13834,6 +13835,7 @@ export type Database = {
       request_discord_reinvite: {
         Args: { p_class_id: number; p_user_id?: string };
         Returns: {
+          channels_repaired: number;
           queued: number;
           roles_repaired: number;
         }[];


### PR DESCRIPTION
Three fixes from one production incident on class 636 (2026-09-09/10). They ship together because they are the same failure seen from three sides: a Discord call that costs more than it should, and the noise that hides what it broke.

## 1. Channels had no repair path (the actual bug)

All five of class 636's connect-time envelopes — three `create_role`, two `create_channel` — died together on `403 Missing Permissions` (code 50013) when the bot was connected without Manage Roles or Manage Channels. `isBotPermissionProblem()` classifies that as terminal, so they dead-lettered at `retry_count 0` rather than retrying.

Once permissions were fixed, the three roles came back and the two channels did not:

- `request_discord_reinvite()` repairs missing **roles** class-wide (`v_missing_roles`) and had no channel equivalent, so the retry button rebuilt half the class.
- `trigger_discord_create_roles_on_server_connect` is `AFTER UPDATE OF discord_server_id`, so it cannot re-fire for a guild that never changed.
- `claim_discord_guild()` on a same-guild refresh only clears the circuit breaker.

Nothing else enqueues them. **Once a `create_channel` terminally dead-letters, nothing in the product can bring it back** — and it fails silently, because the enqueuers that post to those channels read them back with a non-`STRICT` `SELECT` and simply find nothing. The channels stayed missing until they were re-driven by hand, and would otherwise have stayed missing all semester.

`request_discord_reinvite()` now repairs `scheduling` and `operations` the same way it repairs roles, returning `channels_repaired` alongside `roles_repaired`.

Scope is deliberate: exactly what the connect trigger creates. `general` and `regrades` are the other resource-less types but are created lazily on first use, so eagerly creating them would put unused channels in every connected guild. Resource-scoped channels (per assignment, lab, help queue) belong to their own triggers and could turn one button press into an unbounded burst against the per-guild channel-creation limit.

## 2. The same member lookup, twice

`processBatchRoleSync()` reads `GET /guilds/{g}/members/{u}` for every candidate, then enqueues an `add_member_role` whose handler opened by reading the **identical endpoint** about a second later — and the worker processes those four-wide in parallel.

That second wave is where the 429s landed: `remaining: 0` with a sub-second reset, which is a **per-route** bucket, not the global 50/s ceiling the shared Redis limiter covers. Throttling harder cannot help; the limiter can't see that bucket. Halving the traffic can.

`enqueue_discord_role_sync()` takes an optional `p_membership_verified_at` that the batch sync stamps into the envelope. The handler trusts it for `MEMBERSHIP_HINT_TTL_MS` (2 min) and otherwise looks the member up exactly as before, so every other caller — the `user_roles` trigger, the interactions route, a manual retry — is unchanged.

A timestamp rather than a boolean on purpose: an envelope that was requeued with backoff or redelivered after its visibility timeout falls back to checking rather than trusting an observation of unknown age. Clock-skewed future timestamps are refused rather than clamped.

## 3. A 26ms limit reported as an incident

`discordRequest()` threw on 429 without ever honoring `retry_after`. `parseRetryAfterSeconds` then did `Math.ceil(26/1000)` = 1, and `computeBackoffSeconds` applied `Math.max(5, …)` — so a **26ms** limit became a **5s+ requeue** plus an `error`-level Sentry event.

- `discordRequest()` now waits out a `retry_after` under one second and retries once. Anything longer still propagates, so the queue backoff and circuit breaker keep seeing genuine sustained limits. The retry stays inside the limiter slot so the next queued call can't take it and hit the same exhausted bucket.
- A 429 that does reach `processEnvelope` is captured at `warning`, not `error`. It's backpressure, and the operation still happens on requeue.

The backoff floor itself is left alone — with the duplicate call gone and short limits waited out, it now only applies to limits that genuinely deserve it.

## Verification

Migration applied against a local database inside a rolled-back transaction, then the new logic exercised:

| Case | Result |
|---|---|
| Staff press, both channels missing | `channels_repaired = 2`, both envelopes enqueued |
| Second press while those are queued | `0`, no duplicates (still 2 messages) |
| Only `#scheduling` tracked | `1`, only `operations` enqueued |
| Student self-retry | `0` channels, `0` `create_channel` messages — repair is staff-only |
| `enqueue_discord_role_sync` with no hint | envelope byte-identical to before (no `membership_verified_at` key) |
| With a hint | `2026-09-10T04:47:16.395Z` — UTC, `Date.parse()`-clean |
| `remove` action with a hint passed | no hint on the envelope |

Also: 6 new deno tests for the hint helper (TTL boundary, unparseable, expired, future); all 79 `_shared` Discord deno tests pass; `prettier --check` clean on every touched file.

Two pre-existing gate failures are unchanged by this branch, confirmed by running them on unmodified `400bbf28`: `deno check` reports the same 2 errors (`SupabaseTypes.d.ts` ambient const, `original_msg_id`), and `tests/unit/discord-reinvite-throttle.test.ts` fails identically with a local jest-runtime version error. `tsc -p tsconfig.json` reports ~4600 pre-existing errors tree-wide with this node_modules install; none are in the files this branch touches.

The two dead-lettered channels for class 636 were already re-driven by hand in production, so this PR is what stops it happening again rather than a fix that still needs applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
