### PR TITLE
docs: add one-liner for writing local Supabase env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ For development work that requires changes to the database schema or backend fun
      --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
      --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY \
      --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY >> .env.local
+   npx supabase status -o env --override-name api.url=SUPABASE_URL |
+     grep '^SUPABASE_URL=' >> .env.local
    ```
+
+   `--override-name` renames each value once, so the API URL needs the second command to also land under the server-side name `SUPABASE_URL`.
 
    This appends rather than replaces, so delete any earlier copies of those keys from `.env.local` afterwards.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ For development work that requires changes to the database schema or backend fun
    - `SUPABASE_SERVICE_ROLE_KEY` - The "service_role key" (server-side only; used by admin scripts/e2e)
    - (Optional) `ENABLE_SIGNUPS=true` - If you want to easily create new users using the UI for local dev
 
+   Instead of copying the values by hand, you can append them to `.env.local` directly:
+
+   ```bash
+   npx supabase status -o env \
+     --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
+     --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY \
+     --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY >> .env.local
+   ```
+
+   This appends rather than replaces, so delete any earlier copies of those keys from `.env.local` afterwards.
+
    > Security: Never expose `SUPABASE_SERVICE_ROLE_KEY` to the browser or commit it. Keep it in server-only code and CI secrets.
 
 5. Build the application: `npm run build`


### PR DESCRIPTION
The local Supabase setup step asks you to read the URL and keys out of `npx supabase start` output and copy them into `.env.local` by hand, which is easy to get wrong.

`supabase status -o env` can print those values already renamed to the variables `.env.local` expects, so this adds that command to the step:

```bash
npx supabase status -o env \
  --override-name api.url=NEXT_PUBLIC_SUPABASE_URL \
  --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_ANON_KEY \
  --override-name auth.service_role_key=SUPABASE_SERVICE_ROLE_KEY >> .env.local
```

It appends, so the README also notes that you should delete earlier copies of those keys afterwards.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an alternative Supabase local setup workflow that automatically appends service URLs and keys to `.env.local`.
  * Included commands for capturing both client-side and server-side URLs and keys.
  * Clarified that previously copied values should be removed first to avoid duplicates, since the commands append rather than replace existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->