### PR TITLE
fix(chart): raise Kong's client request header buffer past the 8k default

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.22
+version: 0.3.23
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/templates/kong.yaml
+++ b/charts/pawtograder/templates/kong.yaml
@@ -102,6 +102,33 @@ spec:
               value: "160k"
             - name: KONG_NGINX_PROXY_PROXY_BUFFERS
               value: "64 160k"
+            # Those two bound the UPSTREAM RESPONSE headers. This one bounds the
+            # CLIENT REQUEST headers, and it is a different failure entirely.
+            #
+            # nginx defaults large_client_header_buffers to "4 8k", so one header
+            # line over ~8 KB is a 400 — which Kong's `error_page 400 ...
+            # /kong_error_handler` re-skins as {"message":"Request header or
+            # cookie too large","request_id":...}. The whole Cookie header is one
+            # line, and on an install that serves deployment channels the auth
+            # cookie is scoped to the parent zone (utils/channels.ts
+            # sessionCookieOptions), so the entire Supabase session is sent to the
+            # api host on every top-level navigation and wss handshake — including
+            # GoTrue's /auth/v1/callback, which does not read cookies at all.
+            # @supabase/ssr chunks at 3180 B, so a session needing a third chunk
+            # lands at 6.4-9.5 KB and trips this.
+            #
+            # Measured on Khoury prod 2026-09-11: 8100 B of Cookie passed, 8200 B
+            # 400'd, and the 400 carried x-kong-request-id — it was Kong, not the
+            # ingress in front of it, which passed 12 KB happily. PR #877 read the
+            # same 8 KB wall as the ingress's and worked around it by shrinking the
+            # cookie; it is ours, and this raises it.
+            #
+            # 16k lines up with the realtime.maxHeaderLength Khoury prod already
+            # runs (16384), so Kong and Cowboy agree. The real ceiling above both
+            # is the ingress, measured at ~12 KB. Buffers are allocated on demand,
+            # so a request that does not need them pays nothing.
+            - name: KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS
+              value: "4 16k"
             - name: SUPABASE_ANON_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -1497,6 +1497,16 @@ assert_primary_checksum_scope() {
 }
 assert_primary_checksum_scope
 
+echo "== Kong must bound the CLIENT REQUEST headers, not just upstream responses =="
+# nginx defaults large_client_header_buffers to "4 8k", and Kong re-skins the
+# resulting 400 as its own JSON, so an oversized Cookie reads as an application
+# error. On a channels install the auth cookie is parent-zone scoped and reaches
+# the api host on every navigation and wss handshake, and @supabase/ssr's 3180 B
+# chunking puts a three-chunk session at 6.4-9.5 KB -- past the default.
+# Khoury prod, 2026-09-11: 8100 B passed, 8200 B 400'd with x-kong-request-id.
+assert_rendered_contains "kong raises large_client_header_buffers above the 8k default" \
+  templates/kong.yaml "KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS"
+
 echo
 if [ "$FAILED" -ne 0 ]; then
   echo "GUARD-RAIL TESTS FAILED"

--- a/charts/pawtograder/tests/render-guardrails.sh
+++ b/charts/pawtograder/tests/render-guardrails.sh
@@ -1504,8 +1504,12 @@ echo "== Kong must bound the CLIENT REQUEST headers, not just upstream responses
 # the api host on every navigation and wss handshake, and @supabase/ssr's 3180 B
 # chunking puts a three-chunk session at 6.4-9.5 KB -- past the default.
 # Khoury prod, 2026-09-11: 8100 B passed, 8200 B 400'd with x-kong-request-id.
-assert_rendered_contains "kong raises large_client_header_buffers above the 8k default" \
-  templates/kong.yaml "KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS"
+#
+# Pin the VALUE, not just the name: the regression this guards against is someone
+# restoring the "4 8k" default, and an env var set to the broken value is present
+# in the render exactly as much as one set to the working value.
+assert_env_value "kong pins large_client_header_buffers above the 8k default" \
+  templates/kong.yaml KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS "4 16k"
 
 echo
 if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
## What broke

A student linking GitHub on Khoury prod got `Request header or cookie too large` from `api.pawtograder.khoury.northeastern.edu/auth/v1/callback?code=...`.

The chart sets `KONG_NGINX_PROXY_PROXY_BUFFER_SIZE` and `KONG_NGINX_PROXY_PROXY_BUFFERS`, but those bound the **upstream response** headers. Nothing bounded the **client request** headers, so Kong ran on nginx's default `large_client_header_buffers 4 8k` and 400'd any single header line past ~8 KB. Kong's `error_page 400 ... /kong_error_handler` re-skins that as its own JSON body, which is why it reads as an application error rather than a proxy limit.

The `Cookie` header is one line. On an install serving deployment channels the auth cookie is parent-zone scoped (`utils/channels.ts` `sessionCookieOptions`), so the whole Supabase session is sent to the api host on every top-level navigation and wss handshake — including GoTrue's `/auth/v1/callback`, which never reads cookies. `@supabase/ssr` chunks at 3180 B, so a session needing a third chunk lands at 6.4–9.5 KB and trips the default.

## Which nginx

Measured against Khoury prod on 2026-09-11:

| Request | Result |
|---|---|
| api host, 8100 B of `Cookie` | 401 — passes through to GoTrue |
| api host, 8200 B of `Cookie` | **400**, with `x-kong-request-id` |
| api host, 13000 B | 400, with **no** `x-kong-*` headers |
| web host (bypasses Kong), 13000 B | 200 |

So the 8 KB wall is Kong's, and the Khoury ingress in front of it passes 12 KB. #877 read the same wall as the ingress's and bought headroom by shrinking the cookie instead; the `prod-charts` values comment likewise points at the ops-owned `nginx-ingress/nginx-config` ConfigMap. Both were looking at the wrong nginx — this one is ours to raise.

## The change

`KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS: "4 16k"`. 16k lines up with the `realtime.maxHeaderLength` prod already runs (16384), so Kong and Cowboy agree and the ingress (~12 KB) becomes the binding constraint. Buffers are allocated on demand, so a request that does not need them pays nothing.

Also adds a guard-rail render test so the env cannot be dropped silently, and bumps the chart to 0.3.23.

## Scope

This buys headroom; it does not remove the class of bug. The durable fix is still the one #877 named: move the api host out of the auth cookie's domain so the cookie cannot reach it at all. That needs a hostname outside `*.pawtograder.khoury.northeastern.edu`, which is an ops request.

## Test plan

- [x] `charts/pawtograder/tests/render-guardrails.sh` passes, and the new assertion fails when the env is removed
- [x] `prettier --check` clean on all three changed files
- [ ] After deploy: a >8 KB `Cookie` to the api host returns 401 rather than 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the supported HTTP request-header size for Kong, improving handling of requests with large cookies or headers and reducing related 400 errors.

- **Chores**
  - Updated the Pawtograder Helm chart version to 0.3.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->