### PR TITLE
fix(chart): stage backup dumps on their own volume, not node ephemeral disk

### DIFF
--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.22
+version: 0.3.23
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -576,6 +576,12 @@ Key mechanics:
   and a weekly `backup-verify` CronJob re-downloads the newest object,
   re-parses its TOC, and fails if the newest backup is older than 48 h.
   Restore with `pg_restore --clean --if-exists --no-owner --no-acl -d <db> <file>`.
+  Both jobs stage the dump on a per-pod ephemeral PVC, sized by
+  `backup.scratchSize` (30Gi default) on `backup.scratchStorageClass` — the
+  dump must fit whole, since its TOC is verified locally before upload. Size
+  this for your database and point it at a cheap tier; leaving it on node
+  ephemeral storage is what makes a nightly backup fail part-written and put
+  the whole node under DiskPressure.
 - **Web images are environment-specific**: `NEXT_PUBLIC_*` values (incl. the
   cluster's anon key) are baked at build time. Build prod images via
   `release-images.yml` `workflow_dispatch` with the prod hostname/namespace

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -581,7 +581,11 @@ Key mechanics:
   dump must fit whole, since its TOC is verified locally before upload. Size
   this for your database and point it at a cheap tier; leaving it on node
   ephemeral storage is what makes a nightly backup fail part-written and put
-  the whole node under DiskPressure.
+  the whole node under DiskPressure. Point it at NETWORK storage — it falls
+  back to `postgres.persistence.storageClass`, which is node-local on some
+  installs. Because a retained Job keeps its pod and each pod keeps its claim,
+  `backup.successfulJobsHistoryLimit` defaults to 1 (failures keep 3); turn
+  both down under a namespace storage quota.
 - **Web images are environment-specific**: `NEXT_PUBLIC_*` values (incl. the
   cluster's anon key) are baked at build time. Build prod images via
   `release-images.yml` `workflow_dispatch` with the prod hostname/namespace

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -395,6 +395,13 @@ backup:
   enabled: true
   schedule: "0 4 * * *"
   retentionDays: 14
+  # Dump staging goes on ceph-rbd, NOT the local-path class postgres uses above.
+  # The chart falls back to postgres.persistence.storageClass when this is
+  # unset, and inheriting local-path here would stage the whole dump on the
+  # worker's NVMe — the node-filling failure mode the scratch volume exists to
+  # avoid. Staging's DB is small, so 20Gi is ample.
+  scratchSize: 20Gi
+  scratchStorageClass: ceph-rbd
   s3:
     endpoint: https://s3.talos.ripley.cloud
     region: us-east-1

--- a/charts/pawtograder/templates/backup-verify.yaml
+++ b/charts/pawtograder/templates/backup-verify.yaml
@@ -22,8 +22,12 @@ spec:
   schedule: {{ .Values.backup.verify.schedule | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: {{ .Values.backup.verify.startingDeadlineSeconds | default 1800 }}
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # Each retained pod holds its scratch PVC until the pod is deleted, so these
+  # limits are also the retained-storage lever. Successful runs default to 1:
+  # the dump is already uploaded and size-verified, so older success logs are
+  # not worth a claim each. Failures keep 3 — that is what you debug.
+  successfulJobsHistoryLimit: {{ .Values.backup.verify.successfulJobsHistoryLimit | default 1 }}
+  failedJobsHistoryLimit: {{ .Values.backup.verify.failedJobsHistoryLimit | default 3 }}
   jobTemplate:
     spec:
       backoffLimit: 2
@@ -83,6 +87,10 @@ spec:
                     echo "[verify] FATAL: newest backup is older than 48h — the backup CronJob is not producing output"
                     exit 1
                   fi
+                  # Nothing below reads the download again, and a retained pod
+                  # keeps its claim, so free the space now rather than holding a
+                  # dump-sized chunk of the scratch tier until the Job is reaped.
+                  rm -f /scratch/latest.dump
               volumeMounts:
                 - { name: scratch, mountPath: /scratch }
               env:

--- a/charts/pawtograder/templates/backup-verify.yaml
+++ b/charts/pawtograder/templates/backup-verify.yaml
@@ -33,7 +33,10 @@ spec:
           labels:
             {{- include "pawtograder.componentLabels" (dict "ctx" . "component" "backup-verify") | nindent 12 }}
         spec:
-          restartPolicy: OnFailure
+          # Never, not OnFailure — see backup.yaml: OnFailure counts container
+          # restarts inside one pod and deletes that pod when the limit trips,
+          # destroying the logs of every attempt.
+          restartPolicy: Never
           serviceAccountName: {{ include "pawtograder.serviceAccountName" . }}
           {{- include "pawtograder.imagePullSecrets" . | nindent 10 }}
           containers:
@@ -58,10 +61,13 @@ spec:
                     exit 1
                   fi
                   echo "[verify] newest backup: $LATEST"
-                  mc cp "s3/${S3_BUCKET}/${LATEST}" /tmp/latest.dump
+                  # /scratch, not /tmp — this download is the same ~7 GB
+                  # as the dump itself, and on the container writable layer it
+                  # was pushing nodes into DiskPressure. See backup.yaml.
+                  mc cp "s3/${S3_BUCKET}/${LATEST}" /scratch/latest.dump
                   # TOC must parse and contain a sane number of entries.
-                  ENTRIES=$(pg_restore --list /tmp/latest.dump | grep -c '^[0-9]' || true)
-                  echo "[verify] pg_restore --list OK: ${ENTRIES} TOC entries, $(stat -c%s /tmp/latest.dump) bytes"
+                  ENTRIES=$(pg_restore --list /scratch/latest.dump | grep -c '^[0-9]' || true)
+                  echo "[verify] pg_restore --list OK: ${ENTRIES} TOC entries, $(stat -c%s /scratch/latest.dump) bytes"
                   if [ "${ENTRIES}" -lt 10 ]; then
                     echo "[verify] FATAL: suspiciously small TOC (${ENTRIES} entries) — dump is likely empty/corrupt"
                     exit 1
@@ -77,6 +83,8 @@ spec:
                     echo "[verify] FATAL: newest backup is older than 48h — the backup CronJob is not producing output"
                     exit 1
                   fi
+              volumeMounts:
+                - { name: scratch, mountPath: /scratch }
               env:
                 - name: S3_ENDPOINT
                   value: {{ required "backup.s3.endpoint is required when backup.enabled=true" .Values.backup.s3.endpoint | quote }}
@@ -92,4 +100,22 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.secrets.names.s3 }}
                       key: AWS_SECRET_ACCESS_KEY
+          volumes:
+            # Download staging area — per-pod ephemeral PVC, same rationale as
+            # backup.yaml. Falls back to the backup job's own scratch settings.
+            - name: scratch
+              ephemeral:
+                volumeClaimTemplate:
+                  metadata:
+                    annotations:
+                      trident.netapp.io/unixPermissions: "0777"
+                  spec:
+                    accessModes: ["ReadWriteOnce"]
+                    {{- with .Values.backup.verify.scratchStorageClass | default .Values.backup.scratchStorageClass | default .Values.postgres.persistence.storageClass }}
+                    # Omitted when empty — see backup.yaml.
+                    storageClassName: {{ . | quote }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ .Values.backup.verify.scratchSize | default .Values.backup.scratchSize | default "30Gi" | quote }}
 {{- end }}

--- a/charts/pawtograder/templates/backup.yaml
+++ b/charts/pawtograder/templates/backup.yaml
@@ -12,8 +12,15 @@ spec:
   # Skip (and mark missed) a run that couldn't start within this window of
   # its slot, instead of piling up stale runs after controller downtime.
   startingDeadlineSeconds: {{ .Values.backup.startingDeadlineSeconds | default 1800 }}
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  # Each retained pod holds its scratch PVC until the pod is deleted, so these
+  # limits are also the retained-storage lever: worst case is
+  # (successful + failed x attempts) x backup.scratchSize of REQUESTED capacity,
+  # which matters under a namespace storage quota even though `rm` frees the
+  # bytes. Successful runs default to 1 for that reason; failures keep 3,
+  # because with restartPolicy: Never each attempt is a separate pod and those
+  # logs are the whole point of retaining them.
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit | default 1 }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit | default 3 }}
   jobTemplate:
     spec:
       backoffLimit: 2

