### PR TITLE
fix(chart): bake mc into a backup image instead of downloading it per run

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -335,6 +335,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # supabase/postgres + a SHA-pinned mc. Published so installs can point
+      # backup.image at it instead of letting the jobs fetch mc from a third
+      # party on every run — the dependency that broke backups on 2026-09-12
+      # when MinIO archived the open-source mc project and dl.min.io began
+      # returning 410 for every binary.
+      - name: Build & push backup image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: charts/pawtograder/images/backup/Dockerfile
+          push: true
+          tags: ${{ format('{0}/{1}/backup:{2}', env.REGISTRY, env.REPO_OWNER, needs.meta.outputs.version) }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            VERSION=${{ needs.meta.outputs.version }}
+          cache-from: type=gha,scope=backup
+          cache-to: type=gha,scope=backup,mode=max
+
       - name: Build & push maintenance image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -335,24 +335,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # supabase/postgres + a SHA-pinned mc. Published so installs can point
-      # backup.image at it instead of letting the jobs fetch mc from a third
-      # party on every run — the dependency that broke backups on 2026-09-12
-      # when MinIO archived the open-source mc project and dl.min.io began
-      # returning 410 for every binary.
-      - name: Build & push backup image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: charts/pawtograder/images/backup/Dockerfile
-          push: true
-          tags: ${{ format('{0}/{1}/backup:{2}', env.REGISTRY, env.REPO_OWNER, needs.meta.outputs.version) }}
-          build-args: |
-            GIT_SHA=${{ github.sha }}
-            VERSION=${{ needs.meta.outputs.version }}
-          cache-from: type=gha,scope=backup
-          cache-to: type=gha,scope=backup,mode=max
-
       - name: Build & push maintenance image
         uses: docker/build-push-action@v6
         with:
@@ -376,6 +358,52 @@ jobs:
               ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/maintenance:${{ needs.meta.outputs.version }}
           done
 
+  # supabase/postgres + a SHA-pinned mc, so the nightly dump does not fetch its
+  # uploader from a third party on the run that has to work — the dependency
+  # that broke backups on 2026-09-12, when MinIO archived the open-source mc
+  # project and dl.min.io began returning 410 for every binary.
+  #
+  # Its own job, not a step inside build-maintenance, so that it (a) gets the
+  # same "Tag additional refs" aliasing every other image gets — without it
+  # `backup:<channel>-latest` never exists and the CronJobs ImagePullBackOff on
+  # the next run — and (b) can gate publish-chart on its own.
+  build-backup:
+    needs: meta
+    runs-on: pawtograder-ci
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push backup image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: charts/pawtograder/images/backup/Dockerfile
+          push: true
+          tags: ${{ format('{0}/{1}/backup:{2}', env.REGISTRY, env.REPO_OWNER, needs.meta.outputs.version) }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            VERSION=${{ needs.meta.outputs.version }}
+          cache-from: type=gha,scope=backup
+          cache-to: type=gha,scope=backup,mode=max
+
+      - name: Tag additional refs
+        run: |
+          set -euo pipefail
+          for t in $(echo '${{ needs.meta.outputs.tags }}' | tr ',' ' '); do
+            [ "$t" = "${{ needs.meta.outputs.version }}" ] && continue
+            docker buildx imagetools create \
+              --tag ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/backup:${t} \
+              ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/backup:${{ needs.meta.outputs.version }}
+          done
+
   publish-chart:
     # Note: build-web is intentionally not a dep — on v* tag pushes the web
     # image is not built here (URLs would have to be baked at tag time and
@@ -383,7 +411,7 @@ jobs:
     # by tag only, so it's fine to publish the chart without a same-tag
     # web image; consumers of the chart override web.image.tag to a
     # workflow_dispatch-built image keyed to their environment.
-    needs: [meta, build-edge-functions, build-migrations]
+    needs: [meta, build-edge-functions, build-migrations, build-backup]
     if: needs.meta.outputs.is_tag == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -433,7 +461,7 @@ jobs:
       # server rejecting anything, so the fix is on this side.
       HELM_QPS: "50"
       HELM_BURST_LIMIT: "300"
-    needs: [meta, build-web, build-edge-functions, build-migrations, build-maintenance]
+    needs: [meta, build-web, build-edge-functions, build-migrations, build-maintenance, build-backup]
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     # MUST run on the self-hosted, in-network runner. The cluster API
     # (talos.ripley.cloud:6443) is a private 10.201.2.x address, unreachable
@@ -513,6 +541,7 @@ jobs:
             --set web.image.tag="$VERSION" \
             --set edgeFunctions.image.tag="$VERSION" \
             --set migrations.image.tag="$VERSION" \
+            --set backup.image.tag="$VERSION" \
             --set maintenance.enabled=true \
             --set maintenance.image.repository=ghcr.io/pawtograder/maintenance \
             --set maintenance.image.tag="$VERSION" \

--- a/charts/pawtograder/Chart.yaml
+++ b/charts/pawtograder/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   Studio, postgres-meta, supavisor) so the whole stack can be deployed to a
   Kubernetes cluster from a single Helm release.
 type: application
-version: 0.3.23
+version: 0.3.24
 appVersion: "0.0.1"
 kubeVersion: ">=1.27.0-0"
 home: https://pawtograder.net

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -586,9 +586,12 @@ Key mechanics:
   installs. Because a retained Job keeps its pod and each pod keeps its claim,
   `backup.successfulJobsHistoryLimit` defaults to 1 (failures keep 3); turn
   both down under a namespace storage quota.
-  Point `backup.image` at the image built from
-  `charts/pawtograder/images/backup/Dockerfile` — supabase/postgres with a
-  SHA-pinned `mc` baked in. The jobs fall back to installing `mc` at runtime
+  Point `backup.image` at `ghcr.io/pawtograder/backup` (published by
+  `release-images.yml` from `charts/pawtograder/images/backup/Dockerfile`) —
+  supabase/postgres with a SHA-pinned `mc` baked in. Pin the tag: in
+  production an empty or floating `backup.image.tag` is refused, because the
+  image is only pulled on the nightly run and would otherwise fail at 04:00
+  rather than at deploy time. The jobs fall back to installing `mc` at runtime
   when it isn't on PATH, but that fetch is a third-party dependency on the one
   run that has to work: it broke production on 2026-09-12 when MinIO archived
   the open-source `mc` project and `dl.min.io` began returning 410 for every

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -595,7 +595,10 @@ Key mechanics:
   when it isn't on PATH, but that fetch is a third-party dependency on the one
   run that has to work: it broke production on 2026-09-12 when MinIO archived
   the open-source `mc` project and `dl.min.io` began returning 410 for every
-  binary. Keep the image tag in lockstep with `postgres.image.tag`.
+  binary. Tag it like the other Pawtograder images (release version or
+  `<branch>-<sha>`), *not* with the Postgres version — `release-images.yml`
+  publishes it as `backup:<version>`. What tracks `postgres.image.tag` is the
+  Dockerfile's `FROM`, so `pg_dump` still matches the server it dumps.
 - **Web images are environment-specific**: `NEXT_PUBLIC_*` values (incl. the
   cluster's anon key) are baked at build time. Build prod images via
   `release-images.yml` `workflow_dispatch` with the prod hostname/namespace

--- a/charts/pawtograder/README.md
+++ b/charts/pawtograder/README.md
@@ -586,6 +586,13 @@ Key mechanics:
   installs. Because a retained Job keeps its pod and each pod keeps its claim,
   `backup.successfulJobsHistoryLimit` defaults to 1 (failures keep 3); turn
   both down under a namespace storage quota.
+  Point `backup.image` at the image built from
+  `charts/pawtograder/images/backup/Dockerfile` — supabase/postgres with a
+  SHA-pinned `mc` baked in. The jobs fall back to installing `mc` at runtime
+  when it isn't on PATH, but that fetch is a third-party dependency on the one
+  run that has to work: it broke production on 2026-09-12 when MinIO archived
+  the open-source `mc` project and `dl.min.io` began returning 410 for every
+  binary. Keep the image tag in lockstep with `postgres.image.tag`.
 - **Web images are environment-specific**: `NEXT_PUBLIC_*` values (incl. the
   cluster's anon key) are baked at build time. Build prod images via
   `release-images.yml` `workflow_dispatch` with the prod hostname/namespace

--- a/charts/pawtograder/examples/values-prod-noeso.yaml
+++ b/charts/pawtograder/examples/values-prod-noeso.yaml
@@ -257,8 +257,11 @@ backup:
   # backup-verify and restore-drill run falls back to fetching mc at runtime
   # from a third party. That is the dependency that broke backups on
   # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
-  # started returning 410 for every binary. Keep the tag in lockstep with
-  # postgres.image.tag so pg_dump matches the server it dumps.
+  # started returning 410 for every binary.
+  # Tag it like the other Pawtograder images (release version or <branch>-<sha>),
+  # NOT with the Postgres version — release-images.yml publishes this repo as
+  # backup:<version>. What tracks postgres.image.tag is the Dockerfile's FROM,
+  # so pg_dump still matches the server it dumps.
   image:
     repository: ghcr.io/pawtograder/backup
     tag: ""             # ← pin per release

--- a/charts/pawtograder/examples/values-prod-noeso.yaml
+++ b/charts/pawtograder/examples/values-prod-noeso.yaml
@@ -252,6 +252,16 @@ seed:
 # ----- Backups + verification ---------------------------------------------------
 backup:
   enabled: true
+  # Baked mc — see charts/pawtograder/images/backup/Dockerfile. Pin this rather
+  # than leaving the default (plain supabase/postgres), or every backup,
+  # backup-verify and restore-drill run falls back to fetching mc at runtime
+  # from a third party. That is the dependency that broke backups on
+  # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
+  # started returning 410 for every binary. Keep the tag in lockstep with
+  # postgres.image.tag so pg_dump matches the server it dumps.
+  image:
+    repository: ghcr.io/pawtograder/backup
+    tag: ""             # ← pin per release
   schedule: "0 4 * * *"
   retentionDays: 30
   s3:

--- a/charts/pawtograder/examples/values-prod.yaml
+++ b/charts/pawtograder/examples/values-prod.yaml
@@ -349,6 +349,16 @@ seed:
 # ----- Backups + verification ---------------------------------------------------
 backup:
   enabled: true
+  # Baked mc — see charts/pawtograder/images/backup/Dockerfile. Pin this rather
+  # than leaving the default (plain supabase/postgres), or every backup,
+  # backup-verify and restore-drill run falls back to fetching mc at runtime
+  # from a third party. That is the dependency that broke backups on
+  # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
+  # started returning 410 for every binary. Keep the tag in lockstep with
+  # postgres.image.tag so pg_dump matches the server it dumps.
+  image:
+    repository: ghcr.io/pawtograder/backup
+    tag: ""             # ← pin per release
   schedule: "0 4 * * *"
   retentionDays: 30
   s3:

--- a/charts/pawtograder/examples/values-prod.yaml
+++ b/charts/pawtograder/examples/values-prod.yaml
@@ -354,8 +354,11 @@ backup:
   # backup-verify and restore-drill run falls back to fetching mc at runtime
   # from a third party. That is the dependency that broke backups on
   # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
-  # started returning 410 for every binary. Keep the tag in lockstep with
-  # postgres.image.tag so pg_dump matches the server it dumps.
+  # started returning 410 for every binary.
+  # Tag it like the other Pawtograder images (release version or <branch>-<sha>),
+  # NOT with the Postgres version — release-images.yml publishes this repo as
+  # backup:<version>. What tracks postgres.image.tag is the Dockerfile's FROM,
+  # so pg_dump still matches the server it dumps.
   image:
     repository: ghcr.io/pawtograder/backup
     tag: ""             # ← pin per release

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -406,6 +406,12 @@ backup:
   image:
     repository: ghcr.io/pawtograder/backup
     tag: staging-latest
+    # staging-latest FLOATS, and it is not literally ":latest", so the k8s
+    # default would be IfNotPresent — a node would keep its cached copy after
+    # release-images.yml moves the alias, and the nightly dump would silently
+    # run a stale image. The automated deploy pins staging-<sha> and does not
+    # need this; scripts/redeploy-staging.sh uses this file as-is and does.
+    pullPolicy: Always
   schedule: "0 4 * * *"
   retentionDays: 14
   # Dump staging goes on ceph-rbd, NOT the local-path class postgres uses above.

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -393,6 +393,16 @@ studio:
 # ----- Nightly Postgres backups to S3 ---------------------------------------
 backup:
   enabled: true
+  # Baked mc — see charts/pawtograder/images/backup/Dockerfile. Pin this rather
+  # than leaving the default (plain supabase/postgres), or every backup,
+  # backup-verify and restore-drill run falls back to fetching mc at runtime
+  # from a third party. That is the dependency that broke backups on
+  # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
+  # started returning 410 for every binary. Keep the tag in lockstep with
+  # postgres.image.tag so pg_dump matches the server it dumps.
+  image:
+    repository: ghcr.io/pawtograder/backup
+    tag: staging-latest
   schedule: "0 4 * * *"
   retentionDays: 14
   # Dump staging goes on ceph-rbd, NOT the local-path class postgres uses above.

--- a/charts/pawtograder/examples/values-staging.yaml
+++ b/charts/pawtograder/examples/values-staging.yaml
@@ -398,8 +398,11 @@ backup:
   # backup-verify and restore-drill run falls back to fetching mc at runtime
   # from a third party. That is the dependency that broke backups on
   # 2026-09-12, when MinIO archived the open-source mc project and dl.min.io
-  # started returning 410 for every binary. Keep the tag in lockstep with
-  # postgres.image.tag so pg_dump matches the server it dumps.
+  # started returning 410 for every binary.
+  # Tag it like the other Pawtograder images (release version or <branch>-<sha>),
+  # NOT with the Postgres version — release-images.yml publishes this repo as
+  # backup:<version>. What tracks postgres.image.tag is the Dockerfile's FROM,
+  # so pg_dump still matches the server it dumps.
   image:
     repository: ghcr.io/pawtograder/backup
     tag: staging-latest

--- a/charts/pawtograder/images/backup/Dockerfile
+++ b/charts/pawtograder/images/backup/Dockerfile
@@ -1,0 +1,48 @@
+# Pawtograder backup image: supabase/postgres + a pinned `mc`.
+#
+# WHY THIS EXISTS. The backup and backup-verify CronJobs used to `apt-get
+# install curl` and download `mc` from dl.min.io on EVERY run. On 2026-09-12
+# that broke production: MinIO archived the open-source mc project and pulled
+# every binary from dl.min.io, so the whole path started returning "410 Gone"
+# — the pinned archive build and the rolling release URL alike. The nightly
+# dump completed and then died installing its uploader, so nothing reached S3.
+#
+# Baking mc in moves that fetch from "every run, from a third party" to "once,
+# at build time, into an image we control". It also removes a per-run MITM
+# surface, and it means a backup no longer needs egress to anywhere but S3.
+#
+# The base image MUST stay pinned to the same tag as postgres.image /
+# backup.image so pg_dump and pg_restore match the server they dump. Bump both
+# together.
+#
+# Build context: repository root.
+#   docker build -f charts/pawtograder/images/backup/Dockerfile -t <ref> .
+FROM supabase/postgres:17.4.1.075
+
+# Pinned by digest-equivalent checksum, not by trusting the host. Upstream is
+# archived, so this URL is a frozen artifact: the GitHub release asset for the
+# same RELEASE tag dl.min.io used to serve. The binary is byte-identical to
+# what was previously pinned — verified against upstream's own .sha256sum.
+# To move to a different build, change BOTH args together.
+ARG MC_URL="https://github.com/minio/mc/releases/download/RELEASE.2025-08-13T08-35-41Z/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z"
+ARG MC_SHA256="01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891"
+
+# ca-certificates is a RUNTIME dependency, not just a build one: mc needs a
+# trust store to talk HTTPS to the S3 endpoint. curl is left installed rather
+# than purged — `apt-get purge --auto-remove curl` also takes libcurl, which
+# the base image's own tooling links against.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends curl ca-certificates; \
+    curl -fsSL "$MC_URL" -o /usr/local/bin/mc; \
+    echo "$MC_SHA256  /usr/local/bin/mc" | sha256sum -c -; \
+    chmod 0755 /usr/local/bin/mc; \
+    mc --version; \
+    rm -rf /var/lib/apt/lists/*
+
+ARG GIT_SHA=""
+ARG VERSION=""
+LABEL org.opencontainers.image.source="https://github.com/pawtograder/platform" \
+      org.opencontainers.image.title="pawtograder-backup" \
+      org.opencontainers.image.revision="$GIT_SHA" \
+      org.opencontainers.image.version="$VERSION"

--- a/charts/pawtograder/templates/backup-restore-drill.yaml
+++ b/charts/pawtograder/templates/backup-restore-drill.yaml
@@ -72,10 +72,15 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
-                  apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-                  curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
-                  echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
-                  chmod +x /usr/local/bin/mc
+                  # Baked-in mc, with the same runtime fallback as
+                  # backup.yaml — see the rationale there.
+                  if ! command -v mc >/dev/null 2>&1; then
+                    echo "[drill] mc not in image — installing at runtime (see backup.image)"
+                    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+                    curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
+                    echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
+                    chmod +x /usr/local/bin/mc
+                  fi
                   mc alias set s3 "${S3_ENDPOINT}" "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
                   LATEST=$(mc ls "s3/${S3_BUCKET}/" | awk '{print $NF}' | grep '^pawtograder-.*\.dump$' | sort | tail -1 || true)
                   if [ -z "$LATEST" ]; then

--- a/charts/pawtograder/templates/backup-restore-drill.yaml
+++ b/charts/pawtograder/templates/backup-restore-drill.yaml
@@ -65,6 +65,7 @@ spec:
             # needs root (apt), but the postgres container must not run as root.
             - name: fetch-dump
               image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.backup.image) }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
               securityContext:
                 runAsUser: 0
               command:

--- a/charts/pawtograder/templates/backup-verify.yaml
+++ b/charts/pawtograder/templates/backup-verify.yaml
@@ -46,6 +46,7 @@ spec:
           containers:
             - name: verify
               image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.backup.image) }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
               # bash, not sh — see backup.yaml (dash rejects pipefail).
               command:
                 - bash

--- a/charts/pawtograder/templates/backup-verify.yaml
+++ b/charts/pawtograder/templates/backup-verify.yaml
@@ -52,11 +52,15 @@ spec:
                 - -c
                 - |
                   set -euo pipefail
-                  # Same runtime mc install as backup.yaml (SHA-pinned).
-                  apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-                  curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
-                  echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
-                  chmod +x /usr/local/bin/mc
+                  # Baked-in mc, with the same runtime fallback as
+                  # backup.yaml — see the rationale there.
+                  if ! command -v mc >/dev/null 2>&1; then
+                    echo "[verify] mc not in image — installing at runtime (see backup.image)"
+                    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+                    curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
+                    echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
+                    chmod +x /usr/local/bin/mc
+                  fi
                   mc alias set s3 "${S3_ENDPOINT}" "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
                   # Timestamped names sort lexicographically == chronologically.
                   LATEST=$(mc ls "s3/${S3_BUCKET}/" | awk '{print $NF}' | grep '^pawtograder-.*\.dump$' | sort | tail -1)

--- a/charts/pawtograder/templates/backup.yaml
+++ b/charts/pawtograder/templates/backup.yaml
@@ -80,17 +80,25 @@ spec:
                   # truncated/corrupt dump must fail here, not on restore day.
                   pg_restore --list "$FILE" > /dev/null
                   echo "[backup] dump OK: $(stat -c%s "$FILE") bytes"
-                  # Install mc into the supabase/postgres image at runtime.
-                  # Ideally mc would be baked into the image (no network
-                  # dependency, no MITM surface), but the chart can't
-                  # rebuild the postgres image; pin the binary by SHA256
-                  # so a tampered download is rejected. Bump the URL +
-                  # checksum together by setting backup.mc.url and
-                  # backup.mc.sha256 in your values.
-                  apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
-                  curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
-                  echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
-                  chmod +x /usr/local/bin/mc
+                  # mc is BAKED IN when backup.image points at the image
+                  # built from charts/pawtograder/images/backup/Dockerfile,
+                  # which is the supported path: no third-party fetch on the
+                  # run that has to work, and no per-run MITM surface.
+                  #
+                  # The runtime install below is only a fallback for installs
+                  # still pointing backup.image at plain supabase/postgres.
+                  # It is a liability, not a feature: on 2026-09-12 MinIO
+                  # archived the open-source mc project and pulled every
+                  # binary from dl.min.io, and this download started
+                  # returning "410 Gone" — the dump completed and then died
+                  # here, so nothing reached S3. Prefer the baked image.
+                  if ! command -v mc >/dev/null 2>&1; then
+                    echo "[backup] mc not in image — installing at runtime (see backup.image)"
+                    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+                    curl -fsSL "{{ .Values.backup.mc.url }}" -o /usr/local/bin/mc
+                    echo "{{ .Values.backup.mc.sha256 }}  /usr/local/bin/mc" | sha256sum -c -
+                    chmod +x /usr/local/bin/mc
+                  fi
                   mc alias set s3 "${S3_ENDPOINT}" "${AWS_ACCESS_KEY_ID}" "${AWS_SECRET_ACCESS_KEY}"
                   REMOTE="s3/${S3_BUCKET}/$(basename "$FILE")"
                   mc cp "$FILE" "$REMOTE"

--- a/charts/pawtograder/templates/backup.yaml
+++ b/charts/pawtograder/templates/backup.yaml
@@ -55,6 +55,7 @@ spec:
           containers:
             - name: backup
               image: {{ include "pawtograder.image" (dict "ctx" . "image" .Values.backup.image) }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
               # Run under bash, not sh: the supabase/postgres image's /bin/sh is
               # dash, which rejects `set -o pipefail` ("Illegal option -o
               # pipefail", exit 2) — without pipefail a failing pg_dump piped to

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -172,7 +172,11 @@ cannot detect.
 {{- if .Values.seed.enabled -}}
 {{- fail "seed.enabled=true loads demo classes and canned auth users — never in production." -}}
 {{- end -}}
-{{- range $name, $img := dict "web" .Values.web.image "edgeFunctions" .Values.edgeFunctions.image "migrations" .Values.migrations.image -}}
+{{- /* backup is in here too: it is only pulled on the nightly run, so an
+       unpinned tag fails at 04:00 rather than at deploy time. Its default
+       (supabase/postgres:17.4.1.075) is already pinned, so this only bites an
+       install that repoints backup.image and forgets the tag. */ -}}
+{{- range $name, $img := dict "web" .Values.web.image "edgeFunctions" .Values.edgeFunctions.image "migrations" .Values.migrations.image "backup" .Values.backup.image -}}
 {{- $tag := $img.tag | default "" -}}
 {{- if or (eq $tag "latest") (hasSuffix "-latest" $tag) -}}
 {{- fail (printf "%s.image.tag=%q is a floating tag — production deploys must pin an immutable tag (vX.Y.Z or <branch>-<sha>) for traceability and rollback." $name $tag) -}}

--- a/charts/pawtograder/templates/validations.yaml
+++ b/charts/pawtograder/templates/validations.yaml
@@ -349,3 +349,25 @@ element to mean anything.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+Floating backup image tag + a caching pull policy = a stale nightly dump.
+
+Kubernetes only defaults imagePullPolicy to Always for a tag that is literally
+`:latest`. Anything else that floats — `staging-latest`, `main-latest`,
+`<channel>-latest` — defaults to IfNotPresent, so once a node has pulled it, it
+keeps serving that cached layer after the registry alias moves. For most
+workloads a rollout re-pulls soon enough to hide this; the backup image is
+pulled only when the CronJob fires, so the failure mode is a nightly dump that
+silently runs a months-old image. Any environment, because floating tags are
+legitimate outside production (production refuses them outright above).
+*/ -}}
+{{- if .Values.backup.enabled -}}
+{{- $btag := .Values.backup.image.tag | default "" -}}
+{{- $bpol := .Values.backup.image.pullPolicy | default "" -}}
+{{- if or (eq $btag "latest") (hasSuffix "-latest" $btag) -}}
+{{- if ne $bpol "Always" -}}
+{{- fail (printf "backup.image.tag=%q floats but backup.image.pullPolicy=%q. Kubernetes only defaults to Always for a literal \":latest\", so this resolves to IfNotPresent and a node will keep its cached copy after the registry alias moves — the nightly dump then silently runs a stale image, and because the image is pulled only when the CronJob fires you would not find out at deploy time. Set backup.image.pullPolicy=Always, or pin an immutable tag." $btag $bpol) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1888,6 +1888,11 @@ backup:
   image:
     repository: supabase/postgres
     tag: "17.4.1.075"
+    # MUST be Always if the tag above floats (anything ending -latest). A
+    # floating tag that is not literally ":latest" defaults to IfNotPresent, so
+    # a node keeps serving its cached copy after the alias moves and the nightly
+    # job silently runs a stale image. Pinned tags want IfNotPresent.
+    pullPolicy: IfNotPresent
   # Staging space for the dump before it is uploaded. This is a per-pod GENERIC
   # EPHEMERAL VOLUME (created with the pod, deleted with it) — NOT the node's
   # ephemeral storage. It has to be a real volume: the dump is the size of the

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1872,6 +1872,17 @@ backup:
   # a run that exceeds this fails LOUDLY rather than hanging forever.
   activeDeadlineSeconds: 3600
   startingDeadlineSeconds: 1800
+  # Point this at the image built from
+  # charts/pawtograder/images/backup/Dockerfile — supabase/postgres with a
+  # pinned mc baked in. That is the supported configuration: it removes a
+  # third-party download from the one run that has to work. The default below
+  # is plain supabase/postgres, which still works via the runtime-install
+  # fallback in the job scripts — but that fallback is exactly what broke
+  # production on 2026-09-12, when MinIO archived the open-source mc project
+  # and dl.min.io began returning 410 for every binary.
+  #
+  # Keep the tag in lockstep with postgres.image.tag either way, so pg_dump
+  # matches the server it dumps.
   image:
     repository: supabase/postgres
     tag: "17.4.1.075"
@@ -1986,8 +1997,18 @@ backup:
   # supabase/postgres image doesn't include it. Pin both URL and
   # SHA256 together; any mismatch fails the job before secrets are
   # used. Update both when bumping the version.
+  # FALLBACK ONLY — used when backup.image has no mc on PATH. Prefer baking it
+  # in (see backup.image above).
+  #
+  # No longer dl.min.io: MinIO archived the open-source mc project around
+  # 2026-09-12 and pulled every binary, so that host returns "410 Gone" for
+  # the pinned archive build AND the rolling release URL. This is the GitHub
+  # release asset for the same RELEASE tag — a byte-identical binary, hence
+  # the unchanged checksum (verified against upstream's own .sha256sum).
+  # Upstream is archived, so treat this as a frozen artifact that will get no
+  # security updates. Change both fields together.
   mc:
-    url: "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2025-08-13T08-35-41Z"
+    url: "https://github.com/minio/mc/releases/download/RELEASE.2025-08-13T08-35-41Z/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z"
     sha256: "01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891"
 
 # -----------------------------------------------------------------------------

--- a/charts/pawtograder/values.yaml
+++ b/charts/pawtograder/values.yaml
@@ -1881,8 +1881,10 @@ backup:
   # production on 2026-09-12, when MinIO archived the open-source mc project
   # and dl.min.io began returning 410 for every binary.
   #
-  # Keep the tag in lockstep with postgres.image.tag either way, so pg_dump
-  # matches the server it dumps.
+  # Tag it like the other Pawtograder images (release version or
+  # <branch>-<sha>), NOT with the Postgres version: release-images.yml
+  # publishes this repo as backup:<version>. What tracks postgres.image.tag is
+  # the Dockerfile's FROM, so pg_dump still matches the server it dumps.
   image:
     repository: supabase/postgres
     tag: "17.4.1.075"


### PR DESCRIPTION
Chart half of the fix for today's backup outage. Prod-side counterpart: academic-tools/pawtograder#32.

## What happened

`backup`, `backup-verify` and the restore-drill's `fetch-dump` init container all installed `mc` from `dl.min.io` on **every run**. On 2026-09-12 MinIO archived the open-source `mc` project and pulled every binary, so that host now returns `410 Gone` for the pinned archive build *and* the rolling release URL. `dl.min.io` itself says so: *"These files are no longer served from this site. This applies to all community releases."*

Proven on a manual run against chart 0.3.23:

```
[backup] dump OK: 7360498231 bytes
...
curl: (22) The requested URL returned error: 410
```

The 7.36 GB dump completes, then the job dies installing its own uploader, so nothing reaches S3. Worse, the failure lands *after* a 25-minute dump, so each retry burns a full dump to get there.

## Why bake rather than just swap the URL

A URL swap relocates the fragility. This moves the fetch from "every run, from a third party" to "once, at build time, into an image we control" — which also drops a per-run MITM surface and means a backup needs egress to nothing but S3.

**New `charts/pawtograder/images/backup/Dockerfile`:** supabase/postgres with `mc` fetched and SHA-verified at build time. Two deliberate choices:
- `ca-certificates` is kept, not cleaned up — `mc` needs a trust store to reach S3 at *runtime*.
- `curl` is **not** purged. `apt-get purge --auto-remove curl` also takes `libcurl`, which the base image's own tooling links against.

Verified by building it locally:

```
/usr/local/bin/mc: OK                     <- checksum
mc version RELEASE.2025-08-13T08-35-41Z   <- runs
pg_dump (PostgreSQL) 17.4                 <- matches the server
```

**The runtime install becomes a fallback,** guarded by `command -v mc`, so this isn't a breaking change: installs still pointing `backup.image` at plain supabase/postgres keep working. Both branches tested:

| image | guard result |
|---|---|
| the baked image | `mc FOUND -> runtime install skipped` |
| `supabase/postgres:17.4.1.075` | `mc MISSING -> fallback install path taken` |

**The fallback URL is repointed** at the GitHub release asset for the same RELEASE tag, since `dl.min.io` serves nothing now. The binary is byte-identical, so **the pinned checksum is unchanged** — confirmed by computing sha256 locally and matching upstream's own `.sha256sum` asset. The SHA pin did its job: a supply-chain host swap became a non-event.

`backup.image` still defaults to plain supabase/postgres, so no existing install changes behaviour. values.yaml and the chart README both say to point it at the baked image, and to keep its tag in lockstep with `postgres.image.tag` so `pg_dump` matches the server it dumps.

## Correcting this morning's diagnosis

The node-disk PR (#975) attributed the 04:00Z failure to ephemeral-storage exhaustion. That was wrong. `backoffLimit: 2` under `restartPolicy: OnFailure` fails the Job when summed restartCount **>=** backoffLimit — two attempts, not the four I assumed:

| hypothesis | per attempt | 2 attempts | observed |
|---|---|---|---|
| **mc 410** | ~26 min | **52.0 min** | **51.8 min** ✅ |
| disk full at ~4.5 GB of 7.36 GB | ~15 min | 30.6 min | ✗ |

#975 still stands on its own — the Monday `DiskPressure` transitions are real and staging 7.4 GB of unaccounted node disk is a genuine defect — it just wasn't the trigger. And its `restartPolicy: Never` change is the only reason the 410 was ever visible: this run left attempt 1's pod and logs intact, where the old `OnFailure` deleted them, exactly as it did this morning.

## Validation

`helm lint` clean; renders against real prod and staging values; `docker build` succeeds with the checksum verified and both guard branches exercised.

Chart 0.3.23 → 0.3.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a bundled backup image with a verified, preinstalled MinIO Client.
  - Backup, restore-drill, and verification jobs now use the preinstalled client when available, with a checksum-verified runtime fallback otherwise.
  - Updated the fallback download source to the GitHub release asset.

- **Documentation**
  - Documented recommended backup image configuration and image tag requirements.
  - Added guidance on fallback behavior and the bundled backup image.

- **Chores**
  - Incremented the Helm chart version to 0.3.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->