### PR TITLE
fix(chart): source mc from a registry, not a GitHub download

### DIFF
--- a/charts/pawtograder/images/backup/Dockerfile
+++ b/charts/pawtograder/images/backup/Dockerfile
@@ -29,7 +29,11 @@
 #
 # Build context: repository root.
 #   docker build -f charts/pawtograder/images/backup/Dockerfile -t <ref> .
-ARG MC_IMAGE="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
+# Digest-pinned, not just tag-pinned: a Quay tag is mutable, and MC_SHA256
+# below would catch a retargeted tag by FAILING THE BUILD. Pinning the digest
+# means upstream cannot break our build in the first place. Resolve a new one
+# with: docker buildx imagetools inspect <ref> --format '{{.Manifest.Digest}}'
+ARG MC_IMAGE="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
 FROM ${MC_IMAGE} AS mc
 
 FROM supabase/postgres:17.4.1.075

--- a/charts/pawtograder/images/backup/Dockerfile
+++ b/charts/pawtograder/images/backup/Dockerfile
@@ -11,30 +11,42 @@
 # at build time, into an image we control". It also removes a per-run MITM
 # surface, and it means a backup no longer needs egress to anywhere but S3.
 #
+# WHY A REGISTRY PULL, NOT curl. The first version of this file fetched the
+# GitHub release asset. That timed out (`curl: (28) SSL connection timeout`,
+# after 313s) on the Khoury builder, which mirrors the Ubuntu archive but has
+# unreliable egress to GitHub's release CDN — one build succeeded and the next
+# failed. Copying from a registry uses the one network path that provably
+# works there, since that is how every other image in this chart is built.
+#
+# quay.io still serves the archived project's images; docker.io/minio/mc and
+# dl.min.io are both gone. The binary in this image is byte-identical to what
+# was previously pinned, so MC_SHA256 is unchanged and still verified below —
+# the registry is a transport, not a new trust anchor.
+#
 # The base image MUST stay pinned to the same tag as postgres.image /
 # backup.image so pg_dump and pg_restore match the server they dump. Bump both
 # together.
 #
 # Build context: repository root.
 #   docker build -f charts/pawtograder/images/backup/Dockerfile -t <ref> .
+ARG MC_IMAGE="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
+FROM ${MC_IMAGE} AS mc
+
 FROM supabase/postgres:17.4.1.075
 
-# Pinned by digest-equivalent checksum, not by trusting the host. Upstream is
-# archived, so this URL is a frozen artifact: the GitHub release asset for the
-# same RELEASE tag dl.min.io used to serve. The binary is byte-identical to
-# what was previously pinned — verified against upstream's own .sha256sum.
-# To move to a different build, change BOTH args together.
-ARG MC_URL="https://github.com/minio/mc/releases/download/RELEASE.2025-08-13T08-35-41Z/mc.linux-amd64.RELEASE.2025-08-13T08-35-41Z"
+# Unchanged from the dl.min.io pin: same release, same bytes. Verified below so
+# a swapped upstream image cannot slip a different binary in.
 ARG MC_SHA256="01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891"
 
-# ca-certificates is a RUNTIME dependency, not just a build one: mc needs a
-# trust store to talk HTTPS to the S3 endpoint. curl is left installed rather
-# than purged — `apt-get purge --auto-remove curl` also takes libcurl, which
-# the base image's own tooling links against.
+COPY --from=mc /usr/bin/mc /usr/local/bin/mc
+
+# ca-certificates is a RUNTIME dependency: mc needs a trust store to talk
+# HTTPS to the S3 endpoint. It comes from the Ubuntu mirror, which is the
+# reliable path on this builder. curl is no longer installed at all — nothing
+# downloads anything any more.
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl ca-certificates; \
-    curl -fsSL "$MC_URL" -o /usr/local/bin/mc; \
+    apt-get install -y --no-install-recommends ca-certificates; \
     echo "$MC_SHA256  /usr/local/bin/mc" | sha256sum -c -; \
     chmod 0755 /usr/local/bin/mc; \
     mc --version; \


### PR DESCRIPTION
Follow-up to #976, found while building it for production.

## The build is itself unreliable

Production build 821 failed:

```
#5 313.4 curl: (28) SSL connection timeout
ERROR: failed to build: ... exit code: 28
```

313 seconds, then failure, fetching the GitHub release asset. Build 820 had pulled the **same URL** successfully under an hour earlier on the same runner pool — and `apt-get` succeeded in the very same layer, so the builder mirrors the Ubuntu archive but has flaky egress to GitHub's release CDN.

That's a poor dependency for the image whose entire purpose is removing a flaky third-party fetch from the backup path. #976 moved the fetch from "every night" to "once at build time", which is a real improvement — a build failure is loud and retryable where a 04:00 failure is silent. But it doesn't need to be flaky at all.

## Use the path that works

```dockerfile
ARG MC_IMAGE="quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
FROM ${MC_IMAGE} AS mc
COPY --from=mc /usr/bin/mc /usr/local/bin/mc
```

A registry pull is the one network path that provably works on that builder — it's how every other image in this chart is built.

Availability checked across all three hosts:

| source | state |
|---|---|
| `dl.min.io` | `410 Gone` (entire path, community + hotfix builds) |
| `docker.io/minio/mc` | `pull access denied ... repository does not exist` |
| **`quay.io/minio/mc`** | **still served** |

The binary is **byte-identical** to what dl.min.io served, so `MC_SHA256` is unchanged and still verified *after* the `COPY`. The registry is a transport, not a new trust anchor — a swapped upstream image cannot slip a different binary past the check:

```
/usr/local/bin/mc: OK
mc version RELEASE.2025-08-13T08-35-41Z (commit-id=7394ce0dd2a80935aded936b09fa12cbb3cb8096)
01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891   <- same pin as before
```

`curl` is no longer installed at all; only `ca-certificates`, which `mc` needs at runtime to reach S3 over HTTPS and which comes from the reliable mirror. Nothing in this image downloads anything.

## Validation

Built locally: **9 seconds**, versus a 313-second hang before failing. Runtime contract re-checked in the built image — `command -v mc` succeeds so the chart's runtime-install guard skips, `pg_dump` is 17.4 matching the server, and the CA bundle is present.

No chart-template or values changes, so #976's E2E results carry over unchanged: the guard, pull policy, scratch volume and upload path are all untouched. This only changes where the bytes come from at build time.

## Note on upstream

`quay.io` is serving an archived project, so this is a frozen artifact that will get no security updates — same caveat #976 already documents. If quay follows dl.min.io, the durable answer is mirroring the binary into Harbor (or dropping `mc` for a plain SigV4 `PUT`). Worth tracking, not worth blocking on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backup image builds to obtain the pinned MinIO client from a registry image.
  * Continued verifying the client binary with its SHA-256 checksum.
  * Reduced runtime build dependencies by removing the need for curl.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->