--- a/charts/pawtograder/templates/backup.yaml
+++ b/charts/pawtograder/templates/backup.yaml
@@ -20,13 +20,30 @@ spec:
       # Hard ceiling so a wedged dump/upload fails loudly rather than
       # running forever (Forbid would then silently skip every later run).
       activeDeadlineSeconds: {{ .Values.backup.activeDeadlineSeconds | default 3600 }}
+      # NOTE: deliberately NO ttlSecondsAfterFinished here. The
+      # PawtograderBackupJobFailed alert reads kube_job_status_failed off this
+      # Job object, so a TTL would let a failed backup delete its own alert.
+      # Reclamation is left to successful/failedJobsHistoryLimit above, which
+      # reap each pod's scratch PVC along with the Job.
       template:
         metadata:
           labels:
             {{- include "pawtograder.componentLabels" (dict "ctx" . "component" "backup") | nindent 12 }}
         spec:
-          restartPolicy: OnFailure
+          # Never, NOT OnFailure. Under OnFailure the backoff limit counts
+          # container restarts INSIDE one pod, so status.failed reads 1 (not 3)
+          # and the controller DELETES the pod when the limit trips — taking
+          # every attempt's logs with it, which is exactly the state a failed
+          # nightly backup leaves you to debug. With Never each attempt is its
+          # own pod whose logs survive until the history limit reaps the Job.
+          restartPolicy: Never
           serviceAccountName: {{ include "pawtograder.serviceAccountName" . }}
+          # Deliberately NO fsGroup, unlike the restore-drill: this container
+          # runs as root (it apt-installs mc), so it needs no group ownership
+          # help, and setting fsGroup would make kubelet chown the volume root —
+          # which a root-squashed NFS export rejects. What actually lets a
+          # squashed-root writer use a brand-new NetApp volume is the 0777
+          # Trident annotation on the claim below.
           {{- include "pawtograder.imagePullSecrets" . | nindent 10 }}
           containers:
             - name: backup
@@ -46,7 +63,11 @@ spec:
                   # (which the backup-verify CronJob runs weekly against the
                   # newest object). Restore with:
                   #   pg_restore --clean --if-exists --no-owner --no-acl -d <db> <file>
-                  FILE="/tmp/pawtograder-${TS}.dump"
+                  # /scratch, NOT /tmp: a ~7 GB dump on the container's
+                  # writable layer is unaccounted node ephemeral storage, and
+                  # filling it kills the dump mid-write while pressuring every
+                  # other pod on the node. /scratch is a per-pod ephemeral PVC.
+                  FILE="/scratch/pawtograder-${TS}.dump"
                   pg_dump -Fc > "$FILE"
                   # Verify the archive's TOC parses BEFORE uploading — a
                   # truncated/corrupt dump must fail here, not on restore day.
@@ -75,6 +96,10 @@ spec:
                     exit 1
                   fi
                   echo "[backup] uploaded + size-verified $REMOTE"
+                  # Drop the local copy now the remote is byte-verified, so a
+                  # retained completed pod's PVC doesn't hold a dump-sized chunk
+                  # of the scratch tier until the history limit reaps it.
+                  rm -f "$FILE"
                   # Retention is enforced via a bucket ILM expiry rule. Adding
                   # a duplicate errors, so add only when absent — but a bucket
                   # with NO expiry rule and a failing add is a hard error
@@ -83,6 +108,8 @@ spec:
                     mc ilm rule add --expiry-days {{ .Values.backup.retentionDays }} "s3/${S3_BUCKET}"
                     echo "[backup] created ILM expiry rule ({{ .Values.backup.retentionDays }}d)"
                   fi
+              volumeMounts:
+                - { name: scratch, mountPath: /scratch }
               env:
                 - name: PGHOST
                   value: {{ include "pawtograder.postgres.host" . }}
@@ -111,4 +138,27 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.secrets.names.s3 }}
                       key: AWS_SECRET_ACCESS_KEY
+          volumes:
+            # Dump staging area. A generic ephemeral volume, not an emptyDir:
+            # an emptyDir — even with sizeLimit — still draws on the same node
+            # ephemeral storage, so it would only convert a silent disk-full
+            # into a fast eviction. This gives the dump its own volume, created
+            # per pod and deleted with it.
+            - name: scratch
+              ephemeral:
+                volumeClaimTemplate:
+                  metadata:
+                    annotations:
+                      trident.netapp.io/unixPermissions: "0777"
+                  spec:
+                    accessModes: ["ReadWriteOnce"]
+                    {{- with .Values.backup.scratchStorageClass | default .Values.postgres.persistence.storageClass }}
+                    # Omitted when empty so the cluster's DEFAULT StorageClass
+                    # applies — an explicit "" would instead disable dynamic
+                    # provisioning entirely and leave the PVC Pending forever.
+                    storageClassName: {{ . | quote }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ .Values.backup.scratchSize | default "30Gi" | quote }}
 {{- end }}

--- a/charts/pawtograder/templates/prometheus-rules.yaml
+++ b/charts/pawtograder/templates/prometheus-rules.yaml
@@ -42,11 +42,30 @@ spec:
         # separately (below), not as a backup outage. The recency guard (Job
         # started within backupMaxAgeHours) keeps a RETAINED failed Job
         # (failedJobsHistoryLimit) from firing forever after a later run recovers.
+        #
+        # kube_job_status_failed counts failed PODS, not terminal Job failure, and
+        # the dump Job runs restartPolicy: Never — so a transient first attempt
+        # that the controller then retries successfully leaves the count at 1
+        # forever. Both `unless` guards exist to stop that paging: `succeeded`
+        # suppresses a Job that ultimately uploaded a good dump, and `active`
+        # suppresses one that is still retrying (a pending or running replacement
+        # pod counts as active). What survives both is a Job with failed pods, no
+        # success, and nothing left in flight — i.e. terminally failed.
         - alert: PawtograderBackupJobFailed
           expr: |
             (
               max by (job_name, namespace) (
                 kube_job_status_failed{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-[0-9].*"}
+              ) > 0
+            )
+            unless on (job_name, namespace) (
+              max by (job_name, namespace) (
+                kube_job_status_succeeded{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-[0-9].*"}
+              ) > 0
+            )
+            unless on (job_name, namespace) (
+              max by (job_name, namespace) (
+                kube_job_status_active{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-[0-9].*"}
               ) > 0
             )
             and on (job_name, namespace) (
@@ -93,11 +112,22 @@ spec:
         # three drill Job types ({{ $backupJob }}-{verify,restore-drill,pitr-drill}-
         # <timestamp>) while still excluding the dump Job ({{ $backupJob }}-<digit>).
         # Recency-guarded like the dump alert.
+        # Same retry-aware guards as the dump alert above.
         - alert: PawtograderBackupVerifyJobFailed
           expr: |
             (
               max by (job_name, namespace) (
                 kube_job_status_failed{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-(verify|restore-drill|pitr-drill)-[0-9].*"}
+              ) > 0
+            )
+            unless on (job_name, namespace) (
+              max by (job_name, namespace) (
+                kube_job_status_succeeded{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-(verify|restore-drill|pitr-drill)-[0-9].*"}
+              ) > 0
+            )
+            unless on (job_name, namespace) (
+              max by (job_name, namespace) (
+                kube_job_status_active{namespace="{{ $ns }}", job_name=~"{{ $backupJob }}-(verify|restore-drill|pitr-drill)-[0-9].*"}
               ) > 0
             )
             and on (job_name, namespace) (

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1875,6 +1875,21 @@ backup:
   image:
     repository: supabase/postgres
     tag: "17.4.1.075"
+  # Staging space for the dump before it is uploaded. This is a per-pod GENERIC
+  # EPHEMERAL VOLUME (created with the pod, deleted with it) — NOT the node's
+  # ephemeral storage. It has to be a real volume: the dump is the size of the
+  # compressed database (~7 GB on a large install and growing), and staging that
+  # on the container's writable layer is unaccounted node disk that the
+  # scheduler cannot see. When it runs out, pg_dump dies part-written and every
+  # other pod on that node gets DiskPressure. An emptyDir would not fix it —
+  # sizeLimit only turns the disk-full into a faster eviction.
+  #
+  # Size for your DB with room to grow: the dump must fit whole, since the
+  # archive's TOC is verified locally before upload. Empty storageClass inherits
+  # postgres.persistence.storageClass; point it at a cheap/slow tier (this is
+  # write-once-read-once, it does not need the primary's fast tier).
+  scratchSize: 30Gi
+  scratchStorageClass: ""
   s3:
     endpoint: ""
     region: "us-east-1"
@@ -1890,6 +1905,10 @@ backup:
     schedule: "0 6 * * 1" # weekly, after Monday's backup
     activeDeadlineSeconds: 1800
     startingDeadlineSeconds: 1800
+    # Verify downloads the whole newest dump, so it needs the same staging space
+    # as the backup itself. Empty → inherit backup.scratchSize/StorageClass.
+    scratchSize: ""
+    scratchStorageClass: ""
   # Restore DRILL: the full-restore rehearsal `verify` stops short of. It
   # restores the newest dump into a throwaway database on the LIVE postgres,
   # asserts a core table has a plausible row count, then drops the scratch DB.

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1888,8 +1888,22 @@ backup:
   # archive's TOC is verified locally before upload. Empty storageClass inherits
   # postgres.persistence.storageClass; point it at a cheap/slow tier (this is
   # write-once-read-once, it does not need the primary's fast tier).
+  # NOTE: point this at NETWORK storage. It falls back to
+  # postgres.persistence.storageClass, which on some installs is a node-local
+  # class (local-path) — staging the dump there puts it back on the node
+  # filesystem, defeating the point, and worse than /tmp in one way: a
+  # local-path PVC is not charged to the pod's ephemeral storage, so kubelet
+  # will not evict the pod before the node fills.
   scratchSize: 30Gi
   scratchStorageClass: ""
+  # Retained Jobs each keep their pod, and each pod keeps its scratch PVC, so
+  # these are the retained-storage lever as well as the log-retention one.
+  # Worst case is (successful + failed x attempts) x scratchSize of REQUESTED
+  # capacity — 30Gi x 1 successful + 30Gi x 3 failed x 3 attempts here. `rm`
+  # frees the bytes after upload but not the claim, so under a namespace
+  # storage quota or a capacity-bound provisioner, turn these down.
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
   s3:
     endpoint: ""
     region: "us-east-1"
@@ -1909,6 +1923,8 @@ backup:
     # as the backup itself. Empty → inherit backup.scratchSize/StorageClass.
     scratchSize: ""
     scratchStorageClass: ""
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 3
   # Restore DRILL: the full-restore rehearsal `verify` stops short of. It
   # restores the newest dump into a throwaway database on the LIVE postgres,
   # asserts a core table has a plausible row count, then drops the scratch DB.


### PR DESCRIPTION
## What broke

`PawtograderBackupJobFailed` fired in Khoury prod for `pawtograder-backup-29819760` (the Sat 2026-09-12 04:00Z run). Root cause is in the chart, not the cluster: `backup.yaml` ran

```
FILE="/tmp/pawtograder-${TS}.dump"
pg_dump -Fc > "$FILE"
```

with **no volume mounted and an empty `resources: {}`**. In prod that dump is **7.35 GB and growing ~7 MB/day**, staged on the container's writable layer — unaccounted node ephemeral storage the scheduler cannot see and no limit bounds. When the node runs out, `pg_dump` dies part-written and every other pod on that node gets DiskPressure.

`grep -rn ephemeral-storage charts/ docs/` returned nothing before this PR — it was sized nowhere.

### Evidence

- Job failed `BackoffLimitExceeded`, 04:00:00Z → 04:51:47Z. Four container starts in 3,107s, so each attempt died ~15 min in, around **4.5 GB of the 7.35 GB dump**.
- Postgres logged **no** error for the dump, only `could not receive data from client: Connection reset by peer` at 04:52:17 — the pod being torn down. The DB never rejected or killed it; the failure was on the node.
- All 6 nodes Ready, no memory pressure (workers 20–62%), primary up 7d with no restarts.
- Node `DiskPressure` `lastTransitionTime`, decoupled from the kubelet-restart timestamp that Memory/PIDPressure share: **worker-1 = Sep 7 08:05:41Z, worker-2 = Aug 31 06:05:41Z**. Both **Mondays, minutes after** the only two weekly jobs that pull the full dump onto container-local disk — `backup-verify` (06:00 Mon) and `restore-drill` (08:00 Mon). `backup-verify` has the identical defect (`mc cp … /tmp/latest.dump`, same ~7 GB).

Workers have ~51.8 GiB allocatable ephemeral storage and already carry 5.8–7.6 GiB of images each.

## The fix

Both jobs now stage on a **per-pod generic ephemeral volume** — the same idiom `backup-restore-drill.yaml` and `backup-pitr-drill.yaml` already use, including the `trident.netapp.io/unixPermissions: "0777"` annotation that lets a root-squashed root writer use a brand-new NetApp volume.

New knobs: `backup.scratchSize` (30Gi default) and `backup.scratchStorageClass`; `backup.verify.*` inherits both, then falls back to `postgres.persistence.storageClass`.

An **emptyDir was not an option**: even with `sizeLimit` it draws on the same node ephemeral storage, so it would only convert a silent disk-full into a faster eviction.

## Two related fixes that fall out of this

**`restartPolicy: OnFailure` → `Never`.** Under `OnFailure` the backoff limit counts container restarts inside *one* pod, so `status.failed` reads **1** rather than 3, and the controller **deletes that pod** when the limit trips — taking every attempt's logs with it. A failed nightly backup left nothing to debug but the Job object; that is why the diagnosis above had to be reconstructed from `DiskPressure` timestamps. With `Never`, each attempt is its own pod whose logs survive until the history limit reaps the Job.

**`storageClassName` omitted when empty**, matching what `postgres-statefulset.yaml:456` already does. An explicit `""` does *not* mean "use the default class" — it disables dynamic provisioning and leaves the PVC Pending forever. The two drills still have this latent bug; left alone here since they are off by default and prod sets the class explicitly.

Also: the dump is `rm`'d once the upload is byte-verified, so a retained completed pod's PVC doesn't sit on a dump-sized chunk of the scratch tier. And **no `ttlSecondsAfterFinished`** was added — `PawtograderBackupJobFailed` reads `kube_job_status_failed` off the Job object, so a TTL would let a failed backup delete its own alert.

## Not affected

**WAL-G/PITR was never at risk.** It runs from the `base-backup` sidecar on its own bucket (`s3://pawtograder-wal`, no ILM expiry), independent of this Job. It completed a base backup plus retention prune at 03:17Z that same morning and kept archiving WAL every ~60s throughout the incident.

## Validation

- `helm lint` clean.
- `helm template` with the real `values-prod.yaml` renders the full chart with no errors.
- `kubectl apply --dry-run=server` against **live khoury-prod** for both rendered CronJobs: `configured (server dry run)`. (The PodSecurity `restricted` warnings are pre-existing — the container has always run as root to `apt-get install mc`.)
- Verified `storageClassName` is omitted when the class is empty and emitted when set.

## Deploying

Chart bumped 0.3.22 → 0.3.23. Prod needs `backup.scratchStorageClass: netapp-economy` in `prod-charts/values/values-prod.yaml` — that's a separate PR in that repo, and the cheap tier is already proven there by the two drills.

Worth noting the alert self-clears on its own: `PawtograderBackupJobFailed` has an `and on(job_name) kube_job_status_start_time > time() - 36*3600` clause, so it goes quiet 36h after a failed run whether or not anything was fixed. `PawtograderBackupMissing` (36h since last *completion*) is the one that actually tracks the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
